### PR TITLE
Silently fail to auto-open browser in

### DIFF
--- a/.changeset/metal-ties-invent.md
+++ b/.changeset/metal-ties-invent.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Silently fail to auto-open the browser in `wrangler pages dev` command when that errors out.

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -905,7 +905,9 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
         console.log(`Serving at http://127.0.0.1:${port}/`);
 
         if (process.env.BROWSER !== "none") {
-          await open(`http://127.0.0.1:${port}/`);
+          try {
+            await open(`http://127.0.0.1:${port}/`);
+          } catch {}
         }
 
         EXIT_CALLBACKS.push(() => {


### PR DESCRIPTION
Fixes #204.

Silently fail to auto-open the browser in `wrangler pages dev` command when that errors out.

The user can manually open their browser, and everything else still works.