### PR TITLE
Subfolder Relative Pathing Fix

### DIFF
--- a/.changeset/early-games-buy.md
+++ b/.changeset/early-games-buy.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Subfolder Relative Pathing Fix issue #147
+The filename from args didn't handle relative paths passed in from users with scripts in subfolders.
+To handle the subfolder pathing a path.relative using cwd() to user input filepath to the filepath variable passed into Dev

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -491,7 +491,7 @@ export async function main(argv: string[]): Promise<void> {
       render(
         <Dev
           name={args.name || config.name}
-          entry={filename}
+          entry={path.relative(process.cwd(), filename)}
           buildCommand={config.build || {}}
           format={format}
           initialMode={args.local ? "local" : "remote"}


### PR DESCRIPTION
Fixes issue #147 
The `filename` from args didn't handle relative paths passed in from users with scripts in subfolders.
To handle the subfolder pathing a `path.relative` using `cwd()` to user input `filepath` to the `filepath` variable passed into `Dev`