### PR TITLE
import text file types into bundles

### DIFF
--- a/.changeset/pretty-monkeys-invent.md
+++ b/.changeset/pretty-monkeys-invent.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+import text file types into workers

--- a/packages/wrangler/src/module-collection.ts
+++ b/packages/wrangler/src/module-collection.ts
@@ -1,0 +1,63 @@
+import { CfModule } from "./api/worker";
+import type esbuild from "esbuild";
+import path from "node:path";
+import { readFile } from "node:fs/promises";
+import crypto from "node:crypto";
+
+// This is a combination of an esbuild plugin and a mutable array
+// that we use to collect module references from source code.
+// There will be modules that _shouldn't_ be inlined directly into
+// the bundle. (eg. wasm modules, some text files, etc). We can include
+// those files as modules in the multi part forker form upload. This
+// plugin+array is used to collect references to these modules, reference
+// them correctly in the bundle, and add them to the form upload.
+
+export default function makeModuleCollector(): {
+  modules: CfModule[];
+  plugin: esbuild.Plugin;
+} {
+  const modules: CfModule[] = [];
+  return {
+    modules,
+    plugin: {
+      name: "wrangler-module-collector",
+      setup(build) {
+        build.onStart(() => {
+          // reset the moduels collection
+          modules.splice(0);
+        });
+
+        build.onResolve(
+          // filter on "known" file types,
+          // we can expand this list later
+          { filter: /.*\.(pem|txt|html)$/ },
+          async (args: esbuild.OnResolveArgs) => {
+            // take the file and massage it to a
+            // transportable/manageable format
+            const filePath = path.join(args.resolveDir, args.path);
+            const fileContent = await readFile(filePath);
+            const fileHash = crypto
+              .createHash("sha1")
+              .update(fileContent)
+              .digest("hex");
+            const fileName = `${fileHash}-${path.basename(args.path)}`;
+
+            // add the module to the array
+            modules.push({
+              name: fileName,
+              content: fileContent,
+              type: "text",
+            });
+
+            return {
+              path: fileName, // change the reference to the changed module
+              external: true, // mark it as external in the bundle
+              namespace: "wrangler-module-collector-ns", // just a tag, this isn't strictly necessary
+              watchFiles: [filePath], // we also add the file to esbuild's watch list
+            };
+          }
+        );
+      },
+    },
+  };
+}


### PR DESCRIPTION
This is the first of what I think will be a few PRs for supporting non-js modules in workers. When esbuild scans the module graph, we collect references to some well known file types, mark them as `external`, and instead add them directly to the worker form upload. This prevents the need to configure this in `wrangler.toml` or whatever.

In the next PR, I'll do `.wasm` support in a similar vein.

Once we have that in place, I'll probably work on a `--loader` flag to define custom types.