### PR TITLE
Ignore non-JS files when compiling Pages Functions

### DIFF
--- a/.changeset/fluffy-insects-clap.md
+++ b/.changeset/fluffy-insects-clap.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Ignore non-JS files when compiling Pages Functions

--- a/packages/wrangler/pages/functions/filepath-routing.ts
+++ b/packages/wrangler/pages/functions/filepath-routing.ts
@@ -33,7 +33,7 @@ export async function generateConfigFromFileTree({
 
   await forEachFile(baseDir, async (filepath) => {
     const ext = path.extname(filepath);
-    if (/\.(mjs|js|ts)/.test(ext)) {
+    if (/^\.(mjs|js|ts)$/.test(ext)) {
       // transform the code to ensure we're working with vanilla JS + ESM
       const { code } = await transform(await fs.readFile(filepath, "utf-8"), {
         loader: ext === ".ts" ? "ts" : "js",

--- a/packages/wrangler/pages/functions/filepath-routing.ts
+++ b/packages/wrangler/pages/functions/filepath-routing.ts
@@ -33,7 +33,7 @@ export async function generateConfigFromFileTree({
 
   await forEachFile(baseDir, async (filepath) => {
     const ext = path.extname(filepath);
-    if (/^\.(mjs|js|ts)$/.test(ext)) {
+    if (/^\.(mjs|js|ts|tsx|jsx)$/.test(ext)) {
       // transform the code to ensure we're working with vanilla JS + ESM
       const { code } = await transform(await fs.readFile(filepath, "utf-8"), {
         loader: ext === ".ts" ? "ts" : "js",


### PR DESCRIPTION
Fixes #75

More strictly check file extensions when crawling the `/functions` directory to ensure we're only trying to include JS files.