### PR TITLE
update `package-lock.json` with the newer version of the published package (`wrangler@0.0.7`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15192,7 +15192,7 @@
       "license": "ISC"
     },
     "packages/wrangler": {
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "esbuild": "0.14.1",


### PR DESCRIPTION
Whenever we do a changesets release, we have a problem where package-lock.json isn't in sync anymore. Specifically, because workspace definitions are also stored in this file, and we don't update the version numbers, there's a mismatch.

I would've just committed this directly to `main`, but I'm opening the PR to make this problem visible, and see if anyone has any suggestions for hot to fix this. Could the "Version Packages" PR generation process also run `npm install` at the root so package-lock.json also gets updated? Is this something the `changesets` team needs to fix?