### PR TITLE
CI/CD: Release trigger

### DIFF
--- a/.changeset/cold-fireants-provide.md
+++ b/.changeset/cold-fireants-provide.md
@@ -1,0 +1,5 @@
+---
+wrangler: patch
+---
+CI/CD
+- Release flow triggered on PR's closed

--- a/.github/workflows/prereleases.yml
+++ b/.github/workflows/prereleases.yml
@@ -1,26 +1,27 @@
 name: Prerelease
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Tests, Linter & Typecheck"]
+    branches: ["main"]
+    types: 
+      - completed
 
 jobs:
   build:
-    if: ${{ github.repository_owner == 'cloudflare' }}
+
+    if: ${{ github.repository_owner == 'cloudflare' && github.event.workflow_run.conclusion == 'success' }}
     name: Build & Publish an alpha release to NPM
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node_version: [16.7]
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node_version }}
+      
+      - name: Use Node.js 16.7
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node_version }}
-
+          node-version: 16.7
+      
       - uses: actions/cache@v2
         with:
           path: ~/.npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,48 +1,12 @@
-
 name: Release
 
 on:
   pull_request:
     types: [closed]
-    branches:
-      - changeset-release/main
 
 jobs:
-  build:
-    if: ${{ github.event.pull_request.merged == true }}
-    name: Build & Publish an alpha release to NPM
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node_version: [16.7]
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node_version }}
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node_version }}
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: Install NPM dependencies
-        run: npm install
-
-      - name: Copy README.md
-        run: cp README.md packages/wrangler/README.md
-
-      - name: Build
-        run: npm run build
-        working-directory: packages/wrangler
-
   release:
-    if: ${{ github.event.pull_request.merged == true }}
-    needs: [build]
+    if: ${{github.event.pull_request.merged}}
     name: Release
     runs-on: ubuntu-latest
     steps:
@@ -51,10 +15,27 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Node.js 16.7
+      - name: Copy README.md
+        run: cp README.md packages/wrangler/README.md
+
+      - name: Use Node.js 16.7
         uses: actions/setup-node@v2
         with:
           node-version: 16.7
+      
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      
+      - name: Install NPM dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+        working-directory: packages/wrangler
 
       - name: Publish to NPM
         id: changesets


### PR DESCRIPTION
## CI/CD Release Fixup
### Tests run before other workflows
To be sure that Tests, Linting and type checking is occurring on code before it is merged and released/pre-released other workflows have the Testing workflow as a trigger. For example the Tests need to complete and be successful before the prerelease will run.
### Flow tested on fork
Tested the full contribution -> changeset -> PR -> merge -> prerelease and release flow on a fork, to as closely test the GitHub Workflows are properly running in a realistic situation. 
### Release flow triggered on PR's closed
Whenever the a PR is closed/merged the Workflow will trigger for checking for a changeset and adding it to the changeset "Version" PR, when the "Version" PR is closed/merged it will trigger a release. 