### PR TITLE
Pick correct config object when passing env argument

### DIFF
--- a/packages/wrangler/src/config.ts
+++ b/packages/wrangler/src/config.ts
@@ -76,6 +76,8 @@ type Env = {
   jsxFragment?: string; // inherited
   // we should use typescript to parse cron patterns
   triggers?: { crons: Cron[] }; // inherited
+  vars?: Vars;
+  durable_objects?: { bindings: DurableObject[] };
   kv_namespaces?: KVNamespace[];
   usage_model?: UsageModel; // inherited
 };
@@ -108,5 +110,5 @@ export type Config = {
   usage_model?: UsageModel; // inherited
   // top level
   build?: Build;
-  env?: { [envName: string]: Env };
+  env?: { [envName: string]: void | Env };
 };

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -447,7 +447,7 @@ export async function main(argv: string[]): Promise<void> {
 
       // -- snip, end --
 
-      const envRootObj: Config = args.env ? config[`env.${args.env}`] : config;
+      const envRootObj: Config = args.env ? (config.env?.[args.env] ?? config) : config;
 
       render(
         <Dev

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -93,8 +93,6 @@ async function readConfig(path?: string): Promise<Config> {
     });
   });
 
-  console.log(config.env);
-
   // todo: validate, add defaults
   // let's just do some basics for now
 

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -447,7 +447,7 @@ export async function main(argv: string[]): Promise<void> {
 
       // -- snip, end --
 
-      const envRootObj: Config = args.env ? (config.env?.[args.env] ?? config) : config;
+      const envRootObj: Config = args.env ? (config.env?.[args.env] || {}) : config;
 
       render(
         <Dev

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -93,6 +93,8 @@ async function readConfig(path?: string): Promise<Config> {
     });
   });
 
+  console.log(config.env);
+
   // todo: validate, add defaults
   // let's just do some basics for now
 
@@ -447,7 +449,7 @@ export async function main(argv: string[]): Promise<void> {
 
       // -- snip, end --
 
-      const envRootObj: Config = args.env ? (config.env?.[args.env] || {}) : config;
+      const envRootObj = args.env ? config.env[args.env] || {} : config;
 
       render(
         <Dev
@@ -455,8 +457,8 @@ export async function main(argv: string[]): Promise<void> {
           entry={filename}
           format={format}
           initialMode={args.local ? "local" : "remote"}
-          jsxFactory={args["jsx-factory"] || envRootObj.jsxFactory}
-          jsxFragment={args["jsx-fragment"] || envRootObj.jsxFragment}
+          jsxFactory={args["jsx-factory"] || envRootObj?.jsxFactory}
+          jsxFragment={args["jsx-fragment"] || envRootObj?.jsxFragment}
           accountId={config.account_id}
           site={args.site || config.site?.bucket}
           port={args.port || config.dev?.port}
@@ -1241,7 +1243,7 @@ export async function main(argv: string[]): Promise<void> {
             const id =
               args["namespace-id"] ||
               (args.env
-                ? config[`env.${args.env}`]
+                ? config.env[args.env] || {}
                 : config
               ).kv_namespaces.find(
                 (namespace) => namespace.binding === args.binding

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -141,7 +141,7 @@ export default async function publish(props: Props): Promise<void> {
         )
       : { manifest: undefined, namespace: undefined };
 
-  const envRootObj = props.env ? config[`env.${props.env}`] : config;
+  const envRootObj = props.env ? config.env[props.env] || {} : config;
 
   const worker: CfWorkerInit = {
     main: {


### PR DESCRIPTION
When you start your project with `npx wrangler@beta dev src/index.ts --env staging` it would fail with this error:

```
/Users/luzanne/Projects/my-worker/node_modules/wrangler/wrangler-dist/cli.js:27069
            throw ex;
            ^

TypeError: Cannot read properties of undefined (reading 'jsxFactory')
```

After debugging some stuff I found out that the `envRootObj` was not set correctly.`config['env.staging']` does not work, accessing properties goes only 1 deep.

This PR will fix that issue and use the correct config provided by the env variable.

Might be better to also add an extra check here. When an env variable is provided in the arguments, it must be available in the config as well? Thats up to you :)

Config object:
```
{
  _: [ 'dev' ],
  env: 'staging',
  local: false,
  ip: '127.0.0.1',
  port: 8787,
  'local-protocol': 'http',
  localProtocol: 'http',
  'upstream-protocol': 'https',
  upstreamProtocol: 'https',
  '$0': 'wrangler',
  filename: 'src/index.ts',
  config: {
    name: 'my-worker',
    type: 'javascript',
    zone_id: 'xxx',
    account_id: 'xxx',
    workers_dev: true,
    env: { staging: [Object], production: [Object] },
    build: { command: 'npm i && npm run build', upload: [Object] },
    __path__: '/Users/luzanne/Projects/my-worker/wrangler.toml'
  }
}
```