### PR TITLE
Fixed KV getNamespaceId

### DIFF
--- a/.changeset/silly-rockets-rescue.md
+++ b/.changeset/silly-rockets-rescue.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fixed KV getNamespaceId preview flag bug

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules/
 wrangler-dist/
+packages/wrangler/wrangler.toml

--- a/package-lock.json
+++ b/package-lock.json
@@ -13452,7 +13452,7 @@
       "license": "ISC"
     },
     "packages/wrangler": {
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@cloudflare/pages-functions-compiler": "0.3.8",

--- a/packages/wrangler/src/kv.tsx
+++ b/packages/wrangler/src/kv.tsx
@@ -164,10 +164,12 @@ export function getNamespaceId({
 
   // end pre-flight checks
 
-  // we're in preview mode, `--preview true` or `--preivew` was passed
+  // we're in preview mode, `--preview true` or `--preview` was passed
   if (preview && namespace.preview_id) {
     namespaceId = namespace.preview_id;
-  } else {
+    // We don't want to execute code below if preview is set to true, so we just return. Otherwise we will get errors!
+    return namespaceId;
+  } else if (preview) {
     throw new Error(
       `No preview ID found for ${binding}. Add one to your wrangler config file to use a separate namespace for previewing your worker.`
     );
@@ -180,7 +182,9 @@ export function getNamespaceId({
   // --preview false was passed
   if (previewIsDefined && namespace.id) {
     namespaceId = namespace.id;
-  } else {
+    // We don't want to execute code below if preview is set to true, so we just return. Otherwise we can get error!
+    return namespaceId;
+  } else if (previewIsDefined) {
     throw new Error(
       `No namespace ID found for ${binding}. Add one to your wrangler config file to use a separate namespace for previewing your worker.`
     );


### PR DESCRIPTION
> TL;DR; Function `getNamespaceId` in `packages/wrangler/src/kv.tsx` was completely broken and not working.
> And I added `packages/wrangler/wrangler.toml` to `.gitignore`, useful for testing manually ^^

## Description of the bug:
- If we pass no preview or preview set to false, we will get: `No preview ID found for ${binding}. Add one to your wrangler config file to use a separate namespace for previewing your worker.` error
- If we pass preview set to true we will get: `${binding} has both a namespace ID and a preview ID. Specify "--preview" or "--preview false" to avoid writing data to the wrong namespace.` error
- If we delete id from config and leave preview_id we will get `No namespace ID found for ${binding}. Add one to your wrangler config file to use a separate namespace for previewing your worker.` error
- If we delete preview_id from config and leave id we will get first error.

> To reproduce this bug you can try putting kv:key and having namespace set in wrangler.toml
> for example
> ```toml
> # wrangler.toml
> account_id="someid"
>
> [[kv_namespaces]]
> binding="KV_NS"
> id="123abc"
> preview_id="cba321"
> ```
> And execute command
> `wrangler kv:key put --binding=KV_NS  --preview "test" "test_preview"`
> Try with preview set to false and without preview, whatever you do this will fail.

## Code analysis and solution
Let's start from first check:
```ts
  // we're in preview mode, `--preview true` or `--preivew` was passed
  if (preview && namespace.preview_id) {
    namespaceId = namespace.preview_id;
  } else {
    throw new Error(
      `No preview ID found for ${binding}. Add one to your wrangler config file to use a separate namespace for previewing your worker.`
    );
  }
 ```
 In this case if preview **is not set** or is set to **false**  this section will throw error. Always. So in this case we won't be able to pass preview=false or no preview at all.
 I fixed it by changing else to `else if(preview)`, so now it will throw when it should - when preview is passed but no preview_id is set. I also added `return namespaceId` in if body, more on that later.
 
 Onto second check:
 
 ```ts
   const previewIsDefined = typeof preview !== "undefined";

  // --preview false was passed
  if (previewIsDefined && namespace.id) {
    namespaceId = namespace.id;
  } else {
    throw new Error(
      `No namespace ID found for ${binding}. Add one to your wrangler config file to use a separate namespace for previewing your worker.`
    );
  }
```
The same situation as above, if we don't pass preview it will throw error. Always. I fixed it in the same way as above, just added `else if(previewIsDefined)` as condition to throw error. Added `return namespaceId` aswell in if body.

Now about returns. If first check passed the second check was executed aswell. It was passing **_and overwritting `namespaceId` to `namespace.id` even if `preview` was set to `true`_**. If second check was passed, third check executed and obviously failed:
```ts
  const bindingHasOnlyOneId =
    (namespace.id && !namespace.preview_id) ||
    (!namespace.id && namespace.preview_id);
  if (bindingHasOnlyOneId) {
    namespaceId = namespace.id || namespace.preview_id;
  } else {
    throw new Error(
      `${binding} has both a namespace ID and a preview ID. Specify "--preview" or "--preview false" to avoid writing data to the wrong namespace.`
    );
  }
```
Failed because those condition are excluding each other, yet they're executed one by one causing errors.
So I added `return namespaceId` in two first conditions, so they won't run all if one above passed. Now it's working like a charm <3

I hope I explained bug and solution.