### PR TITLE
modify changelog format

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@1.6.2/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": [
+    "@changesets/changelog-github",
+    { "repo": "cloudflare/wrangler2" }
+  ],
   "commit": false,
   "linked": [],
   "access": "public",


### PR DESCRIPTION
This PR changes the format in which changelogs are generated. We use the `@changesets/changelog-github` package, which is a better default than we have now. It includes the PR number and author id. and has links to commit/PR/author.

Example changelog - https://github.com/changesets/changesets/blob/main/packages/cli/CHANGELOG.md
![image](https://user-images.githubusercontent.com/18808/148470980-cc6f728b-3218-4bee-a3f9-8d48b9d0eb08.png)
