### PR TITLE
fix: allow durable object bindings without path

### DIFF
--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -792,7 +792,7 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
         .map(
           (durableObjectBinding) =>
             DURABLE_OBJECTS_BINDING_REGEXP.exec(durableObjectBinding.toString())
-              ?.groups.scriptName
+              ?.groups.scriptName || ''
         )
         .filter((scriptName) => scriptName !== undefined);
       const mounts = Object.fromEntries(
@@ -803,7 +803,7 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
       const durableObjects = Object.fromEntries(
         durableObjectBindings.map((durableObject) => {
           const {
-            groups: { binding, className, scriptName },
+            groups: { binding, className, scriptName = '' },
           } = DURABLE_OBJECTS_BINDING_REGEXP.exec(durableObject.toString());
           return [binding, { className, scriptName: `./${scriptName}` }];
         })


### PR DESCRIPTION
To launch a Durable Object with wrangler, the script requires the --do flag
```sh
--do COUNTER=Counter@path/to/root
```

The path should provide the directory where wrangler.toml is declared. If this is the project root, use this instead

```sh
--do COUNTER=Counter@
```

The @ sign is necessary because of a bug in the parsing of the scriptName. This snippet shows how the scriptName is currently parsed
```js
const DURABLE_OBJECTS_BINDING_REGEXP = new RegExp(
  /^(?<binding>[^=]+)=(?<className>[^@\s]+)(@(?<scriptName>.*)$)?$/
);

// No @ sign
DURABLE_OBJECTS_BINDING_REGEXP.exec('SESSION_STORAGE=SessionStorageDurableObject').groups
// {binding: 'SESSION_STORAGE', className: 'SessionStorageDurableObject', scriptName: undefined}

// With @ sign
DURABLE_OBJECTS_BINDING_REGEXP.exec('SESSION_STORAGE=SessionStorageDurableObject@').groups
// {binding: 'SESSION_STORAGE', className: 'SessionStorageDurableObject', scriptName: ''}
```

Without the @ sign, the scriptName is set to undefined and it's passed to the plugin as `./undefined`
With the @ sign, the scriptName is set to an empty string and it's passed to the plugin as `./`

This PR makes it set to an empty string in both cases so that users don't have to pass a path at all

```sh
--do COUNTER=Counter
```

Here's a link to a conversation in the [Remix discord](https://discord.com/channels/770287896669978684/777863813981536280/927101613049528360) where another dev ran into the bug shortly after I had solved it for myself
