### PR TITLE
Add Pages Functions config output option

### DIFF
--- a/.changeset/young-timers-talk.md
+++ b/.changeset/young-timers-talk.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Add `--output-config-path` option to `wrangler pages functions build` which writes a config file describing the `functions` folder.


### PR DESCRIPTION
Add `--output-config-path` option to `wrangler pages functions build` which writes a config file describing the `functions` folder.

---

Need this for generating these Functions with wrangler in our build machines.