### PR TITLE
Fix the `--watch` option of `wrangler pages functions build`

### DIFF
--- a/.changeset/brown-planes-sip.md
+++ b/.changeset/brown-planes-sip.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix the `--watch` command for `wrangler pages functions build`.

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -986,6 +986,7 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
           minify,
           sourcemap,
           fallbackService,
+          watch,
         }) => {
           const functionsDirectory = "./functions";
 
@@ -995,6 +996,7 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
             minify,
             sourcemap,
             fallbackService,
+            watch,
           });
         }
       )


### PR DESCRIPTION
I had forgotten to actually connect it up, so it was entirely ineffective.