### PR TITLE
Durable Objects 1.5: Tagged migrations (partial)

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,13 @@
           "no-empty": "off",
           "require-yield": "off",
           "no-empty-function": "off",
-          "@typescript-eslint/no-empty-function": "off"
+          "@typescript-eslint/no-empty-function": "off",
+          "@typescript-eslint/no-unused-vars": [
+            "warn",
+            {
+              "argsIgnorePattern": "^_"
+            }
+          ]
         }
       }
     ]

--- a/packages/wrangler/src/api/worker.ts
+++ b/packages/wrangler/src/api/worker.ts
@@ -106,6 +106,13 @@ export interface CfCryptoKey {
  */
 export type CfVariable = string | CfKvNamespace | CfCryptoKey | CfDurableObject;
 
+export type CfDOMigration = {
+  tag: string;
+  new_classes: string[];
+  renamed_class: string[];
+  deleted_classes: string[];
+};
+
 /**
  * Options for creating a `CfWorker`.
  */
@@ -122,6 +129,7 @@ export interface CfWorkerInit {
    * The map of names to variables. (aka. environment variables)
    */
   variables?: { [name: string]: CfVariable };
+  migrations: void | CfDOMigration[];
   compatibility_date: string | void;
   compatibility_flags: void | string[];
   usage_model: void | "bundled" | "unbound";

--- a/packages/wrangler/src/config.ts
+++ b/packages/wrangler/src/config.ts
@@ -1,6 +1,8 @@
 // we're going to manually write both the type definition AND
 // the validator for the config, so that we can give better error messages
 
+import type { CfDOMigration } from "./api/worker";
+
 type Project = "webpack" | "javascript" | "rust";
 
 type Site = {
@@ -72,8 +74,8 @@ type Env = {
   route?: string; // inherited
   webpack_config?: string; // inherited
   site?: Site;
-  jsxFactory?: string; // inherited
-  jsxFragment?: string; // inherited
+  jsx_factory?: string; // inherited
+  jsx_fragment?: string; // inherited
   // we should use typescript to parse cron patterns
   triggers?: { crons: Cron[] }; // inherited
   vars?: Vars;
@@ -98,9 +100,10 @@ export type Config = {
   // -- end mutually exclusive stuff
   // @deprecated Don't use this
   webpack_config?: string; // inherited
-  jsxFactory?: string; // inherited
-  jsxFragment?: string; // inherited
+  jsx_factory?: string; // inherited
+  jsx_fragment?: string; // inherited
   vars?: Vars;
+  migrations?: CfDOMigration[];
   durable_objects?: { bindings: DurableObject[] };
   kv_namespaces?: KVNamespace[];
   site?: Site; // inherited

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -64,8 +64,8 @@ async function readConfig(path?: string): Promise<Config> {
     "zone_id",
     "routes",
     "route",
-    "jsxFactory",
-    "jsxFragment",
+    "jsx_factory",
+    "jsx_fragment",
     "site",
     "triggers",
     "usage_model",
@@ -455,12 +455,13 @@ export async function main(argv: string[]): Promise<void> {
           entry={filename}
           format={format}
           initialMode={args.local ? "local" : "remote"}
-          jsxFactory={args["jsx-factory"] || envRootObj?.jsxFactory}
-          jsxFragment={args["jsx-fragment"] || envRootObj?.jsxFragment}
+          jsxFactory={args["jsx-factory"] || envRootObj?.jsx_factory}
+          jsxFragment={args["jsx-fragment"] || envRootObj?.jsx_fragment}
           accountId={config.account_id}
           site={args.site || config.site?.bucket}
           port={args.port || config.dev?.port}
           public={args.public}
+          migrations={config.migrations}
           compatibilityDate={config.compatibility_date}
           compatibilityFlags={config.compatibility_flags}
           usageModel={config.usage_model}

--- a/packages/wrangler/src/sites.tsx
+++ b/packages/wrangler/src/sites.tsx
@@ -76,7 +76,7 @@ export async function syncAssets(
   scriptName: string,
   dirPath: string,
   preview: boolean,
-  env?: string
+  _env?: string
 ) {
   const title = `__${scriptName}_sites_assets${preview ? "_preview" : ""}`;
   const { id: namespace } = await createKVNamespaceIfNotAlreadyExisting(

--- a/packages/wrangler/src/tail.tsx
+++ b/packages/wrangler/src/tail.tsx
@@ -33,7 +33,7 @@ async function createTailButDontConnect(
 export async function createTail(
   accountId: string,
   workerName: string,
-  filters: Filters
+  _filters: Filters
 ): Promise<{
   tail: WebSocket;
   expiration: Date;


### PR DESCRIPTION
This PR sends forward `migrations` (as defined in https://developers.cloudflare.com/workers/learning/using-durable-objects#durable-object-migrations-in-wranglertoml) when publishing. 

- When publishing, this tries to check existing migration tag, and send migrations only after those from `wrangler.toml`
- However, this in't working as expected. While the migrations get executed, the previous tag is not showing when fetching script details, so it's not possible to figure out which migrations to execute. I think I need to send forward the current migration tag when publishing, but I'm not certain where I'm supposed to do so, and my experiments haven't been fruitful yet. Landing this regardless for now.
- Further `wrangler dev` doesn't appear to 'just work', even though I've been told it's supposed to. I'm reaching out to concerned teams and trying to figure out why. 
- Also, I changed `jsxFactory` -> `jsx_factory` and `jsxFragment` -> `jsx_fragment` in wrangler.toml for consistency. 
- Also, I fixed a bunch of lint errors.