### PR TITLE
Upgrade `miniflare` to `2.0.0-rc.4` & `pages dev` quick wins

### DIFF
--- a/.changeset/eighty-books-chew.md
+++ b/.changeset/eighty-books-chew.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+When using `wrangler pages dev`, enable source maps and log unhandled rejections

--- a/.changeset/warm-moles-march.md
+++ b/.changeset/warm-moles-march.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Upgrade `miniflare` to `2.0.0-rc.4`

--- a/package-lock.json
+++ b/package-lock.json
@@ -2481,11 +2481,12 @@
       }
     },
     "node_modules/@miniflare/cache": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-yvCcIIJRPU5OeU68392c0u0aRYdS/ZStZYrIkLTYQAXNLO2+Kfn/H+bHemnwHEJYAYlZ9kph4pcAeNUMmGb3qQ==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.0.0-rc.4.tgz",
+      "integrity": "sha512-63PeBccUGXCQ0Ekdt9OwgVCuJIKZ+d8lRAFpJtIa7+ZVybW9F9ehOOKZZYFzEbfBA6Y23i046A44SrpNPeAEGA==",
       "dependencies": {
-        "@miniflare/core": "2.0.0-rc.3",
-        "@miniflare/shared": "2.0.0-rc.3",
+        "@miniflare/core": "2.0.0-rc.4",
+        "@miniflare/shared": "2.0.0-rc.4",
         "http-cache-semantics": "^4.1.0",
         "undici": "^4.11.1"
       },
@@ -2494,10 +2495,11 @@
       }
     },
     "node_modules/@miniflare/cli-parser": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-/QI8JjKa9UnlQ+1R3qoYtBBM8md4qE3T8E7bwKY3QJluj129JZ83CvFNna33mvbrpFVE7TO5b/qgAUgwQf7e9g==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.0.0-rc.4.tgz",
+      "integrity": "sha512-jFtG6Ib3fjLenEepKSGJXMUn1hTk1xsjDPVjBX4VNc7P75zMlgdWLmSJSh7qBZpWd4mCUr46MOTtdPXWrW8Opw==",
       "dependencies": {
-        "@miniflare/shared": "2.0.0-rc.3",
+        "@miniflare/shared": "2.0.0-rc.4",
         "kleur": "^4.1.4"
       },
       "engines": {
@@ -2505,11 +2507,12 @@
       }
     },
     "node_modules/@miniflare/core": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-ZZ4uuhhwjTtiAFRuRjHF85p5kYujovA+bof6s52h19eFv1I0IXzpzeE1/qYWXMTft2MF7iRda1GGHXmr2hAetQ==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.0.0-rc.4.tgz",
+      "integrity": "sha512-nORCqBpj2zqZdlHdTk8VePidCc6VMvd3b3qRqC5eA3/p9CMrpBtQbBx074tnxiRimWnl1lP41U2ucZevwjTGZg==",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/shared": "2.0.0-rc.3",
+        "@miniflare/shared": "2.0.0-rc.4",
         "busboy": "^0.3.1",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
@@ -2520,7 +2523,7 @@
         "node": ">=16.7"
       },
       "peerDependencies": {
-        "@miniflare/watcher": "2.0.0-rc.3"
+        "@miniflare/watcher": "2.0.0-rc.4"
       },
       "peerDependenciesMeta": {
         "@miniflare/watcher": {
@@ -2529,12 +2532,13 @@
       }
     },
     "node_modules/@miniflare/durable-objects": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-EowozTC7SgeZcq00DMqRDsdU8TTkrQ9qH+2n+OJTH6NYdfjqqKXR6bOz5i0HdyRzFMucIDvZQhs8Bx/PseAa/g==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.0.0-rc.4.tgz",
+      "integrity": "sha512-Zyv0E71sIYa1OobAmgoaBNum0vzPI6rk6K9Ib5fnMpjx4IzFc+kt6MQq5mUiLUa4yEADmrDHrQ5X4Bqe9Is5lA==",
       "dependencies": {
-        "@miniflare/core": "2.0.0-rc.3",
-        "@miniflare/shared": "2.0.0-rc.3",
-        "@miniflare/storage-memory": "2.0.0-rc.3",
+        "@miniflare/core": "2.0.0-rc.4",
+        "@miniflare/shared": "2.0.0-rc.4",
+        "@miniflare/storage-memory": "2.0.0-rc.4",
         "undici": "^4.11.1"
       },
       "engines": {
@@ -2542,11 +2546,12 @@
       }
     },
     "node_modules/@miniflare/html-rewriter": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-BFIf+W2FjMgJnawmh+vu0wFvict9fUOTt4sFoJfaLwpCxFM0K4842ZItAE8rCEn7YL7HSRKijkTnb1IqFrwt0A==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.0.0-rc.4.tgz",
+      "integrity": "sha512-KzQvG5r0KbMWctskH/1XIBT+YgQdHrXnYnK7nqJ3fhMjNO02xytlmGISHABV8WGCFYuWZglqTxOQPi17we8Ikw==",
       "dependencies": {
-        "@miniflare/core": "2.0.0-rc.3",
-        "@miniflare/shared": "2.0.0-rc.3",
+        "@miniflare/core": "2.0.0-rc.4",
+        "@miniflare/shared": "2.0.0-rc.4",
         "html-rewriter-wasm": "^0.3.2",
         "undici": "^4.11.1"
       },
@@ -2555,12 +2560,13 @@
       }
     },
     "node_modules/@miniflare/http-server": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-QMHB2QgC+LzR8dUaWiBr2dnp7DUcLeLOjvEXsZpsLx4ixkASAFAVdetIWJFj2FKKKiB9D6Jb8yOm7KOu6+RltQ==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.0.0-rc.4.tgz",
+      "integrity": "sha512-ZxPfylDEa9RZkvTDzicbE0AYLoCBintQS2biGHLOiCpVCvSZej43XUs3A8KxSPN0adnz0KUzX58pcXQPU9CXuQ==",
       "dependencies": {
-        "@miniflare/core": "2.0.0-rc.3",
-        "@miniflare/shared": "2.0.0-rc.3",
-        "@miniflare/web-sockets": "2.0.0-rc.3",
+        "@miniflare/core": "2.0.0-rc.4",
+        "@miniflare/shared": "2.0.0-rc.4",
+        "@miniflare/web-sockets": "2.0.0-rc.4",
         "kleur": "^4.1.4",
         "selfsigned": "^1.10.11",
         "undici": "^4.11.1",
@@ -2572,31 +2578,34 @@
       }
     },
     "node_modules/@miniflare/kv": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-MUkmOFPtFtB3QDCRfKfpW+eMR0L3oDBAkmjOfrYb0yUs9Diqg4Ns6v+q2gZfnXyzyU/VCFZdwUrHO44NCS8mMg==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.0.0-rc.4.tgz",
+      "integrity": "sha512-jHkMS6VCadUlTrE4m+aCyrZS5VfQ0D3YhWJwFHWCtqAEItV0ggDN2+saCEoAW0YXzsiadlbuWJeAM4H11g1JNw==",
       "dependencies": {
-        "@miniflare/shared": "2.0.0-rc.3"
+        "@miniflare/shared": "2.0.0-rc.4"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/runner-vm": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-o7G/a/3kAODAsMswBZDPdUL2j33kGcP79rIMpDpwKI42Vqx0lFFsNfc6V/8/lnfmHucVw772h5/jrESTfrhVuQ==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.0.0-rc.4.tgz",
+      "integrity": "sha512-eFOMVvhyHuI5JUOF4/8oyRId3zpKgY0xyN5Jk+7y/I3QiqSZFDFnO1hHPXHzlgimBawFEi0SzSsa5saJB2KFSQ==",
       "dependencies": {
-        "@miniflare/shared": "2.0.0-rc.3"
+        "@miniflare/shared": "2.0.0-rc.4"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/scheduler": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-I1wpKK+uEh335/cUzSbsK9nIjOXxhcyzipNAF1VO2fa6ofW8Fq9EYo2qjWYEuHbLmfEtef6frPGOzSUm73cp8Q==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.0.0-rc.4.tgz",
+      "integrity": "sha512-PGzXSFavmLjxFz2WN6m2rO/HiFIxOLyxw4330AP6UJpGd/HP5tmTsF/aUGE5MjwKkgzQyk815nGZMvusR37fqA==",
       "dependencies": {
-        "@miniflare/core": "2.0.0-rc.3",
-        "@miniflare/shared": "2.0.0-rc.3",
+        "@miniflare/core": "2.0.0-rc.4",
+        "@miniflare/shared": "2.0.0-rc.4",
         "cron-schedule": "^3.0.4"
       },
       "engines": {
@@ -2604,8 +2613,9 @@
       }
     },
     "node_modules/@miniflare/shared": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-pKpErhoGhWhhce+oDiOnoA/N85WZm5Tjc3i9qowmlw3V9SlhM7tw6FRUam5n6aKbO3/yIn4azD/Wc5v6Xh25pg==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.0.0-rc.4.tgz",
+      "integrity": "sha512-bu59+0r+IxmuBmFDDELxJ8vaewuimaBylrkxMF5o+DaZmIXGmxzDmji2LLXT4oDjGHP4FN6Eex5pR0f5eDsjkQ==",
       "dependencies": {
         "ignore": "^5.1.8",
         "kleur": "^4.1.4"
@@ -2615,54 +2625,59 @@
       }
     },
     "node_modules/@miniflare/sites": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-n8T0NilCizz2CoWlOVs56zBuU6R14J8qPHK6lSPms7FUHrMSm1p2OSRcMfEnSvz7Y3Rj+6c5pQAaD9qZwtrviQ==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.0.0-rc.4.tgz",
+      "integrity": "sha512-qWFpvo3eQpPZOp58rzjbTVuB1xZULUpndaiKOp17+WrfXV1on0Y/ipgmFFDqTT5qMsWG14Y68CQeJCzF7ww36A==",
       "dependencies": {
-        "@miniflare/kv": "2.0.0-rc.3",
-        "@miniflare/shared": "2.0.0-rc.3",
-        "@miniflare/storage-file": "2.0.0-rc.3"
+        "@miniflare/kv": "2.0.0-rc.4",
+        "@miniflare/shared": "2.0.0-rc.4",
+        "@miniflare/storage-file": "2.0.0-rc.4"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/storage-file": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-CHXyl3E/BrevVAamMCcxLKJPxelLvzfA6i/EI0b1waUPBKG8H/yIZGpK9CRKT9YHCn/WdZg5OtLdRTJ0n6ocRg==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.0.0-rc.4.tgz",
+      "integrity": "sha512-wu9S71T4fpYm5JQmpA/P+LuWxPoWQwAzFVrN5eAQgx6T8846D/Dl9iBED4bgo+yJiVrlfwFCeojNsqfxziWz/g==",
       "dependencies": {
-        "@miniflare/shared": "2.0.0-rc.3",
-        "@miniflare/storage-memory": "2.0.0-rc.3"
+        "@miniflare/shared": "2.0.0-rc.4",
+        "@miniflare/storage-memory": "2.0.0-rc.4"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/storage-memory": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-TWroGaNRGqfnvx+efrWlDJpuDld+NIWj2Le77SYX7QHjzvFRhdyqsp3soZGFRZzx3aajZaWkHS6ZKDSFlaZs3A==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.0.0-rc.4.tgz",
+      "integrity": "sha512-D/qbZR6JwLyp3uA/2A3UA5XqhnTe2SaSsY/Qw47EfwPicsPEVGQl4dwrVLobslA+mxYVabOMM4G/uCU5c3fI/Q==",
       "dependencies": {
-        "@miniflare/shared": "2.0.0-rc.3"
+        "@miniflare/shared": "2.0.0-rc.4"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/watcher": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-i/UIOvKBTYfRCtlmSwurICg1elKbm4OyTrzgqAZJbwCtsvWZh4hPflQ6FnuL3IcebhHXkcDbdXSxZI2ReP8a2w==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.0.0-rc.4.tgz",
+      "integrity": "sha512-94buFqkifFlTZtwu7DvgmmQzz9NA9YWMGMIfbsVmVMiugTa39topc0KnVrcvBKnkBjQpA8Vk8edkqsn5tXb4fg==",
       "dependencies": {
-        "@miniflare/shared": "2.0.0-rc.3"
+        "@miniflare/shared": "2.0.0-rc.4"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/web-sockets": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-nqGFzKkyUMwPAss2od+tXgMKYSmJ/+I+Zm5pCIjwmukHIf4zxEAE3iMvEbOQ9Xgz9Kc3smhRiMzOwTf2+8VRSg==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.0.0-rc.4.tgz",
+      "integrity": "sha512-d+TNVTu5IjW0mF39PgSodRYWhj//PzyouPiEZ2pH4SHJ+FXjwjgomAehtMh0GTab4SZwXOAhHYgKoH8fzhLt8g==",
       "dependencies": {
-        "@miniflare/core": "2.0.0-rc.3",
-        "@miniflare/shared": "2.0.0-rc.3",
+        "@miniflare/core": "2.0.0-rc.4",
+        "@miniflare/shared": "2.0.0-rc.4",
         "undici": "^4.11.1",
         "ws": "^8.2.2"
       },
@@ -2837,6 +2852,7 @@
     },
     "node_modules/@types/stack-trace": {
       "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/stack-trace/-/stack-trace-0.0.29.tgz",
       "integrity": "sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g=="
     },
     "node_modules/@types/stack-utils": {
@@ -3573,6 +3589,7 @@
     },
     "node_modules/busboy": {
       "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
       "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
       "dependencies": {
         "dicer": "0.3.0"
@@ -3999,6 +4016,14 @@
         "node": ">= 4"
       }
     },
+    "node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/copy-descriptor": {
       "version": "0.1.1",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
@@ -4012,6 +4037,7 @@
     },
     "node_modules/cron-schedule": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/cron-schedule/-/cron-schedule-3.0.4.tgz",
       "integrity": "sha512-wEspID2dNPfWyh7t2ZvE4Izunzk20QacZg8oZcqfTrN1j5kImj0CEYT3ZGZo+KqGQUgRc9tKlEJmY4uFVt4ccA=="
     },
     "node_modules/cross-spawn": {
@@ -4240,6 +4266,7 @@
     },
     "node_modules/dicer": {
       "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
       "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
       "dependencies": {
         "streamsearch": "0.1.2"
@@ -4294,6 +4321,7 @@
     },
     "node_modules/dotenv": {
       "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
       "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
       "engines": {
         "node": ">=10"
@@ -5782,10 +5810,12 @@
     },
     "node_modules/html-rewriter-wasm": {
       "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/html-rewriter-wasm/-/html-rewriter-wasm-0.3.2.tgz",
       "integrity": "sha512-b+pOh+bs00uRVNIZoTgGBREjUKN47pchTNwkxKuP4ecQTFcOA6KJIW+jjvjjXrkSRURZsideLxFKqX7hnxdegQ=="
     },
     "node_modules/http-cache-semantics": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
     },
     "node_modules/http-errors": {
@@ -9543,6 +9573,7 @@
     },
     "node_modules/kleur": {
       "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
       "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
       "engines": {
         "node": ">=6"
@@ -9823,24 +9854,25 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-XpcbNLs5zfosfIJWrtk0L4WYmyJCRZgi2r6pRR9zhBFTRNChHNP0grmcMH0FK9ROH6c/9Pj2MjqqZ9wqHQbaGA==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.0.0-rc.4.tgz",
+      "integrity": "sha512-nzoooM8tctkR6KBBgQo8/HuHdQ8GgqTXbmpqq3DiIH1LTZDiKSYQ420T+t6HhWl1IP6i3htQR5TzBq50iAgm0A==",
       "dependencies": {
-        "@miniflare/cache": "2.0.0-rc.3",
-        "@miniflare/cli-parser": "2.0.0-rc.3",
-        "@miniflare/core": "2.0.0-rc.3",
-        "@miniflare/durable-objects": "2.0.0-rc.3",
-        "@miniflare/html-rewriter": "2.0.0-rc.3",
-        "@miniflare/http-server": "2.0.0-rc.3",
-        "@miniflare/kv": "2.0.0-rc.3",
-        "@miniflare/runner-vm": "2.0.0-rc.3",
-        "@miniflare/scheduler": "2.0.0-rc.3",
-        "@miniflare/shared": "2.0.0-rc.3",
-        "@miniflare/sites": "2.0.0-rc.3",
-        "@miniflare/storage-file": "2.0.0-rc.3",
-        "@miniflare/storage-memory": "2.0.0-rc.3",
-        "@miniflare/watcher": "2.0.0-rc.3",
-        "@miniflare/web-sockets": "2.0.0-rc.3",
+        "@miniflare/cache": "2.0.0-rc.4",
+        "@miniflare/cli-parser": "2.0.0-rc.4",
+        "@miniflare/core": "2.0.0-rc.4",
+        "@miniflare/durable-objects": "2.0.0-rc.4",
+        "@miniflare/html-rewriter": "2.0.0-rc.4",
+        "@miniflare/http-server": "2.0.0-rc.4",
+        "@miniflare/kv": "2.0.0-rc.4",
+        "@miniflare/runner-vm": "2.0.0-rc.4",
+        "@miniflare/scheduler": "2.0.0-rc.4",
+        "@miniflare/shared": "2.0.0-rc.4",
+        "@miniflare/sites": "2.0.0-rc.4",
+        "@miniflare/storage-file": "2.0.0-rc.4",
+        "@miniflare/storage-memory": "2.0.0-rc.4",
+        "@miniflare/watcher": "2.0.0-rc.4",
+        "@miniflare/web-sockets": "2.0.0-rc.4",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
@@ -9853,7 +9885,7 @@
         "node": ">=16.7"
       },
       "peerDependencies": {
-        "@miniflare/storage-redis": "2.0.0-rc.3",
+        "@miniflare/storage-redis": "2.0.0-rc.4",
         "cron-schedule": "^3.0.4",
         "ioredis": "^4.27.9"
       },
@@ -9923,6 +9955,7 @@
     },
     "node_modules/mustache": {
       "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
       "bin": {
         "mustache": "bin/mustache"
@@ -9993,6 +10026,7 @@
     },
     "node_modules/node-forge": {
       "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
       "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "engines": {
         "node": ">= 6.0.0"
@@ -11571,6 +11605,7 @@
     },
     "node_modules/selfsigned": {
       "version": "1.10.11",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.11.tgz",
       "integrity": "sha512-aVmbPOfViZqOZPgRBT0+3u4yZFHpmnIghLMlAcb5/xhp5ZtB/RVnKhz5vl2M32CLXAqR4kha9zfhNg0Lf/sxKA==",
       "dependencies": {
         "node-forge": "^0.10.0"
@@ -11657,6 +11692,7 @@
     },
     "node_modules/set-cookie-parser": {
       "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz",
       "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg=="
     },
     "node_modules/set-value": {
@@ -12185,6 +12221,7 @@
     },
     "node_modules/stack-trace": {
       "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "engines": {
         "node": "*"
@@ -12309,6 +12346,7 @@
     },
     "node_modules/streamsearch": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
       "engines": {
         "node": ">=0.8.0"
@@ -13381,19 +13419,13 @@
     },
     "node_modules/youch": {
       "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-2.2.2.tgz",
       "integrity": "sha512-/FaCeG3GkuJwaMR34GHVg0l8jCbafZLHiFowSjqLlqhC6OMyf2tPJBu8UirF7/NI9X/R5ai4QfEKUCOxMAGxZQ==",
       "dependencies": {
         "@types/stack-trace": "0.0.29",
         "cookie": "^0.4.1",
         "mustache": "^4.2.0",
         "stack-trace": "0.0.10"
-      }
-    },
-    "node_modules/youch/node_modules/cookie": {
-      "version": "0.4.1",
-      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "packages/create-workers-app": {
@@ -13410,7 +13442,7 @@
       "dependencies": {
         "@cloudflare/pages-functions-compiler": "0.3.8",
         "esbuild": "0.14.1",
-        "miniflare": "2.0.0-rc.3",
+        "miniflare": "^2.0.0-rc.4",
         "semiver": "^1.1.0"
       },
       "bin": {
@@ -15400,29 +15432,32 @@
       }
     },
     "@miniflare/cache": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-yvCcIIJRPU5OeU68392c0u0aRYdS/ZStZYrIkLTYQAXNLO2+Kfn/H+bHemnwHEJYAYlZ9kph4pcAeNUMmGb3qQ==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.0.0-rc.4.tgz",
+      "integrity": "sha512-63PeBccUGXCQ0Ekdt9OwgVCuJIKZ+d8lRAFpJtIa7+ZVybW9F9ehOOKZZYFzEbfBA6Y23i046A44SrpNPeAEGA==",
       "requires": {
-        "@miniflare/core": "2.0.0-rc.3",
-        "@miniflare/shared": "2.0.0-rc.3",
+        "@miniflare/core": "2.0.0-rc.4",
+        "@miniflare/shared": "2.0.0-rc.4",
         "http-cache-semantics": "^4.1.0",
         "undici": "^4.11.1"
       }
     },
     "@miniflare/cli-parser": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-/QI8JjKa9UnlQ+1R3qoYtBBM8md4qE3T8E7bwKY3QJluj129JZ83CvFNna33mvbrpFVE7TO5b/qgAUgwQf7e9g==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.0.0-rc.4.tgz",
+      "integrity": "sha512-jFtG6Ib3fjLenEepKSGJXMUn1hTk1xsjDPVjBX4VNc7P75zMlgdWLmSJSh7qBZpWd4mCUr46MOTtdPXWrW8Opw==",
       "requires": {
-        "@miniflare/shared": "2.0.0-rc.3",
+        "@miniflare/shared": "2.0.0-rc.4",
         "kleur": "^4.1.4"
       }
     },
     "@miniflare/core": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-ZZ4uuhhwjTtiAFRuRjHF85p5kYujovA+bof6s52h19eFv1I0IXzpzeE1/qYWXMTft2MF7iRda1GGHXmr2hAetQ==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.0.0-rc.4.tgz",
+      "integrity": "sha512-nORCqBpj2zqZdlHdTk8VePidCc6VMvd3b3qRqC5eA3/p9CMrpBtQbBx074tnxiRimWnl1lP41U2ucZevwjTGZg==",
       "requires": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/shared": "2.0.0-rc.3",
+        "@miniflare/shared": "2.0.0-rc.4",
         "busboy": "^0.3.1",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
@@ -15431,32 +15466,35 @@
       }
     },
     "@miniflare/durable-objects": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-EowozTC7SgeZcq00DMqRDsdU8TTkrQ9qH+2n+OJTH6NYdfjqqKXR6bOz5i0HdyRzFMucIDvZQhs8Bx/PseAa/g==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.0.0-rc.4.tgz",
+      "integrity": "sha512-Zyv0E71sIYa1OobAmgoaBNum0vzPI6rk6K9Ib5fnMpjx4IzFc+kt6MQq5mUiLUa4yEADmrDHrQ5X4Bqe9Is5lA==",
       "requires": {
-        "@miniflare/core": "2.0.0-rc.3",
-        "@miniflare/shared": "2.0.0-rc.3",
-        "@miniflare/storage-memory": "2.0.0-rc.3",
+        "@miniflare/core": "2.0.0-rc.4",
+        "@miniflare/shared": "2.0.0-rc.4",
+        "@miniflare/storage-memory": "2.0.0-rc.4",
         "undici": "^4.11.1"
       }
     },
     "@miniflare/html-rewriter": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-BFIf+W2FjMgJnawmh+vu0wFvict9fUOTt4sFoJfaLwpCxFM0K4842ZItAE8rCEn7YL7HSRKijkTnb1IqFrwt0A==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.0.0-rc.4.tgz",
+      "integrity": "sha512-KzQvG5r0KbMWctskH/1XIBT+YgQdHrXnYnK7nqJ3fhMjNO02xytlmGISHABV8WGCFYuWZglqTxOQPi17we8Ikw==",
       "requires": {
-        "@miniflare/core": "2.0.0-rc.3",
-        "@miniflare/shared": "2.0.0-rc.3",
+        "@miniflare/core": "2.0.0-rc.4",
+        "@miniflare/shared": "2.0.0-rc.4",
         "html-rewriter-wasm": "^0.3.2",
         "undici": "^4.11.1"
       }
     },
     "@miniflare/http-server": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-QMHB2QgC+LzR8dUaWiBr2dnp7DUcLeLOjvEXsZpsLx4ixkASAFAVdetIWJFj2FKKKiB9D6Jb8yOm7KOu6+RltQ==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.0.0-rc.4.tgz",
+      "integrity": "sha512-ZxPfylDEa9RZkvTDzicbE0AYLoCBintQS2biGHLOiCpVCvSZej43XUs3A8KxSPN0adnz0KUzX58pcXQPU9CXuQ==",
       "requires": {
-        "@miniflare/core": "2.0.0-rc.3",
-        "@miniflare/shared": "2.0.0-rc.3",
-        "@miniflare/web-sockets": "2.0.0-rc.3",
+        "@miniflare/core": "2.0.0-rc.4",
+        "@miniflare/shared": "2.0.0-rc.4",
+        "@miniflare/web-sockets": "2.0.0-rc.4",
         "kleur": "^4.1.4",
         "selfsigned": "^1.10.11",
         "undici": "^4.11.1",
@@ -15465,73 +15503,82 @@
       }
     },
     "@miniflare/kv": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-MUkmOFPtFtB3QDCRfKfpW+eMR0L3oDBAkmjOfrYb0yUs9Diqg4Ns6v+q2gZfnXyzyU/VCFZdwUrHO44NCS8mMg==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.0.0-rc.4.tgz",
+      "integrity": "sha512-jHkMS6VCadUlTrE4m+aCyrZS5VfQ0D3YhWJwFHWCtqAEItV0ggDN2+saCEoAW0YXzsiadlbuWJeAM4H11g1JNw==",
       "requires": {
-        "@miniflare/shared": "2.0.0-rc.3"
+        "@miniflare/shared": "2.0.0-rc.4"
       }
     },
     "@miniflare/runner-vm": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-o7G/a/3kAODAsMswBZDPdUL2j33kGcP79rIMpDpwKI42Vqx0lFFsNfc6V/8/lnfmHucVw772h5/jrESTfrhVuQ==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.0.0-rc.4.tgz",
+      "integrity": "sha512-eFOMVvhyHuI5JUOF4/8oyRId3zpKgY0xyN5Jk+7y/I3QiqSZFDFnO1hHPXHzlgimBawFEi0SzSsa5saJB2KFSQ==",
       "requires": {
-        "@miniflare/shared": "2.0.0-rc.3"
+        "@miniflare/shared": "2.0.0-rc.4"
       }
     },
     "@miniflare/scheduler": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-I1wpKK+uEh335/cUzSbsK9nIjOXxhcyzipNAF1VO2fa6ofW8Fq9EYo2qjWYEuHbLmfEtef6frPGOzSUm73cp8Q==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.0.0-rc.4.tgz",
+      "integrity": "sha512-PGzXSFavmLjxFz2WN6m2rO/HiFIxOLyxw4330AP6UJpGd/HP5tmTsF/aUGE5MjwKkgzQyk815nGZMvusR37fqA==",
       "requires": {
-        "@miniflare/core": "2.0.0-rc.3",
-        "@miniflare/shared": "2.0.0-rc.3",
+        "@miniflare/core": "2.0.0-rc.4",
+        "@miniflare/shared": "2.0.0-rc.4",
         "cron-schedule": "^3.0.4"
       }
     },
     "@miniflare/shared": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-pKpErhoGhWhhce+oDiOnoA/N85WZm5Tjc3i9qowmlw3V9SlhM7tw6FRUam5n6aKbO3/yIn4azD/Wc5v6Xh25pg==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.0.0-rc.4.tgz",
+      "integrity": "sha512-bu59+0r+IxmuBmFDDELxJ8vaewuimaBylrkxMF5o+DaZmIXGmxzDmji2LLXT4oDjGHP4FN6Eex5pR0f5eDsjkQ==",
       "requires": {
         "ignore": "^5.1.8",
         "kleur": "^4.1.4"
       }
     },
     "@miniflare/sites": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-n8T0NilCizz2CoWlOVs56zBuU6R14J8qPHK6lSPms7FUHrMSm1p2OSRcMfEnSvz7Y3Rj+6c5pQAaD9qZwtrviQ==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.0.0-rc.4.tgz",
+      "integrity": "sha512-qWFpvo3eQpPZOp58rzjbTVuB1xZULUpndaiKOp17+WrfXV1on0Y/ipgmFFDqTT5qMsWG14Y68CQeJCzF7ww36A==",
       "requires": {
-        "@miniflare/kv": "2.0.0-rc.3",
-        "@miniflare/shared": "2.0.0-rc.3",
-        "@miniflare/storage-file": "2.0.0-rc.3"
+        "@miniflare/kv": "2.0.0-rc.4",
+        "@miniflare/shared": "2.0.0-rc.4",
+        "@miniflare/storage-file": "2.0.0-rc.4"
       }
     },
     "@miniflare/storage-file": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-CHXyl3E/BrevVAamMCcxLKJPxelLvzfA6i/EI0b1waUPBKG8H/yIZGpK9CRKT9YHCn/WdZg5OtLdRTJ0n6ocRg==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.0.0-rc.4.tgz",
+      "integrity": "sha512-wu9S71T4fpYm5JQmpA/P+LuWxPoWQwAzFVrN5eAQgx6T8846D/Dl9iBED4bgo+yJiVrlfwFCeojNsqfxziWz/g==",
       "requires": {
-        "@miniflare/shared": "2.0.0-rc.3",
-        "@miniflare/storage-memory": "2.0.0-rc.3"
+        "@miniflare/shared": "2.0.0-rc.4",
+        "@miniflare/storage-memory": "2.0.0-rc.4"
       }
     },
     "@miniflare/storage-memory": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-TWroGaNRGqfnvx+efrWlDJpuDld+NIWj2Le77SYX7QHjzvFRhdyqsp3soZGFRZzx3aajZaWkHS6ZKDSFlaZs3A==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.0.0-rc.4.tgz",
+      "integrity": "sha512-D/qbZR6JwLyp3uA/2A3UA5XqhnTe2SaSsY/Qw47EfwPicsPEVGQl4dwrVLobslA+mxYVabOMM4G/uCU5c3fI/Q==",
       "requires": {
-        "@miniflare/shared": "2.0.0-rc.3"
+        "@miniflare/shared": "2.0.0-rc.4"
       }
     },
     "@miniflare/watcher": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-i/UIOvKBTYfRCtlmSwurICg1elKbm4OyTrzgqAZJbwCtsvWZh4hPflQ6FnuL3IcebhHXkcDbdXSxZI2ReP8a2w==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.0.0-rc.4.tgz",
+      "integrity": "sha512-94buFqkifFlTZtwu7DvgmmQzz9NA9YWMGMIfbsVmVMiugTa39topc0KnVrcvBKnkBjQpA8Vk8edkqsn5tXb4fg==",
       "requires": {
-        "@miniflare/shared": "2.0.0-rc.3"
+        "@miniflare/shared": "2.0.0-rc.4"
       }
     },
     "@miniflare/web-sockets": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-nqGFzKkyUMwPAss2od+tXgMKYSmJ/+I+Zm5pCIjwmukHIf4zxEAE3iMvEbOQ9Xgz9Kc3smhRiMzOwTf2+8VRSg==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.0.0-rc.4.tgz",
+      "integrity": "sha512-d+TNVTu5IjW0mF39PgSodRYWhj//PzyouPiEZ2pH4SHJ+FXjwjgomAehtMh0GTab4SZwXOAhHYgKoH8fzhLt8g==",
       "requires": {
-        "@miniflare/core": "2.0.0-rc.3",
-        "@miniflare/shared": "2.0.0-rc.3",
+        "@miniflare/core": "2.0.0-rc.4",
+        "@miniflare/shared": "2.0.0-rc.4",
         "undici": "^4.11.1",
         "ws": "^8.2.2"
       }
@@ -15691,6 +15738,7 @@
     },
     "@types/stack-trace": {
       "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/stack-trace/-/stack-trace-0.0.29.tgz",
       "integrity": "sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g=="
     },
     "@types/stack-utils": {
@@ -16168,6 +16216,7 @@
     },
     "busboy": {
       "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
       "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
       "requires": {
         "dicer": "0.3.0"
@@ -16478,6 +16527,11 @@
       "integrity": "sha1-fj5Iu+bZl7FBfdyihoIEtNPYVxU=",
       "dev": true
     },
+    "cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+    },
     "copy-descriptor": {
       "version": "0.1.1",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
@@ -16487,6 +16541,7 @@
     },
     "cron-schedule": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/cron-schedule/-/cron-schedule-3.0.4.tgz",
       "integrity": "sha512-wEspID2dNPfWyh7t2ZvE4Izunzk20QacZg8oZcqfTrN1j5kImj0CEYT3ZGZo+KqGQUgRc9tKlEJmY4uFVt4ccA=="
     },
     "cross-spawn": {
@@ -16657,6 +16712,7 @@
     },
     "dicer": {
       "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
       "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
       "requires": {
         "streamsearch": "0.1.2"
@@ -16695,6 +16751,7 @@
     },
     "dotenv": {
       "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
       "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
     },
     "ee-first": {
@@ -17752,10 +17809,12 @@
     },
     "html-rewriter-wasm": {
       "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/html-rewriter-wasm/-/html-rewriter-wasm-0.3.2.tgz",
       "integrity": "sha512-b+pOh+bs00uRVNIZoTgGBREjUKN47pchTNwkxKuP4ecQTFcOA6KJIW+jjvjjXrkSRURZsideLxFKqX7hnxdegQ=="
     },
     "http-cache-semantics": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
     },
     "http-errors": {
@@ -20468,6 +20527,7 @@
     },
     "kleur": {
       "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
       "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA=="
     },
     "leven": {
@@ -20667,24 +20727,25 @@
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
     },
     "miniflare": {
-      "version": "2.0.0-rc.3",
-      "integrity": "sha512-XpcbNLs5zfosfIJWrtk0L4WYmyJCRZgi2r6pRR9zhBFTRNChHNP0grmcMH0FK9ROH6c/9Pj2MjqqZ9wqHQbaGA==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.0.0-rc.4.tgz",
+      "integrity": "sha512-nzoooM8tctkR6KBBgQo8/HuHdQ8GgqTXbmpqq3DiIH1LTZDiKSYQ420T+t6HhWl1IP6i3htQR5TzBq50iAgm0A==",
       "requires": {
-        "@miniflare/cache": "2.0.0-rc.3",
-        "@miniflare/cli-parser": "2.0.0-rc.3",
-        "@miniflare/core": "2.0.0-rc.3",
-        "@miniflare/durable-objects": "2.0.0-rc.3",
-        "@miniflare/html-rewriter": "2.0.0-rc.3",
-        "@miniflare/http-server": "2.0.0-rc.3",
-        "@miniflare/kv": "2.0.0-rc.3",
-        "@miniflare/runner-vm": "2.0.0-rc.3",
-        "@miniflare/scheduler": "2.0.0-rc.3",
-        "@miniflare/shared": "2.0.0-rc.3",
-        "@miniflare/sites": "2.0.0-rc.3",
-        "@miniflare/storage-file": "2.0.0-rc.3",
-        "@miniflare/storage-memory": "2.0.0-rc.3",
-        "@miniflare/watcher": "2.0.0-rc.3",
-        "@miniflare/web-sockets": "2.0.0-rc.3",
+        "@miniflare/cache": "2.0.0-rc.4",
+        "@miniflare/cli-parser": "2.0.0-rc.4",
+        "@miniflare/core": "2.0.0-rc.4",
+        "@miniflare/durable-objects": "2.0.0-rc.4",
+        "@miniflare/html-rewriter": "2.0.0-rc.4",
+        "@miniflare/http-server": "2.0.0-rc.4",
+        "@miniflare/kv": "2.0.0-rc.4",
+        "@miniflare/runner-vm": "2.0.0-rc.4",
+        "@miniflare/scheduler": "2.0.0-rc.4",
+        "@miniflare/shared": "2.0.0-rc.4",
+        "@miniflare/sites": "2.0.0-rc.4",
+        "@miniflare/storage-file": "2.0.0-rc.4",
+        "@miniflare/storage-memory": "2.0.0-rc.4",
+        "@miniflare/watcher": "2.0.0-rc.4",
+        "@miniflare/web-sockets": "2.0.0-rc.4",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
@@ -20735,6 +20796,7 @@
     },
     "mustache": {
       "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="
     },
     "nanomatch": {
@@ -20779,6 +20841,7 @@
     },
     "node-forge": {
       "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
       "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
     "node-int64": {
@@ -21868,6 +21931,7 @@
     },
     "selfsigned": {
       "version": "1.10.11",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.11.tgz",
       "integrity": "sha512-aVmbPOfViZqOZPgRBT0+3u4yZFHpmnIghLMlAcb5/xhp5ZtB/RVnKhz5vl2M32CLXAqR4kha9zfhNg0Lf/sxKA==",
       "requires": {
         "node-forge": "^0.10.0"
@@ -21943,6 +22007,7 @@
     },
     "set-cookie-parser": {
       "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz",
       "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg=="
     },
     "set-value": {
@@ -22370,6 +22435,7 @@
     },
     "stack-trace": {
       "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "stack-utils": {
@@ -22466,6 +22532,7 @@
     },
     "streamsearch": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
     "string-length": {
@@ -23161,7 +23228,7 @@
         "ink-select-input": "^4.2.1",
         "ink-table": "^3.0.0",
         "ink-text-input": "^4.0.2",
-        "miniflare": "2.0.0-rc.3",
+        "miniflare": "2.0.0-rc.4",
         "node-fetch": "^3.1.0",
         "open": "^8.4.0",
         "path-to-regexp": "^6.2.0",
@@ -23347,18 +23414,13 @@
     },
     "youch": {
       "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-2.2.2.tgz",
       "integrity": "sha512-/FaCeG3GkuJwaMR34GHVg0l8jCbafZLHiFowSjqLlqhC6OMyf2tPJBu8UirF7/NI9X/R5ai4QfEKUCOxMAGxZQ==",
       "requires": {
         "@types/stack-trace": "0.0.29",
         "cookie": "^0.4.1",
         "mustache": "^4.2.0",
         "stack-trace": "0.0.10"
-      },
-      "dependencies": {
-        "cookie": {
-          "version": "0.4.1",
-          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
-        }
       }
     }
   }

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@cloudflare/pages-functions-compiler": "0.3.8",
     "esbuild": "0.14.1",
-    "miniflare": "2.0.0-rc.3",
+    "miniflare": "^2.0.0-rc.4",
     "semiver": "^1.1.0"
   },
   "optionalDependencies": {
@@ -66,13 +66,13 @@
     "open": "^8.4.0",
     "path-to-regexp": "^6.2.0",
     "react": "^17.0.2",
+    "react-error-boundary": "^3.1.4",
     "serve-static": "^1.14.1",
     "signal-exit": "^3.0.6",
     "tmp-promise": "^3.0.3",
     "undici": "^4.11.1",
     "ws": "^8.3.0",
-    "yargs": "^17.3.0",
-    "react-error-boundary": "^3.1.4"
+    "yargs": "^17.3.0"
   },
   "files": [
     "src",

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -717,43 +717,9 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
       const { fetch } = await import("@miniflare/core");
 
       class MiniflareLogger extends Log {
-        logWithLevel(level: number, message: string) {
-          if (level <= this.level) {
-            switch (level) {
-              case LogLevel.NONE: {
-                break;
-              }
-              case LogLevel.ERROR: {
-                console.error(message);
-                break;
-              }
-              case LogLevel.WARN: {
-                console.warn(message);
-                break;
-              }
-              case LogLevel.INFO: {
-                console.info(message);
-                break;
-              }
-              case LogLevel.DEBUG: {
-                console.debug(message);
-                break;
-              }
-              case LogLevel.VERBOSE: {
-                console.debug(message);
-                break;
-              }
-            }
-          }
-        }
-
-        log(_message: string) {}
-
-        error(message: Error) {
-          this.logWithLevel(
-            LogLevel.ERROR,
-            message.stack ? message.stack : `${message}`
-          );
+        log(message: string) {
+          message = message.replace("[mf:", "[pages:");
+          console.log(message);
         }
       }
 
@@ -763,6 +729,8 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
         modules: true,
 
         log: new MiniflareLogger(LogLevel.ERROR),
+        logUnhandledRejections: true,
+        sourceMap: true,
 
         kvNamespaces: kvs.map((kv) => kv.toString()),
 


### PR DESCRIPTION
Hey! 👋 This PR upgrades `miniflare` to version `2.0.0-rc.4`: https://github.com/cloudflare/miniflare/releases/tag/v2.0.0-rc.4.

This version includes support for logging unhandled rejections instead of crashing, which is automatically enabled when using the CLI, and also available as the `logUnhandledRejections` option. Whilst adding this, I thought I'd make a couple other tiny changes to `pages dev`, which have been approved by @GregBrimble in conversation.

- Enabled source map support for nicer stack traces (requires adding `sourcemap: true` to the esbuild options in `@cloudflare/pages-functions-compiler` `buildWorker` function)
- Enabled incoming HTTP request logging
- Added colours and prefixes to Miniflare logs (this also dims internal lines in stack traces for easier debugging)

Logging unhandled rejections and source mapping are process wide, but since this is in the `pages dev` command handler, it shouldn't be a problem.

![unknown](https://user-images.githubusercontent.com/15955327/146673241-ca9ae990-b13d-408f-a687-36dc154d6004.png)

