### PR TITLE
fix: ensure that the name is added to the wrangler.toml file during init

### DIFF
--- a/.changeset/rotten-mayflies-deny.md
+++ b/.changeset/rotten-mayflies-deny.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+---
+
+Ensure that the name is added to the wrangler.toml file during init
+
+The name of the worker was not included in the wrangler.toml.
+Now it is added if the user specfies one at the command line, otherwise it is inferred from the current directory name.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,12 @@
 {
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "cSpell.words": [
+    "bleh",
+    "cfetch",
+    "cloudflareworkers",
+    "execa",
+    "iarna",
+    "Miniflare",
+    "ogcwd"
+  ]
 }

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -144,8 +144,49 @@ describe("wrangler", () => {
         result: false,
       });
       await w("init");
+      expect(fs.existsSync("./wrangler.toml")).toBe(true);
+    });
+
+    it("should add a compatibility date to the wrangler.toml", async () => {
+      mockConfirm({
+        text: "No package.json found. Would you like to create one?",
+        result: false,
+      });
+      await w("init");
       const parsed = TOML.parse(await fsp.readFile("./wrangler.toml", "utf-8"));
       expect(typeof parsed.compatibility_date).toBe("string");
+    });
+
+    it("should add the current directory as the name to the wrangler.toml, if no name is specified", async () => {
+      mockConfirm({
+        text: "No package.json found. Would you like to create one?",
+        result: false,
+      });
+      await w("init");
+      const parsed = TOML.parse(await fsp.readFile("./wrangler.toml", "utf-8"));
+      expect(parsed.name).toEqual(path.basename(tmpDir).toLowerCase());
+    });
+
+    it("should add a specified name to the wrangler.toml", async () => {
+      mockConfirm({
+        text: "No package.json found. Would you like to create one?",
+        result: false,
+      });
+      await w("init foo-bar");
+      const parsed = TOML.parse(await fsp.readFile("./wrangler.toml", "utf-8"));
+      expect(parsed.name).toEqual("foo-bar");
+    });
+
+    it("should error if a specified name is not valid", async () => {
+      mockConfirm({
+        text: "No package.json found. Would you like to create one?",
+        result: false,
+      });
+      const { stderr } = await w("init FOO!!BAR");
+      expect(fs.existsSync("./wrangler.toml")).toBe(false);
+      expect(stderr).toMatchInlineSnapshot(
+        `"Worker name \\"FOO!!BAR\\" invalid. Ensure that you only use lowercase letters, dashes, underscores, and numbers."`
+      );
     });
 
     it("should display warning when wrangler.toml already exists, and exit if user does not want to carry on", async () => {

--- a/packages/wrangler/src/config.ts
+++ b/packages/wrangler/src/config.ts
@@ -120,3 +120,13 @@ export type Config = {
   build?: Build;
   env?: { [envName: string]: void | Env };
 };
+
+export function validateWorkerName(name: string): boolean {
+  if (!/^[a-z0-9_][a-z0-9-_]*$/.test(name)) {
+    console.error(
+      `Worker name "${name}" invalid. Ensure that you only use lowercase letters, dashes, underscores, and numbers.`
+    );
+    return false;
+  }
+  return true;
+}

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -7,6 +7,7 @@ import { hideBin } from "yargs/helpers";
 import type yargs from "yargs";
 import { findUp } from "find-up";
 import TOML from "@iarna/toml";
+import { validateWorkerName } from "./config";
 import type { Config } from "./config";
 import { confirm, prompt } from "./dialogs";
 import { version as wranglerVersion } from "../package.json";
@@ -82,7 +83,7 @@ async function readConfig(path?: string): Promise<Config> {
   const mirroredFields = ["vars", "kv_namespaces", "durable_objects"];
   Object.keys(config.env || {}).forEach((env) => {
     mirroredFields.forEach((field) => {
-      // if it exists on top level, it should exist on env defns
+      // if it exists on top level, it should exist on env definitions
       Object.keys(config[field] || {}).forEach((fieldKey) => {
         if (!(fieldKey in config.env[env][field])) {
           console.error(
@@ -188,6 +189,12 @@ export async function main(argv: string[]): Promise<void> {
       });
     },
     async (args) => {
+      const name =
+        "name" in args ? args.name : path.basename(process.cwd()).toLowerCase();
+      if (!validateWorkerName(name)) {
+        return;
+      }
+
       if ("type" in args) {
         let message = "The --type option is no longer supported.";
         if (args.type === "webpack") {
@@ -214,9 +221,12 @@ export async function main(argv: string[]): Promise<void> {
       try {
         await writeFile(
           destination,
-          `compatibility_date = "${compatibilityDate}"` + "\n"
+          [
+            `name = "${name}"`,
+            `compatibility_date = "${compatibilityDate}"`,
+          ].join("\n")
         );
-        console.log(`✨ Succesfully created wrangler.toml`);
+        console.log(`✨ Successfully created wrangler.toml`);
         // TODO: suggest next steps?
       } catch (err) {
         console.error(`Failed to create wrangler.toml`);
@@ -339,7 +349,7 @@ export async function main(argv: string[]): Promise<void> {
       await login();
 
       // TODO: would be nice if it optionally saved login
-      // creds inside node_modules/.cache or something
+      // credentials inside node_modules/.cache or something
       // this way you could have multiple users on a single machine
     }
   );
@@ -1568,7 +1578,7 @@ export async function main(argv: string[]): Promise<void> {
             // -- snip, end --
 
             // annoyingly, the API for this one doesn't return the
-            // data in the 'standard' format. goddamit.
+            // data in the 'standard' format. goddammit.
             // That's why we have the fallthrough response in cfetch.
             // Oh well.
             console.log(


### PR DESCRIPTION
The name of the worker was not included in the wrangler.toml.
Now it is added if the user specfies one at the command line, otherwise it is inferred from the current directory name.