### PR TITLE
export functions from dialogs.tsx, pass tests

### DIFF
--- a/.changeset/purple-rice-fail.md
+++ b/.changeset/purple-rice-fail.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Export regular functions from dialog.ts, pass tests (followup from https://github.com/cloudflare/wrangler2/pull/124)

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -26,8 +26,8 @@ jest.mock("../dialogs", () => {
  * then an error is thrown.
  */
 function mockConfirm(...expectations: { text: string; result: boolean }[]) {
-  // @ts-expect-error - we're mocking  the implementation of a function
-  // but typescript doesn't know we've replaced confirm up there
+  // @ts-expect-error - we're mocking the implementation of confirm()
+  // but typescript doesn't know we've previously replaced confirm with a mock
   confirm.mockImplementationOnce((text: string) => {
     for (const { text: expectedText, result } of expectations) {
       if (text === expectedText) {

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -5,9 +5,38 @@ import * as TOML from "@iarna/toml";
 import { main } from "../index";
 import { setMock, unsetAllMocks } from "./mock-cfetch";
 import { existsSync } from "node:fs";
-import { dialogs } from "../dialogs";
+import { confirm } from "../dialogs";
 
 jest.mock("../cfetch", () => jest.requireActual("./mock-cfetch"));
+
+jest.mock("../dialogs", () => {
+  return {
+    // @ts-expect-error typescript doesn't know that jest.requireActual
+    // returns the 'object' form of the dialogs module
+    ...jest.requireActual("../dialogs"),
+    confirm: jest.fn().mockName("confirmMock"),
+  };
+});
+
+/**
+ * Mock the implementation of `confirm()` that will respond with configured results
+ * for configured confirmation text messages.
+ *
+ * If there is a call to `confirm()` that does not match any of the expectations
+ * then an error is thrown.
+ */
+function mockConfirm(...expectations: { text: string; result: boolean }[]) {
+  // @ts-expect-error - we're mocking  the implementation of a function
+  // but typescript doesn't know we've replaced confirm up there
+  confirm.mockImplementationOnce((text: string) => {
+    for (const { text: expectedText, result } of expectations) {
+      if (text === expectedText) {
+        return result;
+      }
+    }
+    throw new Error(`Unexpected confirmation message: ${text}`);
+  });
+}
 
 async function w(cmd?: string) {
   const logSpy = jest.spyOn(console, "log").mockImplementation();
@@ -222,22 +251,3 @@ describe("wrangler", () => {
     });
   });
 });
-
-/**
- * Create a mock version of `confirm()` that will respond with configured results
- * for configured confirmation text messages.
- *
- * If there is a call to `confirm()` that does not match any of the expectations
- * then an error is thrown.
- */
-function mockConfirm(...expectations: { text: string; result: boolean }[]) {
-  const mockImplementation = async (text: string) => {
-    for (const { text: expectedText, result } of expectations) {
-      if (text === expectedText) {
-        return result;
-      }
-    }
-    throw new Error(`Unexpected confirmation message: ${text}`);
-  };
-  return jest.spyOn(dialogs, "confirm").mockImplementation(mockImplementation);
-}

--- a/packages/wrangler/src/dialogs.tsx
+++ b/packages/wrangler/src/dialogs.tsx
@@ -23,7 +23,7 @@ function Confirm(props: ConfirmProps) {
   );
 }
 
-function confirm(text: string): Promise<boolean> {
+export function confirm(text: string): Promise<boolean> {
   return new Promise((resolve) => {
     const { unmount } = render(
       <Confirm
@@ -61,7 +61,7 @@ function Prompt(props: PromptProps) {
   );
 }
 
-async function prompt(text: string, type: "text" | "password" = "text") {
+export async function prompt(text: string, type: "text" | "password" = "text") {
   return new Promise((resolve) => {
     const { unmount } = render(
       <Prompt
@@ -75,17 +75,3 @@ async function prompt(text: string, type: "text" | "password" = "text") {
     );
   });
 }
-
-// this one feels a little non "standard"
-// export async function select(
-//   title: string,
-//   choices: { label: string; value: string }[]
-// ): Promise<{ label: string; value: string }>{
-
-// }
-
-// Export as an object so that it is easier to mock for testing
-export const dialogs = {
-  confirm,
-  prompt,
-};

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -8,7 +8,7 @@ import type yargs from "yargs";
 import { findUp } from "find-up";
 import TOML from "@iarna/toml";
 import type { Config } from "./config";
-import { dialogs } from "./dialogs";
+import { confirm, prompt } from "./dialogs";
 import { version as wranglerVersion } from "../package.json";
 import {
   login,
@@ -202,7 +202,7 @@ export async function main(argv: string[]): Promise<void> {
       const destination = path.join(process.cwd(), "wrangler.toml");
       if (fs.existsSync(destination)) {
         console.error(`${destination} file already exists!`);
-        const result = await dialogs.confirm(
+        const result = await confirm(
           "Do you want to continue initializing this project?"
         );
         if (!result) {
@@ -229,9 +229,7 @@ export async function main(argv: string[]): Promise<void> {
 
       if (!pathToPackageJson) {
         if (
-          await dialogs.confirm(
-            "No package.json found. Would you like to create one?"
-          )
+          await confirm("No package.json found. Would you like to create one?")
         ) {
           await writeFile(
             path.join(process.cwd(), "package.json"),
@@ -256,7 +254,7 @@ export async function main(argv: string[]): Promise<void> {
       // and make a tsconfig?
       let pathToTSConfig = await findUp("tsconfig.json");
       if (!pathToTSConfig) {
-        if (await dialogs.confirm("Would you like to use typescript?")) {
+        if (await confirm("Would you like to use typescript?")) {
           await writeFile(
             path.join(process.cwd(), "tsconfig.json"),
             JSON.stringify(
@@ -915,7 +913,7 @@ export async function main(argv: string[]): Promise<void> {
 
             // -- snip, end --
 
-            const secretValue = await dialogs.prompt(
+            const secretValue = await prompt(
               "Enter a secret value:",
               "password"
             );
@@ -1015,11 +1013,7 @@ export async function main(argv: string[]): Promise<void> {
 
             // -- snip, end --
 
-            if (
-              await dialogs.confirm(
-                "Are you sure you want to delete this secret?"
-              )
-            ) {
+            if (await confirm("Are you sure you want to delete this secret?")) {
               console.log(
                 `Deleting the secret ${args.key} on script ${scriptName}.`
               );


### PR DESCRIPTION
As mentioned in https://github.com/cloudflare/wrangler2/pull/124#discussion_r770953444, it's possible to use regular exports from a module, but still be able to mock their implementations in jest. This PR does so, and passes tests.
