### PR TITLE
bind durable objects in local mode

### DIFF
--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -252,6 +252,7 @@ function useLocalWorker(props: {
         port.toString(),
         "--kv-persist",
         "--cache-persist",
+        "--do-persist",
         ...Object.entries(variables)
           .map(([varKey, varVal]) => {
             if (typeof varVal === "string") {
@@ -261,6 +262,8 @@ function useLocalWorker(props: {
               typeof varVal.namespaceId === "string"
             ) {
               return `--kv ${varKey}`;
+            } else if ("class_name" in varVal) {
+              return `--do ${varKey}=${varVal.class_name}`;
             }
           })
           .filter(Boolean),


### PR DESCRIPTION
This commit adds durable object bindings when in local mode for `wrangler dev`. (We still have to make durable object bindings work for 'remote' mode, that'll happen soo.)