### PR TITLE
add `.prettierignore`, run it on the whole codebase

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+packages/wrangler/vendor/
+packages/wrangler/wrangler-dist/

--- a/packages/example-worker-app/public/404.html
+++ b/packages/example-worker-app/public/404.html
@@ -1,40 +1,50 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
-    <head>
-        <link rel="icon" type="image/x-icon" href="favicon.ico">
-        <link href="https://fonts.googleapis.com/css?family=Pacifico&display=swap" rel="stylesheet">
-        <link href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css" rel="stylesheet">
-        <style>
-            h1 {
-                font-family: Pacifico, sans-serif;
-                font-size: 4em;
-                color: #3eb5f1;
-                margin: 0;
-            }
+  <head>
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link
+      href="https://fonts.googleapis.com/css?family=Pacifico&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css"
+      rel="stylesheet"
+    />
+    <style>
+      h1 {
+        font-family: Pacifico, sans-serif;
+        font-size: 4em;
+        color: #3eb5f1;
+        margin: 0;
+      }
 
-            h2 {
-                font-weight: 300;
-                font-family: sans-serif;
-            }
+      h2 {
+        font-weight: 300;
+        font-family: sans-serif;
+      }
 
-            .centered {
-                position: fixed;
-                top: 50%;
-                left: 50%;
-                transform: translate(-50%, -50%);
-                text-align: center;
-            }
+      .centered {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        text-align: center;
+      }
 
-            #ferris {
-                width: 75%;
-            }
-        </style>
-    </head>
-    <body>
-        <div class="centered">
-            <h1>404 Not Found</h1>
-            <h2>Oh dang! We couldn't find that page.</h2>
-            <img id="ferris" alt="a sad crab is unable to unable to lasso a paper airplane. 404 not found." src="./img/404-wrangler-ferris.gif">
-        </div>
-    </body>
+      #ferris {
+        width: 75%;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="centered">
+      <h1>404 Not Found</h1>
+      <h2>Oh dang! We couldn't find that page.</h2>
+      <img
+        id="ferris"
+        alt="a sad crab is unable to unable to lasso a paper airplane. 404 not found."
+        src="./img/404-wrangler-ferris.gif"
+      />
+    </div>
+  </body>
 </html>

--- a/packages/example-worker-app/public/index.html
+++ b/packages/example-worker-app/public/index.html
@@ -1,40 +1,50 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
-    <head>
-        <link rel="icon" type="image/x-icon" href="favicon.ico">
-        <link href="https://fonts.googleapis.com/css?family=Pacifico&display=swap" rel="stylesheet">
-        <link href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css" rel="stylesheet">
-        <style>
-            h1 {
-                font-family: Pacifico, sans-serif;
-                font-size: 4em;
-                color: #3eb5f1;
-                margin: 0;
-            }
+  <head>
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link
+      href="https://fonts.googleapis.com/css?family=Pacifico&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css"
+      rel="stylesheet"
+    />
+    <style>
+      h1 {
+        font-family: Pacifico, sans-serif;
+        font-size: 4em;
+        color: #3eb5f1;
+        margin: 0;
+      }
 
-            h2 {
-                font-weight: 300;
-                font-family: sans-serif;
-            }
+      h2 {
+        font-weight: 300;
+        font-family: sans-serif;
+      }
 
-            .centered {
-                position: fixed;
-                top: 50%;
-                left: 50%;
-                transform: translate(-50%, -50%);
-                text-align: center;
-            }
+      .centered {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        text-align: center;
+      }
 
-            #ferris {
-                width: 75%;
-            }
-        </style>
-    </head>
-    <body>
-        <div class="centered">
-            <h1>200 Success</h1>
-            <h2>Hello World! Welcome to your Workers Site.</h2>
-            <img id="ferris" alt="a happy crab is wearing a cowboy hat and holding a lasso. 200 success." src="./img/200-wrangler-ferris.gif">
-        </div>
-    </body>
+      #ferris {
+        width: 75%;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="centered">
+      <h1>200 Success</h1>
+      <h2>Hello World! Welcome to your Workers Site.</h2>
+      <img
+        id="ferris"
+        alt="a happy crab is wearing a cowboy hat and holding a lasso. 200 success."
+        src="./img/200-wrangler-ferris.gif"
+      />
+    </div>
+  </body>
 </html>

--- a/packages/wrangler/CHANGELOG.md
+++ b/packages/wrangler/CHANGELOG.md
@@ -1,25 +1,26 @@
 # wrangler
 
 ## 0.1.0
+
 ### Minor Changes
 
 - 689cd55: CI/CD Improvements
-  
+
   ## Changeset
-  
+
   Adding configuration allows for use of CLI for changesets. A necessary supplement to the changesets bot, and GitHub Action.
-  
+
   - Installed Changeset CLI tool
   - NPX changeset init
     - Added changesets directory
     - Config
     - README
   - Modified the config for `main` branch instead of `master`
-  
+
   ## ESLint & Prettier Integration
-  
+
   Running Prettier as a rule through ESLint to improve CI/CD usage
-  
+
   - Added additional TypeScript support for ESLint
   - Prettier errors as ESLint rule
   - .vscode directory w/ settings.json config added that enforces
@@ -29,7 +30,7 @@
 
 - b0fcc7d: CI/CD Tests & Type Checking
   GH Workflow additions:
-  
+
   - Added Testing script
   - Added Linting script
   - tsc is using skipLibCheck as a current workaround
@@ -37,6 +38,7 @@
   - Runs on every Pull Request instance
   - Removed npm ci in favor of npm install
     - Removed --prefer-offline in favor of local cache artifact
+
 - 2f760f5: remove `--polyfill-node`
 - fd53780: `kv:key put`: make only one of `value` or `--path <path>` necessary
 - dc41476: Added optional shortcuts


### PR DESCRIPTION
This commit adds a `.prettierignore` config, and runs prettier on the whole codebase, catching some files we'd missed out on.

There's no changeset required for this commit.