### PR TITLE
Caching node_modules in Workflows

### DIFF
--- a/.github/workflows/pages-ci.yml
+++ b/.github/workflows/pages-ci.yml
@@ -21,13 +21,15 @@ jobs:
           node-version: ${{ matrix.node_version }}
 
       - uses: actions/cache@v2
+        id: cache
         with:
-          path: ~/.npm
+          path: |
+            node_modules
+            */*/node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
 
-      - name: Install NPM dependencies
+      - name: Install NPM Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: npm install
 
       - name: Copy README.md

--- a/.github/workflows/pages-ci.yml
+++ b/.github/workflows/pages-ci.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: ${{ matrix.node_version }}
 
       - uses: actions/cache@v2
-        id: cache
+        id: node-modules-cache
         with:
           path: |
             node_modules

--- a/.github/workflows/pages-ci.yml
+++ b/.github/workflows/pages-ci.yml
@@ -29,7 +29,6 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install NPM Dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: npm install
 
       - name: Copy README.md

--- a/.github/workflows/prereleases.yml
+++ b/.github/workflows/prereleases.yml
@@ -4,32 +4,33 @@ on:
   workflow_run:
     workflows: ["Tests, Linter & Typecheck"]
     branches: ["main"]
-    types: 
+    types:
       - completed
 
 jobs:
   build:
-
     if: ${{ github.repository_owner == 'cloudflare' && github.event.workflow_run.conclusion == 'success' }}
     name: Build & Publish an alpha release to NPM
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
-      
+
       - name: Use Node.js 16.7
         uses: actions/setup-node@v2
         with:
           node-version: 16.7
-      
-      - uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
 
-      - name: Install NPM dependencies
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install NPM Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: npm install
 
       - name: Copy README.md

--- a/.github/workflows/prereleases.yml
+++ b/.github/workflows/prereleases.yml
@@ -30,7 +30,6 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install NPM Dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: npm install
 
       - name: Copy README.md

--- a/.github/workflows/prereleases.yml
+++ b/.github/workflows/prereleases.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: 16.7
 
       - uses: actions/cache@v2
-        id: cache
+        id: node-modules-cache
         with:
           path: |
             node_modules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,6 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install NPM Dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: npm install
 
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,20 +22,22 @@ jobs:
           node-version: 16.7
 
       - uses: actions/cache@v2
+        id: cache
         with:
-          path: ~/.npm
+          path: |
+            node_modules
+            */*/node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
 
-      - name: Install NPM dependencies
+      - name: Install NPM Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: npm install
 
       - name: Build
         run: npm run build
         working-directory: packages/wrangler
 
-      - name: Publish to NPM
+      - name: Create Version PR or Publish to NPM
         id: changesets
         uses: changesets/action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: 16.7
 
       - uses: actions/cache@v2
-        id: cache
+        id: node-modules-cache
         with:
           path: |
             node_modules

--- a/.github/workflows/tests-typecheck.yml
+++ b/.github/workflows/tests-typecheck.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
 
       - uses: actions/cache@v2
-        id: cache
+        id: node-modules-cache
         with:
           path: |
             node_modules

--- a/.github/workflows/tests-typecheck.yml
+++ b/.github/workflows/tests-typecheck.yml
@@ -28,7 +28,6 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install NPM Dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: npm install
 
       - name: Run Type Checking & ESLint

--- a/.github/workflows/tests-typecheck.yml
+++ b/.github/workflows/tests-typecheck.yml
@@ -20,13 +20,15 @@ jobs:
         uses: actions/checkout@v2
 
       - uses: actions/cache@v2
+        id: cache
         with:
-          path: ~/.npm
+          path: |
+            node_modules
+            */*/node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
 
-      - name: Install NPM dependencies
+      - name: Install NPM Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: npm install
 
       - name: Run Type Checking & ESLint


### PR DESCRIPTION
Previously the caching was occurring on the `~/.npm` the cache is now directly caching `node_modules` 
caching node_modules at any directory level. 
To prevent restoring `node_modules` when the cache changed, the cache action is given no `restore-keys` in the cache Action. The `id` is added to the cache Action which is used at the NPM install step the cache is checked using `id` and skips install if the cache exists.