### PR TITLE
Refactor how we pass bindings from config to the worker upload api.

### DIFF
--- a/.changeset/young-buses-try.md
+++ b/.changeset/young-buses-try.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Refactor the way we convert configurations for bindings all the way through to the API where we upload a worker definition. This commit preserves the configuration structure (mostly) until the point we serialise it for the API. This prevents the way we use duck typing to detect a binding type when uploading, makes the types a bit simpler, and makes it easier to add other types of bindings in the future (notably, the upcoming service bindings.)

--- a/packages/wrangler/src/api/form_data.ts
+++ b/packages/wrangler/src/api/form_data.ts
@@ -36,11 +36,11 @@ interface WorkerMetadata {
   usage_model?: "bundled" | "unbound";
   migrations?: CfDurableObjectMigrations;
   bindings: (
-    | { type: "kv_namespace"; binding: string; namespace_id: string }
+    | { type: "kv_namespace"; name: string; namespace_id: string }
     | { type: "plain_text"; name: string; text: string }
     | {
-        name: string;
         type: "durable_object_namespace";
+        name: string;
         class_name: string;
         script_name?: string;
       }
@@ -67,7 +67,7 @@ export function toFormData(worker: CfWorkerInit): FormData {
 
   bindings.kv_namespaces?.forEach(({ id, binding }) => {
     metadataBindings.push({
-      binding,
+      name: binding,
       type: "kv_namespace",
       namespace_id: id,
     });

--- a/packages/wrangler/src/api/worker.ts
+++ b/packages/wrangler/src/api/worker.ts
@@ -62,6 +62,9 @@ export interface CfModule {
   type?: CfModuleType;
 }
 
+/**
+ * A map of variable names to values.
+ */
 interface CfVars {
   [key: string]: string;
 }

--- a/packages/wrangler/src/api/worker.ts
+++ b/packages/wrangler/src/api/worker.ts
@@ -62,22 +62,28 @@ export interface CfModule {
   type?: CfModuleType;
 }
 
+interface CfVars {
+  [key: string]: string;
+}
+
 /**
  * A KV namespace.
  */
-export interface CfKvNamespace {
-  /**
-   * The namespace ID.
-   */
-  namespaceId: string;
+interface CfKvNamespace {
+  binding: string;
+  id: string;
 }
 
-export interface CfDurableObject {
+/**
+ * A Durable Object.
+ */
+interface CfDurableObject {
+  name: string;
   class_name: string;
   script_name?: string;
 }
 
-interface CfDOMigrations {
+export interface CfDurableObjectMigrations {
   old_tag?: string;
   new_tag: string;
   steps: {
@@ -86,35 +92,6 @@ interface CfDOMigrations {
     deleted_classes?: string[];
   }[];
 }
-
-/**
- * A `WebCrypto` key.
- *
- * @link https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/importKey
- */
-export interface CfCryptoKey {
-  /**
-   * The format.
-   */
-  format: string;
-  /**
-   * The algorithm.
-   */
-  algorithm: string;
-  /**
-   * The usages.
-   */
-  usages: string[];
-  /**
-   * The data.
-   */
-  data: BufferSource | JsonWebKey;
-}
-
-/**
- * A variable (aka. environment variable).
- */
-export type CfVariable = string | CfKvNamespace | CfCryptoKey | CfDurableObject;
 
 /**
  * Options for creating a `CfWorker`.
@@ -133,10 +110,14 @@ export interface CfWorkerInit {
    */
   modules: void | CfModule[];
   /**
-   * The map of names to variables. (aka. environment variables)
+   * All the bindings
    */
-  variables?: { [name: string]: CfVariable };
-  migrations: void | CfDOMigrations;
+  bindings: {
+    kv_namespaces?: CfKvNamespace[];
+    durable_objects?: { bindings: CfDurableObject[] };
+    vars?: CfVars;
+  };
+  migrations: void | CfDurableObjectMigrations;
   compatibility_date: string | void;
   compatibility_flags: void | string[];
   usage_model: void | "bundled" | "unbound";

--- a/packages/wrangler/src/config.ts
+++ b/packages/wrangler/src/config.ts
@@ -29,13 +29,13 @@ export type Vars = { [key: string]: string };
 
 type Cron = string; // TODO: we should be able to parse a cron pattern with ts
 
-export type KVNamespace = {
+type KVNamespace = {
   binding: string;
   preview_id?: string;
   id: string;
 };
 
-export type DurableObject = {
+type DurableObject = {
   name: string;
   class_name: string;
   script_name?: string;

--- a/packages/wrangler/src/config.ts
+++ b/packages/wrangler/src/config.ts
@@ -1,7 +1,7 @@
 // we're going to manually write both the type definition AND
 // the validator for the config, so that we can give better error messages
 
-type DOMigration = {
+type DurableObjectMigration = {
   tag: string;
   new_classes?: string[];
   renamed_classes?: string[];
@@ -25,17 +25,17 @@ type Dev = {
   upstream_protocol?: string;
 };
 
-type Vars = { [key: string]: string };
+export type Vars = { [key: string]: string };
 
 type Cron = string; // TODO: we should be able to parse a cron pattern with ts
 
-type KVNamespace = {
-  binding?: string;
-  preview_id: string;
+export type KVNamespace = {
+  binding: string;
+  preview_id?: string;
   id: string;
 };
 
-type DurableObject = {
+export type DurableObject = {
   name: string;
   class_name: string;
   script_name?: string;
@@ -108,7 +108,7 @@ export type Config = {
   jsx_factory?: string; // inherited
   jsx_fragment?: string; // inherited
   vars?: Vars;
-  migrations?: DOMigration[];
+  migrations?: DurableObjectMigration[];
   durable_objects?: { bindings: DurableObject[] };
   kv_namespaces?: KVNamespace[];
   site?: Site; // inherited

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -335,7 +335,14 @@ function useLocalWorker(props: {
         removeSignalExitListener.current = undefined;
       }
     };
-  }, [bundle, format, port]);
+  }, [
+    bundle,
+    format,
+    port,
+    bindings.durable_objects?.bindings,
+    bindings.kv_namespaces,
+    bindings.vars,
+  ]);
   return { inspectorUrl };
 }
 
@@ -632,6 +639,8 @@ function useWorker(props: {
     compatibilityDate,
     compatibilityFlags,
     usageModel,
+    bindings,
+    modules,
   ]);
   return token;
 }

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -9,7 +9,7 @@ import React, { useState, useEffect, useRef } from "react";
 import path from "path";
 import open from "open";
 import { DtInspector } from "./api/inspect";
-import type { CfModule, CfVariable } from "./api/worker";
+import type { CfModule } from "./api/worker";
 import { createWorker } from "./api/worker";
 import type { CfWorkerInit } from "./api/worker";
 import { spawn } from "child_process";
@@ -38,7 +38,7 @@ type Props = {
   initialMode: "local" | "remote";
   jsxFactory: void | string;
   jsxFragment: void | string;
-  variables: { [name: string]: CfVariable };
+  bindings: CfWorkerInit["bindings"];
   public: void | string;
   site: void | string;
   compatibilityDate: void | string;
@@ -99,7 +99,7 @@ function Dev(props: Props): JSX.Element {
           name={props.name}
           bundle={bundle}
           format={props.format}
-          variables={props.variables}
+          bindings={props.bindings}
           site={props.site}
           public={props.public}
           port={props.port}
@@ -111,7 +111,7 @@ function Dev(props: Props): JSX.Element {
           format={props.format}
           accountId={props.accountId}
           apiToken={apiToken}
-          variables={props.variables}
+          bindings={props.bindings}
           site={props.site}
           public={props.public}
           port={props.port}
@@ -172,7 +172,7 @@ function Remote(props: {
   port: number;
   accountId: void | string;
   apiToken: void | string;
-  variables: { [name: string]: CfVariable };
+  bindings: CfWorkerInit["bindings"];
   compatibilityDate: string | void;
   compatibilityFlags: void | string[];
   usageModel: void | "bundled" | "unbound";
@@ -186,7 +186,7 @@ function Remote(props: {
     modules: props.bundle ? props.bundle.modules : [],
     accountId: props.accountId,
     apiToken: props.apiToken,
-    variables: props.variables,
+    bindings: props.bindings,
     sitesFolder: props.site,
     port: props.port,
     compatibilityDate: props.compatibilityDate,
@@ -203,7 +203,7 @@ function Local(props: {
   name: void | string;
   bundle: EsbuildBundle | void;
   format: CfScriptFormat;
-  variables: { [name: string]: CfVariable };
+  bindings: CfWorkerInit["bindings"];
   public: void | string;
   site: void | string;
   port: number;
@@ -212,7 +212,7 @@ function Local(props: {
     name: props.name,
     bundle: props.bundle,
     format: props.format,
-    variables: props.variables,
+    bindings: props.bindings,
     port: props.port,
   });
   useInspector(inspectorUrl);
@@ -223,11 +223,11 @@ function useLocalWorker(props: {
   name: void | string;
   bundle: EsbuildBundle | void;
   format: CfScriptFormat;
-  variables: { [name: string]: CfVariable };
+  bindings: CfWorkerInit["bindings"];
   port: number;
 }) {
   // TODO: pass vars via command line
-  const { bundle, format, variables, port } = props;
+  const { bundle, format, bindings, port } = props;
   const local = useRef<ReturnType<typeof spawn>>();
   const removeSignalExitListener = useRef<() => void>();
   const [inspectorUrl, setInspectorUrl] = useState<string | void>();
@@ -264,20 +264,17 @@ function useLocalWorker(props: {
         "--kv-persist",
         "--cache-persist",
         "--do-persist",
-        ...Object.entries(variables)
-          .map(([varKey, varVal]) => {
-            if (typeof varVal === "string") {
-              return `--binding ${varKey}=${varVal}`;
-            } else if (
-              "namespaceId" in varVal &&
-              typeof varVal.namespaceId === "string"
-            ) {
-              return `--kv ${varKey}`;
-            } else if ("class_name" in varVal) {
-              return `--do ${varKey}=${varVal.class_name}`;
-            }
-          })
-          .filter(Boolean),
+        ...Object.entries(bindings.vars || {}).map(([key, value]) => {
+          return `--binding ${key}=${value}`;
+        }),
+        ...(bindings.kv_namespaces || []).map(({ binding }) => {
+          return `--kv ${binding}`;
+        }),
+        ...(bindings.durable_objects?.bindings || []).map(
+          ({ name, class_name }) => {
+            return `--do ${name}=${class_name}`;
+          }
+        ),
         "--modules",
         format ||
         (bundle.type === "esm" ? "modules" : "service-worker") === "modules"
@@ -372,8 +369,6 @@ function useTmpDir(): string | void {
   }, [handleError]);
   return directory?.path;
 }
-
-function runCommand() {}
 
 function useCustomBuild(
   expectedEntry: string,
@@ -528,7 +523,7 @@ function useWorker(props: {
   modules: CfModule[];
   accountId: string;
   apiToken: string;
-  variables: { [name: string]: CfVariable };
+  bindings: CfWorkerInit["bindings"];
   sitesFolder: void | string;
   port: number;
   compatibilityDate: string | void;
@@ -542,7 +537,7 @@ function useWorker(props: {
     modules,
     accountId,
     apiToken,
-    variables,
+    bindings,
     sitesFolder,
     compatibilityDate,
     compatibilityFlags,
@@ -591,19 +586,23 @@ function useWorker(props: {
           type: format || bundle.type === "esm" ? "esm" : "commonjs",
           content,
         },
-        modules: assets.manifest
-          ? modules.concat({
-              name: "__STATIC_CONTENT_MANIFEST",
-              content: JSON.stringify(assets.manifest),
-              type: "text",
-            })
-          : modules,
-        variables: assets.namespace
-          ? {
-              ...variables,
-              __STATIC_CONTENT: { namespaceId: assets.namespace },
-            }
-          : variables,
+        modules: modules.concat(
+          assets.manifest
+            ? {
+                name: "__STATIC_CONTENT_MANIFEST",
+                content: JSON.stringify(assets.manifest),
+                type: "text",
+              }
+            : []
+        ),
+        bindings: {
+          ...bindings,
+          kv_namespaces: (bindings.kv_namespaces || []).concat(
+            assets.namespace
+              ? { binding: "__STATIC_CONTENT", id: assets.namespace }
+              : []
+          ),
+        },
         migrations: undefined, // no migrations in dev
         compatibility_date: compatibilityDate,
         compatibility_flags: compatibilityFlags,


### PR DESCRIPTION
There are 3 types of 'bindings' that we upload with a worker definition: `vars`, `kv_namespaces`, and `durable_objects`. These are configured in `wrangler.toml`, and get passed through to the api that uploads a worker definition (in `form_data.ts`), when using `dev` and `publish` commands.

We currently serialise it as a big `variables` object, where the key of the objects defines the binding "name", and the value contains information to be bound. (https://github.com/cloudflare/wrangler2/blob/0330ecf1b54c92dfe86cb3f38394f453ed418381/packages/wrangler/src/index.tsx#L507-L530) This code sucks for many reasons: it loses some type information, hard to read/grok, hard to add new types of bindings, and mostly it's unnecessary.

This PR refactors this code to instead mostly preserve the configuration style structure all the way until we actually serialise it when uploading a worker definition. I also added some more types along the way, and cleared some dead code.

I will follow up this PR with 2 PRs soon: one, which introduces service bindings (as a fresh take on https://github.com/cloudflare/wrangler2/pull/156), and another one that introduces tests for configuration.


--- 

I'm currently testing this manually locally as extensively as I can, but opening up the PR to get some eyes on it since it touches a bunch of moving parts. 