### PR TITLE
A Worker name is not the main module's name.

### DIFF
--- a/packages/wrangler/src/api/worker.ts
+++ b/packages/wrangler/src/api/worker.ts
@@ -121,6 +121,10 @@ export type CfVariable = string | CfKvNamespace | CfCryptoKey | CfDurableObject;
  */
 export interface CfWorkerInit {
   /**
+   * The name of the worker.
+   */
+  name: string;
+  /**
    * The entrypoint module.
    */
   main: CfModule;

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -449,12 +449,11 @@ function useWorker(props: {
       } else {
         console.log("⎔ Starting server...");
       }
-      const scriptName = path.basename(bundle.path);
 
       const assets = sitesFolder
         ? await syncAssets(
             accountId,
-            scriptName,
+            path.basename(bundle.path),
             sitesFolder,
             true,
             undefined // TODO: env
@@ -466,8 +465,9 @@ function useWorker(props: {
 
       const content = await readFile(bundle.path, "utf-8");
       const init: CfWorkerInit = {
+        name: name || path.basename(bundle.path),
         main: {
-          name: name || path.basename(bundle.path),
+          name: path.basename(bundle.path),
           type: format || bundle.type === "esm" ? "esm" : "commonjs",
           content,
         },

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -54,17 +54,20 @@ export default async function publish(props: Props): Promise<void> {
 
   assert(config.account_id, "missing account id");
 
+  let scriptName = props.name || config.name;
+  assert(
+    scriptName,
+    'You need to provide a name when publishing a worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`'
+  );
+
   let file: string;
   if (props.script) {
     file = props.script;
-    assert(props.name, "name is required when using script");
   } else {
     assert(build?.upload?.main, "missing main file");
-    assert(config.name, "missing name");
     file = path.join(path.dirname(__path__), build.upload.main);
   }
 
-  let scriptName = props.script ? props.name : config.name;
   if (props.legacyEnv) {
     scriptName += props.env ? `-${props.env}` : "";
   }
@@ -184,8 +187,9 @@ export default async function publish(props: Props): Promise<void> {
   const envRootObj = props.env ? config.env[props.env] || {} : config;
 
   const worker: CfWorkerInit = {
+    name: scriptName,
     main: {
-      name: scriptName,
+      name: path.basename(chunks[0]),
       content: content,
       type: bundle.type === "esm" ? "esm" : "commonjs",
     },


### PR DESCRIPTION
This PR separates the idea of a worker's name from the main module/script's file name. This is part of an upcoming fix to get wrangler dev for Durable Objects working.