### PR TITLE
support importing `.wasm` files / `workers-rs` support

### DIFF
--- a/.changeset/thin-terms-walk.md
+++ b/.changeset/thin-terms-walk.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+support importing `.wasm` files / `workers-rs` support

--- a/packages/wrangler/src/module-collection.ts
+++ b/packages/wrangler/src/module-collection.ts
@@ -30,10 +30,11 @@ export default function makeModuleCollector(): {
         build.onResolve(
           // filter on "known" file types,
           // we can expand this list later
-          { filter: /.*\.(pem|txt|html)$/ },
+          { filter: /.*\.(pem|txt|html|wasm)$/ },
           async (args: esbuild.OnResolveArgs) => {
             // take the file and massage it to a
             // transportable/manageable format
+            const fileExt = path.extname(args.path);
             const filePath = path.join(args.resolveDir, args.path);
             const fileContent = await readFile(filePath);
             const fileHash = crypto
@@ -46,7 +47,7 @@ export default function makeModuleCollector(): {
             modules.push({
               name: fileName,
               content: fileContent,
-              type: "text",
+              type: fileExt === ".wasm" ? "compiled-wasm" : "text",
             });
 
             return {


### PR DESCRIPTION
Following up from https://github.com/cloudflare/wrangler2/pull/107, this PR adds support for importing `.wasm` files. Specifically, it works directly on the output of [`workers-rs`](https://github.com/cloudflare/workers-rs). I'll test with other wasm outputs (like assemblyscript etc) later.