### PR TITLE
don't log file contents when writing via `kv:key put <key> --path <path>`

### DIFF
--- a/.changeset/clever-toys-retire.md
+++ b/.changeset/clever-toys-retire.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+don't log file contents when writing via `kv:key put <key> --path <path>`

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -1367,7 +1367,16 @@ export async function main(argv: string[]): Promise<void> {
               : args.value;
             const config = args.config as Config;
 
-            console.log(`writing ${key}=${value} to namespace ${namespaceId}`);
+            if (args.path) {
+              console.log(
+                `writing the contents of ${args.path} to the key "${key}" on namespace ${namespaceId}`
+              );
+            } else {
+              console.log(
+                `writing the value "${value}" to key "${key}" on namespace ${namespaceId}`
+              );
+            }
+
             if (args.local) {
               const { Miniflare } = await import("miniflare");
               const mf = new Miniflare({
@@ -1578,6 +1587,10 @@ export async function main(argv: string[]): Promise<void> {
           },
           async ({ key, ...args }) => {
             const namespaceId = getNamespaceId(args);
+
+            console.log(
+              `deleting the key "${key}" on namespace ${namespaceId}`
+            );
 
             if (args.local) {
               const { Miniflare } = await import("miniflare");


### PR DESCRIPTION
There are a couple of reasons we don't want to log the contents; it could be secret, or it could just be very long. This commit changes the messaging to instead just say which file is being uploaded. I also took this opportunity to add a log when we're deleting a key with `kv:key delete <key>`.