### PR TITLE
make `wrangler dev` work with durable objects

### DIFF
--- a/.changeset/swift-lamps-shop.md
+++ b/.changeset/swift-lamps-shop.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Make `wrangler dev` work with durable objects

--- a/packages/wrangler/src/api/form_data.ts
+++ b/packages/wrangler/src/api/form_data.ts
@@ -113,32 +113,15 @@ export function toFormData(worker: CfWorkerInit): FormData {
     bindings.push(binding);
   }
 
-  const metadata =
-    mainType !== "commonjs"
-      ? {
-          main_module: name,
-          bindings,
-        }
-      : {
-          body_part: name,
-          bindings,
-        };
-  if (compatibility_date) {
-    // @ts-expect-error - we should type metadata
-    metadata.compatibility_date = compatibility_date;
-  }
-  if (compatibility_flags) {
-    // @ts-expect-error - we should type metadata
-    metadata.compatibility_flags = compatibility_flags;
-  }
-  if (usage_model) {
-    // @ts-expect-error - we should type metadata
-    metadata.usage_model = usage_model;
-  }
-  if (migrations) {
-    // @ts-expect-error - we should type metadata
-    metadata.migrations = migrations;
-  }
+  // TODO: this object should be typed
+  const metadata = {
+    ...(mainType !== "commonjs" ? { main_module: name } : { body_part: name }),
+    bindings,
+    ...(compatibility_date && { compatibility_date }),
+    ...(compatibility_flags && { compatibility_flags }),
+    ...(usage_model && { usage_model }),
+    ...(migrations && { migrations }),
+  };
 
   formData.set("metadata", JSON.stringify(metadata));
 

--- a/packages/wrangler/src/api/worker.ts
+++ b/packages/wrangler/src/api/worker.ts
@@ -123,7 +123,7 @@ export interface CfWorkerInit {
   /**
    * The name of the worker.
    */
-  name: string;
+  name: string | void;
   /**
    * The entrypoint module.
    */

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -486,8 +486,7 @@ function useWorker(props: {
 
       const content = await readFile(bundle.path, "utf-8");
       const init: CfWorkerInit = {
-        name:
-          name || path.basename(bundle.path).replace(/([^a-zA-Z_-]+)/g, "-"),
+        name,
         main: {
           name: path.basename(bundle.path),
           type: format || bundle.type === "esm" ? "esm" : "commonjs",

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -465,7 +465,9 @@ export async function main(argv: string[]): Promise<void> {
       // but we haven't fixed it internally yet
       if ("durable_objects" in envRootObj) {
         if (!(args.name || config.name)) {
-          throw new Error("Workers with durable objects need to be named");
+          console.warn(
+            'A worker with durable objects need to be named, or it may not work as expected. Add a "name" into wrangler.toml, or pass it in the command line with --name.'
+          );
         }
         // TODO: if not already published, publish a draft worker
       }


### PR DESCRIPTION
When proxying to the preview endpoint, we need to pass the named host as the target header. This PR fixes the host name generation in `preview.ts`. I also took this opportunity to remove some variable aliases.