### PR TITLE
enable eslint's `no-shadow` rule

### DIFF
--- a/.changeset/large-guests-retire.md
+++ b/.changeset/large-guests-retire.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+chore: enable eslint's no-shadow rule

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
           "@typescript-eslint/consistent-type-imports": [
             "error"
           ],
+          "no-shadow": "warn",
           "@typescript-eslint/no-floating-promises": "error",
           "no-empty": "off",
           "require-yield": "off",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
           "@typescript-eslint/consistent-type-imports": [
             "error"
           ],
-          "no-shadow": "warn",
+          "no-shadow": "error",
           "@typescript-eslint/no-floating-promises": "error",
           "no-empty": "off",
           "require-yield": "off",

--- a/packages/wrangler/src/api/form_data.ts
+++ b/packages/wrangler/src/api/form_data.ts
@@ -67,7 +67,6 @@ export function toFormData(worker: CfWorkerInit): FormData {
     compatibility_date,
     compatibility_flags,
   } = worker;
-  const { name, type: mainType } = main;
 
   const metadataBindings: WorkerMetadata["bindings"] = [];
 
@@ -104,7 +103,9 @@ export function toFormData(worker: CfWorkerInit): FormData {
   });
 
   const metadata: WorkerMetadata = {
-    ...(mainType !== "commonjs" ? { main_module: name } : { body_part: name }),
+    ...(main.type !== "commonjs"
+      ? { main_module: main.name }
+      : { body_part: main.name }),
     bindings: metadataBindings,
     ...(compatibility_date && { compatibility_date }),
     ...(compatibility_flags && { compatibility_flags }),
@@ -114,7 +115,7 @@ export function toFormData(worker: CfWorkerInit): FormData {
 
   formData.set("metadata", JSON.stringify(metadata));
 
-  if (mainType === "commonjs" && modules && modules.length > 0) {
+  if (main.type === "commonjs" && modules && modules.length > 0) {
     throw new TypeError(
       "More than one module can only be specified when type = 'esm'"
     );
@@ -122,7 +123,7 @@ export function toFormData(worker: CfWorkerInit): FormData {
 
   for (const module of [main].concat(modules || [])) {
     const { name } = module;
-    const blob = toModule(module, mainType ?? "esm");
+    const blob = toModule(module, main.type ?? "esm");
     formData.set(name, blob, name);
   }
 

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -658,7 +658,6 @@ function useProxy({
   publicRoot: void | string;
   port: number;
 }) {
-  // const tokenRef = useRef<void |{host:string, value:string}>(token);
   useEffect(() => {
     if (!token) return;
     // TODO(soon): since headers are added in callbacks, the server

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -491,7 +491,10 @@ function useEsbuild(props: {
             else {
               // nothing really changes here, so let's increment the id
               // to change the return object's identity
-              setBundle((bundle) => ({ ...bundle, id: bundle.id + 1 }));
+              setBundle((previousBundle) => ({
+                ...previousBundle,
+                id: previousBundle.id + 1,
+              }));
             }
           },
         },
@@ -655,6 +658,7 @@ function useProxy({
   publicRoot: void | string;
   port: number;
 }) {
+  // const tokenRef = useRef<void |{host:string, value:string}>(token);
   useEffect(() => {
     if (!token) return;
     // TODO(soon): since headers are added in callbacks, the server
@@ -818,31 +822,24 @@ function useHotkeys(initial: useHotkeysInitialState, port: number) {
     ) => {
       switch (input) {
         case "b": // open browser
-          await open(
-            `http://localhost:${port}/`
-            // {
-            //   app: {
-            //     name: open.apps.chrome, // TODO: fallback on other browsers
-            //   },
-            // }
-          );
+          await open(`http://localhost:${port}/`);
           break;
         case "d": // toggle inspector
           await open(
             `https://built-devtools.pages.dev/js_app?experiments=true&v8only=true&ws=localhost:9229/ws`
-            // {
-            //   app: {
-            //     name: open.apps.chrome,
-            //     // todo - add firefox and edge fallbacks
-            //   },
-            // }
           );
           break;
         case "s": // toggle tunnel
-          setToggles((toggles) => ({ ...toggles, tunnel: !toggles.tunnel }));
+          setToggles((previousToggles) => ({
+            ...previousToggles,
+            tunnel: !previousToggles.tunnel,
+          }));
           break;
         case "l": // toggle local
-          setToggles((toggles) => ({ ...toggles, local: !toggles.local }));
+          setToggles((previousToggles) => ({
+            ...previousToggles,
+            local: !previousToggles.local,
+          }));
           break;
         case "q": // shut down
         case "x": // shut down

--- a/packages/wrangler/src/dialogs.tsx
+++ b/packages/wrangler/src/dialogs.tsx
@@ -67,9 +67,9 @@ export async function prompt(text: string, type: "text" | "password" = "text") {
       <Prompt
         text={text}
         type={type}
-        onSubmit={(text) => {
+        onSubmit={(inputText) => {
           unmount();
-          resolve(text);
+          resolve(inputText);
         }}
       />
     );

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -3,7 +3,8 @@ import { render } from "ink";
 import Dev from "./dev";
 import { readFile } from "node:fs/promises";
 import makeCLI from "yargs";
-import type yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+import type Yargs from "yargs";
 import { findUp } from "find-up";
 import TOML from "@iarna/toml";
 import type { Config } from "./config";
@@ -43,15 +44,15 @@ import { setTimeout } from "node:timers/promises";
 import * as fs from "node:fs";
 import { execa } from "execa";
 
-async function readConfig(path?: string): Promise<Config> {
+async function readConfig(configPath?: string): Promise<Config> {
   const config: Config = {};
-  if (!path) {
-    path = await findUp("wrangler.toml");
+  if (!configPath) {
+    configPath = await findUp("wrangler.toml");
     // TODO - terminate this early instead of going all the way to the root
   }
 
-  if (path) {
-    const tml: string = await readFile(path, "utf-8");
+  if (configPath) {
+    const tml: string = await readFile(configPath, "utf-8");
     const parsed = TOML.parse(tml) as Config;
     Object.assign(config, parsed);
   }
@@ -109,7 +110,7 @@ async function readConfig(path?: string): Promise<Config> {
   // let's just do some basics for now
 
   // @ts-expect-error we're being sneaky here for now
-  config.__path__ = path;
+  config.__path__ = configPath;
 
   return config;
 }
@@ -117,7 +118,7 @@ async function readConfig(path?: string): Promise<Config> {
 // a helper to demand one of a set of options
 // via https://github.com/yargs/yargs/issues/1093#issuecomment-491299261
 function demandOneOfOption(...options: string[]) {
-  return function (argv: yargs.Arguments) {
+  return function (argv: Yargs.Arguments) {
     const count = options.filter((option) => argv[option]).length;
     const lastOption = options.pop();
 
@@ -144,7 +145,7 @@ class DeprecationError extends Error {}
 class NotImplementedError extends Error {}
 
 export async function main(argv: string[]): Promise<void> {
-  const yargs = makeCLI(argv)
+  const wrangler = makeCLI(argv)
     // We handle errors ourselves in a try-catch around `yargs.parse`.
     // If you want the "help info" to be displayed then throw an instance of `CommandLineArgsError`.
     // Otherwise we just log the error that was thrown without any "help info".
@@ -160,7 +161,7 @@ export async function main(argv: string[]): Promise<void> {
     .wrap(null);
 
   // the default is to simply print the help menu
-  yargs.command(
+  wrangler.command(
     ["*"],
     false,
     () => {},
@@ -168,7 +169,7 @@ export async function main(argv: string[]): Promise<void> {
       if (args._.length > 0) {
         throw new CommandLineArgsError(`Unknown command: ${args._}.`);
       } else {
-        yargs.showHelp("log");
+        wrangler.showHelp("log");
       }
     }
   );
@@ -181,7 +182,7 @@ export async function main(argv: string[]): Promise<void> {
   // (It's also annoying that choices[] doesn't get inferred as an enum. 🤷‍♂.)
 
   // [DEPRECATED] generate
-  yargs.command(
+  wrangler.command(
     // we definitely want to move away from us cloning github templates
     // we can do something better here, let's see
     "generate [name] [template]",
@@ -206,7 +207,7 @@ export async function main(argv: string[]): Promise<void> {
   );
 
   // init
-  yargs.command(
+  wrangler.command(
     "init [name]",
     "📥 Create a wrangler.toml configuration file",
     (yargs) => {
@@ -320,7 +321,7 @@ export async function main(argv: string[]): Promise<void> {
   );
 
   // build
-  yargs.command(
+  wrangler.command(
     "build",
     false,
     (yargs) => {
@@ -337,7 +338,7 @@ export async function main(argv: string[]): Promise<void> {
   );
 
   // login
-  yargs.command(
+  wrangler.command(
     // this needs scopes as an option?
     "login",
     false, // we don't need to show this in the menu
@@ -380,7 +381,7 @@ export async function main(argv: string[]): Promise<void> {
   );
 
   // logout
-  yargs.command(
+  wrangler.command(
     // this needs scopes as an option?
     "logout",
     false, // we don't need to show this in the menu
@@ -392,7 +393,7 @@ export async function main(argv: string[]): Promise<void> {
   );
 
   // whoami
-  yargs.command(
+  wrangler.command(
     "whoami",
     false, // we don't need to show this the menu
     // "🕵️  Retrieve your user info and test your auth config",
@@ -403,7 +404,7 @@ export async function main(argv: string[]): Promise<void> {
   );
 
   // config
-  yargs.command(
+  wrangler.command(
     "config",
     false,
     () => {},
@@ -416,7 +417,7 @@ export async function main(argv: string[]): Promise<void> {
   );
 
   // dev
-  yargs.command(
+  wrangler.command(
     "dev <filename>",
     "👂 Start a local server for developing your worker",
     (yargs) => {
@@ -562,7 +563,7 @@ export async function main(argv: string[]): Promise<void> {
   );
 
   // publish
-  yargs.command(
+  wrangler.command(
     "publish [script]",
     "🆙 Publish your Worker to Cloudflare.",
     (yargs) => {
@@ -654,7 +655,7 @@ export async function main(argv: string[]): Promise<void> {
   );
 
   // tail
-  yargs.command(
+  wrangler.command(
     "tail [name]",
     "🦚 Starts a log tailing session for a deployed Worker.",
     (yargs) => {
@@ -770,7 +771,7 @@ export async function main(argv: string[]): Promise<void> {
   );
 
   // preview
-  yargs.command(
+  wrangler.command(
     "preview [method] [body]",
     false,
     (yargs) => {
@@ -804,12 +805,12 @@ export async function main(argv: string[]): Promise<void> {
   );
 
   // route
-  yargs.command(
+  wrangler.command(
     "route",
     false, // I think we want to hide this command
     // "➡️  List or delete worker routes",
-    (yargs) => {
-      return yargs
+    (routeYargs) => {
+      return routeYargs
         .command(
           "list",
           "List a route associated with a zone",
@@ -876,7 +877,7 @@ export async function main(argv: string[]): Promise<void> {
   );
 
   // subdomain
-  yargs.command(
+  wrangler.command(
     "subdomain [name]",
     false,
     // "👷 Create or change your workers.dev subdomain.",
@@ -891,11 +892,11 @@ export async function main(argv: string[]): Promise<void> {
   );
 
   // secret
-  yargs.command(
+  wrangler.command(
     "secret",
     "🤫 Generate a secret that can be referenced in the worker script",
-    (yargs) => {
-      return yargs
+    (secretYargs) => {
+      return secretYargs
         .command(
           "put <key>",
           "Create or update a secret variable for a script",
@@ -1126,11 +1127,11 @@ export async function main(argv: string[]): Promise<void> {
 
   // kv
   // :namespace
-  yargs.command(
+  wrangler.command(
     "kv:namespace",
     "🗂️  Interact with your Workers KV Namespaces",
-    (yargs) => {
-      return yargs
+    (namespaceYargs) => {
+      return namespaceYargs
         .command(
           "create <namespace>",
           "Create a new namespace",
@@ -1361,11 +1362,11 @@ export async function main(argv: string[]): Promise<void> {
   );
 
   // :key
-  yargs.command(
+  wrangler.command(
     "kv:key",
     "🔑 Individually manage Workers KV key-value pairs",
-    (yargs) => {
-      return yargs
+    (kvKeyYargs) => {
+      return kvKeyYargs
         .command(
           "put <key> [value]",
           "Writes a single key/value pair to the given namespace.",
@@ -1684,11 +1685,11 @@ export async function main(argv: string[]): Promise<void> {
   );
 
   // :bulk
-  yargs.command(
+  wrangler.command(
     "kv:bulk",
     "💪 Interact with multiple Workers KV key-value pairs at once",
-    (yargs) => {
-      return yargs
+    (kvBulkYargs) => {
+      return kvBulkYargs
         .command(
           "put <filename>",
           "Upload multiple key-value pairs to a namespace",
@@ -1864,9 +1865,9 @@ export async function main(argv: string[]): Promise<void> {
     }
   );
 
-  yargs.command("pages", "⚡️ Configure Cloudflare Pages", pages);
+  wrangler.command("pages", "⚡️ Configure Cloudflare Pages", pages);
 
-  yargs
+  wrangler
     .option("config", {
       alias: "c",
       describe: "Path to .toml configuration file",
@@ -1882,18 +1883,18 @@ export async function main(argv: string[]): Promise<void> {
       default: false, // I bet this will a point of contention. We'll revisit it.
     });
 
-  yargs.group(["config", "help", "version"], "Flags:");
-  yargs.help().alias("h", "help");
-  yargs.version(wranglerVersion).alias("v", "version");
-  yargs.exitProcess(false);
+  wrangler.group(["config", "help", "version"], "Flags:");
+  wrangler.help().alias("h", "help");
+  wrangler.version(wranglerVersion).alias("v", "version");
+  wrangler.exitProcess(false);
 
   await initialiseUserConfig();
 
   try {
-    await yargs.parse();
+    await wrangler.parse();
   } catch (e) {
     if (e instanceof CommandLineArgsError) {
-      yargs.showHelp("error");
+      wrangler.showHelp("error");
       console.error(""); // Just adds a bit of space
     }
     console.error(e.message);

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -3,7 +3,6 @@ import { render } from "ink";
 import Dev from "./dev";
 import { readFile } from "node:fs/promises";
 import makeCLI from "yargs";
-import { hideBin } from "yargs/helpers";
 import type Yargs from "yargs";
 import { findUp } from "find-up";
 import TOML from "@iarna/toml";

--- a/packages/wrangler/src/kv.tsx
+++ b/packages/wrangler/src/kv.tsx
@@ -190,9 +190,7 @@ export function getNamespaceId({
     );
   }
 
-  const namespace = config.kv_namespaces.find(
-    (namespace) => namespace.binding === binding
-  );
+  const namespace = config.kv_namespaces.find((ns) => ns.binding === binding);
 
   // we couldn't find a namespace with that binding
   if (!namespace) {

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable no-shadow */
+
 import type { BuilderCallback } from "yargs";
 import { join } from "path";
 import { tmpdir } from "os";

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -158,7 +158,7 @@ export default async function publish(props: Props): Promise<void> {
     const scripts = await cfetch<{ id: string; migration_tag: string }[]>(
       `/accounts/${accountId}/workers/scripts`
     );
-    const script = scripts.find((script) => script.id === scriptName);
+    const script = scripts.find((scr) => scr.id === scriptName);
     if (script?.migration_tag) {
       // was already published once
       const foundIndex = config.migrations.findIndex(

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -158,7 +158,7 @@ export default async function publish(props: Props): Promise<void> {
     const scripts = await cfetch<{ id: string; migration_tag: string }[]>(
       `/accounts/${accountId}/workers/scripts`
     );
-    const script = scripts.find((scr) => scr.id === scriptName);
+    const script = scripts.find(({ id }) => id === scriptName);
     if (script?.migration_tag) {
       // was already published once
       const foundIndex = config.migrations.findIndex(

--- a/packages/wrangler/src/user.tsx
+++ b/packages/wrangler/src/user.tsx
@@ -578,19 +578,16 @@ export async function getAuthURL(scopes?: string[]): Promise<string> {
  * Refresh an access token from the remote service.
  */
 async function exchangeRefreshTokenForAccessToken(): Promise<AccessContext> {
-  const { refreshToken } = LocalState;
-
-  if (!refreshToken) {
+  if (!LocalState.refreshToken) {
     console.warn("No refresh token is present.");
   }
 
-  const url = TOKEN_URL;
   const body =
     `grant_type=refresh_token&` +
-    `refresh_token=${refreshToken?.value}&` +
+    `refresh_token=${LocalState.refreshToken?.value}&` +
     `client_id=${CLIENT_ID}`;
 
-  const response = await fetch(url, {
+  const response = await fetch(TOKEN_URL, {
     method: "POST",
     body,
     headers: {
@@ -617,10 +614,9 @@ async function exchangeRefreshTokenForAccessToken(): Promise<AccessContext> {
       LocalState.accessToken = accessToken;
 
       if (refresh_token) {
-        const refreshToken: RefreshToken = {
+        LocalState.refreshToken = {
           value: refresh_token,
         };
-        LocalState.refreshToken = refreshToken;
       }
 
       if (scope) {
@@ -666,7 +662,6 @@ async function exchangeAuthCodeForAccessToken(): Promise<AccessContext> {
     console.warn("No authorization grant code is being passed.");
   }
 
-  const url = TOKEN_URL;
   const body =
     `grant_type=authorization_code&` +
     `code=${encodeURIComponent(authorizationCode || "")}&` +
@@ -674,7 +669,7 @@ async function exchangeAuthCodeForAccessToken(): Promise<AccessContext> {
     `client_id=${encodeURIComponent(CLIENT_ID)}&` +
     `code_verifier=${codeVerifier}`;
 
-  const response = await fetch(url, {
+  const response = await fetch(TOKEN_URL, {
     method: "POST",
     body,
     headers: {
@@ -709,10 +704,9 @@ async function exchangeAuthCodeForAccessToken(): Promise<AccessContext> {
   LocalState.accessToken = accessToken;
 
   if (refresh_token) {
-    const refreshToken: RefreshToken = {
+    LocalState.refreshToken = {
       value: refresh_token,
     };
-    LocalState.refreshToken = refreshToken;
   }
 
   if (scope) {
@@ -921,15 +915,14 @@ export async function refreshToken(): Promise<boolean> {
 
 export async function logout(): Promise<void> {
   throwIfNotInitialised();
-  const { refreshToken } = LocalState;
-  if (!refreshToken) {
+  if (!LocalState.refreshToken) {
     console.log("Not logged in, exiting...");
     return;
   }
   const body =
     `client_id=${encodeURIComponent(CLIENT_ID)}&` +
     `token_type_hint=refresh_token&` +
-    `token=${encodeURIComponent(refreshToken?.value || "")}`;
+    `token=${encodeURIComponent(LocalState.refreshToken?.value || "")}`;
 
   const response = await fetch(REVOKE_URL, {
     method: "POST",


### PR DESCRIPTION
This PR enables eslint's `no-shadow` rule. I started a refactor of a couple of pieces and found myself getting confused with vars that claimed to be defined without it being so. The `no-shadow` rule prevents vars from being defined in inner scopes if they've already been defined in an outer scope.

This PR is mostly clean. It did lead to some wordy vars in `index.tsx`, but that's fine, it only made them more obvious.

I didn't bother doing this in `pages.tsx`, I'll leave that up to the pages team. Instead, I've just disabled the rule for that file.