### PR TITLE
Upgrade `miniflare` to `2.0.0-rc.5`

### DIFF
--- a/.changeset/selfish-eagles-drop.md
+++ b/.changeset/selfish-eagles-drop.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Upgrade `miniflare` to `2.0.0-rc.5`

--- a/package-lock.json
+++ b/package-lock.json
@@ -2481,12 +2481,12 @@
       }
     },
     "node_modules/@miniflare/cache": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.0.0-rc.4.tgz",
-      "integrity": "sha512-63PeBccUGXCQ0Ekdt9OwgVCuJIKZ+d8lRAFpJtIa7+ZVybW9F9ehOOKZZYFzEbfBA6Y23i046A44SrpNPeAEGA==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.0.0-rc.5.tgz",
+      "integrity": "sha512-i7T6OYCQOrJ2XqMYW5uDZ03K3zMSku3d7Mny6+yT6BCqMw0amTLnEGvqR/rwxmInSAF9Y4KHXH/VyhLggocMFQ==",
       "dependencies": {
-        "@miniflare/core": "2.0.0-rc.4",
-        "@miniflare/shared": "2.0.0-rc.4",
+        "@miniflare/core": "2.0.0-rc.5",
+        "@miniflare/shared": "2.0.0-rc.5",
         "http-cache-semantics": "^4.1.0",
         "undici": "^4.11.1"
       },
@@ -2495,11 +2495,11 @@
       }
     },
     "node_modules/@miniflare/cli-parser": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.0.0-rc.4.tgz",
-      "integrity": "sha512-jFtG6Ib3fjLenEepKSGJXMUn1hTk1xsjDPVjBX4VNc7P75zMlgdWLmSJSh7qBZpWd4mCUr46MOTtdPXWrW8Opw==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.0.0-rc.5.tgz",
+      "integrity": "sha512-p5xKD0sGQBa681/U/2a8de4nw5ua6BHD4y3/AmF1j8kjwp3Fbz/TodLscuoMxwMcP8+f86mf5xX1Py84yD7azw==",
       "dependencies": {
-        "@miniflare/shared": "2.0.0-rc.4",
+        "@miniflare/shared": "2.0.0-rc.5",
         "kleur": "^4.1.4"
       },
       "engines": {
@@ -2507,12 +2507,12 @@
       }
     },
     "node_modules/@miniflare/core": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.0.0-rc.4.tgz",
-      "integrity": "sha512-nORCqBpj2zqZdlHdTk8VePidCc6VMvd3b3qRqC5eA3/p9CMrpBtQbBx074tnxiRimWnl1lP41U2ucZevwjTGZg==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.0.0-rc.5.tgz",
+      "integrity": "sha512-nZNlvx0ck/M04ow7q3YD9xxkbT53E7BkYWR68ECvxXQHWTBqje7Weg3yzWu3UbhnAgugB6Q5h5FFmGGYT1mfhQ==",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/shared": "2.0.0-rc.4",
+        "@miniflare/shared": "2.0.0-rc.5",
         "busboy": "^0.3.1",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
@@ -2523,7 +2523,7 @@
         "node": ">=16.7"
       },
       "peerDependencies": {
-        "@miniflare/watcher": "2.0.0-rc.4"
+        "@miniflare/watcher": "2.0.0-rc.5"
       },
       "peerDependenciesMeta": {
         "@miniflare/watcher": {
@@ -2532,13 +2532,13 @@
       }
     },
     "node_modules/@miniflare/durable-objects": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.0.0-rc.4.tgz",
-      "integrity": "sha512-Zyv0E71sIYa1OobAmgoaBNum0vzPI6rk6K9Ib5fnMpjx4IzFc+kt6MQq5mUiLUa4yEADmrDHrQ5X4Bqe9Is5lA==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.0.0-rc.5.tgz",
+      "integrity": "sha512-Re/r8qQdCk7CcxqaVm78vGAkFqlB49oZ2Vfrd+85xupSySiSrhs5MPIaKvn7gp0Msq86LOWDbKTN0r80rfp0Dw==",
       "dependencies": {
-        "@miniflare/core": "2.0.0-rc.4",
-        "@miniflare/shared": "2.0.0-rc.4",
-        "@miniflare/storage-memory": "2.0.0-rc.4",
+        "@miniflare/core": "2.0.0-rc.5",
+        "@miniflare/shared": "2.0.0-rc.5",
+        "@miniflare/storage-memory": "2.0.0-rc.5",
         "undici": "^4.11.1"
       },
       "engines": {
@@ -2546,12 +2546,12 @@
       }
     },
     "node_modules/@miniflare/html-rewriter": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.0.0-rc.4.tgz",
-      "integrity": "sha512-KzQvG5r0KbMWctskH/1XIBT+YgQdHrXnYnK7nqJ3fhMjNO02xytlmGISHABV8WGCFYuWZglqTxOQPi17we8Ikw==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.0.0-rc.5.tgz",
+      "integrity": "sha512-S3iRohlCiMoT8EiW7luUoZWhetyuDFGfso4MPB5GvNgDHzRyrVooK/myHhLXMfH+fVEF3+tkgGyMavd+G0XJ3w==",
       "dependencies": {
-        "@miniflare/core": "2.0.0-rc.4",
-        "@miniflare/shared": "2.0.0-rc.4",
+        "@miniflare/core": "2.0.0-rc.5",
+        "@miniflare/shared": "2.0.0-rc.5",
         "html-rewriter-wasm": "^0.3.2",
         "undici": "^4.11.1"
       },
@@ -2560,13 +2560,13 @@
       }
     },
     "node_modules/@miniflare/http-server": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.0.0-rc.4.tgz",
-      "integrity": "sha512-ZxPfylDEa9RZkvTDzicbE0AYLoCBintQS2biGHLOiCpVCvSZej43XUs3A8KxSPN0adnz0KUzX58pcXQPU9CXuQ==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.0.0-rc.5.tgz",
+      "integrity": "sha512-6hn3gSFFh1wtDUcg6SS5nZuy+Oy3iGPseV3EO3qhD4rEJFEFBMu9mlow8Dj8CeTJeMgy8UjlLbH5MJUV3hyTLA==",
       "dependencies": {
-        "@miniflare/core": "2.0.0-rc.4",
-        "@miniflare/shared": "2.0.0-rc.4",
-        "@miniflare/web-sockets": "2.0.0-rc.4",
+        "@miniflare/core": "2.0.0-rc.5",
+        "@miniflare/shared": "2.0.0-rc.5",
+        "@miniflare/web-sockets": "2.0.0-rc.5",
         "kleur": "^4.1.4",
         "selfsigned": "^1.10.11",
         "undici": "^4.11.1",
@@ -2578,34 +2578,34 @@
       }
     },
     "node_modules/@miniflare/kv": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.0.0-rc.4.tgz",
-      "integrity": "sha512-jHkMS6VCadUlTrE4m+aCyrZS5VfQ0D3YhWJwFHWCtqAEItV0ggDN2+saCEoAW0YXzsiadlbuWJeAM4H11g1JNw==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.0.0-rc.5.tgz",
+      "integrity": "sha512-2dyeELSebysfddfga8tP9fysxOCP3xXXOaBMeiMxa2GfX5eN/kluCwyvJxzlUvUHcZhNwNrYZCApXsaWf6z/5w==",
       "dependencies": {
-        "@miniflare/shared": "2.0.0-rc.4"
+        "@miniflare/shared": "2.0.0-rc.5"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/runner-vm": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.0.0-rc.4.tgz",
-      "integrity": "sha512-eFOMVvhyHuI5JUOF4/8oyRId3zpKgY0xyN5Jk+7y/I3QiqSZFDFnO1hHPXHzlgimBawFEi0SzSsa5saJB2KFSQ==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.0.0-rc.5.tgz",
+      "integrity": "sha512-yQLtvoG+hkZ9Gn/GsHNVytqFah0lckrtoP6TyE/aNrY23/cH8PRS0l8jgjq6tmdDHWH5F+UYUqYyILQykeY5JA==",
       "dependencies": {
-        "@miniflare/shared": "2.0.0-rc.4"
+        "@miniflare/shared": "2.0.0-rc.5"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/scheduler": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.0.0-rc.4.tgz",
-      "integrity": "sha512-PGzXSFavmLjxFz2WN6m2rO/HiFIxOLyxw4330AP6UJpGd/HP5tmTsF/aUGE5MjwKkgzQyk815nGZMvusR37fqA==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.0.0-rc.5.tgz",
+      "integrity": "sha512-PPc/o4dVwhiB42fTlCROWy4fjHAwBhPGA61lcoqAJsEyVdS6bJHbJF0W95KICldEvqLmdQKWnMSR+MrYnAo7lA==",
       "dependencies": {
-        "@miniflare/core": "2.0.0-rc.4",
-        "@miniflare/shared": "2.0.0-rc.4",
+        "@miniflare/core": "2.0.0-rc.5",
+        "@miniflare/shared": "2.0.0-rc.5",
         "cron-schedule": "^3.0.4"
       },
       "engines": {
@@ -2613,9 +2613,9 @@
       }
     },
     "node_modules/@miniflare/shared": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.0.0-rc.4.tgz",
-      "integrity": "sha512-bu59+0r+IxmuBmFDDELxJ8vaewuimaBylrkxMF5o+DaZmIXGmxzDmji2LLXT4oDjGHP4FN6Eex5pR0f5eDsjkQ==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.0.0-rc.5.tgz",
+      "integrity": "sha512-ubyp0v5lQh1so5W4InT5zQKKRUZ+dYPJUI0TrLyne4DWd4Nwi2uEmrxEc5ZwEZ/n8VxzxI96jybcEwDXoUirFw==",
       "dependencies": {
         "ignore": "^5.1.8",
         "kleur": "^4.1.4"
@@ -2625,59 +2625,59 @@
       }
     },
     "node_modules/@miniflare/sites": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.0.0-rc.4.tgz",
-      "integrity": "sha512-qWFpvo3eQpPZOp58rzjbTVuB1xZULUpndaiKOp17+WrfXV1on0Y/ipgmFFDqTT5qMsWG14Y68CQeJCzF7ww36A==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.0.0-rc.5.tgz",
+      "integrity": "sha512-Qw4B2BXcl9aMj7FfgswTQcmOl52XUxtij9LfTzvGk1JOAf5GzwLLpmKWunF2rr6X/1NHsNRXFeGq23eMzHQpuQ==",
       "dependencies": {
-        "@miniflare/kv": "2.0.0-rc.4",
-        "@miniflare/shared": "2.0.0-rc.4",
-        "@miniflare/storage-file": "2.0.0-rc.4"
+        "@miniflare/kv": "2.0.0-rc.5",
+        "@miniflare/shared": "2.0.0-rc.5",
+        "@miniflare/storage-file": "2.0.0-rc.5"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/storage-file": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.0.0-rc.4.tgz",
-      "integrity": "sha512-wu9S71T4fpYm5JQmpA/P+LuWxPoWQwAzFVrN5eAQgx6T8846D/Dl9iBED4bgo+yJiVrlfwFCeojNsqfxziWz/g==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.0.0-rc.5.tgz",
+      "integrity": "sha512-ogm0E5Hwen00xmT3nJ91c6fvHIv6vmv3sf3IFn5yul4disX9A7VDlQF9ZxlXaGgcD4k97T5HhL68L7zj15ugUA==",
       "dependencies": {
-        "@miniflare/shared": "2.0.0-rc.4",
-        "@miniflare/storage-memory": "2.0.0-rc.4"
+        "@miniflare/shared": "2.0.0-rc.5",
+        "@miniflare/storage-memory": "2.0.0-rc.5"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/storage-memory": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.0.0-rc.4.tgz",
-      "integrity": "sha512-D/qbZR6JwLyp3uA/2A3UA5XqhnTe2SaSsY/Qw47EfwPicsPEVGQl4dwrVLobslA+mxYVabOMM4G/uCU5c3fI/Q==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.0.0-rc.5.tgz",
+      "integrity": "sha512-SWmOY2fu+1I/p0SM6+nAn8dq2ie1diuqy9Su7yaMxj5oTLUgdWbXutX0UTqYhDn2shTw+P6jGHv6tf0LGCW7Hg==",
       "dependencies": {
-        "@miniflare/shared": "2.0.0-rc.4"
+        "@miniflare/shared": "2.0.0-rc.5"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/watcher": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.0.0-rc.4.tgz",
-      "integrity": "sha512-94buFqkifFlTZtwu7DvgmmQzz9NA9YWMGMIfbsVmVMiugTa39topc0KnVrcvBKnkBjQpA8Vk8edkqsn5tXb4fg==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.0.0-rc.5.tgz",
+      "integrity": "sha512-Cx5lSzPN5xoTC6gTGxzx5YPzGGeLGK7MHL86tMZqfxcku/pjdup3h2NkhGiwUAatm1DX05xrj6FmDJaJOc+FNA==",
       "dependencies": {
-        "@miniflare/shared": "2.0.0-rc.4"
+        "@miniflare/shared": "2.0.0-rc.5"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/web-sockets": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.0.0-rc.4.tgz",
-      "integrity": "sha512-d+TNVTu5IjW0mF39PgSodRYWhj//PzyouPiEZ2pH4SHJ+FXjwjgomAehtMh0GTab4SZwXOAhHYgKoH8fzhLt8g==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.0.0-rc.5.tgz",
+      "integrity": "sha512-HXTjmf46S9HdwWm2OinOsve3ld9EX8wgzgHnqAGGVop/TkeBUsQ4mO53cGRPjNdu9cDT8ukr312xtX/wFe0Jsg==",
       "dependencies": {
-        "@miniflare/core": "2.0.0-rc.4",
-        "@miniflare/shared": "2.0.0-rc.4",
+        "@miniflare/core": "2.0.0-rc.5",
+        "@miniflare/shared": "2.0.0-rc.5",
         "undici": "^4.11.1",
         "ws": "^8.2.2"
       },
@@ -9851,25 +9851,25 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.0.0-rc.4.tgz",
-      "integrity": "sha512-nzoooM8tctkR6KBBgQo8/HuHdQ8GgqTXbmpqq3DiIH1LTZDiKSYQ420T+t6HhWl1IP6i3htQR5TzBq50iAgm0A==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.0.0-rc.5.tgz",
+      "integrity": "sha512-4i6qC+jLpsV8c/W2m04qMokrXY9ybg0jeK9F3+F/4fkpvtT784dMhdhdKbfY2qGr9q+CuAmMkO6myOrs7F6RHA==",
       "dependencies": {
-        "@miniflare/cache": "2.0.0-rc.4",
-        "@miniflare/cli-parser": "2.0.0-rc.4",
-        "@miniflare/core": "2.0.0-rc.4",
-        "@miniflare/durable-objects": "2.0.0-rc.4",
-        "@miniflare/html-rewriter": "2.0.0-rc.4",
-        "@miniflare/http-server": "2.0.0-rc.4",
-        "@miniflare/kv": "2.0.0-rc.4",
-        "@miniflare/runner-vm": "2.0.0-rc.4",
-        "@miniflare/scheduler": "2.0.0-rc.4",
-        "@miniflare/shared": "2.0.0-rc.4",
-        "@miniflare/sites": "2.0.0-rc.4",
-        "@miniflare/storage-file": "2.0.0-rc.4",
-        "@miniflare/storage-memory": "2.0.0-rc.4",
-        "@miniflare/watcher": "2.0.0-rc.4",
-        "@miniflare/web-sockets": "2.0.0-rc.4",
+        "@miniflare/cache": "2.0.0-rc.5",
+        "@miniflare/cli-parser": "2.0.0-rc.5",
+        "@miniflare/core": "2.0.0-rc.5",
+        "@miniflare/durable-objects": "2.0.0-rc.5",
+        "@miniflare/html-rewriter": "2.0.0-rc.5",
+        "@miniflare/http-server": "2.0.0-rc.5",
+        "@miniflare/kv": "2.0.0-rc.5",
+        "@miniflare/runner-vm": "2.0.0-rc.5",
+        "@miniflare/scheduler": "2.0.0-rc.5",
+        "@miniflare/shared": "2.0.0-rc.5",
+        "@miniflare/sites": "2.0.0-rc.5",
+        "@miniflare/storage-file": "2.0.0-rc.5",
+        "@miniflare/storage-memory": "2.0.0-rc.5",
+        "@miniflare/watcher": "2.0.0-rc.5",
+        "@miniflare/web-sockets": "2.0.0-rc.5",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
@@ -9882,7 +9882,7 @@
         "node": ">=16.7"
       },
       "peerDependencies": {
-        "@miniflare/storage-redis": "2.0.0-rc.4",
+        "@miniflare/storage-redis": "2.0.0-rc.5",
         "cron-schedule": "^3.0.4",
         "ioredis": "^4.27.9"
       },
@@ -13457,7 +13457,7 @@
       "dependencies": {
         "@cloudflare/pages-functions-compiler": "0.3.8",
         "esbuild": "0.14.1",
-        "miniflare": "2.0.0-rc.4",
+        "miniflare": "2.0.0-rc.5",
         "semiver": "^1.1.0"
       },
       "bin": {
@@ -15468,32 +15468,32 @@
       }
     },
     "@miniflare/cache": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.0.0-rc.4.tgz",
-      "integrity": "sha512-63PeBccUGXCQ0Ekdt9OwgVCuJIKZ+d8lRAFpJtIa7+ZVybW9F9ehOOKZZYFzEbfBA6Y23i046A44SrpNPeAEGA==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.0.0-rc.5.tgz",
+      "integrity": "sha512-i7T6OYCQOrJ2XqMYW5uDZ03K3zMSku3d7Mny6+yT6BCqMw0amTLnEGvqR/rwxmInSAF9Y4KHXH/VyhLggocMFQ==",
       "requires": {
-        "@miniflare/core": "2.0.0-rc.4",
-        "@miniflare/shared": "2.0.0-rc.4",
+        "@miniflare/core": "2.0.0-rc.5",
+        "@miniflare/shared": "2.0.0-rc.5",
         "http-cache-semantics": "^4.1.0",
         "undici": "^4.11.1"
       }
     },
     "@miniflare/cli-parser": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.0.0-rc.4.tgz",
-      "integrity": "sha512-jFtG6Ib3fjLenEepKSGJXMUn1hTk1xsjDPVjBX4VNc7P75zMlgdWLmSJSh7qBZpWd4mCUr46MOTtdPXWrW8Opw==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.0.0-rc.5.tgz",
+      "integrity": "sha512-p5xKD0sGQBa681/U/2a8de4nw5ua6BHD4y3/AmF1j8kjwp3Fbz/TodLscuoMxwMcP8+f86mf5xX1Py84yD7azw==",
       "requires": {
-        "@miniflare/shared": "2.0.0-rc.4",
+        "@miniflare/shared": "2.0.0-rc.5",
         "kleur": "^4.1.4"
       }
     },
     "@miniflare/core": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.0.0-rc.4.tgz",
-      "integrity": "sha512-nORCqBpj2zqZdlHdTk8VePidCc6VMvd3b3qRqC5eA3/p9CMrpBtQbBx074tnxiRimWnl1lP41U2ucZevwjTGZg==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.0.0-rc.5.tgz",
+      "integrity": "sha512-nZNlvx0ck/M04ow7q3YD9xxkbT53E7BkYWR68ECvxXQHWTBqje7Weg3yzWu3UbhnAgugB6Q5h5FFmGGYT1mfhQ==",
       "requires": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/shared": "2.0.0-rc.4",
+        "@miniflare/shared": "2.0.0-rc.5",
         "busboy": "^0.3.1",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
@@ -15502,35 +15502,35 @@
       }
     },
     "@miniflare/durable-objects": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.0.0-rc.4.tgz",
-      "integrity": "sha512-Zyv0E71sIYa1OobAmgoaBNum0vzPI6rk6K9Ib5fnMpjx4IzFc+kt6MQq5mUiLUa4yEADmrDHrQ5X4Bqe9Is5lA==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.0.0-rc.5.tgz",
+      "integrity": "sha512-Re/r8qQdCk7CcxqaVm78vGAkFqlB49oZ2Vfrd+85xupSySiSrhs5MPIaKvn7gp0Msq86LOWDbKTN0r80rfp0Dw==",
       "requires": {
-        "@miniflare/core": "2.0.0-rc.4",
-        "@miniflare/shared": "2.0.0-rc.4",
-        "@miniflare/storage-memory": "2.0.0-rc.4",
+        "@miniflare/core": "2.0.0-rc.5",
+        "@miniflare/shared": "2.0.0-rc.5",
+        "@miniflare/storage-memory": "2.0.0-rc.5",
         "undici": "^4.11.1"
       }
     },
     "@miniflare/html-rewriter": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.0.0-rc.4.tgz",
-      "integrity": "sha512-KzQvG5r0KbMWctskH/1XIBT+YgQdHrXnYnK7nqJ3fhMjNO02xytlmGISHABV8WGCFYuWZglqTxOQPi17we8Ikw==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.0.0-rc.5.tgz",
+      "integrity": "sha512-S3iRohlCiMoT8EiW7luUoZWhetyuDFGfso4MPB5GvNgDHzRyrVooK/myHhLXMfH+fVEF3+tkgGyMavd+G0XJ3w==",
       "requires": {
-        "@miniflare/core": "2.0.0-rc.4",
-        "@miniflare/shared": "2.0.0-rc.4",
+        "@miniflare/core": "2.0.0-rc.5",
+        "@miniflare/shared": "2.0.0-rc.5",
         "html-rewriter-wasm": "^0.3.2",
         "undici": "^4.11.1"
       }
     },
     "@miniflare/http-server": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.0.0-rc.4.tgz",
-      "integrity": "sha512-ZxPfylDEa9RZkvTDzicbE0AYLoCBintQS2biGHLOiCpVCvSZej43XUs3A8KxSPN0adnz0KUzX58pcXQPU9CXuQ==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.0.0-rc.5.tgz",
+      "integrity": "sha512-6hn3gSFFh1wtDUcg6SS5nZuy+Oy3iGPseV3EO3qhD4rEJFEFBMu9mlow8Dj8CeTJeMgy8UjlLbH5MJUV3hyTLA==",
       "requires": {
-        "@miniflare/core": "2.0.0-rc.4",
-        "@miniflare/shared": "2.0.0-rc.4",
-        "@miniflare/web-sockets": "2.0.0-rc.4",
+        "@miniflare/core": "2.0.0-rc.5",
+        "@miniflare/shared": "2.0.0-rc.5",
+        "@miniflare/web-sockets": "2.0.0-rc.5",
         "kleur": "^4.1.4",
         "selfsigned": "^1.10.11",
         "undici": "^4.11.1",
@@ -15539,82 +15539,82 @@
       }
     },
     "@miniflare/kv": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.0.0-rc.4.tgz",
-      "integrity": "sha512-jHkMS6VCadUlTrE4m+aCyrZS5VfQ0D3YhWJwFHWCtqAEItV0ggDN2+saCEoAW0YXzsiadlbuWJeAM4H11g1JNw==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.0.0-rc.5.tgz",
+      "integrity": "sha512-2dyeELSebysfddfga8tP9fysxOCP3xXXOaBMeiMxa2GfX5eN/kluCwyvJxzlUvUHcZhNwNrYZCApXsaWf6z/5w==",
       "requires": {
-        "@miniflare/shared": "2.0.0-rc.4"
+        "@miniflare/shared": "2.0.0-rc.5"
       }
     },
     "@miniflare/runner-vm": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.0.0-rc.4.tgz",
-      "integrity": "sha512-eFOMVvhyHuI5JUOF4/8oyRId3zpKgY0xyN5Jk+7y/I3QiqSZFDFnO1hHPXHzlgimBawFEi0SzSsa5saJB2KFSQ==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.0.0-rc.5.tgz",
+      "integrity": "sha512-yQLtvoG+hkZ9Gn/GsHNVytqFah0lckrtoP6TyE/aNrY23/cH8PRS0l8jgjq6tmdDHWH5F+UYUqYyILQykeY5JA==",
       "requires": {
-        "@miniflare/shared": "2.0.0-rc.4"
+        "@miniflare/shared": "2.0.0-rc.5"
       }
     },
     "@miniflare/scheduler": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.0.0-rc.4.tgz",
-      "integrity": "sha512-PGzXSFavmLjxFz2WN6m2rO/HiFIxOLyxw4330AP6UJpGd/HP5tmTsF/aUGE5MjwKkgzQyk815nGZMvusR37fqA==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.0.0-rc.5.tgz",
+      "integrity": "sha512-PPc/o4dVwhiB42fTlCROWy4fjHAwBhPGA61lcoqAJsEyVdS6bJHbJF0W95KICldEvqLmdQKWnMSR+MrYnAo7lA==",
       "requires": {
-        "@miniflare/core": "2.0.0-rc.4",
-        "@miniflare/shared": "2.0.0-rc.4",
+        "@miniflare/core": "2.0.0-rc.5",
+        "@miniflare/shared": "2.0.0-rc.5",
         "cron-schedule": "^3.0.4"
       }
     },
     "@miniflare/shared": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.0.0-rc.4.tgz",
-      "integrity": "sha512-bu59+0r+IxmuBmFDDELxJ8vaewuimaBylrkxMF5o+DaZmIXGmxzDmji2LLXT4oDjGHP4FN6Eex5pR0f5eDsjkQ==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.0.0-rc.5.tgz",
+      "integrity": "sha512-ubyp0v5lQh1so5W4InT5zQKKRUZ+dYPJUI0TrLyne4DWd4Nwi2uEmrxEc5ZwEZ/n8VxzxI96jybcEwDXoUirFw==",
       "requires": {
         "ignore": "^5.1.8",
         "kleur": "^4.1.4"
       }
     },
     "@miniflare/sites": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.0.0-rc.4.tgz",
-      "integrity": "sha512-qWFpvo3eQpPZOp58rzjbTVuB1xZULUpndaiKOp17+WrfXV1on0Y/ipgmFFDqTT5qMsWG14Y68CQeJCzF7ww36A==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.0.0-rc.5.tgz",
+      "integrity": "sha512-Qw4B2BXcl9aMj7FfgswTQcmOl52XUxtij9LfTzvGk1JOAf5GzwLLpmKWunF2rr6X/1NHsNRXFeGq23eMzHQpuQ==",
       "requires": {
-        "@miniflare/kv": "2.0.0-rc.4",
-        "@miniflare/shared": "2.0.0-rc.4",
-        "@miniflare/storage-file": "2.0.0-rc.4"
+        "@miniflare/kv": "2.0.0-rc.5",
+        "@miniflare/shared": "2.0.0-rc.5",
+        "@miniflare/storage-file": "2.0.0-rc.5"
       }
     },
     "@miniflare/storage-file": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.0.0-rc.4.tgz",
-      "integrity": "sha512-wu9S71T4fpYm5JQmpA/P+LuWxPoWQwAzFVrN5eAQgx6T8846D/Dl9iBED4bgo+yJiVrlfwFCeojNsqfxziWz/g==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.0.0-rc.5.tgz",
+      "integrity": "sha512-ogm0E5Hwen00xmT3nJ91c6fvHIv6vmv3sf3IFn5yul4disX9A7VDlQF9ZxlXaGgcD4k97T5HhL68L7zj15ugUA==",
       "requires": {
-        "@miniflare/shared": "2.0.0-rc.4",
-        "@miniflare/storage-memory": "2.0.0-rc.4"
+        "@miniflare/shared": "2.0.0-rc.5",
+        "@miniflare/storage-memory": "2.0.0-rc.5"
       }
     },
     "@miniflare/storage-memory": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.0.0-rc.4.tgz",
-      "integrity": "sha512-D/qbZR6JwLyp3uA/2A3UA5XqhnTe2SaSsY/Qw47EfwPicsPEVGQl4dwrVLobslA+mxYVabOMM4G/uCU5c3fI/Q==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.0.0-rc.5.tgz",
+      "integrity": "sha512-SWmOY2fu+1I/p0SM6+nAn8dq2ie1diuqy9Su7yaMxj5oTLUgdWbXutX0UTqYhDn2shTw+P6jGHv6tf0LGCW7Hg==",
       "requires": {
-        "@miniflare/shared": "2.0.0-rc.4"
+        "@miniflare/shared": "2.0.0-rc.5"
       }
     },
     "@miniflare/watcher": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.0.0-rc.4.tgz",
-      "integrity": "sha512-94buFqkifFlTZtwu7DvgmmQzz9NA9YWMGMIfbsVmVMiugTa39topc0KnVrcvBKnkBjQpA8Vk8edkqsn5tXb4fg==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.0.0-rc.5.tgz",
+      "integrity": "sha512-Cx5lSzPN5xoTC6gTGxzx5YPzGGeLGK7MHL86tMZqfxcku/pjdup3h2NkhGiwUAatm1DX05xrj6FmDJaJOc+FNA==",
       "requires": {
-        "@miniflare/shared": "2.0.0-rc.4"
+        "@miniflare/shared": "2.0.0-rc.5"
       }
     },
     "@miniflare/web-sockets": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.0.0-rc.4.tgz",
-      "integrity": "sha512-d+TNVTu5IjW0mF39PgSodRYWhj//PzyouPiEZ2pH4SHJ+FXjwjgomAehtMh0GTab4SZwXOAhHYgKoH8fzhLt8g==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.0.0-rc.5.tgz",
+      "integrity": "sha512-HXTjmf46S9HdwWm2OinOsve3ld9EX8wgzgHnqAGGVop/TkeBUsQ4mO53cGRPjNdu9cDT8ukr312xtX/wFe0Jsg==",
       "requires": {
-        "@miniflare/core": "2.0.0-rc.4",
-        "@miniflare/shared": "2.0.0-rc.4",
+        "@miniflare/core": "2.0.0-rc.5",
+        "@miniflare/shared": "2.0.0-rc.5",
         "undici": "^4.11.1",
         "ws": "^8.2.2"
       }
@@ -20774,25 +20774,25 @@
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
     },
     "miniflare": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.0.0-rc.4.tgz",
-      "integrity": "sha512-nzoooM8tctkR6KBBgQo8/HuHdQ8GgqTXbmpqq3DiIH1LTZDiKSYQ420T+t6HhWl1IP6i3htQR5TzBq50iAgm0A==",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.0.0-rc.5.tgz",
+      "integrity": "sha512-4i6qC+jLpsV8c/W2m04qMokrXY9ybg0jeK9F3+F/4fkpvtT784dMhdhdKbfY2qGr9q+CuAmMkO6myOrs7F6RHA==",
       "requires": {
-        "@miniflare/cache": "2.0.0-rc.4",
-        "@miniflare/cli-parser": "2.0.0-rc.4",
-        "@miniflare/core": "2.0.0-rc.4",
-        "@miniflare/durable-objects": "2.0.0-rc.4",
-        "@miniflare/html-rewriter": "2.0.0-rc.4",
-        "@miniflare/http-server": "2.0.0-rc.4",
-        "@miniflare/kv": "2.0.0-rc.4",
-        "@miniflare/runner-vm": "2.0.0-rc.4",
-        "@miniflare/scheduler": "2.0.0-rc.4",
-        "@miniflare/shared": "2.0.0-rc.4",
-        "@miniflare/sites": "2.0.0-rc.4",
-        "@miniflare/storage-file": "2.0.0-rc.4",
-        "@miniflare/storage-memory": "2.0.0-rc.4",
-        "@miniflare/watcher": "2.0.0-rc.4",
-        "@miniflare/web-sockets": "2.0.0-rc.4",
+        "@miniflare/cache": "2.0.0-rc.5",
+        "@miniflare/cli-parser": "2.0.0-rc.5",
+        "@miniflare/core": "2.0.0-rc.5",
+        "@miniflare/durable-objects": "2.0.0-rc.5",
+        "@miniflare/html-rewriter": "2.0.0-rc.5",
+        "@miniflare/http-server": "2.0.0-rc.5",
+        "@miniflare/kv": "2.0.0-rc.5",
+        "@miniflare/runner-vm": "2.0.0-rc.5",
+        "@miniflare/scheduler": "2.0.0-rc.5",
+        "@miniflare/shared": "2.0.0-rc.5",
+        "@miniflare/sites": "2.0.0-rc.5",
+        "@miniflare/storage-file": "2.0.0-rc.5",
+        "@miniflare/storage-memory": "2.0.0-rc.5",
+        "@miniflare/watcher": "2.0.0-rc.5",
+        "@miniflare/web-sockets": "2.0.0-rc.5",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
@@ -23290,7 +23290,7 @@
         "ink-table": "^3.0.0",
         "ink-text-input": "^4.0.2",
         "mime": "^3.0.0",
-        "miniflare": "2.0.0-rc.4",
+        "miniflare": "2.0.0-rc.5",
         "node-fetch": "^3.1.0",
         "open": "^8.4.0",
         "path-to-regexp": "^6.2.0",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@cloudflare/pages-functions-compiler": "0.3.8",
     "esbuild": "0.14.1",
-    "miniflare": "2.0.0-rc.4",
+    "miniflare": "2.0.0-rc.5",
     "semiver": "^1.1.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Hey! 👋 This PR upgrades `miniflare` to version `2.0.0-rc.5`: https://github.com/cloudflare/miniflare/releases/tag/v2.0.0-rc.5.

This version implements service bindings and matches some other core behaviour of the Workers runtime, like blocking asynchronous I/O outside request handlers, and limiting request recursion depth. It also doesn't proxy primitive classes like `Object` by default, fixing #91. The old behaviour can be enabled with `--proxy-primitive` for Rust workers. See [this comment](https://github.com/cloudflare/miniflare/blob/720794accee7582b01e849182244a65ce60c9d60/packages/core/src/plugins/core.ts#L487-L555) for more details.

---

Local service bindings are not yet implemented in this PR. We need to have a discussion about how best to do these.

Normally, you'd just need to set the service `name` to bind too, since Cloudflare already knows all of your services. 
However, Miniflare needs to know where the other service's files are on disk, so it first requires you to mount (https://v2.miniflare.dev/core/mount) any services you want to bind.

---

I've made a few other minor changes to `pages dev`:

- The service bindings implementation lets you specify a custom handler function, which simplifies the code for `env.ASSETS.fetch`.
- Instead of calling `await generateAssetsFetch(directory)` on every request, I've lifted it out. Every call to `generateAssetsFetch` creates a persistent watcher for `_headers` and `_redirects` files, so this makes sure we only have one of those.
- `miniflare.startServer()` can throw if Miniflare initialisation fails for any reason (e.g. syntax error in user code). These errors are now logged.
- Imported `Headers`, `Response` and `Request` from `@miniflare/core` instead of `undici`. This fixes #165.