### PR TITLE
Persist KV, DO & Cache locally when `wrangler pages dev`-ing

### DIFF
--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -302,6 +302,10 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
           },
         },
 
+        kvPersist: true,
+        durableObjectsPersist: true,
+        cachePersist: true,
+
         ...miniflareArgs,
       });
       const miniflareServer = await miniflare.createServer();


### PR DESCRIPTION
Brings behavior parity with `wrangler dev` by persisting KV, DO & Cache to disk when developing locally.