### PR TITLE
chore: add a pre-push hook to check (and generate) changesets

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,21 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx changeset status --since main 2>/dev/null || {
+    if [ $? -ne 0 ]; then
+        echo >&2 "Some packages have been changed but no changesets were committed."
+        echo >&2 ""
+        echo >&2 "Type 'Y' if you would like to add a changeset now, otherwise press any key:"
+        exec < /dev/tty
+        read -p "(Y|any key)>: " ack
+        if [[ $ack =~ ^[Yy]$ ]]; then
+            npx changeset
+            echo $?
+            if ([ $? -ne 0]); then
+              exit 1
+            fi
+            git add .changeset
+            git commit --fixup HEAD
+        fi
+        fi
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,9 @@
         "prettier": "^2.5.1",
         "typescript": "^4.5.2"
       },
+      "devDependencies": {
+        "husky": "^7.0.0"
+      },
       "engines": {
         "node": ">=16.0.0"
       }
@@ -6764,6 +6767,21 @@
       "dev": true,
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
+      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
+      "dev": true,
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {
@@ -20496,6 +20514,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
       "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
+      "dev": true
+    },
+    "husky": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
+      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
       "dev": true
     },
     "iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "check": "prettier packages/** --check && tsc && npm run lint && npm run build && npm run test",
     "prettify": "prettier packages/** --write",
     "build": "npm run build --workspace=wrangler",
-    "test": "npm run test --workspace=wrangler"
+    "test": "npm run test --workspace=wrangler",
+    "prepare": "husky install"
   },
   "engines": {
     "node": ">=16.0.0"
@@ -96,5 +97,8 @@
   },
   "volta": {
     "node": "16.7.0"
+  },
+  "devDependencies": {
+    "husky": "^7.0.0"
   }
 }


### PR DESCRIPTION
This is a proof of concept - DO NOT MERGE - yet.

---

ISSUES:
- This is not 100% clear to anyone who does not know what they are doing - and is arguably not useful to those that do.
- How to handle escaping via Ctrl-C from changeset generation. Currently it will still try to generate a fixup commit.