### PR TITLE
add --watch arg to pages dev

### DIFF
--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -200,6 +200,11 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
             description: "Durable Object to bind (NAME=CLASS)",
             alias: "o",
           },
+          watch: {
+            type: "array",
+            description: "Additional directories to watch for code changes",
+            alias: "w",
+          },
           // TODO: Miniflare user options
         });
     },
@@ -212,6 +217,7 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
       binding: bindings = [],
       kv: kvs = [],
       do: durableObjects = [],
+      watch,
       "--": remaining = [],
     }) => {
       if (!local) {
@@ -237,7 +243,7 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
         const scriptPath = join(tmpdir(), "./functionsWorker.js");
         miniflareArgs = {
           scriptPath,
-          buildWatchPaths: [functionsDirectory],
+          buildWatchPaths: [functionsDirectory, ...watch.map(w => w.toString())],
           buildCommand: `npx @cloudflare/pages-functions-compiler build ${functionsDirectory} --outfile ${scriptPath}`,
         };
       } else {


### PR DESCRIPTION
This PR adds the `--watch` arg to `wrangler pages dev`, which allows including other build directories into the watch list of miniflare.

There are use-cases where a pages function imports the result of another build. In my case, it's the build of an Remix app. Reduced for the sake of simplicity, my function looks like:

```ts
import { handleRequest } from "../worker/remix";
export async function onRequest({ request }: EventContext<Env, string, unknown>) {
  return handleRequest(request);
}
```

Changes to my remix app are not reflected when running `wrangler pages dev`. This is because it doesn't watch for changes of `../worker` in my case.

This is why I agree with #49, that it would be very useful to be able to pass one or multiple `--watch` args to `wranger pages dev`. With the PR, I can run wrangler via `wrangler pages dev public --watch ./worker` and now get updates when I change my remix app.

Fixes #49