### PR TITLE
pass bindings correctly to miniflare in `dev`

### DIFF
--- a/.changeset/sharp-humans-reply.md
+++ b/.changeset/sharp-humans-reply.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Pass bindings correctly to miniflare/child_process.spawn in `dev`, to prevent miniflare from erroring out on startup

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -264,15 +264,15 @@ function useLocalWorker(props: {
         "--kv-persist",
         "--cache-persist",
         "--do-persist",
-        ...Object.entries(bindings.vars || {}).map(([key, value]) => {
-          return `--binding ${key}=${value}`;
+        ...Object.entries(bindings.vars || {}).flatMap(([key, value]) => {
+          return ["--binding", `${key}=${value}`];
         }),
-        ...(bindings.kv_namespaces || []).map(({ binding }) => {
-          return `--kv ${binding}`;
+        ...(bindings.kv_namespaces || []).flatMap(({ binding }) => {
+          return ["--kv", binding];
         }),
-        ...(bindings.durable_objects?.bindings || []).map(
+        ...(bindings.durable_objects?.bindings || []).flatMap(
           ({ name, class_name }) => {
-            return `--do ${name}=${class_name}`;
+            return ["--do", `${name}=${class_name}`];
           }
         ),
         "--modules",
@@ -289,15 +289,15 @@ function useLocalWorker(props: {
         }
       });
 
-      local.current.stdout.on("data", (_data: string) => {
-        // console.log(`stdout: ${data}`);
+      local.current.stdout.on("data", (data: Buffer) => {
+        console.log(`${data.toString()}`);
       });
 
-      local.current.stderr.on("data", (data: string) => {
-        // console.error(`stderr: ${data}`);
+      local.current.stderr.on("data", (data: Buffer) => {
+        console.error(`${data.toString()}`);
         const matches =
           /Debugger listening on (ws:\/\/127\.0\.0\.1:9229\/[A-Za-z0-9-]+)/.exec(
-            data
+            data.toString()
           );
         if (matches) {
           setInspectorUrl(matches[1]);


### PR DESCRIPTION
When calling miniflare in `dev,` the bindings are incorrectly passed into the process that's spawned; each arg needs to be a separate element in the args array to the spawn call. This PR fixes that. It also enables logs on the miniflare process. (They're a bit noisy, but we can make that better separately.)

I'm personally annoyed because I can swear this was working previously, but without tests that's just my word against... my own word, lol.

fixes #172