### PR TITLE
Add Pages CI to publish wrangler@pages

### DIFF
--- a/.github/workflows/pages-ci.yml
+++ b/.github/workflows/pages-ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - pages
+
+jobs:
+  build:
+    name: Build & Publish an alpha release to NPM
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node_version: [16.7]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node_version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node_version }}
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install NPM dependencies
+        run: npm install
+
+      - name: Copy README.md
+        run: cp README.md packages/wrangler/README.md
+
+      - name: Modify package.json version
+        run: node .github/version-script.js
+
+      - name: Build
+        run: npm run build
+        working-directory: packages/wrangler
+
+      - name: Publish Alpha to NPM
+        run: npm publish --tag pages
+        env:
+          NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+        working-directory: packages/wrangler


### PR DESCRIPTION
This adds a GitHub Action to deploy the `pages` branch to `wrangler@pages`. We'll be able to use this to more quickly iterate on Pages specific features.