### PR TITLE
Add `wrangler2` as an alias

### DIFF
--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -3,7 +3,10 @@
   "version": "0.0.0",
   "author": "wrangler@cloudflare.com",
   "description": "Command-line interface for all things Cloudflare Workers",
-  "bin": "./bin/wrangler.js",
+  "bin": {
+    "wrangler": "./bin/wrangler.js",
+    "wrangler2": "./bin/wrangler.js"
+  },
   "license": "MIT OR Apache-2.0",
   "bugs": {
     "url": "https://github.com/cloudflare/wrangler/issues"


### PR DESCRIPTION
So that when wrangler2 is installed along @cloudflare/wrangler, they can each be referenced in npm run scripts.

See https://github.com/cloudflare/wrangler/pull/2139