### PR TITLE
fix: prevent `dev` from infinitely restarting

### DIFF
--- a/.changeset/new-candles-collect.md
+++ b/.changeset/new-candles-collect.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: prevent `useWorker`'s inifinite restarts during `dev`

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -556,7 +556,7 @@ function useWorker(props: {
   } = props;
   const [token, setToken] = useState<CfPreviewToken>();
 
-  // This is the most reliable way to reliably detect whether
+  // This is the most reliable way to detect whether
   // something's "happened" in our system; We make a ref and
   // mark it once we log our initial message. Refs are vars!
   const startedRef = useRef(false);

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -555,6 +555,12 @@ function useWorker(props: {
     port,
   } = props;
   const [token, setToken] = useState<CfPreviewToken>();
+
+  // This is the most reliable way to reliably detect whether
+  // something's "happened" in our system; We make a ref and
+  // mark it once we log our initial message. Refs are vars!
+  const startedRef = useRef(false);
+
   useEffect(() => {
     async function start() {
       if (!bundle) return;
@@ -569,10 +575,11 @@ function useWorker(props: {
         return;
       }
 
-      if (token) {
-        console.log("⎔ Detected changes, restarting server...");
-      } else {
+      if (!startedRef.current) {
         console.log("⎔ Starting server...");
+        startedRef.current = true;
+      } else {
+        console.log("⎔ Detected changes, restarting server...");
       }
 
       const assets = sitesFolder
@@ -624,7 +631,6 @@ function useWorker(props: {
           apiToken,
         })
       );
-      console.log(`⬣ Listening at http://localhost:${port}`);
     }
     start().catch((err) => {
       // we want to log the error, but not end the process
@@ -644,7 +650,6 @@ function useWorker(props: {
     usageModel,
     bindings,
     modules,
-    token,
   ]);
   return token;
 }
@@ -680,6 +685,8 @@ function useProxy({
         }
       },
     });
+
+    console.log(`⬣ Listening at http://localhost:${port}`);
 
     const server = proxy.listen(port);
 


### PR DESCRIPTION
In https://github.com/cloudflare/wrangler2/pull/164/, we added `token` to `useWorker`'s `useEffect` array that detects when to start the server process. However, the effect itself sets `token`, so the build would inifinitely restart on every run.

We could potentially fix this by using `useMemo` or something, but that's overkill for the reason we use `token` - to detect whether it's the first or subsequent time we've started the server, and what message to log to the terminal. So we introduce a ref `startedRef` to play that role, and mark it as true when we log the message the first time. This fixes the infinite loop.

This bug shows how urgent it is to write tests for everything else. We'll get there.