### PR TITLE
Disable `@typescript-lint/no-explicit-any` eslint rule in pages code

### DIFF
--- a/.changeset/modern-hounds-fold.md
+++ b/.changeset/modern-hounds-fold.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Disable @typescript-lint/noexplicit-any eslint rule in pages code

--- a/.changeset/modern-hounds-fold.md
+++ b/.changeset/modern-hounds-fold.md
@@ -2,4 +2,4 @@
 "wrangler": patch
 ---
 
-Disable @typescript-lint/noexplicit-any eslint rule in pages code
+Disable @typescript-lint/no-explicit-any eslint rule in pages code

--- a/packages/wrangler/pages/functions/filepath-routing.ts
+++ b/packages/wrangler/pages/functions/filepath-routing.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import path from "path";
 import fs from "fs/promises";
 import { transform } from "esbuild";

--- a/packages/wrangler/pages/functions/routes.ts
+++ b/packages/wrangler/pages/functions/routes.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import path from "path";
 import fs from "fs/promises";
 import { isValidIdentifer, normalizeIdentifier } from "./identifiers";

--- a/packages/wrangler/pages/functions/template-worker.ts
+++ b/packages/wrangler/pages/functions/template-worker.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { match } from "path-to-regexp";
 import type { HTTPMethod } from "./routes";
 


### PR DESCRIPTION
This PR disables the `@typescript-lint/no-explicit-any` eslint rule in pages code. The Pages team should fix this, since it's causing noise in our PRs. I've also filed an issue to fix this at https://github.com/cloudflare/wrangler2/issues/201.