### PR TITLE
Removed Job Dependency

### DIFF
--- a/.github/workflows/tests-typecheck.yml
+++ b/.github/workflows/tests-typecheck.yml
@@ -15,8 +15,6 @@ jobs:
         os: [ubuntu-latest]
         node_version: [16.7]
       fail-fast: false
-    needs:
-      - build
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Old Workflow had a job dependency for the tests to run the previous job had to finish. Removed that so the tests can run and the YAML would be valid. 