### PR TITLE
Durable Objects 1.6: actual Tagged Migrations

### DIFF
--- a/packages/example-worker-app/wrangler.toml
+++ b/packages/example-worker-app/wrangler.toml
@@ -1,0 +1,4 @@
+[[migrations]]
+tag = "v3"
+deleted_classes = [ "Counter", "B" ]
+

--- a/packages/example-worker-app/wrangler.toml
+++ b/packages/example-worker-app/wrangler.toml
@@ -1,4 +1,0 @@
-[[migrations]]
-tag = "v3"
-deleted_classes = [ "Counter", "B" ]
-

--- a/packages/wrangler/src/api/worker.ts
+++ b/packages/wrangler/src/api/worker.ts
@@ -77,7 +77,7 @@ export interface CfDurableObject {
   script_name?: string;
 }
 
-interface CfDOMigration {
+interface CfDOMigrations {
   old_tag?: string;
   new_tag: string;
   steps: {
@@ -132,7 +132,7 @@ export interface CfWorkerInit {
    * The map of names to variables. (aka. environment variables)
    */
   variables?: { [name: string]: CfVariable };
-  migrations: void | CfDOMigration;
+  migrations: void | CfDOMigrations;
   compatibility_date: string | void;
   compatibility_flags: void | string[];
   usage_model: void | "bundled" | "unbound";

--- a/packages/wrangler/src/api/worker.ts
+++ b/packages/wrangler/src/api/worker.ts
@@ -77,6 +77,16 @@ export interface CfDurableObject {
   script_name?: string;
 }
 
+interface CfDOMigration {
+  old_tag?: string;
+  new_tag: string;
+  steps: {
+    new_classes?: string[];
+    renamed_classes?: string[];
+    deleted_classes?: string[];
+  }[];
+}
+
 /**
  * A `WebCrypto` key.
  *
@@ -106,13 +116,6 @@ export interface CfCryptoKey {
  */
 export type CfVariable = string | CfKvNamespace | CfCryptoKey | CfDurableObject;
 
-export type CfDOMigration = {
-  tag: string;
-  new_classes: string[];
-  renamed_class: string[];
-  deleted_classes: string[];
-};
-
 /**
  * Options for creating a `CfWorker`.
  */
@@ -129,7 +132,7 @@ export interface CfWorkerInit {
    * The map of names to variables. (aka. environment variables)
    */
   variables?: { [name: string]: CfVariable };
-  migrations: void | CfDOMigration[];
+  migrations: void | CfDOMigration;
   compatibility_date: string | void;
   compatibility_flags: void | string[];
   usage_model: void | "bundled" | "unbound";

--- a/packages/wrangler/src/config.ts
+++ b/packages/wrangler/src/config.ts
@@ -1,7 +1,12 @@
 // we're going to manually write both the type definition AND
 // the validator for the config, so that we can give better error messages
 
-import type { CfDOMigration } from "./api/worker";
+type DOMigration = {
+  tag: string;
+  new_classes?: string[];
+  renamed_classes?: string[];
+  deleted_classes?: string[];
+};
 
 type Project = "webpack" | "javascript" | "rust";
 
@@ -103,7 +108,7 @@ export type Config = {
   jsx_factory?: string; // inherited
   jsx_fragment?: string; // inherited
   vars?: Vars;
-  migrations?: CfDOMigration[];
+  migrations?: DOMigration[];
   durable_objects?: { bindings: DurableObject[] };
   kv_namespaces?: KVNamespace[];
   site?: Site; // inherited

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -9,7 +9,7 @@ import React, { useState, useEffect, useRef } from "react";
 import path from "path";
 import open from "open";
 import { DtInspector } from "./api/inspect";
-import type { CfDOMigration, CfModule, CfVariable } from "./api/worker";
+import type { CfModule, CfVariable } from "./api/worker";
 import { createWorker } from "./api/worker";
 import type { CfWorkerInit } from "./api/worker";
 import { spawn } from "child_process";
@@ -35,7 +35,6 @@ type Props = {
   jsxFactory: void | string;
   jsxFragment: void | string;
   variables: { [name: string]: CfVariable };
-  migrations: CfDOMigration[] | void;
   public: void | string;
   site: void | string;
   compatibilityDate: void | string;
@@ -105,7 +104,6 @@ export function Dev(props: Props): JSX.Element {
           compatibilityDate={props.compatibilityDate}
           compatibilityFlags={props.compatibilityFlags}
           usageModel={props.usageModel}
-          migrations={props.migrations}
         />
       )}
       <Box borderStyle="round" paddingLeft={1} paddingRight={1}>
@@ -161,7 +159,6 @@ function Remote(props: {
   accountId: void | string;
   apiToken: void | string;
   variables: { [name: string]: CfVariable };
-  migrations: void | CfDOMigration[];
   compatibilityDate: string | void;
   compatibilityFlags: void | string[];
   usageModel: void | "bundled" | "unbound";
@@ -176,7 +173,6 @@ function Remote(props: {
     accountId: props.accountId,
     apiToken: props.apiToken,
     variables: props.variables,
-    migrations: props.migrations,
     sitesFolder: props.site,
     port: props.port,
     compatibilityDate: props.compatibilityDate,
@@ -413,7 +409,6 @@ function useWorker(props: {
   accountId: string;
   apiToken: string;
   variables: { [name: string]: CfVariable };
-  migrations: void | CfDOMigration[];
   sitesFolder: void | string;
   port: number;
   compatibilityDate: string | void;

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -461,7 +461,6 @@ export async function main(argv: string[]): Promise<void> {
           site={args.site || config.site?.bucket}
           port={args.port || config.dev?.port}
           public={args.public}
-          migrations={config.migrations}
           compatibilityDate={config.compatibility_date}
           compatibilityFlags={config.compatibility_flags}
           usageModel={config.usage_model}

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -150,6 +150,7 @@ export default async function publish(props: Props): Promise<void> {
           `The published script ${scriptName} has a migration tag "${script.migration_tag}, which was not found in wrangler.toml. You may have already delated it. Applying all available migrations to the script...`
         );
         migrations = {
+          old_tag: script.migration_tag,
           new_tag: config.migrations[config.migrations.length - 1].tag,
           steps: config.migrations.map(({ tag: _tag, ...rest }) => rest),
         };


### PR DESCRIPTION
This PR does proper tagged migrations, fixing some of the issues from #67.  So now you can publish durable objects. Nice.

Next up, we should have better validation and suggestions on how to make migrations (what I'm calling 'guided migrations'). Also, I have to fix `wrangler dev` for durable objects.