### PR TITLE
switch from entry to result.metafile.inputs

### DIFF
--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -1,59 +1,59 @@
-import esbuild from "esbuild";
-import httpProxy from "http-proxy";
-import { readFile } from "fs/promises";
-import type { DirectoryResult } from "tmp-promise";
-import tmp from "tmp-promise";
-import type { CfPreviewToken } from "./api/preview";
-import { Box, Text, useInput } from "ink";
-import React, { useState, useEffect, useRef } from "react";
-import path from "path";
-import open from "open";
-import { DtInspector } from "./api/inspect";
-import type { CfModule, CfVariable } from "./api/worker";
-import { createWorker } from "./api/worker";
-import type { CfWorkerInit } from "./api/worker";
-import { spawn } from "child_process";
-import onExit from "signal-exit";
-import { syncAssets } from "./sites";
-import clipboardy from "clipboardy";
-import http from "node:http";
-import serveStatic from "serve-static";
-import commandExists from "command-exists";
-import assert from "assert";
-import { getAPIToken } from "./user";
-import fetch from "node-fetch";
-import NodeModulesPolyfills from "@esbuild-plugins/node-modules-polyfill";
-import NodeGlobalsPolyfills from "@esbuild-plugins/node-globals-polyfill";
+import esbuild from 'esbuild'
+import httpProxy from 'http-proxy'
+import { readFile } from 'fs/promises'
+import { DirectoryResult } from 'tmp-promise'
+import tmp from 'tmp-promise'
+import { CfPreviewToken } from './api/preview'
+import { Box, Text, useInput } from 'ink'
+import React, { useState, useEffect, useRef } from 'react'
+import path from 'path'
+import open from 'open'
+import { DtInspector } from './api/inspect'
+import { CfModule, CfVariable } from './api/worker'
+import { createWorker } from './api/worker'
+import { CfWorkerInit } from './api/worker'
+import { spawn } from 'child_process'
+import onExit from 'signal-exit'
+import { syncAssets } from './sites'
+import clipboardy from 'clipboardy'
+import http from 'node:http'
+import serveStatic from 'serve-static'
+import commandExists from 'command-exists'
+import assert from 'assert'
+import { getAPIToken } from './user'
+import fetch from 'node-fetch'
+import NodeModulesPolyfills from '@esbuild-plugins/node-modules-polyfill'
+import NodeGlobalsPolyfills from '@esbuild-plugins/node-globals-polyfill'
 
-type CfScriptFormat = void | "modules" | "service-worker";
+type CfScriptFormat = void | 'modules' | 'service-worker'
 
 type Props = {
-  name?: string;
-  entry: string;
-  port?: number;
-  format: CfScriptFormat;
-  accountId: void | string;
-  initialMode: "local" | "remote";
-  jsxFactory: void | string;
-  jsxFragment: void | string;
-  variables: { [name: string]: CfVariable };
-  public: void | string;
-  site: void | string;
-  compatibilityDate: void | string;
-  compatibilityFlags: void | string[];
-  usageModel: void | "bundled" | "unbound";
-  polyfillNode: void | boolean;
-};
+  name?: string
+  entry: string
+  port?: number
+  format: CfScriptFormat
+  accountId: void | string
+  initialMode: 'local' | 'remote'
+  jsxFactory: void | string
+  jsxFragment: void | string
+  variables: { [name: string]: CfVariable }
+  public: void | string
+  site: void | string
+  compatibilityDate: void | string
+  compatibilityFlags: void | string[]
+  usageModel: void | 'bundled' | 'unbound'
+  polyfillNode: void | boolean
+}
 
-export function Dev(props: Props): JSX.Element {
-  if (props.public && props.format === "service-worker") {
+export function Dev (props: Props): JSX.Element {
+  if (props.public && props.format === 'service-worker') {
     throw new Error(
-      "You cannot use the service worker format with a `public` directory."
-    );
+      'You cannot use the service worker format with a `public` directory.'
+    )
   }
-  const port = props.port || 8787;
-  const apiToken = getAPIToken();
-  const directory = useTmpDir();
+  const port = props.port || 8787
+  const apiToken = getAPIToken()
+  const directory = useTmpDir()
 
   const bundle = useEsbuild({
     entry: props.entry,
@@ -61,26 +61,26 @@ export function Dev(props: Props): JSX.Element {
     staticRoot: props.public,
     jsxFactory: props.jsxFactory,
     jsxFragment: props.jsxFragment,
-    polyfillNode: props.polyfillNode,
-  });
-  if (bundle && bundle.type === "commonjs" && !props.format && props.public) {
+    polyfillNode: props.polyfillNode
+  })
+  if (bundle && bundle.type === 'commonjs' && !props.format && props.public) {
     throw new Error(
-      "You cannot use the service worker format with a `public` directory."
-    );
+      'You cannot use the service worker format with a `public` directory.'
+    )
   }
 
   // @ts-expect-error whack
-  useDevtoolsRefresh(bundle?.id ?? 0);
+  useDevtoolsRefresh(bundle?.id ?? 0)
 
   const toggles = useHotkeys(
     {
-      local: props.initialMode === "local",
-      tunnel: false,
+      local: props.initialMode === 'local',
+      tunnel: false
     },
     port
-  );
+  )
 
-  useTunnel(toggles.tunnel);
+  useTunnel(toggles.tunnel)
 
   return (
     <>
@@ -110,65 +110,65 @@ export function Dev(props: Props): JSX.Element {
           usageModel={props.usageModel}
         />
       )}
-      <Box borderStyle="round" paddingLeft={1} paddingRight={1}>
+      <Box borderStyle='round' paddingLeft={1} paddingRight={1}>
         <Text>
           {`B to open a browser, D to open Devtools, S to ${
-            toggles.tunnel ? "turn off" : "turn on"
+            toggles.tunnel ? 'turn off' : 'turn on'
           } (experimental) sharing, L to ${
-            toggles.local ? "turn off" : "turn on"
+            toggles.local ? 'turn off' : 'turn on'
           } local mode, X to exit`}
         </Text>
       </Box>
     </>
-  );
+  )
 }
 
-function useDevtoolsRefresh(bundleId: number) {
+function useDevtoolsRefresh (bundleId: number) {
   // TODO: this is a hack while we figure out
   // a better cleaner solution to get devtools to reconnect
   // without having to do a full refresh
-  const ref = useRef();
+  const ref = useRef()
   // @ts-expect-error whack
-  ref.current = bundleId;
+  ref.current = bundleId
 
   useEffect(() => {
     const server = http.createServer((req, res) => {
-      res.setHeader("Access-Control-Allow-Origin", "*");
-      res.setHeader("Access-Control-Request-Method", "*");
-      res.setHeader("Access-Control-Allow-Methods", "OPTIONS, GET");
-      res.setHeader("Access-Control-Allow-Headers", "*");
-      if (req.method === "OPTIONS") {
-        res.writeHead(200);
-        res.end();
-        return;
+      res.setHeader('Access-Control-Allow-Origin', '*')
+      res.setHeader('Access-Control-Request-Method', '*')
+      res.setHeader('Access-Control-Allow-Methods', 'OPTIONS, GET')
+      res.setHeader('Access-Control-Allow-Headers', '*')
+      if (req.method === 'OPTIONS') {
+        res.writeHead(200)
+        res.end()
+        return
       }
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ value: ref.current }));
-    });
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ value: ref.current }))
+    })
 
-    server.listen(3142);
+    server.listen(3142)
     return () => {
-      server.close();
-    };
-  }, []);
+      server.close()
+    }
+  }, [])
 }
 
-function Remote(props: {
-  name: void | string;
-  bundle: EsbuildBundle | void;
-  format: CfScriptFormat;
-  public: void | string;
-  site: void | string;
-  port: number;
-  accountId: void | string;
-  apiToken: void | string;
-  variables: { [name: string]: CfVariable };
-  compatibilityDate: string | void;
-  compatibilityFlags: void | string[];
-  usageModel: void | "bundled" | "unbound";
+function Remote (props: {
+  name: void | string
+  bundle: EsbuildBundle | void
+  format: CfScriptFormat
+  public: void | string
+  site: void | string
+  port: number
+  accountId: void | string
+  apiToken: void | string
+  variables: { [name: string]: CfVariable }
+  compatibilityDate: string | void
+  compatibilityFlags: void | string[]
+  usageModel: void | 'bundled' | 'unbound'
 }) {
-  assert(props.accountId, "accountId is required");
-  assert(props.apiToken, "apiToken is required");
+  assert(props.accountId, 'accountId is required')
+  assert(props.apiToken, 'apiToken is required')
   const token = useWorker({
     name: props.name,
     bundle: props.bundle,
@@ -181,181 +181,180 @@ function Remote(props: {
     port: props.port,
     compatibilityDate: props.compatibilityDate,
     compatibilityFlags: props.compatibilityFlags,
-    usageModel: props.usageModel,
-  });
+    usageModel: props.usageModel
+  })
 
-  useProxy({ token, publicRoot: props.public, port: props.port });
+  useProxy({ token, publicRoot: props.public, port: props.port })
 
-  useInspector(token ? token.inspectorUrl.href : undefined);
-  return null;
+  useInspector(token ? token.inspectorUrl.href : undefined)
+  return null
 }
-function Local(props: {
-  name: void | string;
-  bundle: EsbuildBundle | void;
-  format: CfScriptFormat;
-  variables: { [name: string]: CfVariable };
-  public: void | string;
-  site: void | string;
-  port: number;
+function Local (props: {
+  name: void | string
+  bundle: EsbuildBundle | void
+  format: CfScriptFormat
+  variables: { [name: string]: CfVariable }
+  public: void | string
+  site: void | string
+  port: number
 }) {
   const { inspectorUrl } = useLocalWorker({
     name: props.name,
     bundle: props.bundle,
     format: props.format,
     variables: props.variables,
-    port: props.port,
-  });
-  useInspector(inspectorUrl);
-  return null;
+    port: props.port
+  })
+  useInspector(inspectorUrl)
+  return null
 }
 
-function useLocalWorker(props: {
-  name: void | string;
-  bundle: EsbuildBundle | void;
-  format: CfScriptFormat;
-  variables: { [name: string]: CfVariable };
-  port: number;
+function useLocalWorker (props: {
+  name: void | string
+  bundle: EsbuildBundle | void
+  format: CfScriptFormat
+  variables: { [name: string]: CfVariable }
+  port: number
 }) {
   // TODO: pass vars via command line
-  const { bundle, format, variables, port } = props;
-  const local = useRef<ReturnType<typeof spawn>>();
-  const removeSignalExitListener = useRef<() => void>();
-  const [inspectorUrl, setInspectorUrl] = useState<string | void>();
+  const { bundle, format, variables, port } = props
+  const local = useRef<ReturnType<typeof spawn>>()
+  const removeSignalExitListener = useRef<() => void>()
+  const [inspectorUrl, setInspectorUrl] = useState<string | void>()
   useEffect(() => {
-    async function startLocalWorker() {
-      if (!bundle) return;
-      if (format === "modules" && bundle.type === "commonjs") {
-        console.error("⎔ Cannot use modules with a commonjs bundle.");
+    async function startLocalWorker () {
+      if (!bundle) return
+      if (format === 'modules' && bundle.type === 'commonjs') {
+        console.error('⎔ Cannot use modules with a commonjs bundle.')
         // TODO: a much better error message here, with what to do next
-        return;
+        return
       }
-      if (format === "service-worker" && bundle.type !== "esm") {
-        console.error("⎔ Cannot use service-worker with a esm bundle.");
+      if (format === 'service-worker' && bundle.type !== 'esm') {
+        console.error('⎔ Cannot use service-worker with a esm bundle.')
         // TODO: a much better error message here, with what to do next
-        return;
+        return
       }
 
-      console.log("⎔ Starting a local server...");
-      local.current = spawn("node", [
-        "--experimental-vm-modules",
-        "--inspect",
-        require.resolve("miniflare/cli"),
+      console.log('⎔ Starting a local server...')
+      local.current = spawn('node', [
+        '--experimental-vm-modules',
+        '--inspect',
+        require.resolve('miniflare/cli'),
         bundle.path,
-        "--watch",
-        "--wrangler-config",
-        path.join(__dirname, "../miniflare-config-stubs/wrangler.empty.toml"),
-        "--env",
-        path.join(__dirname, "../miniflare-config-stubs/.env.empty"),
-        "--package",
-        path.join(__dirname, "../miniflare-config-stubs/package.empty.json"),
-        "--port",
+        '--watch',
+        '--wrangler-config',
+        path.join(__dirname, '../miniflare-config-stubs/wrangler.empty.toml'),
+        '--env',
+        path.join(__dirname, '../miniflare-config-stubs/.env.empty'),
+        '--package',
+        path.join(__dirname, '../miniflare-config-stubs/package.empty.json'),
+        '--port',
         port.toString(),
-        "--kv-persist",
-        "--cache-persist",
-        "--do-persist",
+        '--kv-persist',
+        '--cache-persist',
+        '--do-persist',
         ...Object.entries(variables)
           .map(([varKey, varVal]) => {
-            if (typeof varVal === "string") {
-              return `--binding ${varKey}=${varVal}`;
+            if (typeof varVal === 'string') {
+              return `--binding ${varKey}=${varVal}`
             } else if (
-              "namespaceId" in varVal &&
-              typeof varVal.namespaceId === "string"
+              'namespaceId' in varVal &&
+              typeof varVal.namespaceId === 'string'
             ) {
-              return `--kv ${varKey}`;
-            } else if ("class_name" in varVal) {
-              return `--do ${varKey}=${varVal.class_name}`;
+              return `--kv ${varKey}`
+            } else if ('class_name' in varVal) {
+              return `--do ${varKey}=${varVal.class_name}`
             }
           })
           .filter(Boolean),
-        "--modules",
+        '--modules',
         format ||
-        (bundle.type === "esm" ? "modules" : "service-worker") === "modules"
-          ? "true"
-          : "false",
-      ]);
-      console.log(`⬣ Listening at http://localhost:${port}`);
+        (bundle.type === 'esm' ? 'modules' : 'service-worker') === 'modules'
+          ? 'true'
+          : 'false'
+      ])
+      console.log(`⬣ Listening at http://localhost:${port}`)
 
-      local.current.on("close", (code) => {
+      local.current.on('close', code => {
         if (code !== null) {
-          console.log(`miniflare process exited with code ${code}`);
+          console.log(`miniflare process exited with code ${code}`)
         }
-      });
+      })
 
-      local.current.stdout.on("data", (_data: string) => {
+      local.current.stdout.on('data', (_data: string) => {
         // console.log(`stdout: ${data}`);
-      });
+      })
 
-      local.current.stderr.on("data", (data: string) => {
+      local.current.stderr.on('data', (data: string) => {
         // console.error(`stderr: ${data}`);
-        const matches =
-          /Debugger listening on (ws:\/\/127\.0\.0\.1:9229\/[A-Za-z0-9-]+)/.exec(
-            data
-          );
+        const matches = /Debugger listening on (ws:\/\/127\.0\.0\.1:9229\/[A-Za-z0-9-]+)/.exec(
+          data
+        )
         if (matches) {
-          setInspectorUrl(matches[1]);
+          setInspectorUrl(matches[1])
         }
-      });
+      })
 
       removeSignalExitListener.current = onExit((_code, _signal) => {
-        console.log("⎔ Shutting down local server.");
-        local.current?.kill();
-        local.current = undefined;
-      });
+        console.log('⎔ Shutting down local server.')
+        local.current?.kill()
+        local.current = undefined
+      })
     }
 
-    startLocalWorker();
+    startLocalWorker()
 
     return () => {
       if (local.current) {
-        console.log("⎔ Shutting down local server.");
-        local.current?.kill();
-        local.current = undefined;
-        removeSignalExitListener.current && removeSignalExitListener.current();
-        removeSignalExitListener.current = undefined;
-      }
-    };
-  }, [bundle, format, port]);
-  return { inspectorUrl };
-}
-
-function useTmpDir(): string | void {
-  const [directory, setDirectory] = useState<DirectoryResult>();
-  useEffect(() => {
-    let dir: DirectoryResult;
-    async function create() {
-      try {
-        dir = await tmp.dir({ unsafeCleanup: true });
-        setDirectory(dir);
-        return;
-      } catch (err) {
-        console.error("failed to create tmp dir");
-        console.error(err);
-        throw err;
+        console.log('⎔ Shutting down local server.')
+        local.current?.kill()
+        local.current = undefined
+        removeSignalExitListener.current && removeSignalExitListener.current()
+        removeSignalExitListener.current = undefined
       }
     }
-    create();
+  }, [bundle, format, port])
+  return { inspectorUrl }
+}
+
+function useTmpDir (): string | void {
+  const [directory, setDirectory] = useState<DirectoryResult>()
+  useEffect(() => {
+    let dir: DirectoryResult
+    async function create () {
+      try {
+        dir = await tmp.dir({ unsafeCleanup: true })
+        setDirectory(dir)
+        return
+      } catch (err) {
+        console.error('failed to create tmp dir')
+        console.error(err)
+        throw err
+      }
+    }
+    create()
     return () => {
-      dir.cleanup();
-    };
-  }, []);
-  return directory?.path;
+      dir.cleanup()
+    }
+  }, [])
+  return directory?.path
 }
 
 type EsbuildBundle = {
-  id: number;
-  path: string;
-  entry: string;
-  type: "esm" | "commonjs";
-  exports: string[];
-};
+  id: number
+  path: string
+  entry: string
+  type: 'esm' | 'commonjs'
+  exports: string[]
+}
 
-function useEsbuild(props: {
-  entry: string;
-  destination: string | void;
-  staticRoot: void | string;
-  jsxFactory: string | void;
-  jsxFragment: string | void;
-  polyfillNode: boolean | void;
+function useEsbuild (props: {
+  entry: string
+  destination: string | void
+  staticRoot: void | string
+  jsxFactory: string | void
+  jsxFragment: string | void
+  polyfillNode: boolean | void
 }): EsbuildBundle | void {
   const {
     entry,
@@ -363,78 +362,79 @@ function useEsbuild(props: {
     staticRoot,
     jsxFactory,
     jsxFragment,
-    polyfillNode,
-  } = props;
-  const [bundle, setBundle] = useState<EsbuildBundle>();
+    polyfillNode
+  } = props
+  const [bundle, setBundle] = useState<EsbuildBundle>()
   useEffect(() => {
-    let result: esbuild.BuildResult;
-    async function build() {
-      if (!destination) return;
+    let result: esbuild.BuildResult
+    async function build () {
+      if (!destination) return
       result = await esbuild.build({
         entryPoints: [entry],
         define: {
-          ...(polyfillNode && { global: "globalThis" }),
+          ...(polyfillNode && { global: 'globalThis' })
         },
         bundle: true,
         outdir: destination,
         metafile: true,
-        format: "esm",
+        format: 'esm',
         sourcemap: true,
         loader: {
-          ".js": "jsx",
+          '.js': 'jsx'
         },
         plugins: polyfillNode
           ? [NodeGlobalsPolyfills({ buffer: true }), NodeModulesPolyfills()]
           : undefined,
         ...(jsxFactory && { jsxFactory }),
         ...(jsxFragment && { jsxFragment }),
-        external: ["__STATIC_CONTENT_MANIFEST"],
+        external: ['__STATIC_CONTENT_MANIFEST'],
         // TODO: import.meta.url
         watch: {
-          async onRebuild(error) {
-            if (error) console.error("watch build failed:", error);
+          async onRebuild (error) {
+            if (error) console.error('watch build failed:', error)
             else {
               // nothing really changes here, so let's increment the id
               // to change the return object's identity
-              setBundle((bundle) => ({ ...bundle, id: bundle.id + 1 }));
+              setBundle(bundle => ({ ...bundle, id: bundle.id + 1 }))
             }
-          },
-        },
-      });
+          }
+        }
+      })
 
       const chunks = Object.entries(result.metafile.outputs).find(
-        ([_path, { entryPoint }]) => entryPoint === entry
-      ); // assumedly only one entry point
+        ([_path, { entryPoint }]) =>
+          entryPoint === Object.keys(result.metafile.inputs)[0]
+      ) // assumedly only one entry point
 
       setBundle({
         id: 0,
         entry,
         path: chunks[0],
-        type: chunks[1].exports.length > 0 ? "esm" : "commonjs",
-        exports: chunks[1].exports,
-      });
+        type: chunks[1].exports.length > 0 ? 'esm' : 'commonjs',
+        exports: chunks[1].exports
+      })
     }
-    build();
+    build()
     return () => {
-      result?.stop();
-    };
-  }, [entry, destination, staticRoot, jsxFactory, jsxFragment, polyfillNode]);
-  return bundle;
+      result?.stop()
+    }
+  }, [entry, destination, staticRoot, jsxFactory, jsxFragment, polyfillNode])
+  return bundle
 }
 
-function useWorker(props: {
-  name: void | string;
-  bundle: EsbuildBundle | void;
-  format: CfScriptFormat;
-  modules: CfModule[];
-  accountId: string;
-  apiToken: string;
-  variables: { [name: string]: CfVariable };
-  sitesFolder: void | string;
-  port: number;
-  compatibilityDate: string | void;
-  compatibilityFlags: string[] | void;
-  usageModel: void | "bundled" | "unbound";
+function useWorker (props: {
+  name: void | string
+  bundle: EsbuildBundle | void
+  format: CfScriptFormat
+  modules: CfModule[]
+  accountId: string
+  apiToken: string
+  variables: { [name: string]: CfVariable }
+  sitesFolder: void | string
+  port: number
+  compatibilityDate: string | void
+  compatibilityFlags: string[] | void
+  usageModel: void | 'bundled' | 'unbound'
 }): CfPreviewToken | void {
   const {
     name,
@@ -448,29 +448,29 @@ function useWorker(props: {
     compatibilityDate,
     compatibilityFlags,
     usageModel,
-    port,
-  } = props;
-  const [token, setToken] = useState<CfPreviewToken>();
+    port
+  } = props
+  const [token, setToken] = useState<CfPreviewToken>()
   useEffect(() => {
-    async function start() {
-      if (!bundle) return;
-      if (format === "modules" && bundle.type === "commonjs") {
-        console.error("⎔ Cannot use modules with a commonjs bundle.");
+    async function start () {
+      if (!bundle) return
+      if (format === 'modules' && bundle.type === 'commonjs') {
+        console.error('⎔ Cannot use modules with a commonjs bundle.')
         // TODO: a much better error message here, with what to do next
-        return;
+        return
       }
-      if (format === "service-worker" && bundle.type !== "esm") {
-        console.error("⎔ Cannot use service-worker with a esm bundle.");
+      if (format === 'service-worker' && bundle.type !== 'esm') {
+        console.error('⎔ Cannot use service-worker with a esm bundle.')
         // TODO: a much better error message here, with what to do next
-        return;
+        return
       }
 
       if (token) {
-        console.log("⎔ Detected changes, restarting server...");
+        console.log('⎔ Detected changes, restarting server...')
       } else {
-        console.log("⎔ Starting server...");
+        console.log('⎔ Starting server...')
       }
-      const scriptName = path.basename(bundle.path);
+      const scriptName = path.basename(bundle.path)
 
       const assets = sitesFolder
         ? await syncAssets(
@@ -482,43 +482,43 @@ function useWorker(props: {
           )
         : {
             manifest: undefined,
-            namespace: undefined,
-          }; // TODO: cancellable?
+            namespace: undefined
+          } // TODO: cancellable?
 
-      const content = await readFile(bundle.path, "utf-8");
+      const content = await readFile(bundle.path, 'utf-8')
       const init: CfWorkerInit = {
         main: {
           name: name || path.basename(bundle.path),
-          type: format || bundle.type === "esm" ? "esm" : "commonjs",
-          content,
+          type: format || bundle.type === 'esm' ? 'esm' : 'commonjs',
+          content
         },
         modules: assets.manifest
           ? modules.concat({
-              name: "__STATIC_CONTENT_MANIFEST",
+              name: '__STATIC_CONTENT_MANIFEST',
               content: JSON.stringify(assets.manifest),
-              type: "text",
+              type: 'text'
             })
           : modules,
         variables: assets.namespace
           ? {
               ...variables,
-              __STATIC_CONTENT: { namespaceId: assets.namespace },
+              __STATIC_CONTENT: { namespaceId: assets.namespace }
             }
           : variables,
         migrations: undefined, // no migrations in dev
         compatibility_date: compatibilityDate,
         compatibility_flags: compatibilityFlags,
-        usage_model: usageModel,
-      };
+        usage_model: usageModel
+      }
       setToken(
         await createWorker(init, {
           accountId,
-          apiToken,
+          apiToken
         })
-      );
-      console.log(`⬣ Listening at http://localhost:${port}`);
+      )
+      console.log(`⬣ Listening at http://localhost:${port}`)
     }
-    start();
+    start()
   }, [
     name,
     bundle,
@@ -529,165 +529,165 @@ function useWorker(props: {
     sitesFolder,
     compatibilityDate,
     compatibilityFlags,
-    usageModel,
-  ]);
-  return token;
+    usageModel
+  ])
+  return token
 }
 
-function useProxy({
+function useProxy ({
   token,
   publicRoot,
-  port,
+  port
 }: {
-  token: CfPreviewToken | void;
-  publicRoot: void | string;
-  port: number;
+  token: CfPreviewToken | void
+  publicRoot: void | string
+  port: number
 }) {
   useEffect(() => {
-    if (!token) return;
+    if (!token) return
     const proxy = httpProxy.createProxyServer({
       secure: false,
       changeOrigin: true,
       headers: {
-        "cf-workers-preview-token": token.value,
+        'cf-workers-preview-token': token.value
       },
-      target: `https://${token.host}`,
+      target: `https://${token.host}`
       // TODO: log websockets too? validate durables, etc
-    });
+    })
 
     const servePublic =
       publicRoot &&
       serveStatic(publicRoot, {
-        cacheControl: false,
-      });
+        cacheControl: false
+      })
     const server = http
       .createServer((req, res) => {
         if (publicRoot) {
           servePublic(req, res, () => {
-            proxy.web(req, res);
-          });
+            proxy.web(req, res)
+          })
         } else {
-          proxy.web(req, res);
+          proxy.web(req, res)
         }
       })
-      .listen(port); // TODO: custom port
+      .listen(port) // TODO: custom port
 
-    proxy.on("proxyRes", function (proxyRes, req, res) {
+    proxy.on('proxyRes', function (proxyRes, req, res) {
       // log all requests
       console.log(
         new Date().toLocaleTimeString(),
         req.method,
         req.url,
         res.statusCode // TODO add a status message like Ok etc?
-      );
-    });
+      )
+    })
     // TODO: log errors?
 
     return () => {
-      proxy.close();
-      server.close();
-    };
-  }, [token, publicRoot, port]);
+      proxy.close()
+      server.close()
+    }
+  }, [token, publicRoot, port])
 }
 
-function useInspector(inspectorUrl: string | void) {
+function useInspector (inspectorUrl: string | void) {
   useEffect(() => {
-    if (!inspectorUrl) return;
+    if (!inspectorUrl) return
 
-    const inspector = new DtInspector(inspectorUrl);
-    const abortController = inspector.proxyTo(9229);
+    const inspector = new DtInspector(inspectorUrl)
+    const abortController = inspector.proxyTo(9229)
     return () => {
-      inspector.close();
-      abortController.abort();
-    };
-  }, [inspectorUrl]);
+      inspector.close()
+      abortController.abort()
+    }
+  }, [inspectorUrl])
 }
 
-function sleep(period: number) {
-  return new Promise((resolve) => setTimeout(resolve, period));
+function sleep (period: number) {
+  return new Promise(resolve => setTimeout(resolve, period))
 }
-const SLEEP_DURATION = 2000;
+const SLEEP_DURATION = 2000
 // really need a first class api for this
-const hostNameRegex = /userHostname="(.*)"/g;
-async function findTunnelHostname() {
-  let hostName: string;
+const hostNameRegex = /userHostname="(.*)"/g
+async function findTunnelHostname () {
+  let hostName: string
   while (!hostName) {
     try {
-      const resp = await fetch("http://localhost:8789/metrics");
-      const data = await resp.text();
-      const matches = Array.from(data.matchAll(hostNameRegex));
-      hostName = matches[0][1];
+      const resp = await fetch('http://localhost:8789/metrics')
+      const data = await resp.text()
+      const matches = Array.from(data.matchAll(hostNameRegex))
+      hostName = matches[0][1]
     } catch (err) {
-      await sleep(SLEEP_DURATION);
+      await sleep(SLEEP_DURATION)
     }
   }
-  return hostName;
+  return hostName
 }
 
-function useTunnel(toggle: boolean) {
-  const tunnel = useRef<ReturnType<typeof spawn>>();
-  const removeSignalExitListener = useRef<() => void>();
+function useTunnel (toggle: boolean) {
+  const tunnel = useRef<ReturnType<typeof spawn>>()
+  const removeSignalExitListener = useRef<() => void>()
   // TODO: test if cloudflared is available, if not
   // point them to a url where they can get docs to install it
   useEffect(() => {
-    async function startTunnel() {
+    async function startTunnel () {
       if (toggle) {
         try {
-          await commandExists("cloudflared");
+          await commandExists('cloudflared')
         } catch (e) {
           console.error(
-            "To share your worker on the internet, please install `cloudflared` from https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation"
-          );
-          return;
+            'To share your worker on the internet, please install `cloudflared` from https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation'
+          )
+          return
         }
-        console.log("⎔ Starting a tunnel...");
-        tunnel.current = spawn("cloudflared", [
-          "tunnel",
-          "--url",
-          "http://localhost:8787",
-          "--metrics",
-          "localhost:8789",
-        ]);
+        console.log('⎔ Starting a tunnel...')
+        tunnel.current = spawn('cloudflared', [
+          'tunnel',
+          '--url',
+          'http://localhost:8787',
+          '--metrics',
+          'localhost:8789'
+        ])
 
-        tunnel.current.on("close", (code) => {
+        tunnel.current.on('close', code => {
           if (code !== 0) {
-            console.log(`Tunnel process exited with code ${code}`);
+            console.log(`Tunnel process exited with code ${code}`)
           }
-        });
+        })
 
         removeSignalExitListener.current = onExit((_code, _signal) => {
-          console.log("⎔ Shutting down local tunnel.");
-          tunnel.current?.kill();
-          tunnel.current = undefined;
-        });
+          console.log('⎔ Shutting down local tunnel.')
+          tunnel.current?.kill()
+          tunnel.current = undefined
+        })
 
-        const hostName = await findTunnelHostname();
-        clipboardy.write(hostName);
-        console.log(`⬣ Sharing at ${hostName}, copied to clipboard.`);
+        const hostName = await findTunnelHostname()
+        clipboardy.write(hostName)
+        console.log(`⬣ Sharing at ${hostName}, copied to clipboard.`)
       }
     }
 
-    startTunnel();
+    startTunnel()
 
     return () => {
       if (tunnel.current) {
-        console.log("⎔ Shutting down tunnel.");
-        tunnel.current?.kill();
-        tunnel.current = undefined;
-        removeSignalExitListener.current && removeSignalExitListener.current();
-        removeSignalExitListener.current = undefined;
+        console.log('⎔ Shutting down tunnel.')
+        tunnel.current?.kill()
+        tunnel.current = undefined
+        removeSignalExitListener.current && removeSignalExitListener.current()
+        removeSignalExitListener.current = undefined
       }
-    };
-  }, [toggle]);
+    }
+  }, [toggle])
 }
 
 type useHotkeysInitialState = {
-  local: boolean;
-  tunnel: boolean;
-};
-function useHotkeys(initial: useHotkeysInitialState, port: number) {
+  local: boolean
+  tunnel: boolean
+}
+function useHotkeys (initial: useHotkeysInitialState, port: number) {
   // UGH, we should put port in context instead
-  const [toggles, setToggles] = useState(initial);
+  const [toggles, setToggles] = useState(initial)
   useInput(
     (
       input,
@@ -695,7 +695,7 @@ function useHotkeys(initial: useHotkeysInitialState, port: number) {
       key
     ) => {
       switch (input) {
-        case "b": // open browser
+        case 'b': // open browser
           open(
             `http://localhost:${port}/`
             // {
@@ -703,9 +703,9 @@ function useHotkeys(initial: useHotkeysInitialState, port: number) {
             //     name: open.apps.chrome, // TODO: fallback on other browsers
             //   },
             // }
-          );
-          break;
-        case "d": // toggle inspector
+          )
+          break
+        case 'd': // toggle inspector
           open(
             `https://built-devtools.pages.dev/js_app?experiments=true&v8only=true&ws=localhost:9229/ws`
             // {
@@ -714,23 +714,23 @@ function useHotkeys(initial: useHotkeysInitialState, port: number) {
             //     // todo - add firefox and edge fallbacks
             //   },
             // }
-          );
-          break;
-        case "s": // toggle tunnel
-          setToggles((toggles) => ({ ...toggles, tunnel: !toggles.tunnel }));
-          break;
-        case "l": // toggle local
-          setToggles((toggles) => ({ ...toggles, local: !toggles.local }));
-          break;
-        case "q": // shut down
-        case "x": // shut down
-          process.exit(0);
-          break;
+          )
+          break
+        case 's': // toggle tunnel
+          setToggles(toggles => ({ ...toggles, tunnel: !toggles.tunnel }))
+          break
+        case 'l': // toggle local
+          setToggles(toggles => ({ ...toggles, local: !toggles.local }))
+          break
+        case 'q': // shut down
+        case 'x': // shut down
+          process.exit(0)
+          break
         default:
           // nothing?
-          break;
+          break
       }
     }
-  );
-  return toggles;
+  )
+  return toggles
 }


### PR DESCRIPTION
While using `wrangler dev ./index` I get
```
TypeError: Cannot read properties of undefined (reading '0')
    at null.build (/home/jgentes/workers/wrangler2/packages/wrangler/src/dev.tsx:411:15)
```

This is caused due to the `entry` value being verbatim what was used as a command line argument, ie. `./index`, whereas the `entryPoint` value in `result.metafile.outputs` has the extension added to the file, ie `./index.js`.

I'm going to submit a PR that uses what esBuild recognizes as the input value in `result.metafile.inputs` instead of the `entry` value:

```
const chunks = Object.entries(result.metafile.outputs).find(
        ([_path, { entryPoint }]) =>
          entryPoint === Object.keys(result.metafile.inputs)[0]
      ) // assumedly only one entry point
```