### PR TITLE
make only one of `value` or `--path <path>` necessary for `kv:key put`

### DIFF
--- a/.changeset/rich-penguins-remain.md
+++ b/.changeset/rich-penguins-remain.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+`kv:key put`: make only one of `value` or `--path <path>` necessary

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -1316,7 +1316,7 @@ export async function main(argv: string[]): Promise<void> {
     (yargs) => {
       return yargs
         .command(
-          "put <key> <value>",
+          "put <key> [value]",
           "Writes a single key/value pair to the given namespace.",
           (yargs) => {
             return yargs
@@ -1357,7 +1357,8 @@ export async function main(argv: string[]): Promise<void> {
               .option("path", {
                 type: "string",
                 describe: "Read value from the file at a given path.",
-              });
+              })
+              .check(demandOneOfOption("value", "path"));
           },
           async ({ key, ttl, expiration, ...args }) => {
             const namespaceId = getNamespaceId(args);
@@ -1826,9 +1827,19 @@ export async function main(argv: string[]): Promise<void> {
   yargs.version(wranglerVersion).alias("v", "version");
   await initialiseUserConfig();
 
-  await yargs.parse(argv, (err, argv, output) => {
-    if (output) {
-      console.log(output);
-    }
-  });
+  await yargs.parse(
+    argv
+    /* TODO: we'd like to use the parse callback, 
+    but there's a serious bug with it 
+    https://github.com/yargs/yargs/issues/1975#issuecomment-874237906
+    
+    , (err, argv, output) => {
+      if (output) {
+        console.log(output);
+      }
+      console.log({ err });
+      console.log("what now");
+    } 
+  */
+  );
 }

--- a/packages/wrangler/src/kv.tsx
+++ b/packages/wrangler/src/kv.tsx
@@ -118,7 +118,7 @@ export function getNamespaceId({
   if (!config) {
     throw new Error(
       "Failed to find a config file.\n" +
-        "Either use --namespace to upload directly or create a configuration file with a binding."
+        "Either use --namespace-id to upload directly or create a configuration file with a binding."
     );
   }
 
@@ -149,7 +149,7 @@ export function getNamespaceId({
   // there's no KV namespaces
   if (!config.kv_namespaces || config.kv_namespaces.length === 0) {
     throw new Error(
-      "No KV Namespace to upload to! Either use --namespace to upload directly or add a KV namespace to your wrangler config file."
+      "No KV Namespace to upload to! Either use --namespace-id to upload directly or add a KV namespace to your wrangler config file."
     );
   }
 


### PR DESCRIPTION
This also uncovered a yargs bug with `.parse()`, boo.