### PR TITLE
Upgrade `miniflare` to `2.0.0` 🎉

### DIFF
--- a/.changeset/grumpy-knives-bathe.md
+++ b/.changeset/grumpy-knives-bathe.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Upgrade `miniflare` to `2.0.0`

--- a/package-lock.json
+++ b/package-lock.json
@@ -5207,14 +5207,6 @@
       ],
       "peer": true
     },
-    "node_modules/esbuild-plugin-replace": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/esbuild-plugin-replace/-/esbuild-plugin-replace-1.1.0.tgz",
-      "integrity": "sha512-NxyLnzR2jCtS94vFVTbXlLehXkZEj2bMl5uPN9IepMCrkjVG8xdGEVPempWB8pmZuN19XuzKItNdKSVEPI0tmA==",
-      "dependencies": {
-        "magic-string": "^0.25.7"
-      }
-    },
     "node_modules/esbuild-register": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.3.1.tgz",
@@ -11031,14 +11023,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/magic-string": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-      "dependencies": {
-        "sourcemap-codec": "^1.4.4"
-      }
-    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -13611,11 +13595,6 @@
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw=="
     },
-    "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
-    },
     "node_modules/spawndamnit": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/spawndamnit/-/spawndamnit-2.0.0.tgz",
@@ -15161,7 +15140,6 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "esbuild": "0.14.1",
-        "esbuild-plugin-replace": "^1.1.0",
         "miniflare": "2.0.0",
         "path-to-regexp": "^6.2.0",
         "semiver": "^1.1.0"
@@ -19351,14 +19329,6 @@
       "integrity": "sha512-9rkHZzp10zI90CfKbFrwmQjqZaeDmyQ6s9/hvCwRkbOCHuto6RvMYH9ghQpcr5cUxD5OQIA+sHXi0zokRNXjcg==",
       "optional": true,
       "peer": true
-    },
-    "esbuild-plugin-replace": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/esbuild-plugin-replace/-/esbuild-plugin-replace-1.1.0.tgz",
-      "integrity": "sha512-NxyLnzR2jCtS94vFVTbXlLehXkZEj2bMl5uPN9IepMCrkjVG8xdGEVPempWB8pmZuN19XuzKItNdKSVEPI0tmA==",
-      "requires": {
-        "magic-string": "^0.25.7"
-      }
     },
     "esbuild-register": {
       "version": "3.3.1",
@@ -23627,14 +23597,6 @@
         "yallist": "^4.0.0"
       }
     },
-    "magic-string": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-      "requires": {
-        "sourcemap-codec": "^1.4.4"
-      }
-    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -25525,11 +25487,6 @@
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw=="
     },
-    "sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
-    },
     "spawndamnit": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/spawndamnit/-/spawndamnit-2.0.0.tgz",
@@ -26561,7 +26518,6 @@
         "clipboardy": "^3.0.0",
         "command-exists": "^1.2.9",
         "esbuild": "0.14.1",
-        "esbuild-plugin-replace": "^1.1.0",
         "execa": "^6.0.0",
         "faye-websocket": "^0.11.4",
         "finalhandler": "^1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2492,25 +2492,25 @@
       }
     },
     "node_modules/@miniflare/cache": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.0.0-rc.5.tgz",
-      "integrity": "sha512-i7T6OYCQOrJ2XqMYW5uDZ03K3zMSku3d7Mny6+yT6BCqMw0amTLnEGvqR/rwxmInSAF9Y4KHXH/VyhLggocMFQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.0.0.tgz",
+      "integrity": "sha512-Luk/MmRKZPy481b+3wKVYKL/kMwM/X9Tl6Wxj1XrE/P3x4SwZNGI6w0kIxHMYSlBy8OsQJso/XDPu1jJhIltJQ==",
       "dependencies": {
-        "@miniflare/core": "2.0.0-rc.5",
-        "@miniflare/shared": "2.0.0-rc.5",
+        "@miniflare/core": "2.0.0",
+        "@miniflare/shared": "2.0.0",
         "http-cache-semantics": "^4.1.0",
-        "undici": "^4.11.1"
+        "undici": "4.12.1"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/cli-parser": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.0.0-rc.5.tgz",
-      "integrity": "sha512-p5xKD0sGQBa681/U/2a8de4nw5ua6BHD4y3/AmF1j8kjwp3Fbz/TodLscuoMxwMcP8+f86mf5xX1Py84yD7azw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.0.0.tgz",
+      "integrity": "sha512-GYPWk/qXr19/4c5nmhBzl0RcyPnXFtYNQoWnys/v6rAWCEBzKROBVh3tInrvO7v2jyDYWYfbOnbCf9ZxZDSRSQ==",
       "dependencies": {
-        "@miniflare/shared": "2.0.0-rc.5",
+        "@miniflare/shared": "2.0.0",
         "kleur": "^4.1.4"
       },
       "engines": {
@@ -2518,23 +2518,23 @@
       }
     },
     "node_modules/@miniflare/core": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.0.0-rc.5.tgz",
-      "integrity": "sha512-nZNlvx0ck/M04ow7q3YD9xxkbT53E7BkYWR68ECvxXQHWTBqje7Weg3yzWu3UbhnAgugB6Q5h5FFmGGYT1mfhQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-w37nbFzlp6R2TL0WG8m5iaZWK4BKdDkoACEnc9kQaaBEYI1HRne1rjzT+8DqgrrFqBjDIa+7cT6tn74eGer7Dg==",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/shared": "2.0.0-rc.5",
+        "@miniflare/shared": "2.0.0",
         "busboy": "^0.3.1",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
         "set-cookie-parser": "^2.4.8",
-        "undici": "^4.11.1"
+        "undici": "4.12.1"
       },
       "engines": {
         "node": ">=16.7"
       },
       "peerDependencies": {
-        "@miniflare/watcher": "2.0.0-rc.5"
+        "@miniflare/watcher": "2.0.0"
       },
       "peerDependenciesMeta": {
         "@miniflare/watcher": {
@@ -2551,44 +2551,44 @@
       }
     },
     "node_modules/@miniflare/durable-objects": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.0.0-rc.5.tgz",
-      "integrity": "sha512-Re/r8qQdCk7CcxqaVm78vGAkFqlB49oZ2Vfrd+85xupSySiSrhs5MPIaKvn7gp0Msq86LOWDbKTN0r80rfp0Dw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.0.0.tgz",
+      "integrity": "sha512-xu1wFcQ4XXwqOr/Z2QCARgbeau7SujtVV7LDPcWs8LWBYteEsFwl96mpoDv/ho2Zk67xUMK3TIvGakBbnQWsjQ==",
       "dependencies": {
-        "@miniflare/core": "2.0.0-rc.5",
-        "@miniflare/shared": "2.0.0-rc.5",
-        "@miniflare/storage-memory": "2.0.0-rc.5",
-        "undici": "^4.11.1"
+        "@miniflare/core": "2.0.0",
+        "@miniflare/shared": "2.0.0",
+        "@miniflare/storage-memory": "2.0.0",
+        "undici": "4.12.1"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/html-rewriter": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.0.0-rc.5.tgz",
-      "integrity": "sha512-S3iRohlCiMoT8EiW7luUoZWhetyuDFGfso4MPB5GvNgDHzRyrVooK/myHhLXMfH+fVEF3+tkgGyMavd+G0XJ3w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.0.0.tgz",
+      "integrity": "sha512-GFfrYsswtp8ZvDsJ2UybdpKYqclS4TMX7i9YvQMBUBolS7ovdEa0+UoWsDyHmw/iRjJI+mcov5IRQImrC8HFOw==",
       "dependencies": {
-        "@miniflare/core": "2.0.0-rc.5",
-        "@miniflare/shared": "2.0.0-rc.5",
+        "@miniflare/core": "2.0.0",
+        "@miniflare/shared": "2.0.0",
         "html-rewriter-wasm": "^0.3.2",
-        "undici": "^4.11.1"
+        "undici": "4.12.1"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/http-server": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.0.0-rc.5.tgz",
-      "integrity": "sha512-6hn3gSFFh1wtDUcg6SS5nZuy+Oy3iGPseV3EO3qhD4rEJFEFBMu9mlow8Dj8CeTJeMgy8UjlLbH5MJUV3hyTLA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.0.0.tgz",
+      "integrity": "sha512-moIpSSYOpLUZ2RjYOXO+mZMKOzOKuxHfF8V9pDdtQ/s9kF9CjyPUNG2TKBcfhKFmdWFdhxdUm+fbHo2DOVytRw==",
       "dependencies": {
-        "@miniflare/core": "2.0.0-rc.5",
-        "@miniflare/shared": "2.0.0-rc.5",
-        "@miniflare/web-sockets": "2.0.0-rc.5",
+        "@miniflare/core": "2.0.0",
+        "@miniflare/shared": "2.0.0",
+        "@miniflare/web-sockets": "2.0.0",
         "kleur": "^4.1.4",
         "selfsigned": "^1.10.11",
-        "undici": "^4.11.1",
+        "undici": "4.12.1",
         "ws": "^8.2.2",
         "youch": "^2.2.2"
       },
@@ -2597,34 +2597,34 @@
       }
     },
     "node_modules/@miniflare/kv": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.0.0-rc.5.tgz",
-      "integrity": "sha512-2dyeELSebysfddfga8tP9fysxOCP3xXXOaBMeiMxa2GfX5eN/kluCwyvJxzlUvUHcZhNwNrYZCApXsaWf6z/5w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.0.0.tgz",
+      "integrity": "sha512-f087ATCuFPQR3ZgLKt5kIeRYFdwt2pCNfRPb5pNf5t8tI1xT5O1IacC13WLo6nCO0uBfCovUQV11mGdSuDpG7w==",
       "dependencies": {
-        "@miniflare/shared": "2.0.0-rc.5"
+        "@miniflare/shared": "2.0.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/runner-vm": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.0.0-rc.5.tgz",
-      "integrity": "sha512-yQLtvoG+hkZ9Gn/GsHNVytqFah0lckrtoP6TyE/aNrY23/cH8PRS0l8jgjq6tmdDHWH5F+UYUqYyILQykeY5JA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.0.0.tgz",
+      "integrity": "sha512-2kFTS+IhtoZjsDRyIba2xQWG0B73KaJGaymmk5cYjXqBML1DA9C7nxpkiJbbEDdAGG0hQRD7ILSe3M4gCQ51Bg==",
       "dependencies": {
-        "@miniflare/shared": "2.0.0-rc.5"
+        "@miniflare/shared": "2.0.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/scheduler": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.0.0-rc.5.tgz",
-      "integrity": "sha512-PPc/o4dVwhiB42fTlCROWy4fjHAwBhPGA61lcoqAJsEyVdS6bJHbJF0W95KICldEvqLmdQKWnMSR+MrYnAo7lA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.0.0.tgz",
+      "integrity": "sha512-H0gUrvhSb6XeSUpOcr0vuuFVxciE4LIKQB/vgVLPjYULQqvU85ZZU1/hocYxJ35f9h8U7iK13FUzORfwj5EBbA==",
       "dependencies": {
-        "@miniflare/core": "2.0.0-rc.5",
-        "@miniflare/shared": "2.0.0-rc.5",
+        "@miniflare/core": "2.0.0",
+        "@miniflare/shared": "2.0.0",
         "cron-schedule": "^3.0.4"
       },
       "engines": {
@@ -2632,9 +2632,9 @@
       }
     },
     "node_modules/@miniflare/shared": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.0.0-rc.5.tgz",
-      "integrity": "sha512-ubyp0v5lQh1so5W4InT5zQKKRUZ+dYPJUI0TrLyne4DWd4Nwi2uEmrxEc5ZwEZ/n8VxzxI96jybcEwDXoUirFw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.0.0.tgz",
+      "integrity": "sha512-cWLl8qvYueQ4Kgx1m9ve1m9lCVL2/rnaBQ21jxb8CS5zQ6csMBIrvA0pCDfRK6YeAY76ScNM0uO6aiRW7easEA==",
       "dependencies": {
         "ignore": "^5.1.8",
         "kleur": "^4.1.4"
@@ -2644,60 +2644,60 @@
       }
     },
     "node_modules/@miniflare/sites": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.0.0-rc.5.tgz",
-      "integrity": "sha512-Qw4B2BXcl9aMj7FfgswTQcmOl52XUxtij9LfTzvGk1JOAf5GzwLLpmKWunF2rr6X/1NHsNRXFeGq23eMzHQpuQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.0.0.tgz",
+      "integrity": "sha512-uG4bEPfcc1OLToiOXHNZrjU0aoUyugUu5q+mUGwR2ApCHbt/bRv6FZVxOSQWZcbzVYGujnk9vGAALVg/hwd0Hw==",
       "dependencies": {
-        "@miniflare/kv": "2.0.0-rc.5",
-        "@miniflare/shared": "2.0.0-rc.5",
-        "@miniflare/storage-file": "2.0.0-rc.5"
+        "@miniflare/kv": "2.0.0",
+        "@miniflare/shared": "2.0.0",
+        "@miniflare/storage-file": "2.0.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/storage-file": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.0.0-rc.5.tgz",
-      "integrity": "sha512-ogm0E5Hwen00xmT3nJ91c6fvHIv6vmv3sf3IFn5yul4disX9A7VDlQF9ZxlXaGgcD4k97T5HhL68L7zj15ugUA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.0.0.tgz",
+      "integrity": "sha512-ADWmq7OLjQDgAaOiTBfUn44VDxTt2gqsHrr00KIXGdaVVU6R1HS8VryRCx4o/1w23p31ySSez2+h2g5rWB4WQg==",
       "dependencies": {
-        "@miniflare/shared": "2.0.0-rc.5",
-        "@miniflare/storage-memory": "2.0.0-rc.5"
+        "@miniflare/shared": "2.0.0",
+        "@miniflare/storage-memory": "2.0.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/storage-memory": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.0.0-rc.5.tgz",
-      "integrity": "sha512-SWmOY2fu+1I/p0SM6+nAn8dq2ie1diuqy9Su7yaMxj5oTLUgdWbXutX0UTqYhDn2shTw+P6jGHv6tf0LGCW7Hg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.0.0.tgz",
+      "integrity": "sha512-bWN0HvjnWwCDfBhlMXNC1ir9BceUA+LvWqmCDQcrY8K8nm+hH1/DU1TtSjGDnmAELNV5Rv1b0OwmhYkyNlq+nQ==",
       "dependencies": {
-        "@miniflare/shared": "2.0.0-rc.5"
+        "@miniflare/shared": "2.0.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/watcher": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.0.0-rc.5.tgz",
-      "integrity": "sha512-Cx5lSzPN5xoTC6gTGxzx5YPzGGeLGK7MHL86tMZqfxcku/pjdup3h2NkhGiwUAatm1DX05xrj6FmDJaJOc+FNA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.0.0.tgz",
+      "integrity": "sha512-0B7w1B1d4hHVyLPznDuGxxwDku4wxLjPXqcIcVZhQmIK1+IaRwx/qJ5PolAwLTaqkLaYA7K/WlY8aumDa/VLsQ==",
       "dependencies": {
-        "@miniflare/shared": "2.0.0-rc.5"
+        "@miniflare/shared": "2.0.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/web-sockets": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.0.0-rc.5.tgz",
-      "integrity": "sha512-HXTjmf46S9HdwWm2OinOsve3ld9EX8wgzgHnqAGGVop/TkeBUsQ4mO53cGRPjNdu9cDT8ukr312xtX/wFe0Jsg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.0.0.tgz",
+      "integrity": "sha512-mU/Fw0a3/giJRbhOJVEsvm8Wlau2vVK241vI5K2VRjT6S5w9XGeog7ohBPtbTDYjkB0gdmZX/9KPQVBidJgB8Q==",
       "dependencies": {
-        "@miniflare/core": "2.0.0-rc.5",
-        "@miniflare/shared": "2.0.0-rc.5",
-        "undici": "^4.11.1",
+        "@miniflare/core": "2.0.0",
+        "@miniflare/shared": "2.0.0",
+        "undici": "4.12.1",
         "ws": "^8.2.2"
       },
       "engines": {
@@ -11211,29 +11211,29 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.0.0-rc.5.tgz",
-      "integrity": "sha512-4i6qC+jLpsV8c/W2m04qMokrXY9ybg0jeK9F3+F/4fkpvtT784dMhdhdKbfY2qGr9q+CuAmMkO6myOrs7F6RHA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.0.0.tgz",
+      "integrity": "sha512-vjaVGh8PPT5wsMs+XkTUEeg0S7Yrl4LAHY5/mwoocI+Z8iCCHTECEAB/Ioymh5Z3pnczj1AZ99DPMFBTXRI29A==",
       "dependencies": {
-        "@miniflare/cache": "2.0.0-rc.5",
-        "@miniflare/cli-parser": "2.0.0-rc.5",
-        "@miniflare/core": "2.0.0-rc.5",
-        "@miniflare/durable-objects": "2.0.0-rc.5",
-        "@miniflare/html-rewriter": "2.0.0-rc.5",
-        "@miniflare/http-server": "2.0.0-rc.5",
-        "@miniflare/kv": "2.0.0-rc.5",
-        "@miniflare/runner-vm": "2.0.0-rc.5",
-        "@miniflare/scheduler": "2.0.0-rc.5",
-        "@miniflare/shared": "2.0.0-rc.5",
-        "@miniflare/sites": "2.0.0-rc.5",
-        "@miniflare/storage-file": "2.0.0-rc.5",
-        "@miniflare/storage-memory": "2.0.0-rc.5",
-        "@miniflare/watcher": "2.0.0-rc.5",
-        "@miniflare/web-sockets": "2.0.0-rc.5",
+        "@miniflare/cache": "2.0.0",
+        "@miniflare/cli-parser": "2.0.0",
+        "@miniflare/core": "2.0.0",
+        "@miniflare/durable-objects": "2.0.0",
+        "@miniflare/html-rewriter": "2.0.0",
+        "@miniflare/http-server": "2.0.0",
+        "@miniflare/kv": "2.0.0",
+        "@miniflare/runner-vm": "2.0.0",
+        "@miniflare/scheduler": "2.0.0",
+        "@miniflare/shared": "2.0.0",
+        "@miniflare/sites": "2.0.0",
+        "@miniflare/storage-file": "2.0.0",
+        "@miniflare/storage-memory": "2.0.0",
+        "@miniflare/watcher": "2.0.0",
+        "@miniflare/web-sockets": "2.0.0",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
-        "undici": "^4.11.1"
+        "undici": "4.12.1"
       },
       "bin": {
         "miniflare": "bootstrap.js"
@@ -11242,7 +11242,7 @@
         "node": ">=16.7"
       },
       "peerDependencies": {
-        "@miniflare/storage-redis": "2.0.0-rc.5",
+        "@miniflare/storage-redis": "2.0.0",
         "cron-schedule": "^3.0.4",
         "ioredis": "^4.27.9"
       },
@@ -15162,7 +15162,7 @@
       "dependencies": {
         "esbuild": "0.14.1",
         "esbuild-plugin-replace": "^1.1.0",
-        "miniflare": "2.0.0-rc.5",
+        "miniflare": "2.0.0",
         "path-to-regexp": "^6.2.0",
         "semiver": "^1.1.0"
       },
@@ -17353,37 +17353,37 @@
       }
     },
     "@miniflare/cache": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.0.0-rc.5.tgz",
-      "integrity": "sha512-i7T6OYCQOrJ2XqMYW5uDZ03K3zMSku3d7Mny6+yT6BCqMw0amTLnEGvqR/rwxmInSAF9Y4KHXH/VyhLggocMFQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.0.0.tgz",
+      "integrity": "sha512-Luk/MmRKZPy481b+3wKVYKL/kMwM/X9Tl6Wxj1XrE/P3x4SwZNGI6w0kIxHMYSlBy8OsQJso/XDPu1jJhIltJQ==",
       "requires": {
-        "@miniflare/core": "2.0.0-rc.5",
-        "@miniflare/shared": "2.0.0-rc.5",
+        "@miniflare/core": "2.0.0",
+        "@miniflare/shared": "2.0.0",
         "http-cache-semantics": "^4.1.0",
-        "undici": "^4.11.1"
+        "undici": "4.12.1"
       }
     },
     "@miniflare/cli-parser": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.0.0-rc.5.tgz",
-      "integrity": "sha512-p5xKD0sGQBa681/U/2a8de4nw5ua6BHD4y3/AmF1j8kjwp3Fbz/TodLscuoMxwMcP8+f86mf5xX1Py84yD7azw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.0.0.tgz",
+      "integrity": "sha512-GYPWk/qXr19/4c5nmhBzl0RcyPnXFtYNQoWnys/v6rAWCEBzKROBVh3tInrvO7v2jyDYWYfbOnbCf9ZxZDSRSQ==",
       "requires": {
-        "@miniflare/shared": "2.0.0-rc.5",
+        "@miniflare/shared": "2.0.0",
         "kleur": "^4.1.4"
       }
     },
     "@miniflare/core": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.0.0-rc.5.tgz",
-      "integrity": "sha512-nZNlvx0ck/M04ow7q3YD9xxkbT53E7BkYWR68ECvxXQHWTBqje7Weg3yzWu3UbhnAgugB6Q5h5FFmGGYT1mfhQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-w37nbFzlp6R2TL0WG8m5iaZWK4BKdDkoACEnc9kQaaBEYI1HRne1rjzT+8DqgrrFqBjDIa+7cT6tn74eGer7Dg==",
       "requires": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/shared": "2.0.0-rc.5",
+        "@miniflare/shared": "2.0.0",
         "busboy": "^0.3.1",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
         "set-cookie-parser": "^2.4.8",
-        "undici": "^4.11.1"
+        "undici": "4.12.1"
       },
       "dependencies": {
         "dotenv": {
@@ -17394,120 +17394,120 @@
       }
     },
     "@miniflare/durable-objects": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.0.0-rc.5.tgz",
-      "integrity": "sha512-Re/r8qQdCk7CcxqaVm78vGAkFqlB49oZ2Vfrd+85xupSySiSrhs5MPIaKvn7gp0Msq86LOWDbKTN0r80rfp0Dw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.0.0.tgz",
+      "integrity": "sha512-xu1wFcQ4XXwqOr/Z2QCARgbeau7SujtVV7LDPcWs8LWBYteEsFwl96mpoDv/ho2Zk67xUMK3TIvGakBbnQWsjQ==",
       "requires": {
-        "@miniflare/core": "2.0.0-rc.5",
-        "@miniflare/shared": "2.0.0-rc.5",
-        "@miniflare/storage-memory": "2.0.0-rc.5",
-        "undici": "^4.11.1"
+        "@miniflare/core": "2.0.0",
+        "@miniflare/shared": "2.0.0",
+        "@miniflare/storage-memory": "2.0.0",
+        "undici": "4.12.1"
       }
     },
     "@miniflare/html-rewriter": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.0.0-rc.5.tgz",
-      "integrity": "sha512-S3iRohlCiMoT8EiW7luUoZWhetyuDFGfso4MPB5GvNgDHzRyrVooK/myHhLXMfH+fVEF3+tkgGyMavd+G0XJ3w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.0.0.tgz",
+      "integrity": "sha512-GFfrYsswtp8ZvDsJ2UybdpKYqclS4TMX7i9YvQMBUBolS7ovdEa0+UoWsDyHmw/iRjJI+mcov5IRQImrC8HFOw==",
       "requires": {
-        "@miniflare/core": "2.0.0-rc.5",
-        "@miniflare/shared": "2.0.0-rc.5",
+        "@miniflare/core": "2.0.0",
+        "@miniflare/shared": "2.0.0",
         "html-rewriter-wasm": "^0.3.2",
-        "undici": "^4.11.1"
+        "undici": "4.12.1"
       }
     },
     "@miniflare/http-server": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.0.0-rc.5.tgz",
-      "integrity": "sha512-6hn3gSFFh1wtDUcg6SS5nZuy+Oy3iGPseV3EO3qhD4rEJFEFBMu9mlow8Dj8CeTJeMgy8UjlLbH5MJUV3hyTLA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.0.0.tgz",
+      "integrity": "sha512-moIpSSYOpLUZ2RjYOXO+mZMKOzOKuxHfF8V9pDdtQ/s9kF9CjyPUNG2TKBcfhKFmdWFdhxdUm+fbHo2DOVytRw==",
       "requires": {
-        "@miniflare/core": "2.0.0-rc.5",
-        "@miniflare/shared": "2.0.0-rc.5",
-        "@miniflare/web-sockets": "2.0.0-rc.5",
+        "@miniflare/core": "2.0.0",
+        "@miniflare/shared": "2.0.0",
+        "@miniflare/web-sockets": "2.0.0",
         "kleur": "^4.1.4",
         "selfsigned": "^1.10.11",
-        "undici": "^4.11.1",
+        "undici": "4.12.1",
         "ws": "^8.2.2",
         "youch": "^2.2.2"
       }
     },
     "@miniflare/kv": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.0.0-rc.5.tgz",
-      "integrity": "sha512-2dyeELSebysfddfga8tP9fysxOCP3xXXOaBMeiMxa2GfX5eN/kluCwyvJxzlUvUHcZhNwNrYZCApXsaWf6z/5w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.0.0.tgz",
+      "integrity": "sha512-f087ATCuFPQR3ZgLKt5kIeRYFdwt2pCNfRPb5pNf5t8tI1xT5O1IacC13WLo6nCO0uBfCovUQV11mGdSuDpG7w==",
       "requires": {
-        "@miniflare/shared": "2.0.0-rc.5"
+        "@miniflare/shared": "2.0.0"
       }
     },
     "@miniflare/runner-vm": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.0.0-rc.5.tgz",
-      "integrity": "sha512-yQLtvoG+hkZ9Gn/GsHNVytqFah0lckrtoP6TyE/aNrY23/cH8PRS0l8jgjq6tmdDHWH5F+UYUqYyILQykeY5JA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.0.0.tgz",
+      "integrity": "sha512-2kFTS+IhtoZjsDRyIba2xQWG0B73KaJGaymmk5cYjXqBML1DA9C7nxpkiJbbEDdAGG0hQRD7ILSe3M4gCQ51Bg==",
       "requires": {
-        "@miniflare/shared": "2.0.0-rc.5"
+        "@miniflare/shared": "2.0.0"
       }
     },
     "@miniflare/scheduler": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.0.0-rc.5.tgz",
-      "integrity": "sha512-PPc/o4dVwhiB42fTlCROWy4fjHAwBhPGA61lcoqAJsEyVdS6bJHbJF0W95KICldEvqLmdQKWnMSR+MrYnAo7lA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.0.0.tgz",
+      "integrity": "sha512-H0gUrvhSb6XeSUpOcr0vuuFVxciE4LIKQB/vgVLPjYULQqvU85ZZU1/hocYxJ35f9h8U7iK13FUzORfwj5EBbA==",
       "requires": {
-        "@miniflare/core": "2.0.0-rc.5",
-        "@miniflare/shared": "2.0.0-rc.5",
+        "@miniflare/core": "2.0.0",
+        "@miniflare/shared": "2.0.0",
         "cron-schedule": "^3.0.4"
       }
     },
     "@miniflare/shared": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.0.0-rc.5.tgz",
-      "integrity": "sha512-ubyp0v5lQh1so5W4InT5zQKKRUZ+dYPJUI0TrLyne4DWd4Nwi2uEmrxEc5ZwEZ/n8VxzxI96jybcEwDXoUirFw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.0.0.tgz",
+      "integrity": "sha512-cWLl8qvYueQ4Kgx1m9ve1m9lCVL2/rnaBQ21jxb8CS5zQ6csMBIrvA0pCDfRK6YeAY76ScNM0uO6aiRW7easEA==",
       "requires": {
         "ignore": "^5.1.8",
         "kleur": "^4.1.4"
       }
     },
     "@miniflare/sites": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.0.0-rc.5.tgz",
-      "integrity": "sha512-Qw4B2BXcl9aMj7FfgswTQcmOl52XUxtij9LfTzvGk1JOAf5GzwLLpmKWunF2rr6X/1NHsNRXFeGq23eMzHQpuQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.0.0.tgz",
+      "integrity": "sha512-uG4bEPfcc1OLToiOXHNZrjU0aoUyugUu5q+mUGwR2ApCHbt/bRv6FZVxOSQWZcbzVYGujnk9vGAALVg/hwd0Hw==",
       "requires": {
-        "@miniflare/kv": "2.0.0-rc.5",
-        "@miniflare/shared": "2.0.0-rc.5",
-        "@miniflare/storage-file": "2.0.0-rc.5"
+        "@miniflare/kv": "2.0.0",
+        "@miniflare/shared": "2.0.0",
+        "@miniflare/storage-file": "2.0.0"
       }
     },
     "@miniflare/storage-file": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.0.0-rc.5.tgz",
-      "integrity": "sha512-ogm0E5Hwen00xmT3nJ91c6fvHIv6vmv3sf3IFn5yul4disX9A7VDlQF9ZxlXaGgcD4k97T5HhL68L7zj15ugUA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.0.0.tgz",
+      "integrity": "sha512-ADWmq7OLjQDgAaOiTBfUn44VDxTt2gqsHrr00KIXGdaVVU6R1HS8VryRCx4o/1w23p31ySSez2+h2g5rWB4WQg==",
       "requires": {
-        "@miniflare/shared": "2.0.0-rc.5",
-        "@miniflare/storage-memory": "2.0.0-rc.5"
+        "@miniflare/shared": "2.0.0",
+        "@miniflare/storage-memory": "2.0.0"
       }
     },
     "@miniflare/storage-memory": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.0.0-rc.5.tgz",
-      "integrity": "sha512-SWmOY2fu+1I/p0SM6+nAn8dq2ie1diuqy9Su7yaMxj5oTLUgdWbXutX0UTqYhDn2shTw+P6jGHv6tf0LGCW7Hg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.0.0.tgz",
+      "integrity": "sha512-bWN0HvjnWwCDfBhlMXNC1ir9BceUA+LvWqmCDQcrY8K8nm+hH1/DU1TtSjGDnmAELNV5Rv1b0OwmhYkyNlq+nQ==",
       "requires": {
-        "@miniflare/shared": "2.0.0-rc.5"
+        "@miniflare/shared": "2.0.0"
       }
     },
     "@miniflare/watcher": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.0.0-rc.5.tgz",
-      "integrity": "sha512-Cx5lSzPN5xoTC6gTGxzx5YPzGGeLGK7MHL86tMZqfxcku/pjdup3h2NkhGiwUAatm1DX05xrj6FmDJaJOc+FNA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.0.0.tgz",
+      "integrity": "sha512-0B7w1B1d4hHVyLPznDuGxxwDku4wxLjPXqcIcVZhQmIK1+IaRwx/qJ5PolAwLTaqkLaYA7K/WlY8aumDa/VLsQ==",
       "requires": {
-        "@miniflare/shared": "2.0.0-rc.5"
+        "@miniflare/shared": "2.0.0"
       }
     },
     "@miniflare/web-sockets": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.0.0-rc.5.tgz",
-      "integrity": "sha512-HXTjmf46S9HdwWm2OinOsve3ld9EX8wgzgHnqAGGVop/TkeBUsQ4mO53cGRPjNdu9cDT8ukr312xtX/wFe0Jsg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.0.0.tgz",
+      "integrity": "sha512-mU/Fw0a3/giJRbhOJVEsvm8Wlau2vVK241vI5K2VRjT6S5w9XGeog7ohBPtbTDYjkB0gdmZX/9KPQVBidJgB8Q==",
       "requires": {
-        "@miniflare/core": "2.0.0-rc.5",
-        "@miniflare/shared": "2.0.0-rc.5",
-        "undici": "^4.11.1",
+        "@miniflare/core": "2.0.0",
+        "@miniflare/shared": "2.0.0",
+        "undici": "4.12.1",
         "ws": "^8.2.2"
       }
     },
@@ -23751,29 +23751,29 @@
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
     },
     "miniflare": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.0.0-rc.5.tgz",
-      "integrity": "sha512-4i6qC+jLpsV8c/W2m04qMokrXY9ybg0jeK9F3+F/4fkpvtT784dMhdhdKbfY2qGr9q+CuAmMkO6myOrs7F6RHA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.0.0.tgz",
+      "integrity": "sha512-vjaVGh8PPT5wsMs+XkTUEeg0S7Yrl4LAHY5/mwoocI+Z8iCCHTECEAB/Ioymh5Z3pnczj1AZ99DPMFBTXRI29A==",
       "requires": {
-        "@miniflare/cache": "2.0.0-rc.5",
-        "@miniflare/cli-parser": "2.0.0-rc.5",
-        "@miniflare/core": "2.0.0-rc.5",
-        "@miniflare/durable-objects": "2.0.0-rc.5",
-        "@miniflare/html-rewriter": "2.0.0-rc.5",
-        "@miniflare/http-server": "2.0.0-rc.5",
-        "@miniflare/kv": "2.0.0-rc.5",
-        "@miniflare/runner-vm": "2.0.0-rc.5",
-        "@miniflare/scheduler": "2.0.0-rc.5",
-        "@miniflare/shared": "2.0.0-rc.5",
-        "@miniflare/sites": "2.0.0-rc.5",
-        "@miniflare/storage-file": "2.0.0-rc.5",
-        "@miniflare/storage-memory": "2.0.0-rc.5",
-        "@miniflare/watcher": "2.0.0-rc.5",
-        "@miniflare/web-sockets": "2.0.0-rc.5",
+        "@miniflare/cache": "2.0.0",
+        "@miniflare/cli-parser": "2.0.0",
+        "@miniflare/core": "2.0.0",
+        "@miniflare/durable-objects": "2.0.0",
+        "@miniflare/html-rewriter": "2.0.0",
+        "@miniflare/http-server": "2.0.0",
+        "@miniflare/kv": "2.0.0",
+        "@miniflare/runner-vm": "2.0.0",
+        "@miniflare/scheduler": "2.0.0",
+        "@miniflare/shared": "2.0.0",
+        "@miniflare/sites": "2.0.0",
+        "@miniflare/storage-file": "2.0.0",
+        "@miniflare/storage-memory": "2.0.0",
+        "@miniflare/watcher": "2.0.0",
+        "@miniflare/web-sockets": "2.0.0",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
-        "undici": "^4.11.1"
+        "undici": "4.12.1"
       }
     },
     "minimatch": {
@@ -26574,7 +26574,7 @@
         "ink-testing-library": "^2.1.0",
         "ink-text-input": "^4.0.2",
         "mime": "^3.0.0",
-        "miniflare": "2.0.0-rc.5",
+        "miniflare": "2.0.0",
         "node-fetch": "^3.1.0",
         "open": "^8.4.0",
         "path-to-regexp": "^6.2.0",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -37,7 +37,6 @@
   ],
   "dependencies": {
     "esbuild": "0.14.1",
-    "esbuild-plugin-replace": "^1.1.0",
     "miniflare": "2.0.0",
     "path-to-regexp": "^6.2.0",
     "semiver": "^1.1.0"

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "esbuild": "0.14.1",
     "esbuild-plugin-replace": "^1.1.0",
-    "miniflare": "2.0.0-rc.5",
+    "miniflare": "2.0.0",
     "path-to-regexp": "^6.2.0",
     "semiver": "^1.1.0"
   },

--- a/packages/wrangler/pages/functions/buildWorker.ts
+++ b/packages/wrangler/pages/functions/buildWorker.ts
@@ -1,6 +1,5 @@
 import path from "path";
 import { build } from "esbuild";
-import { replace } from "esbuild-plugin-replace";
 
 type Options = {
   routesModule: string;
@@ -34,12 +33,10 @@ export function buildWorker({
     sourcemap,
     watch,
     allowOverwrite: true,
+    define: {
+      __FALLBACK_SERVICE__: JSON.stringify(fallbackService),
+    },
     plugins: [
-      replace({
-        __FALLBACK_SERVICE_FETCH__: fallbackService
-          ? `env.${fallbackService}.fetch`
-          : "fetch",
-      }),
       {
         name: "wrangler notifier and monitor",
         setup(pluginBuild) {

--- a/packages/wrangler/pages/functions/template-worker.ts
+++ b/packages/wrangler/pages/functions/template-worker.ts
@@ -29,6 +29,8 @@ type RouteHandler = {
 
 // inject `routes` via ESBuild
 declare const routes: RouteHandler[];
+// define `__FALLBACK_SERVICE__` via ESBuild
+declare const __FALLBACK_SERVICE__: string;
 
 // expect an ASSETS fetcher binding pointing to the asset-server stage
 type Env = {
@@ -89,8 +91,11 @@ function* executeRequest(request: Request, env: Env) {
 
   // Finally, yield to the fallback service (`env.ASSETS.fetch` in Pages' case)
   return {
-    // @ts-expect-error we don't define a type for the special global __FALLBACK_SERVICE_FETCH__ since we replace it when we're building anyway
-    handler: () => __FALLBACK_SERVICE_FETCH__(request.url, request),
+    handler: () =>
+      __FALLBACK_SERVICE__
+        ? // @ts-expect-error expecting __FALLBACK_SERVICE__ to be the name of a service binding, so fetch should be defined
+          env[__FALLBACK_SERVICE__].fetch(request)
+        : fetch(request),
     params: {} as Params,
   };
 }

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -802,6 +802,7 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
 
           watch([functionsDirectory], {
             persistent: true,
+            ignoreInitial: true,
           }).on("all", async () => {
             await buildFunctions({
               scriptPath,
@@ -932,7 +933,10 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
           }
 
           if (directory !== undefined && liveReload) {
-            watch([directory], { persistent: true }).on("all", async () => {
+            watch([directory], {
+              persistent: true,
+              ignoreInitial: true,
+            }).on("all", async () => {
               await miniflare.reload();
             });
           }


### PR DESCRIPTION
Hey! 👋 This PR upgrades `miniflare` to version `2.0.0`. There were only a couple changes since `2.0.0-rc.5`, mostly around making `fetch` behave more like Cloudflare's. See the [bottom of the changelog](https://github.com/cloudflare/miniflare/releases/tag/v2.0.0).

I've also made another few minor tweaks to `pages dev`:

1. **Remove redundant immediate pages dev rebuilds/reloads:** watching `all` events without `ignoreInitial` set to `true` means `chokidar` calls the callback immediately. This caused functions to be built twice, and Miniflare to be `reload`ed immediately after startup.
2. **Wait for esbuild to finish before starting Miniflare:** instead of using a `scriptReady` boolean, this now uses a deferred `Promise`, so the event loop isn't blocked. This is now `await`ed before constructing the `new Miniflare`, as this is what asynchronously kicks off loading the script. It looks like this wasn't doing anything before though, since `scriptReady` was initialised to `true`.
3. **Fix `ReferenceError: __FALLBACK_SERVICE_FETCH__ is not defined` on watch update with `pages dev`:** subsequent Pages Functions worker builds due to file changes were not replacing `__FALLBACK_SERVICE_FETCH__` leading to `ReferenceError`s (I think this is a bug in `esbuild-plugin-replace`). This change switches to using `esbuild`'s built-in `define` option, instead of `esbuild-plugin-replace`, removing an additional dependency.

cc @GregBrimble 