### PR TITLE
Added support for environments on secrets command

### DIFF
--- a/.changeset/famous-readers-look.md
+++ b/.changeset/famous-readers-look.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Added support for environments on secrets command

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -880,6 +880,8 @@ export async function main(argv: string[]): Promise<void> {
             }
             const config = args.config as Config;
 
+            console.log(config);
+
             const scriptName = args.name || config.name;
             if (!scriptName) {
               console.error("Missing script name");
@@ -913,7 +915,7 @@ export async function main(argv: string[]): Promise<void> {
             async function submitSecret() {
               let url = `/accounts/${config.account_id}/workers/scripts/${scriptName}/secrets`;
               if (args.env) {
-                url = `/accounts/${config.account_id}/workers/services/${scriptName}/development/${args.env}/secrets`;
+                url = `/accounts/${config.account_id}/workers/services/${scriptName}/environments/${args.env}/secrets`;
               }
               return await cfetch(url, {
                 method: "PUT",
@@ -1008,7 +1010,7 @@ export async function main(argv: string[]): Promise<void> {
 
             let url = `/accounts/${config.account_id}/workers/scripts/${scriptName}/secrets`;
             if (args.env) {
-              url = `/accounts/${config.account_id}/workers/services/${scriptName}/development/${args.env}/secrets`;
+              url = `/accounts/${config.account_id}/workers/services/${scriptName}/environments/${args.env}/secrets`;
             }
 
             if (await confirm("Are you sure you want to delete this secret?")) {
@@ -1072,7 +1074,7 @@ export async function main(argv: string[]): Promise<void> {
 
             let url = `/accounts/${config.account_id}/workers/scripts/${scriptName}/secrets`;
             if (args.env) {
-              url = `/accounts/${config.account_id}/workers/services/${scriptName}/development/${args.env}/secrets`;
+              url = `/accounts/${config.account_id}/workers/services/${scriptName}/environments/${args.env}/secrets`;
             }
 
             console.log(await cfetch(url));

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -880,8 +880,6 @@ export async function main(argv: string[]): Promise<void> {
             }
             const config = args.config as Config;
 
-            console.log(config);
-
             const scriptName = args.name || config.name;
             if (!scriptName) {
               console.error("Missing script name");

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -880,7 +880,6 @@ export async function main(argv: string[]): Promise<void> {
             }
             const config = args.config as Config;
 
-            // TODO: use environment (how does current wrangler do it?)
             const scriptName = args.name || config.name;
             if (!scriptName) {
               console.error("Missing script name");
@@ -912,18 +911,19 @@ export async function main(argv: string[]): Promise<void> {
               "password"
             );
             async function submitSecret() {
-              return await cfetch(
-                `/accounts/${config.account_id}/workers/scripts/${scriptName}/secrets/`,
-                {
-                  method: "PUT",
-                  headers: { "Content-Type": "application/json" },
-                  body: JSON.stringify({
-                    name: args.key,
-                    text: secretValue,
-                    type: "secret_text",
-                  }),
-                }
-              );
+              let url = `/accounts/${config.account_id}/workers/scripts/${scriptName}/secrets`;
+              if (args.env) {
+                url = `/accounts/${config.account_id}/workers/services/${scriptName}/development/${args.env}/secrets`;
+              }
+              return await cfetch(url, {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  name: args.key,
+                  text: secretValue,
+                  type: "secret_text",
+                }),
+              });
             }
 
             try {
@@ -981,7 +981,6 @@ export async function main(argv: string[]): Promise<void> {
             }
             const config = args.config as Config;
 
-            // TODO: use environment (how does current wrangler do it?)
             const scriptName = args.name || config.name;
             if (!scriptName) {
               throw new Error("Missing script name");
@@ -1007,16 +1006,18 @@ export async function main(argv: string[]): Promise<void> {
 
             // -- snip, end --
 
+            let url = `/accounts/${config.account_id}/workers/scripts/${scriptName}/secrets`;
+            if (args.env) {
+              url = `/accounts/${config.account_id}/workers/services/${scriptName}/development/${args.env}/secrets`;
+            }
+
             if (await confirm("Are you sure you want to delete this secret?")) {
               console.log(
                 `Deleting the secret ${args.key} on script ${scriptName}.`
               );
 
               console.log(
-                await cfetch(
-                  `/accounts/${config.account_id}/workers/scripts/${scriptName}/secrets/${args.key}`,
-                  { method: "DELETE" }
-                )
+                await cfetch(`${url}/${args.key}`, { method: "DELETE" })
               );
             }
           }
@@ -1043,7 +1044,6 @@ export async function main(argv: string[]): Promise<void> {
             }
             const config = args.config as Config;
 
-            // TODO: use environment (how does current wrangler do it?)
             const scriptName = args.name || config.name;
             if (!scriptName) {
               console.error("Missing script name");
@@ -1070,11 +1070,12 @@ export async function main(argv: string[]): Promise<void> {
 
             // -- snip, end --
 
-            console.log(
-              await cfetch(
-                `/accounts/${config.account_id}/workers/scripts/${scriptName}/secrets`
-              )
-            );
+            let url = `/accounts/${config.account_id}/workers/scripts/${scriptName}/secrets`;
+            if (args.env) {
+              url = `/accounts/${config.account_id}/workers/services/${scriptName}/development/${args.env}/secrets`;
+            }
+
+            console.log(await cfetch(url));
           }
         );
     }


### PR DESCRIPTION
First things first, awesome stuff going on here 🚀   

Super happy to be able to contribute 🙂 

I ran into something while debugging my wrangler-github-action-deployment secrets locally with wrangler V2. 
It seemed like the `environment` flag wasn't being passed along, so I looked at the code and saw the todo comments so I thought I'd help out 😅 

I've reversed engineered the endpoints by checking the dashboard while performing the same actions. I did check wrangler V1 code but couldn't make much sense out of that.

From what I've seen there are two different ways of retrieving secrets. One including variables (so non-secrets), the other one solely secrets. I've gone with the secrets only as it made more sense to me semantically but not sure which one of these endpoints you guys would prefer.

I've tested the GET / PUT / DELETE endpoints defined in this PR through insomnia and confirmed these routes to be listing the actual environment secrets.

I'll be adding tests as well just bear with me while I figure those out. I just wanted to get this out there for when something already required changes

TODO:
* [ ] Add tests