### PR TITLE
fix: `release.yml`'s changeset publish script should be a single command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          publish:
-            - cp README.md packages/wrangler/README.md
-            - npx changeset publish --tag beta
+          publish: cp README.md packages/wrangler/README.md && npx changeset publish --tag beta
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
The `release.yml` script had bad syntax, the `publish` field doesn't accept arrays, it has to be a single command. This was breaking our changesets flow (and we may have lost some changelogs). This PR fixes the script. I'll probably merge this directly right now.