### PR TITLE
Add built to tests

### DIFF
--- a/.github/workflows/tests-typecheck.yml
+++ b/.github/workflows/tests-typecheck.yml
@@ -1,4 +1,4 @@
-name: Tests, Linter & Typecheck
+name: Tests, Linter, Typecheck & Build
 
 on: [push, pull_request]
 
@@ -31,3 +31,7 @@ jobs:
 
       - name: Test
         run: npm run test
+
+      - name: Build
+        run: npm run build
+        working-directory: packages/wrangler

--- a/.github/workflows/tests-typecheck.yml
+++ b/.github/workflows/tests-typecheck.yml
@@ -26,12 +26,8 @@ jobs:
       - name: Install NPM Dependencies
         run: npm install
 
-      - name: Run Type Checking & ESLint
+      - name: Run Prettier, Type Checking, ESLint & Build
         run: npm run check
 
       - name: Test
         run: npm run test
-
-      - name: Build
-        run: npm run build
-        working-directory: packages/wrangler

--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
   },
   "scripts": {
     "lint": "eslint packages/**",
-    "check": "prettier packages/** --check && tsc && npm run lint",
+    "check": "prettier packages/** --check && tsc && npm run lint && npm run build",
     "prettify": "prettier packages/** --write",
+    "build": "npm run build --workspace=wrangler",
     "test": "npm run test --workspace=wrangler"
   },
   "engines": {


### PR DESCRIPTION
By adding the build step to this test workflow, we can ensure that we don't ever merge anything that breaks the main branch and its auto release workflow.