### PR TITLE
Make publish faster, support multi-zone routes

### DIFF
--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -411,19 +411,27 @@ compatibility_date = "${compatibilityDate}"
           describe: "Root folder of static assets for Workers Sites",
           type: "string",
         })
-        .option("triggers", {
-          describe: "an array of crons",
-          type: "array",
+        .option("schedules", {
+          describe: "cron schedules to attach",
+          alias: ["schedule", "triggers"],
+          type: "array"
         })
         .option("zone", {
           describe: "a domain or a zone id",
           alias: "zone_id",
           type: "string",
+          hidden: true // No longer needed, since routes support multi-zone.
         })
         .option("routes", {
           describe: "routes to upload",
           alias: "route",
           type: "array",
+        })
+        .option("services", {
+          describe: "experimental support for services",
+          type: "boolean",
+          default: "false",
+          hidden: true
         });
     },
     async (args) => {


### PR DESCRIPTION
## Improvements
* `wrangler publish` is faster
  * First, script upload is attempted.
  * If that succeeds, all routes/schedules are applied in parallel.
  * If `workers.dev` subdomain is _new_, add 5 second delay to prevent negative cache-hits.
* `--triggers` renamed to `--schedules`
   * We have already rebranded "triggers" to not just be cron, but also routes. For now, `--triggers` are still supported as an alias. 
 
## New
* `wrangler publish` supports multi-zone routes:
  * e.g. `wrangler publish --route=example.com --route=anotherdomain.com`
  * Notice you don't need a `zone` or `zone_id` for any of them!
* Experimental flag for services, which is currently hidden.
 
## Example
```sh
$ npm run start -- \
  publish index.js --name=test12345 \
  --route=test.example.com \
  --route=test.anotherdomain.com \
  --schedule="5 4 * * *"
```
```txt
Uploaded test12345 (1.73 sec)
Deployed test12345 (1.87 sec)
  test12345.subdomain.workers.dev
  test.example.com
  test.anotherdomain.com
  5 4 * * *
```