### PR TITLE
Further wrangler `init` tests (and refactorings)

### DIFF
--- a/.changeset/forty-cooks-flash.md
+++ b/.changeset/forty-cooks-flash.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+---
+
+Error and exit if the `--type` option is used for the `init` command.
+
+The `--type` option is no longer needed, nor supported.
+
+The type of a project is implicitly javascript, even if it includes a wasm (e.g. built from rust).
+
+Projects that would have had the `webpack` type need to be configured separately to have a custom build.

--- a/.changeset/short-humans-repeat.md
+++ b/.changeset/short-humans-repeat.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Allow the developer to exit `init` if there is already a toml file

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -96,6 +96,7 @@
     "node": ">=16.7.0"
   },
   "jest": {
+    "restoreMocks": true,
     "testRegex": ".*.(test|spec)\\.[jt]sx?$",
     "transformIgnorePatterns": [
       "node_modules/(?!node-fetch|fetch-blob|find-up|locate-path|p-locate|p-limit|yocto-queue|path-exists|data-uri-to-buffer|formdata-polyfill|execa|strip-final-newline|npm-run-path|path-key|onetime|mimic-fn|human-signals|is-stream)"

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -114,6 +114,35 @@ describe("wrangler", () => {
       const { stderr } = await w("init");
       expect(stderr).toContain("wrangler.toml file already exists!");
     });
+
+    it("should error if `--type` is used", async () => {
+      const noValue = await w("init --type");
+      expect(noValue.stderr).toMatchInlineSnapshot(
+        `"The --type option is no longer supported."`
+      );
+    });
+
+    it("should error if `--type javascript` is used", async () => {
+      const javascriptValue = await w("init --type javascript");
+      expect(javascriptValue.stderr).toMatchInlineSnapshot(
+        `"The --type option is no longer supported."`
+      );
+    });
+
+    it("should error if `--type rust` is used", async () => {
+      const rustValue = await w("init --type rust");
+      expect(rustValue.stderr).toMatchInlineSnapshot(
+        `"The --type option is no longer supported."`
+      );
+    });
+
+    it("should error if `--type webpack` is used", async () => {
+      const webpackValue = await w("init --type webpack");
+      expect(webpackValue.stderr).toMatchInlineSnapshot(`
+        "The --type option is no longer supported.
+        If you wish to use webpack then you will need to create a custom build."
+      `);
+    });
   });
 
   describe("kv:namespace", () => {

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -112,7 +112,7 @@ describe("wrangler", () => {
     it("should error when wrangler.toml already exists", async () => {
       fs.closeSync(fs.openSync("./wrangler.toml", "w"));
       const { stderr } = await w("init");
-      expect(stderr).toContain("wrangler.toml already exists.");
+      expect(stderr).toContain("wrangler.toml file already exists!");
     });
   });
 

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import * as TOML from "@iarna/toml";
 import { main } from "../index";
 import { setMock, unsetAllMocks } from "./mock-cfetch";
+import { existsSync } from "node:fs";
 
 jest.mock("../cfetch", () => jest.requireActual("./mock-cfetch"));
 
@@ -99,7 +100,9 @@ describe("wrangler", () => {
     });
 
     afterEach(async () => {
-      await fsp.rm("./wrangler.toml");
+      if (existsSync("./wrangler.toml")) {
+        await fsp.rm("./wrangler.toml");
+      }
       process.chdir(ogcwd);
     });
 

--- a/packages/wrangler/src/dialogs.tsx
+++ b/packages/wrangler/src/dialogs.tsx
@@ -23,7 +23,7 @@ function Confirm(props: ConfirmProps) {
   );
 }
 
-export function confirm(text: string): Promise<boolean> {
+function confirm(text: string): Promise<boolean> {
   return new Promise((resolve) => {
     const { unmount } = render(
       <Confirm
@@ -61,7 +61,7 @@ function Prompt(props: PromptProps) {
   );
 }
 
-export async function prompt(text: string, type: "text" | "password" = "text") {
+async function prompt(text: string, type: "text" | "password" = "text") {
   return new Promise((resolve) => {
     const { unmount } = render(
       <Prompt
@@ -83,3 +83,9 @@ export async function prompt(text: string, type: "text" | "password" = "text") {
 // ): Promise<{ label: string; value: string }>{
 
 // }
+
+// Export as an object so that it is easier to mock for testing
+export const dialogs = {
+  confirm,
+  prompt,
+};

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -190,7 +190,9 @@ export async function main(argv: string[]): Promise<void> {
     async () => {
       const destination = path.join(process.cwd(), "wrangler.toml");
       if (fs.existsSync(destination)) {
-        console.error(`${destination} already exists.`);
+        console.error(
+          `${destination} file already exists! Please remove it before running this command again.`
+        );
       } else {
         const compatibilityDate = new Date().toISOString().substring(0, 10);
         try {

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -201,23 +201,27 @@ export async function main(argv: string[]): Promise<void> {
 
       const destination = path.join(process.cwd(), "wrangler.toml");
       if (fs.existsSync(destination)) {
-        console.error(
-          `${destination} file already exists! Please remove it before running this command again.`
+        console.error(`${destination} file already exists!`);
+        const result = await dialogs.confirm(
+          "Do you want to continue initializing this project?"
         );
-      } else {
-        const compatibilityDate = new Date().toISOString().substring(0, 10);
-        try {
-          await writeFile(
-            destination,
-            `compatibility_date = "${compatibilityDate}"` + "\n"
-          );
-          console.log(`✨ Succesfully created wrangler.toml`);
-          // TODO: suggest next steps?
-        } catch (err) {
-          console.error(`Failed to create wrangler.toml`);
-          console.error(err);
-          throw err;
+        if (!result) {
+          return;
         }
+      }
+
+      const compatibilityDate = new Date().toISOString().substring(0, 10);
+      try {
+        await writeFile(
+          destination,
+          `compatibility_date = "${compatibilityDate}"` + "\n"
+        );
+        console.log(`✨ Succesfully created wrangler.toml`);
+        // TODO: suggest next steps?
+      } catch (err) {
+        console.error(`Failed to create wrangler.toml`);
+        console.error(err);
+        throw err;
       }
 
       // if no package.json, ask, and if yes, create one

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -8,7 +8,7 @@ import type yargs from "yargs";
 import { findUp } from "find-up";
 import TOML from "@iarna/toml";
 import type { Config } from "./config";
-import { confirm, prompt } from "./dialogs";
+import { dialogs } from "./dialogs";
 import { version as wranglerVersion } from "../package.json";
 import {
   login,
@@ -214,7 +214,9 @@ export async function main(argv: string[]): Promise<void> {
 
       if (!pathToPackageJson) {
         if (
-          await confirm("No package.json found. Would you like to create one?")
+          await dialogs.confirm(
+            "No package.json found. Would you like to create one?"
+          )
         ) {
           await writeFile(
             path.join(process.cwd(), "package.json"),
@@ -239,7 +241,7 @@ export async function main(argv: string[]): Promise<void> {
       // and make a tsconfig?
       let pathToTSConfig = await findUp("tsconfig.json");
       if (!pathToTSConfig) {
-        if (await confirm("Would you like to use typescript?")) {
+        if (await dialogs.confirm("Would you like to use typescript?")) {
           await writeFile(
             path.join(process.cwd(), "tsconfig.json"),
             JSON.stringify(
@@ -898,7 +900,7 @@ export async function main(argv: string[]): Promise<void> {
 
             // -- snip, end --
 
-            const secretValue = await prompt(
+            const secretValue = await dialogs.prompt(
               "Enter a secret value:",
               "password"
             );
@@ -998,7 +1000,11 @@ export async function main(argv: string[]): Promise<void> {
 
             // -- snip, end --
 
-            if (await confirm("Are you sure you want to delete this secret?")) {
+            if (
+              await dialogs.confirm(
+                "Are you sure you want to delete this secret?"
+              )
+            ) {
               console.log(
                 `Deleting the secret ${args.key} on script ${scriptName}.`
               );

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -187,7 +187,18 @@ export async function main(argv: string[]): Promise<void> {
         type: "string",
       });
     },
-    async () => {
+    async (args) => {
+      if ("type" in args) {
+        let message = "The --type option is no longer supported.";
+        if (args.type === "webpack") {
+          message +=
+            "\nIf you wish to use webpack then you will need to create a custom build.";
+          // TODO: Add a link to docs
+        }
+        console.error(message);
+        return;
+      }
+
       const destination = path.join(process.cwd(), "wrangler.toml");
       if (fs.existsSync(destination)) {
         console.error(


### PR DESCRIPTION
See the individual commits...

- Simplify log capturing in tests 
- test: align init error message with wrangler 1
- test: always restore jest mocks after each test
- test: move confirm() and prompt() into an object for easier mocking
- fix: error and exit if init --type is used
- test: ensure fixture clean up is resilient to missing files
- fix: allow the user to exit init if there is already a toml file