### PR TITLE
Durable Objects 1: bind to external scripts

### DIFF
--- a/packages/wrangler/src/api/worker.ts
+++ b/packages/wrangler/src/api/worker.ts
@@ -72,6 +72,11 @@ export interface CfKvNamespace {
   namespaceId: string;
 }
 
+export interface CfDurableObject {
+  class_name: string;
+  script_name?: string;
+}
+
 /**
  * A `WebCrypto` key.
  *
@@ -99,7 +104,7 @@ export interface CfCryptoKey {
 /**
  * A variable (aka. environment variable).
  */
-export type CfVariable = string | CfKvNamespace | CfCryptoKey;
+export type CfVariable = string | CfKvNamespace | CfCryptoKey | CfDurableObject;
 
 /**
  * Options for creating a `CfWorker`.

--- a/packages/wrangler/src/config.ts
+++ b/packages/wrangler/src/config.ts
@@ -28,6 +28,12 @@ type KVNamespace = {
   id: string;
 };
 
+type DurableObject = {
+  name: string;
+  class_name: string;
+  script_name?: string;
+};
+
 type Build = {
   command?: string;
   cwd?: string;
@@ -93,6 +99,7 @@ export type Config = {
   jsxFactory?: string; // inherited
   jsxFragment?: string; // inherited
   vars?: Vars;
+  durable_objects?: { bindings: DurableObject[] };
   kv_namespaces?: KVNamespace[];
   site?: Site; // inherited
   // we should use typescript to parse cron patterns

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -447,7 +447,7 @@ export async function main(argv: string[]): Promise<void> {
 
       // -- snip, end --
 
-      const envRootObj = args.env ? config[`env.${args.env}`] : config;
+      const envRootObj: Config = args.env ? config[`env.${args.env}`] : config;
 
       render(
         <Dev
@@ -476,6 +476,12 @@ export async function main(argv: string[]): Promise<void> {
                   );
                 }
                 return { ...obj, [binding]: { namespaceId: preview_id } };
+              },
+              {}
+            ),
+            ...(envRootObj?.durable_objects?.bindings || []).reduce(
+              (obj, { name, class_name, script_name }) => {
+                return { ...obj, [name]: { class_name, script_name } };
               },
               {}
             ),

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -160,6 +160,15 @@ export default async function publish(props: Props): Promise<void> {
         },
         {}
       ),
+      ...(envRootObj?.durable_objects?.bindings || []).reduce(
+        (obj, { name, class_name, script_name }) => {
+          return {
+            ...obj,
+            [name]: { class_name, ...(script_name && { script_name }) },
+          };
+        },
+        {}
+      ),
       ...(assets.namespace
         ? { __STATIC_CONTENT: { namespaceId: assets.namespace } }
         : {}),


### PR DESCRIPTION
This commit lets you bind a worker to durable objects defined on external scripts. The configuration is the same as wrangler v1:
```
[durable_objects]
bindings = [{name = "COUNTER", class_name = "Counter", script_name = "counter-durable"}]
```