### PR TITLE
Fix proxy request typing bug and fallback 404 behavior in pages

### DIFF
--- a/.changeset/long-ligers-study.md
+++ b/.changeset/long-ligers-study.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Patches typing mismatches between us, undici and miniflare when proxying requests in pages dev, and also adds fallback 404 behavior which was missed

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -787,7 +787,7 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
                   const url = new URL(request.url);
                   url.host = `127.0.0.1:${proxyPort}`;
                   request = new Request(url.toString(), request);
-                  return await fetch(request);
+                  return await fetch(request.url, request);
                 } catch (thrown) {
                   console.error(`Could not proxy request: ${thrown}`);
 

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -474,6 +474,9 @@ const generateAssetsFetch = async (
         deconstructedResponse.body = serveAsset(asset);
         return deconstructedResponse;
       }
+
+      deconstructedResponse.status = 404;
+      return deconstructedResponse;
     };
 
     let asset;


### PR DESCRIPTION
Somehow introduced a small bug with #105 . Miniflare doesn't seem to like using undici's Request type directly. Not quite sure why, and I don't have time to completely figure it out this week.

But here's a quick fix.

Also adds fallback 404 behavior which I also missed in #105.