### PR TITLE
fix functions directory location

### DIFF
--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -219,7 +219,9 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
         return;
       }
 
-      const functionsDirectory = "./functions";
+      const functionsDirectory = directory !== undefined
+        ? join(directory, "./functions")
+        : "./functions";
       const usingFunctions = existsSync(functionsDirectory);
 
       const proxy = await spawnProxyProcess({


### PR DESCRIPTION
This PR fix the location of the `functions` directory when providing a `directory` to `wrangler pages dev`.

Before this PR:

```
$ wrangler pages dev worker/public/
...
No Worker script found at worker/public/_worker.js. Please either create a functions directory or create a single Worker at worker/public/_worker.js.
```
