### PR TITLE
test: ensure that kv:namespace tests are independent of each other

### DIFF
--- a/packages/wrangler/src/__tests__/mock-cfetch.js
+++ b/packages/wrangler/src/__tests__/mock-cfetch.js
@@ -10,8 +10,11 @@ let mocks = [];
 
 export function mockCfetch(resource, init) {
   for (const { regexp, handler } of mocks) {
-    if (regexp.test(resource)) {
-      return handler(resource, init); // should we have some kind of fallthrough system? we'll see.
+    // The `resource` regular expression will extract the labelled groups from the URL.
+    // Let's pass these through to the handler, to allow it to do additional checks or behaviour.
+    const uri = regexp.exec(resource);
+    if (uri !== null) {
+      return handler(uri, init); // TODO: should we have some kind of fallthrough system? we'll see.
     }
   }
   throw new Error(`no mocks found for ${resource}`);


### PR DESCRIPTION
Tests that rely on the results of other tests can be difficult to debug
and make maintenance more complex.