### PR TITLE
Add support for CF_ACCOUNT_ID and CF_API_TOKEN

### DIFF
--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -56,11 +56,6 @@ async function readConfig(path?: string): Promise<Config> {
   // todo: validate, add defaults
   // let's just do some basics for now
 
-  // env var overrides
-  if (process.env.CF_ACCOUNT_ID) {
-    config.account_id = process.env.CF_ACCOUNT_ID;
-  }
-
   // @ts-expect-error we're being sneaky here for now
   config.__path__ = path;
 

--- a/packages/wrangler/src/user.tsx
+++ b/packages/wrangler/src/user.tsx
@@ -217,6 +217,7 @@ import url from "node:url";
 import http from "node:http";
 import { readFile, writeFile, rm, mkdir } from "node:fs/promises";
 import path from "node:path";
+import process from "node:process";
 import os from "node:os";
 import TOML from "@iarna/toml";
 import assert from "node:assert";
@@ -334,6 +335,10 @@ function throwIfNotInitialised() {
 }
 
 export function getAPIToken(): string {
+  if (process.env.CF_API_TOKEN) {
+    return process.env.CF_API_TOKEN;
+  }
+
   throwIfNotInitialised();
   return LocalState.accessToken?.value;
 }
@@ -948,6 +953,10 @@ export function listScopes(): void {
 export async function getAccountId() {
   const apiToken = getAPIToken();
   if (!apiToken) return;
+
+  if (process.env.CF_ACCOUNT_ID) {
+    return process.env.CF_ACCOUNT_ID;
+  }
 
   let response: Response;
   try {


### PR DESCRIPTION
This is a very simple PR that adds support for `CF_ACCOUNT_ID` and `CF_ACCOUNT_TOKEN` to be passed in. I tested this with `kv:namespace list` but looking at the code it should work for all just commands fine.

(Thanks for making Wrangler v2 in TS 🧡)