### PR TITLE
allow specifying only "index" without extension or nothing at all to launch "wrangler dev"

### DIFF
--- a/.changeset/loud-dolls-pay.md
+++ b/.changeset/loud-dolls-pay.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+allow specifying only "index" without extension or nothing at all to launch "wrangler dev"

--- a/.changeset/loud-dolls-pay.md
+++ b/.changeset/loud-dolls-pay.md
@@ -2,4 +2,4 @@
 "wrangler": patch
 ---
 
-allow specifying only "index" without extension or nothing at all to launch "wrangler dev"
+allow specifying only "index" without extension or nothing at all for "wrangler dev" and "wrangler publish"

--- a/.changeset/loud-dolls-pay.md
+++ b/.changeset/loud-dolls-pay.md
@@ -1,5 +1,5 @@
 ---
-"wrangler": minor
+"wrangler": patch
 ---
 
 allow specifying only "index" without extension or nothing at all to launch "wrangler dev"

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -501,7 +501,8 @@ function useEsbuild(props: {
       });
 
       const chunks = Object.entries(result.metafile.outputs).find(
-        ([_path, { entryPoint }]) => entryPoint === entry
+        ([_path, { entryPoint }]) =>
+          entryPoint === Object.keys(result.metafile.inputs)[0]
       ); // assumedly only one entry point
 
       setBundle({

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -125,7 +125,7 @@ export default async function publish(props: Props): Promise<void> {
       entryPoint ===
       (props.public
         ? path.join(path.dirname(file), "static-asset-facade.js")
-        : file)
+        : Object.keys(result.metafile.inputs)[0])
   );
 
   const { format } = props;


### PR DESCRIPTION
While using `wrangler dev ./index` I get
```
TypeError: Cannot read properties of undefined (reading '0')
    at null.build (/home/jgentes/workers/wrangler2/packages/wrangler/src/dev.tsx:411:15)
```

This is caused due to the `entry` value being verbatim what was used as a command line argument, ie. `./index`, whereas the `entryPoint` value in `result.metafile.outputs` has the extension added to the file, ie `./index.js`.

I'm going to submit a PR that uses what esBuild recognizes as the input value in `result.metafile.inputs` instead of the `entry` value:

```
const chunks = Object.entries(result.metafile.outputs).find(
        ([_path, { entryPoint }]) =>
          entryPoint === Object.keys(result.metafile.inputs)[0]
      ) // assumedly only one entry point
```