### PR TITLE
pass tests from #105

### DIFF
--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wrangler",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "author": "wrangler@cloudflare.com",
   "description": "Command-line interface for all things Cloudflare Workers",
   "bin": {

--- a/packages/wrangler/src/__tests__/mock-cfetch.js
+++ b/packages/wrangler/src/__tests__/mock-cfetch.js
@@ -1,7 +1,7 @@
 // This file mocks ../cfetch.ts
 // so we can insert whatever responses we want from it
 
-const pathToRegexp = require("path-to-regexp");
+const { pathToRegexp } = require("path-to-regexp");
 // TODO: add jsdoc style types here
 
 // type MockHandler = (resource: string, init?: RequestInit) => any; // TODO: use a generic here


### PR DESCRIPTION
Not sure how, but some shenanigans with #105 broke how we resolve `path-to-regexp` (and I think it's actually accurate now?) and broke our tests. This PR fixes the tests. Also a stray package.json fix.

No changeset for this fix.