### PR TITLE
Ensure package-lock.json is updated on release

### DIFF
--- a/.github/changeset-version.js
+++ b/.github/changeset-version.js
@@ -1,0 +1,9 @@
+const { execSync } = require("node:child_process");
+
+// This script is used by the `release.yml` workflow to update the version of the packages being released.
+// The standard step is only to run `changeset version` but this does not update the package-lock.json file.
+// So we also run `npm install`, which does this update.
+// This is a workaround until this is handled automatically by `changeset version`.
+// See https://github.com/changesets/changesets/issues/421.
+execSync("npx changeset version");
+execSync("npm install");

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
+          version: node .github/changeset-version.js
           publish: npx changeset publish --tag beta
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Workaround a problem in changesets where it does not update the package-lock.json
after the version has been bumped in package.json.

See https://github.com/changesets/changesets/issues/421

Fixes #198