### PR TITLE
Add a new line to the generated package.json in the prerelease script

### DIFF
--- a/.github/version-script.js
+++ b/.github/version-script.js
@@ -13,7 +13,7 @@ try {
     package.version = "0.0.0-" + stdout.trim();
     fs.writeFileSync(
       "./packages/wrangler/package.json",
-      JSON.stringify(package, null, 2)
+      JSON.stringify(package, null, 2) + "\n"
     );
   });
 } catch (error) {


### PR DESCRIPTION
We now check for lint fails before we publish to npm (via https://github.com/cloudflare/wrangler2/pull/175). The script that rewrites `pacakges/wrangler/package.json` doesn't add a newline to the end oft he generated file, which makes `prettier --check` fail. This PR adds that newline, and should make the script pass.