### PR TITLE
enable `@typescript-eslint/no-floating-promises`, pass lint+type check

### DIFF
--- a/.changeset/strong-penguins-report.md
+++ b/.changeset/strong-penguins-report.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+enable @typescript-eslint/no-floating-promises, pass lint+type check

--- a/.github/workflows/tests-typecheck.yml
+++ b/.github/workflows/tests-typecheck.yml
@@ -48,13 +48,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-        # Prefer offline will skip registry verification with cached NPM packages
       - name: Install NPM dependencies
         run: npm install
 
       - name: Run Type Checking & ESLint
-        #TODO remove the --skipLibCheck flag at some point
-        run: tsc --skipLibCheck && npm run lint
+        run: npm run check
 
       - name: Test
         run: npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.27.1",
         "eslint-plugin-react-hooks": "^4.3.0",
+        "ioredis": "^4.28.2",
         "jest": "^27.4.2",
         "prettier": "^2.5.1",
         "source-map-explorer": "^2.5.2",
@@ -3983,6 +3984,14 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+      "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
@@ -4275,6 +4284,14 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -6309,6 +6326,31 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ioredis": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.2.tgz",
+      "integrity": "sha512-kQ+Iv7+c6HsDdPP2XUHaMv8DhnSeAeKEwMbaoqsXYbO+03dItXt7+5jGQDRyjdRUV2rFJbzg7P4Qt1iX2tqkOg==",
+      "dependencies": {
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.1",
+        "denque": "^1.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isarguments": "^3.1.0",
+        "p-map": "^2.1.0",
+        "redis-commands": "1.7.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
       }
     },
     "node_modules/is-accessor-descriptor": {
@@ -9722,6 +9764,21 @@
       "version": "4.17.21",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+    },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
@@ -11021,6 +11078,22 @@
         }
       }
     },
+    "node_modules/react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
@@ -11174,6 +11247,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/regenerator-runtime": {
@@ -12405,6 +12502,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "node_modules/static-extend": {
       "version": "0.1.2",
@@ -13656,6 +13758,7 @@
         "open": "^8.4.0",
         "path-to-regexp": "^6.2.0",
         "react": "^17.0.2",
+        "react-error-boundary": "^3.1.4",
         "serve-static": "^1.14.1",
         "signal-exit": "^3.0.6",
         "tmp-promise": "^3.0.3",
@@ -16693,6 +16796,11 @@
       "version": "1.0.4",
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
     },
+    "cluster-key-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+      "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw=="
+    },
     "co": {
       "version": "4.6.0",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
@@ -16917,6 +17025,11 @@
     "delayed-stream": {
       "version": "1.0.0",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "denque": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
     },
     "depd": {
       "version": "1.1.2",
@@ -18339,6 +18452,24 @@
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
+      }
+    },
+    "ioredis": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.2.tgz",
+      "integrity": "sha512-kQ+Iv7+c6HsDdPP2XUHaMv8DhnSeAeKEwMbaoqsXYbO+03dItXt7+5jGQDRyjdRUV2rFJbzg7P4Qt1iX2tqkOg==",
+      "requires": {
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.1",
+        "denque": "^1.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isarguments": "^3.1.0",
+        "p-map": "^2.1.0",
+        "redis-commands": "1.7.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
       }
     },
     "is-accessor-descriptor": {
@@ -20820,6 +20951,21 @@
       "version": "4.17.21",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+    },
     "lodash.isequal": {
       "version": "4.5.0",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
@@ -21697,6 +21843,15 @@
         }
       }
     },
+    "react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
+      }
+    },
     "react-is": {
       "version": "17.0.2",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
@@ -21805,6 +21960,24 @@
       "requires": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
+      }
+    },
+    "redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+    },
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
+    },
+    "redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+      "requires": {
+        "redis-errors": "^1.0.0"
       }
     },
     "regenerator-runtime": {
@@ -22745,6 +22918,11 @@
         }
       }
     },
+    "standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
+    },
     "static-extend": {
       "version": "0.1.2",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
@@ -23540,6 +23718,7 @@
         "open": "^8.4.0",
         "path-to-regexp": "^6.2.0",
         "react": "^17.0.2",
+        "react-error-boundary": "^3.1.4",
         "semiver": "^1.1.0",
         "serve-static": "^1.14.1",
         "signal-exit": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.27.1",
     "eslint-plugin-react-hooks": "^4.3.0",
+    "ioredis": "^4.28.2",
     "jest": "^27.4.2",
     "prettier": "^2.5.1",
     "source-map-explorer": "^2.5.2",
@@ -30,7 +31,7 @@
   },
   "scripts": {
     "lint": "eslint packages/**",
-    "check": "tsc && npm run lint",
+    "check": "prettier packages/** --check && tsc && npm run lint",
     "prettify": "prettier packages/** --write"
   },
   "engines": {
@@ -42,6 +43,13 @@
       "packages/wrangler/vendor"
     ],
     "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+      "ecmaVersion": 2020,
+      "project": [
+        "tsconfig.json"
+      ],
+      "sourceType": "module"
+    },
     "plugins": [
       "@typescript-eslint",
       "eslint-plugin-react",
@@ -66,10 +74,10 @@
           "plugin:react-hooks/recommended"
         ],
         "rules": {
-          "prettier/prettier": "error",
           "@typescript-eslint/consistent-type-imports": [
             "error"
           ],
+          "@typescript-eslint/no-floating-promises": "error",
           "no-empty": "off",
           "require-yield": "off",
           "no-empty-function": "off",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -73,7 +73,8 @@
     "tmp-promise": "^3.0.3",
     "undici": "^4.11.1",
     "ws": "^8.3.0",
-    "yargs": "^17.3.0"
+    "yargs": "^17.3.0",
+    "react-error-boundary": "^3.1.4"
   },
   "files": [
     "src",

--- a/packages/wrangler/scripts/bundle.ts
+++ b/packages/wrangler/scripts/bundle.ts
@@ -21,4 +21,7 @@ async function run() {
   });
 }
 
-run();
+run().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/wrangler/src/api/inspect.ts
+++ b/packages/wrangler/src/api/inspect.ts
@@ -140,16 +140,16 @@ export type DtEvent = DtLogEvent | DtExceptionEvent;
  */
 export type DtListener = (event: DtEvent) => void;
 
-interface DtProtocolRequest<T> {
-  id: number;
-  method: string;
-  params?: T;
-}
+// interface DtProtocolRequest<T> {
+//   id: number;
+//   method: string;
+//   params?: T;
+// }
 
-interface DtProtocolResponse<T> {
-  id: number;
-  result: T;
-}
+// interface DtProtocolResponse<T> {
+//   id: number;
+//   result: T;
+// }
 
 /**
  * A DevTools inspector that listens to logs and debug events from a Worker.

--- a/packages/wrangler/src/api/inspect.ts
+++ b/packages/wrangler/src/api/inspect.ts
@@ -140,17 +140,6 @@ export type DtEvent = DtLogEvent | DtExceptionEvent;
  */
 export type DtListener = (event: DtEvent) => void;
 
-// interface DtProtocolRequest<T> {
-//   id: number;
-//   method: string;
-//   params?: T;
-// }
-
-// interface DtProtocolResponse<T> {
-//   id: number;
-//   result: T;
-// }
-
 /**
  * A DevTools inspector that listens to logs and debug events from a Worker.
  *

--- a/packages/wrangler/src/dialogs.tsx
+++ b/packages/wrangler/src/dialogs.tsx
@@ -4,14 +4,14 @@ import { Box, Text, useInput, render } from "ink";
 import TextInput from "ink-text-input";
 type ConfirmProps = {
   text: string;
-  onConfirm: (answer: boolean) => Promise<void>;
+  onConfirm: (answer: boolean) => void;
 };
 function Confirm(props: ConfirmProps) {
   useInput((input: string) => {
     if (input === "y") {
-      props.onConfirm(true).catch((err) => console.error(err));
+      props.onConfirm(true);
     } else if (input === "n") {
-      props.onConfirm(false).catch((err) => console.error(err));
+      props.onConfirm(false);
     } else {
       console.log("Unrecognised input");
     }
@@ -28,7 +28,7 @@ export function confirm(text: string): Promise<boolean> {
     const { unmount } = render(
       <Confirm
         text={text}
-        onConfirm={async (answer: boolean) => {
+        onConfirm={(answer: boolean) => {
           unmount();
           resolve(answer);
         }}

--- a/packages/wrangler/src/dialogs.tsx
+++ b/packages/wrangler/src/dialogs.tsx
@@ -4,14 +4,14 @@ import { Box, Text, useInput, render } from "ink";
 import TextInput from "ink-text-input";
 type ConfirmProps = {
   text: string;
-  onConfirm: (answer: boolean) => void | Promise<void>;
+  onConfirm: (answer: boolean) => Promise<void>;
 };
 function Confirm(props: ConfirmProps) {
   useInput((input: string) => {
     if (input === "y") {
-      props.onConfirm(true);
+      props.onConfirm(true).catch((err) => console.error(err));
     } else if (input === "n") {
-      props.onConfirm(false);
+      props.onConfirm(false).catch((err) => console.error(err));
     } else {
       console.log("Unrecognised input");
     }
@@ -28,7 +28,7 @@ export function confirm(text: string): Promise<boolean> {
     const { unmount } = render(
       <Confirm
         text={text}
-        onConfirm={(answer: boolean) => {
+        onConfirm={async (answer: boolean) => {
           unmount();
           resolve(answer);
         }}

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render } from "ink";
-import { Dev } from "./dev";
+import Dev from "./dev";
 import { readFile } from "node:fs/promises";
 import makeCLI from "yargs";
 import { hideBin } from "yargs/helpers";
@@ -689,9 +689,9 @@ export async function main(argv: string[]): Promise<void> {
         `successfully created tail, expires at ${expiration.toLocaleString()}`
       );
 
-      onExit(() => {
+      onExit(async () => {
         tail.terminate();
-        deleteTail();
+        await deleteTail();
       });
 
       tail.on("message", (data) => {
@@ -1124,7 +1124,7 @@ export async function main(argv: string[]): Promise<void> {
                 // TODO: these options shouldn't be required
                 script: ` `, // has to be a string with at least one char
               });
-              mf.getKVNamespace(title); // this should "create" the namespace
+              await mf.getKVNamespace(title); // this should "create" the namespace
               console.log(`✨ Success! Created KV namespace ${title}`);
               return;
             }

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -5,7 +5,7 @@ import { existsSync, lstatSync, readFileSync } from "fs";
 import { execSync, spawn } from "child_process";
 import { Headers, Request, Response } from "undici";
 import type { MiniflareOptions } from "miniflare";
-import type { RequestInfo, RequestInit } from "@miniflare/core";
+import type { RequestInfo, RequestInit } from "undici";
 import open from "open";
 import { watch } from "chokidar";
 
@@ -747,7 +747,7 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
           }
         }
 
-        log(message: string) {}
+        log(_message: string) {}
 
         error(message: Error) {
           this.logWithLevel(
@@ -786,7 +786,7 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
             ) => {
               if (proxyPort) {
                 try {
-                  let request = new Request(input as any, init);
+                  let request = new Request(input, init);
                   const url = new URL(request.url);
                   url.host = `127.0.0.1:${proxyPort}`;
                   request = new Request(url.toString(), request);
@@ -830,16 +830,20 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
       console.log(`Serving at http://127.0.0.1:${port}/`);
 
       if (process.env.BROWSER !== "none") {
-        open(`http://127.0.0.1:${port}/`);
+        await open(`http://127.0.0.1:${port}/`);
       }
 
       process.on("SIGINT", () => {
         server.close();
-        miniflare.dispose();
+        miniflare.dispose().catch((err) => {
+          console.error(err);
+        });
       });
       process.on("SIGTERM", () => {
         server.close();
-        miniflare.dispose();
+        miniflare.dispose().catch((err) => {
+          console.error(err);
+        });
       });
     }
   );

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -137,7 +137,7 @@ export default async function publish(props: Props): Promise<void> {
   }
 
   const content = await readFile(chunks[0], { encoding: "utf-8" });
-  destination.cleanup();
+  await destination.cleanup();
 
   // if config.migrations
   // get current migration tag
@@ -283,8 +283,8 @@ export default async function publish(props: Props): Promise<void> {
         // This is to prevent an issue where a negative cache-hit
         // causes the subdomain to be unavailable for 30 seconds.
         // This is a temporary measure until we fix this on the edge.
-        .then((url) => {
-          sleep(3000);
+        .then(async (url) => {
+          await sleep(3000);
           return url;
         })
     );

--- a/packages/wrangler/src/user.tsx
+++ b/packages/wrangler/src/user.tsx
@@ -816,7 +816,7 @@ export async function loginOrRefreshIfRequired(): Promise<boolean> {
 
 export async function login(props?: LoginProps): Promise<boolean> {
   const urlToOpen = await getAuthURL(props?.scopes);
-  open(urlToOpen);
+  await open(urlToOpen);
   // TODO: log url only if on system where it's unreliable/unavailable
   // console.log(`💁 Opened ${urlToOpen}`);
   let server;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,6 @@
     "jsx": "react",
     "resolveJsonModule": true
   },
-  "lib": ["esnext", "webworker"],
+  "lib": ["esnext"],
   "exclude": ["node_modules/", "packages/wrangler/vendor"]
 }


### PR DESCRIPTION
Enabling that lint rule exposed a bunch of places where we weren't logging errors, and also caught at least 3 bugs. Glad I did this.

I also disabled prettier as an eslint error,  and added it to the `check` script instead.

I added `ioredis` as a root dependency. We don't use it, but we can't pass typecheck without it installed (because miniflare uses it, even tho it's an optional dep, and there's no good way to disable a third party's type errors in this fashion)

I also added `react-error-boundary` so we don't blow up completely, and have an option to handle errors from `dev` gracefully.