### PR TITLE
Reverse execution order of Pages Functions middlewares

### DIFF
--- a/.changeset/fuzzy-ads-rush.md
+++ b/.changeset/fuzzy-ads-rush.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Reverse execution order of Pages Functions middlewares

--- a/packages/wrangler/pages/functions/filepath-routing.test.ts
+++ b/packages/wrangler/pages/functions/filepath-routing.test.ts
@@ -1,8 +1,15 @@
 import { compareRoutes } from "./filepath-routing";
 
 describe("compareRoutes()", () => {
+  test("routes / last", () => {
+    expect(compareRoutes("/", "/foo")).toBeGreaterThanOrEqual(1);
+    expect(compareRoutes("/", "/:foo")).toBeGreaterThanOrEqual(1);
+    expect(compareRoutes("/", "/:foo*")).toBeGreaterThanOrEqual(1);
+  });
+
   test("routes with fewer segments come after those with more segments", () => {
-    expect(compareRoutes("/foo", "/foo/bar")).toBe(1);
+    expect(compareRoutes("/foo", "/foo/bar")).toBeGreaterThanOrEqual(1);
+    expect(compareRoutes("/foo", "/foo/bar/cat")).toBeGreaterThanOrEqual(1);
   });
 
   test("routes with wildcard segments come after those without", () => {

--- a/packages/wrangler/pages/functions/filepath-routing.ts
+++ b/packages/wrangler/pages/functions/filepath-routing.ts
@@ -166,7 +166,7 @@ export function compareRoutes(a: string, b: string) {
       method = null;
     }
 
-    const segments = segmentedPath.slice(1).split("/");
+    const segments = segmentedPath.slice(1).split("/").filter(Boolean);
     return [method, segments];
   }
 

--- a/packages/wrangler/pages/functions/template-worker.ts
+++ b/packages/wrangler/pages/functions/template-worker.ts
@@ -45,8 +45,8 @@ type WorkerContext = {
 function* executeRequest(request: Request, env: Env) {
   const requestPath = new URL(request.url).pathname;
 
-  // First, iterate through the routes and execute "middlewares" on partial route matches
-  for (const route of routes) {
+  // First, iterate through the routes (backwards) and execute "middlewares" on partial route matches
+  for (const route of [...routes].reverse()) {
     if (
       route.methods.length &&
       !route.methods.includes(request.method as HTTPMethod)


### PR DESCRIPTION
Fixes #110

Reverses the execution order of Pages Functions middlewares.

Now, a directory like

```txt
- functions
  - _middleware.ts     // a
  - api
    - _middleware.ts   // b
    - todo
      - _middleware.ts // c
      - d.ts
```

will execute with the order, a -> b -> c -> d, for requests to `/api/todo/d`