### PR TITLE
Experimental worker-to-worker bindings support

### DIFF
--- a/.changeset/sixty-crews-breathe.md
+++ b/.changeset/sixty-crews-breathe.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Experimental worker-to-worker bindings support

--- a/packages/wrangler/src/api/worker.ts
+++ b/packages/wrangler/src/api/worker.ts
@@ -72,6 +72,9 @@ export interface CfKvNamespace {
   namespaceId: string;
 }
 
+/**
+ * A Durable Object.
+ */
 export interface CfDurableObject {
   class_name: string;
   script_name?: string;
@@ -112,9 +115,23 @@ export interface CfCryptoKey {
 }
 
 /**
+ * A service binding (reference to another worker).
+ */
+export interface CfServiceRef {
+  /**
+   * Name of the script to reference.
+   */
+  script_name: string;
+  /**
+   * Environment of the script to reference, uses default environment if not provided.
+   */
+  env: string | undefined;
+}
+
+/**
  * A variable (aka. environment variable).
  */
-export type CfVariable = string | CfKvNamespace | CfCryptoKey | CfDurableObject;
+export type CfVariable = string | CfKvNamespace | CfCryptoKey | CfDurableObject | CfServiceRef;
 
 /**
  * Options for creating a `CfWorker`.

--- a/packages/wrangler/src/config.ts
+++ b/packages/wrangler/src/config.ts
@@ -41,6 +41,12 @@ type DurableObject = {
   script_name?: string;
 };
 
+type Service = {
+  name?: string;
+  script_name: string;
+  env?: string;
+};
+
 type Build = {
   command?: string;
   cwd?: string;
@@ -86,6 +92,7 @@ type Env = {
   vars?: Vars;
   durable_objects?: { bindings: DurableObject[] };
   kv_namespaces?: KVNamespace[];
+  services?: Service[];
   usage_model?: UsageModel; // inherited
 };
 
@@ -111,6 +118,7 @@ export type Config = {
   migrations?: DOMigration[];
   durable_objects?: { bindings: DurableObject[] };
   kv_namespaces?: KVNamespace[];
+  services?: Service[];
   site?: Site; // inherited
   // we should use typescript to parse cron patterns
   triggers?: { crons: Cron[] }; // inherited

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -525,6 +525,16 @@ export async function main(argv: string[]): Promise<void> {
               },
               {}
             ),
+            ...(envRootObj?.services || []).reduce(
+              (obj, { name, script_name, env }) => {
+                const varname = name || script_name;
+                return {
+                  ...obj,
+                  [varname]: { script_name, env },
+                };
+              },
+              {},
+            ),
           }}
         />
       );

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -79,7 +79,7 @@ async function readConfig(path?: string): Promise<Config> {
     });
   });
 
-  const mirroredFields = ["vars", "kv_namespaces", "durable_objects"];
+  const mirroredFields = ["vars", "kv_namespaces", "durable_objects", "services"];
   Object.keys(config.env || {}).forEach((env) => {
     mirroredFields.forEach((field) => {
       // if it exists on top level, it should exist on env defns

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -226,6 +226,16 @@ export default async function publish(props: Props): Promise<void> {
         },
         {}
       ),
+      ...(envRootObj?.services || []).reduce(
+        (obj, { name, script_name, env }) => {
+          const varname = name || script_name;
+          return {
+            ...obj,
+            [varname]: { script_name, env },
+          };
+        },
+        {},
+      ),
       ...(assets.namespace
         ? { __STATIC_CONTENT: { namespaceId: assets.namespace } }
         : {}),


### PR DESCRIPTION
Adds support for experimental worker-to-worker bindings, letting you call a worker from another worker. The Wrangler config field looks like follows:

```toml
services = [{ name = "foo", script_name = "foo-service", env = "production" }]
```
Where:
- `name` is the name of the binding in your worker code
- `script_name` is the script to reference
- `env` (optional) is the environment of the script to reference (e.g. `production`, `staging`, etc)

### What doesn't work?

- The API still doesn't support worker-to-worker bindings for previews, so `wrangler dev` will fail for now