### PR TITLE
Experimental worker-to-worker bindings support

### DIFF
--- a/.changeset/shiny-crews-warn.md
+++ b/.changeset/shiny-crews-warn.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Add experimental support for worker-to-worker service bindings. This introduces a new field in configuration `experimental_services`, and serialises it when creating and uploading a worker definition. This is highly experimental, and doesn't work with `wrangler dev` yet.

--- a/packages/wrangler/src/api/form_data.ts
+++ b/packages/wrangler/src/api/form_data.ts
@@ -44,6 +44,12 @@ interface WorkerMetadata {
         class_name: string;
         script_name?: string;
       }
+    | {
+        type: "service";
+        name: string;
+        script_name: string;
+        environment: string;
+      }
   )[];
 }
 
@@ -86,6 +92,15 @@ export function toFormData(worker: CfWorkerInit): FormData {
 
   Object.entries(bindings.vars || {})?.forEach(([key, value]) => {
     metadataBindings.push({ name: key, type: "plain_text", text: value });
+  });
+
+  bindings.services?.forEach(({ name, script_name, environment }) => {
+    metadataBindings.push({
+      name,
+      type: "service",
+      script_name,
+      environment,
+    });
   });
 
   const metadata: WorkerMetadata = {

--- a/packages/wrangler/src/api/form_data.ts
+++ b/packages/wrangler/src/api/form_data.ts
@@ -36,11 +36,11 @@ interface WorkerMetadata {
   usage_model?: "bundled" | "unbound";
   migrations?: CfDurableObjectMigrations;
   bindings: (
-    | { type: "kv_namespace"; binding: string; namespace_id: string }
+    | { type: "kv_namespace"; name: string; namespace_id: string }
     | { type: "plain_text"; name: string; text: string }
     | {
-        name: string;
         type: "durable_object_namespace";
+        name: string;
         class_name: string;
         script_name?: string;
       }
@@ -67,7 +67,7 @@ export function toFormData(worker: CfWorkerInit): FormData {
 
   bindings.kv_namespaces?.forEach(({ id, binding }) => {
     metadataBindings.push({
-      binding,
+      name: binding,
       type: "kv_namespace",
       namespace_id: id,
     });

--- a/packages/wrangler/src/api/form_data.ts
+++ b/packages/wrangler/src/api/form_data.ts
@@ -36,11 +36,11 @@ interface WorkerMetadata {
   usage_model?: "bundled" | "unbound";
   migrations?: CfDurableObjectMigrations;
   bindings: (
-    | { type: "kv_namespace"; name: string; namespace_id: string }
+    | { type: "kv_namespace"; binding: string; namespace_id: string }
     | { type: "plain_text"; name: string; text: string }
     | {
-        type: "durable_object_namespace";
         name: string;
+        type: "durable_object_namespace";
         class_name: string;
         script_name?: string;
       }
@@ -67,7 +67,7 @@ export function toFormData(worker: CfWorkerInit): FormData {
 
   bindings.kv_namespaces?.forEach(({ id, binding }) => {
     metadataBindings.push({
-      name: binding,
+      binding,
       type: "kv_namespace",
       namespace_id: id,
     });

--- a/packages/wrangler/src/api/form_data.ts
+++ b/packages/wrangler/src/api/form_data.ts
@@ -47,7 +47,7 @@ interface WorkerMetadata {
     | {
         type: "service";
         name: string;
-        script_name: string;
+        service: string;
         environment: string;
       }
   )[];
@@ -94,11 +94,11 @@ export function toFormData(worker: CfWorkerInit): FormData {
     metadataBindings.push({ name: key, type: "plain_text", text: value });
   });
 
-  bindings.services?.forEach(({ name, script_name, environment }) => {
+  bindings.services?.forEach(({ name, service, environment }) => {
     metadataBindings.push({
       name,
       type: "service",
-      script_name,
+      service,
       environment,
     });
   });

--- a/packages/wrangler/src/api/worker.ts
+++ b/packages/wrangler/src/api/worker.ts
@@ -86,6 +86,15 @@ interface CfDurableObject {
   script_name?: string;
 }
 
+/**
+ * A Service.
+ */
+interface CfService {
+  name: string;
+  script_name: string;
+  environment: string;
+}
+
 export interface CfDurableObjectMigrations {
   old_tag?: string;
   new_tag: string;
@@ -119,6 +128,7 @@ export interface CfWorkerInit {
     kv_namespaces?: CfKvNamespace[];
     durable_objects?: { bindings: CfDurableObject[] };
     vars?: CfVars;
+    services?: CfService[];
   };
   migrations: void | CfDurableObjectMigrations;
   compatibility_date: string | void;

--- a/packages/wrangler/src/api/worker.ts
+++ b/packages/wrangler/src/api/worker.ts
@@ -61,7 +61,6 @@ export interface CfModule {
    */
   type?: CfModuleType;
 }
-
 /**
  * A map of variable names to values.
  */

--- a/packages/wrangler/src/api/worker.ts
+++ b/packages/wrangler/src/api/worker.ts
@@ -61,6 +61,7 @@ export interface CfModule {
    */
   type?: CfModuleType;
 }
+
 /**
  * A map of variable names to values.
  */

--- a/packages/wrangler/src/api/worker.ts
+++ b/packages/wrangler/src/api/worker.ts
@@ -91,7 +91,7 @@ interface CfDurableObject {
  */
 interface CfService {
   name: string;
-  script_name: string;
+  service: string;
   environment: string;
 }
 

--- a/packages/wrangler/src/config.ts
+++ b/packages/wrangler/src/config.ts
@@ -41,6 +41,12 @@ type DurableObject = {
   script_name?: string;
 };
 
+type Service = {
+  name: string;
+  script_name: string;
+  environment: string;
+};
+
 type Build = {
   command?: string;
   cwd?: string;
@@ -86,6 +92,8 @@ type Env = {
   vars?: Vars;
   durable_objects?: { bindings: DurableObject[] };
   kv_namespaces?: KVNamespace[];
+  experimental_services?: Service[];
+  migrations?: DurableObjectMigration[];
   usage_model?: UsageModel; // inherited
 };
 
@@ -108,9 +116,10 @@ export type Config = {
   jsx_factory?: string; // inherited
   jsx_fragment?: string; // inherited
   vars?: Vars;
-  migrations?: DurableObjectMigration[];
   durable_objects?: { bindings: DurableObject[] };
   kv_namespaces?: KVNamespace[];
+  experimental_services?: Service[];
+  migrations?: DurableObjectMigration[];
   site?: Site; // inherited
   // we should use typescript to parse cron patterns
   triggers?: { crons: Cron[] }; // inherited

--- a/packages/wrangler/src/config.ts
+++ b/packages/wrangler/src/config.ts
@@ -35,7 +35,7 @@ type KVNamespace = {
   id: string;
 };
 
-type DurableObject = {
+export type DurableObject = {
   name: string;
   class_name: string;
   script_name?: string;

--- a/packages/wrangler/src/config.ts
+++ b/packages/wrangler/src/config.ts
@@ -43,7 +43,7 @@ type DurableObject = {
 
 type Service = {
   name: string;
-  script_name: string;
+  service: string;
   environment: string;
 };
 

--- a/packages/wrangler/src/config.ts
+++ b/packages/wrangler/src/config.ts
@@ -35,7 +35,7 @@ type KVNamespace = {
   id: string;
 };
 
-export type DurableObject = {
+type DurableObject = {
   name: string;
   class_name: string;
   script_name?: string;

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -79,7 +79,12 @@ async function readConfig(path?: string): Promise<Config> {
     });
   });
 
-  const mirroredFields = ["vars", "kv_namespaces", "durable_objects"];
+  const mirroredFields = [
+    "vars",
+    "kv_namespaces",
+    "durable_objects",
+    "experimental_services",
+  ];
   Object.keys(config.env || {}).forEach((env) => {
     mirroredFields.forEach((field) => {
       // if it exists on top level, it should exist on env defns
@@ -92,6 +97,12 @@ async function readConfig(path?: string): Promise<Config> {
       });
     });
   });
+
+  if ("experimental_services" in config) {
+    console.warn(
+      "The experimental_services field is only for cloudflare internal usage right now, and is subject to change. Please do not use this on production projects"
+    );
+  }
 
   // todo: validate, add defaults
   // let's just do some basics for now
@@ -528,6 +539,7 @@ export async function main(argv: string[]): Promise<void> {
             ),
             vars: envRootObj.vars,
             durable_objects: envRootObj.durable_objects,
+            services: envRootObj.experimental_services,
           }}
         />
       );

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -209,6 +209,7 @@ export default async function publish(props: Props): Promise<void> {
     ),
     vars: envRootObj.vars,
     durable_objects: envRootObj.durable_objects,
+    services: envRootObj.experimental_services,
   };
 
   const worker: CfWorkerInit = {


### PR DESCRIPTION
Adds support for experimental worker-to-worker bindings, letting you call a worker from another worker. The Wrangler config field looks like follows:

```toml
services = [{ name = "foo", script_name = "foo-service", environment = "production" }]
```
Where:
- `name` is the name of the binding in your worker code
- `script_name` is the script to reference
- `environment` is the environment of the script to reference (e.g. `production`, `staging`, etc)

### What doesn't work?

- The API still doesn't support worker-to-worker bindings for previews, so `wrangler dev` will fail for now

### Differences from #156

This PR is based in #156, with a few changes -

- the configuration field `env` is renamed to `environment` (we want to move away from short forms like `env`)
- the configuration field `environment` is not an optional field (because we want to explicitly bind to environments, or folks could accidentally mess with production data)
- the configuration field services is called `experimental_services` so it's clear on usage that this is not ready for production usage yet, and is only for our internal testing. We also log a warning when we see the field.