### PR TITLE
Add `--compatibility-date`, `--compatibility-flags`, `--latest` cli arguments to `dev` and `publish`

### DIFF
--- a/.changeset/pretty-starfishes-judge.md
+++ b/.changeset/pretty-starfishes-judge.md
@@ -1,0 +1,12 @@
+---
+"wrangler": patch
+---
+
+Add `--compatibility-date`, `--compatibility-flags`, `--latest` cli arguments to `dev` and `publish`.
+
+- A cli arg for adding a compatibility data, e.g `--compatibility_date 2022-01-05`
+- A shorthand `--latest` that sets `compatibility_date` to today's date. Usage of this flag logs a warning.
+- `latest` is NOT a config field in `wrangler.toml`.
+- In `dev`, when a compatibility date is not available in either `wrangler.toml` or as a cli arg, then we default to `--latest`, and log a warning.
+- In `publish` we error if a compatibility date is not available in either `wrangler.toml` or as a cli arg. Usage of `--latest` logs a warning.
+- We also accept compatibility flags via the cli, e.g: `--compatibility-flags formdata_parser_supports_files`

--- a/.changeset/pretty-starfishes-judge.md
+++ b/.changeset/pretty-starfishes-judge.md
@@ -7,6 +7,6 @@ Add `--compatibility-date`, `--compatibility-flags`, `--latest` cli arguments to
 - A cli arg for adding a compatibility data, e.g `--compatibility_date 2022-01-05`
 - A shorthand `--latest` that sets `compatibility_date` to today's date. Usage of this flag logs a warning.
 - `latest` is NOT a config field in `wrangler.toml`.
-- In `dev`, when a compatibility date is not available in either `wrangler.toml` or as a cli arg, then we default to `--latest`, and log a warning.
+- In `dev`, when a compatibility date is not available in either `wrangler.toml` or as a cli arg, then we default to `--latest`.
 - In `publish` we error if a compatibility date is not available in either `wrangler.toml` or as a cli arg. Usage of `--latest` logs a warning.
 - We also accept compatibility flags via the cli, e.g: `--compatibility-flags formdata_parser_supports_files`

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -529,12 +529,6 @@ export async function main(argv: string[]): Promise<void> {
 
       const envRootObj = args.env ? config.env[args.env] || {} : config;
 
-      if (!envRootObj.compatibility_date && !args["compatibility-date"]) {
-        console.warn(
-          "⚠️  Using the latest version of the Workers runtime. To silence this warning, please choose a specific version of the runtime with --compatibility-date, or add a compatibility_date to your wrangler.toml.\n"
-        );
-      }
-
       // TODO: this error shouldn't actually happen,
       // but we haven't fixed it internally yet
       if ("durable_objects" in envRootObj) {

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -435,6 +435,20 @@ export async function main(argv: string[]): Promise<void> {
           type: "string",
           // TODO: get choices for the toml file?
         })
+        .option("compatibility-date", {
+          describe: "Date to use for compatibility checks",
+          type: "string",
+        })
+        .option("compatibility-flags", {
+          describe: "Flags to use for compatibility checks",
+          type: "array",
+          alias: "compatibility-flag",
+        })
+        .option("latest", {
+          describe: "Use the latest version of the worker runtime",
+          type: "boolean",
+          default: true,
+        })
         .option("ip", {
           describe: "IP address to listen on",
           type: "string",
@@ -515,12 +529,18 @@ export async function main(argv: string[]): Promise<void> {
 
       const envRootObj = args.env ? config.env[args.env] || {} : config;
 
+      if (!envRootObj.compatibility_date && !args["compatibility-date"]) {
+        console.warn(
+          "⚠️  Using the latest version of the Workers runtime. To silence this warning, please choose a specific version of the runtime with --compatibility-date, or add a compatibility_date to your wrangler.toml.\n"
+        );
+      }
+
       // TODO: this error shouldn't actually happen,
       // but we haven't fixed it internally yet
       if ("durable_objects" in envRootObj) {
         if (!(args.name || config.name)) {
           console.warn(
-            'A worker with durable objects need to be named, or it may not work as expected. Add a "name" into wrangler.toml, or pass it in the command line with --name.'
+            'A worker with durable objects needs to be named, or it may not work as expected. Add a "name" into wrangler.toml, or pass it in the command line with --name.'
           );
         }
         // TODO: if not already published, publish a draft worker
@@ -539,8 +559,15 @@ export async function main(argv: string[]): Promise<void> {
           site={args.site || config.site?.bucket}
           port={args.port || config.dev?.port}
           public={args["experimental-public"]}
-          compatibilityDate={config.compatibility_date}
-          compatibilityFlags={config.compatibility_flags}
+          compatibilityDate={
+            args["compatibility-date"] ||
+            config.compatibility_date ||
+            new Date().toISOString().substring(0, 10)
+          }
+          compatibilityFlags={
+            (args["compatibility-flags"] as string[]) ||
+            config.compatibility_flags
+          }
           usageModel={config.usage_model}
           bindings={{
             kv_namespaces: envRootObj.kv_namespaces?.map(
@@ -591,6 +618,20 @@ export async function main(argv: string[]): Promise<void> {
         .option("name", {
           describe: "name to use when uploading",
           type: "string",
+        })
+        .option("compatibility-date", {
+          describe: "Date to use for compatibility checks",
+          type: "string",
+        })
+        .option("compatibility-flags", {
+          describe: "Flags to use for compatibility checks",
+          type: "array",
+          alias: "compatibility-flag",
+        })
+        .option("latest", {
+          describe: "Use the latest version of the worker runtime",
+          type: "boolean",
+          default: false,
         })
         .option("experimental-public", {
           describe: "Static assets to be served",
@@ -645,6 +686,12 @@ export async function main(argv: string[]): Promise<void> {
 
       const config = args.config as Config;
 
+      if (args.latest) {
+        console.warn(
+          "⚠️  Using the latest version of the Workers runtime. To silence this warning, please choose a specific version of the runtime with --compatibility-date, or add a compatibility_date to your wrangler.toml.\n"
+        );
+      }
+
       // -- snip, extract --
       if (!args.local) {
         const loggedIn = await loginOrRefreshIfRequired();
@@ -668,6 +715,10 @@ export async function main(argv: string[]): Promise<void> {
         name: args.name,
         script: args.script,
         env: args.env,
+        compatibilityDate: args.latest
+          ? new Date().toISOString().substring(0, 10)
+          : args["compatibility-date"],
+        compatibilityFlags: args["compatibility-flags"] as string[],
         triggers: args.triggers,
         jsxFactory: args["jsx-factory"],
         jsxFragment: args["jsx-fragment"],

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -19,6 +19,8 @@ type Props = {
   script?: string;
   name?: string;
   env?: string;
+  compatibilityDate?: string;
+  compatibilityFlags?: string[];
   public?: string;
   site?: string;
   triggers?: (string | number)[];
@@ -47,6 +49,13 @@ export default async function publish(props: Props): Promise<void> {
     // @ts-expect-error hidden
     __path__,
   } = config;
+
+  const envRootObj = props.env ? config.env[props.env] || {} : config;
+
+  assert(
+    envRootObj.compatibility_date || props["compatibility-date"],
+    "A compatibility_date is required when publishing. Add one to your wrangler.toml file, or pass it in your terminal as --compatibility_date. See https://developers.cloudflare.com/workers/platform/compatibility-dates for more information."
+  );
 
   const triggers = props.triggers || config.triggers?.crons;
   const routes = props.routes || config.routes;
@@ -200,7 +209,6 @@ export default async function publish(props: Props): Promise<void> {
         )
       : { manifest: undefined, namespace: undefined };
 
-  const envRootObj = props.env ? config.env[props.env] || {} : config;
   const bindings: CfWorkerInit["bindings"] = {
     kv_namespaces: envRootObj.kv_namespaces?.concat(
       assets.namespace


### PR DESCRIPTION
Closes https://github.com/cloudflare/wrangler2/issues/193.

This PR adds cli fields for 2 existing configuration fields: `--compatibility-date`, `--compatibility-flags` matching `compatibility_date` and `compatibility_flags` respectively. It also adds a cli arg `--latest` which is shorthand for `--compatibility_date <today>`. It follows the rules from the linked issue -

- A cli arg for adding a compatibility data, e.g  `--compatibility_date 2022-01-05`
- A shorthand `--latest` that sets `compatibility_date` to today's date. Usage of this flag logs a warning.
- `latest` is NOT a config field in `wrangler.toml`.
- In `dev`, when a compatibility date is not available in either `wrangler.toml` or as a cli arg, then we default to `--latest`.
- In `publish` we error if a compatibility date is not available in either `wrangler.toml` or as a cli arg. Usage of `--latest` logs a warning.
- We also accept compatibility flags via the cli, e.g: `--compatibility-flags formdata_parser_supports_files`

I haven't added validation for the actual values of these args, I'll get to that next week when I work on the config validation work. The wording of the messages/errors are also up for discussion. I'm happy to keep this PR alive until we get it right.