### PR TITLE
Removing Tests Build & Adding Release Trigger constraints

### DIFF
--- a/.changeset/swift-beers-mix.md
+++ b/.changeset/swift-beers-mix.md
@@ -1,0 +1,8 @@
+---
+wrangler: patch
+---
+
+CI/CD Cleanup
+- Removed the build step from tests, which should speed up the "Tests" Workflow.
+- Added a branch specific trigger for "Release", now the Workflow for "Release" should only work on PRs closed to `main`
+- Removed the "Changeset PR" Workflow. Now the "Release" Workflow will handle everything needed for Changesets.

--- a/.github/workflows/tests-typecheck.yml
+++ b/.github/workflows/tests-typecheck.yml
@@ -7,26 +7,6 @@ on:
   pull_request:
 
 jobs:
-  build:
-    name: "Build Wrangler: ${{ matrix.os }} (node@${{ matrix.node_version }})"
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        node_version: [16.7]
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node_version }}
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node_version }}
-      - name: Install NPM Dependencies
-        run: npm install
-      - name: Build
-        run: npm run build
-        working-directory: packages/wrangler
-
   test:
     name: "Tests & Typechecking: ${{ matrix.os }} (node@${{ matrix.node_version }})"
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Removed the build step from tests, which should speed up the Tests Workflow.
Added a branch specific trigger for `Release`, now the workflow for `Release` should only work on PRs closed to main
Removed the `Changeset PR` Workflow. Now the `Release` workflow will handle everything needed for Changesets