### PR TITLE
refactor: proxy/preview server

### DIFF
--- a/.changeset/angry-schools-walk.md
+++ b/.changeset/angry-schools-walk.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+refactor: proxy/preview server
+
+This PR refactors how we setup the proxy server between the developer and the edge preview service during `wrangler dev`. Of note, we start the server immediately. We also buffer requests/streams and hold on to them, when starting/refreshing the token. This means a developer should never see `ERR_CONNECTION_REFUSED` error page, or have an older worker respond after making a change to the code. And when the token does get refreshed, we flush said streams/requests with the newer values, making the iteration process a lot smoother and predictable.

--- a/packages/wrangler/src/proxy.ts
+++ b/packages/wrangler/src/proxy.ts
@@ -1,97 +1,288 @@
 import { connect } from "node:http2";
+import type { ServerHttp2Stream } from "node:http2";
 import { createServer } from "node:http";
-import type { Server, IncomingHttpHeaders, RequestListener } from "node:http";
+import type {
+  IncomingHttpHeaders,
+  RequestListener,
+  IncomingMessage,
+  ServerResponse,
+  Server,
+} from "node:http";
 import WebSocket from "faye-websocket";
 import serveStatic from "serve-static";
+import type { CfPreviewToken } from "./api/preview";
+import { useEffect, useRef } from "react";
 
-export interface HttpProxyInit {
-  host: string;
-  assetPath?: string | null;
-  onRequest?: (headers: IncomingHttpHeaders) => void;
-  onResponse?: (headers: IncomingHttpHeaders) => void;
+/**
+ * `usePreviewServer` is a React hook that creates a local development
+ * server that can be used to develop a Worker.
+ *
+ * When we run `wrangler dev`, we start by uploading the compiled worker
+ * to the preview service, which responds with a preview token.
+ * (see `useWorker`/`createWorker` for details.)
+ * We can then use that token to connect to the preview server for a
+ * great local development experience. Further, as we change the worker,
+ * we can update the preview token transparently without having to restart
+ * the development server.
+ */
+
+/** Rewrite request headers to add the preview token. */
+function addCfPreviewTokenHeader(
+  headers: IncomingHttpHeaders,
+  previewTokenValue: string
+) {
+  headers["cf-workers-preview-token"] = previewTokenValue;
 }
 
 /**
- * Creates a HTTP/1 proxy that sends requests over HTTP/2.
+ * Rewrite references in request headers
+ * from the preview host to the local host.
  */
-export function createHttpProxy(init: HttpProxyInit): Server {
-  const { host, assetPath, onRequest = () => {}, onResponse = () => {} } = init;
-  const remote = connect(`https://${host}`);
-  const local = createServer();
-  // HTTP/2 -> HTTP/2
-  local.on("stream", (stream, headers: IncomingHttpHeaders) => {
-    onRequest(headers);
-    headers[":authority"] = host;
-    const request = stream.pipe(remote.request(headers));
-    request.on("response", (responseHeaders: IncomingHttpHeaders) => {
-      onResponse(responseHeaders);
-      stream.respond(responseHeaders);
-      request.pipe(stream, { end: true });
-    });
-  });
-  // HTTP/1 -> HTTP/2
-  const handleRequest: RequestListener = (message, response) => {
-    const { httpVersionMajor, headers, method, url } = message;
-    if (httpVersionMajor >= 2) {
-      return; // Already handled by the "stream" event.
+function rewriteRemoteHostToLocalHostInHeaders(
+  headers: IncomingHttpHeaders,
+  remoteHost: string,
+  localPort: number
+) {
+  for (const [name, value] of Object.entries(headers)) {
+    // Rewrite the remote host to the local host.
+    if (typeof value === "string" && value.includes(remoteHost)) {
+      headers[name] = value
+        .replaceAll(`https://${remoteHost}`, `http://localhost:${localPort}`)
+        .replaceAll(remoteHost, `localhost:${localPort}`);
     }
-    onRequest(headers);
-    headers[":method"] = method;
-    headers[":path"] = url;
-    headers[":authority"] = host;
-    headers[":scheme"] = "https";
-    for (const name of Object.keys(headers)) {
-      if (HTTP1_HEADERS.has(name.toLowerCase())) {
-        delete headers[name];
-      }
-    }
-    const request = message.pipe(remote.request(headers));
-    request.on("response", (responseHeaders) => {
-      const status = responseHeaders[":status"];
-      onResponse(responseHeaders);
-      for (const name of Object.keys(responseHeaders)) {
-        if (name.startsWith(":")) {
-          delete responseHeaders[name];
-        }
-      }
-      response.writeHead(status, responseHeaders);
-      request.pipe(response, { end: true });
-    });
-  };
-  // If an asset path is defined, check the file system
-  // for a file first and serve if it exists.
-  if (assetPath) {
-    const handleAsset = serveStatic(assetPath, {
-      cacheControl: false,
-    });
-    local.on("request", (request, response) => {
-      handleAsset(request, response, () => {
-        handleRequest(request, response);
-      });
-    });
-  } else {
-    local.on("request", handleRequest);
   }
-  // HTTP/1 -> WebSocket (over HTTP/1)
-  local.on("upgrade", (message, socket, body) => {
-    const { headers, url } = message;
-    onRequest(headers);
-    headers["host"] = host;
-    const localWebsocket = new WebSocket(message, socket, body);
-    // TODO(soon): Custom WebSocket protocol is not working?
-    const remoteWebsocketClient = new WebSocket.Client(
-      `wss://${host}${url}`,
-      [],
-      { headers }
-    );
-    localWebsocket.pipe(remoteWebsocketClient).pipe(localWebsocket);
-  });
-  remote.on("close", () => {
-    local.close();
-  });
-  return local;
 }
 
+export function usePreviewServer({
+  previewToken,
+  publicRoot,
+  port,
+}: {
+  previewToken: CfPreviewToken | undefined;
+  publicRoot: undefined | string;
+  port: number;
+}) {
+  /** Creates an HTTP/1 proxy that sends requests over HTTP/2. */
+  const proxyServer = useRef<Server>();
+  if (!proxyServer.current) {
+    proxyServer.current = createServer()
+      .on("request", function (req, res) {
+        // log all requests
+        console.log(
+          new Date().toLocaleTimeString(),
+          req.method,
+          req.url,
+          res.statusCode
+        );
+      })
+      .on("upgrade", (req) => {
+        // log all websocket connections
+        console.log(
+          new Date().toLocaleTimeString(),
+          req.method,
+          req.url,
+          101,
+          "(WebSocket)"
+        );
+      })
+      .on("error", (err) => {
+        // log all connection errors
+        console.error(new Date().toLocaleTimeString(), err);
+      });
+  }
+
+  /**
+   * When we're not connected / getting a fresh token on changes,
+   * we'd like to buffer streams/requests until we're connected.
+   * Once connected, we can flush the buffered streams/requests.
+   * streamBufferRef is used to buffer http/2 streams, while
+   * requestResponseBufferRef is used to buffer http/1 requests.
+   */
+  const streamBufferRef = useRef<
+    { stream: ServerHttp2Stream; headers: IncomingHttpHeaders }[]
+  >([]);
+  const requestResponseBufferRef = useRef<
+    { request: IncomingMessage; response: ServerResponse }[]
+  >([]);
+
+  useEffect(() => {
+    const proxy = proxyServer.current;
+
+    // If we don't have a token, that means either we're just starting up,
+    // or we're refreshing the token.
+    if (!previewToken) {
+      const cleanupListeners: (() => void)[] = [];
+      const bufferStream = (
+        stream: ServerHttp2Stream,
+        headers: IncomingHttpHeaders
+      ) => {
+        // store the stream in a buffer so we can replay it later
+        streamBufferRef.current.push({ stream, headers });
+      };
+      proxy.on("stream", bufferStream);
+      cleanupListeners.push(() => proxy.off("stream", bufferStream));
+
+      const bufferRequestResponse = (
+        request: IncomingMessage,
+        response: ServerResponse
+      ) => {
+        // store the request and response in a buffer so we can replay it later
+        requestResponseBufferRef.current.push({ request, response });
+      };
+
+      proxy.on("request", bufferRequestResponse);
+      cleanupListeners.push(() => proxy.off("request", bufferRequestResponse));
+      return () => {
+        cleanupListeners.forEach((cleanup) => cleanup());
+      };
+    }
+
+    // We have a token. Let's proxy requests to the preview end point.
+    const cleanupListeners: (() => void)[] = [];
+
+    const assetPath = typeof publicRoot === "string" ? publicRoot : null;
+
+    // create a ClientHttp2Session
+    const remote = connect(`https://${previewToken.host}`);
+    cleanupListeners.push(() => remote.destroy());
+
+    /** HTTP/2 -> HTTP/2  */
+    function handleStream(
+      stream: ServerHttp2Stream,
+      headers: IncomingHttpHeaders
+    ) {
+      addCfPreviewTokenHeader(headers, previewToken.value);
+      headers[":authority"] = previewToken.host;
+      const request = stream.pipe(remote.request(headers));
+      request.on("response", (responseHeaders: IncomingHttpHeaders) => {
+        rewriteRemoteHostToLocalHostInHeaders(
+          responseHeaders,
+          previewToken.host,
+          port
+        );
+        stream.respond(responseHeaders);
+        request.pipe(stream, { end: true });
+      });
+    }
+    proxy.on("stream", handleStream);
+    cleanupListeners.push(() => proxy.off("stream", handleStream));
+
+    // flush and replay buffered streams
+    streamBufferRef.current.forEach((buffer) =>
+      handleStream(buffer.stream, buffer.headers)
+    );
+    streamBufferRef.current = [];
+
+    /** HTTP/1 -> HTTP/2  */
+    const handleRequest: RequestListener = (
+      message: IncomingMessage,
+      response: ServerResponse
+    ) => {
+      const { httpVersionMajor, headers, method, url } = message;
+      if (httpVersionMajor >= 2) {
+        return; // Already handled by the "stream" event.
+      }
+      addCfPreviewTokenHeader(headers, previewToken.value);
+      headers[":method"] = method;
+      headers[":path"] = url;
+      headers[":authority"] = previewToken.host;
+      headers[":scheme"] = "https";
+      for (const name of Object.keys(headers)) {
+        if (HTTP1_HEADERS.has(name.toLowerCase())) {
+          delete headers[name];
+        }
+      }
+      const request = message.pipe(remote.request(headers));
+      request.on("response", (responseHeaders) => {
+        const status = responseHeaders[":status"];
+        rewriteRemoteHostToLocalHostInHeaders(
+          responseHeaders,
+          previewToken.host,
+          port
+        );
+        for (const name of Object.keys(responseHeaders)) {
+          if (name.startsWith(":")) {
+            delete responseHeaders[name];
+          }
+        }
+        response.writeHead(status, responseHeaders);
+        request.pipe(response, { end: true });
+      });
+    };
+
+    // If an asset path is defined, check the file system
+    // for a file first and serve if it exists.
+    const actualHandleRequest = assetPath
+      ? createHandleAssetsRequest(assetPath, handleRequest)
+      : handleRequest;
+
+    proxy.on("request", actualHandleRequest);
+    cleanupListeners.push(() => proxy.off("request", actualHandleRequest));
+
+    // flush and replay buffered requests
+    requestResponseBufferRef.current.forEach(({ request, response }) =>
+      actualHandleRequest(request, response)
+    );
+    requestResponseBufferRef.current = [];
+
+    /** HTTP/1 -> WebSocket (over HTTP/1)  */
+    const handleUpgrade = (
+      message: IncomingMessage,
+      socket: WebSocket,
+      body: Buffer
+    ) => {
+      const { headers, url } = message;
+      addCfPreviewTokenHeader(headers, previewToken.value);
+      headers["host"] = previewToken.host;
+      const localWebsocket = new WebSocket(message, socket, body);
+      // TODO(soon): Custom WebSocket protocol is not working?
+      const remoteWebsocketClient = new WebSocket.Client(
+        `wss://${previewToken.host}${url}`,
+        [],
+        { headers }
+      );
+      localWebsocket.pipe(remoteWebsocketClient).pipe(localWebsocket);
+      // We close down websockets whenever we refresh the token.
+      cleanupListeners.push(() => {
+        localWebsocket.destroy();
+        remoteWebsocketClient.destroy();
+      });
+    };
+    proxy.on("upgrade", handleUpgrade);
+    cleanupListeners.push(() => proxy.off("upgrade", handleUpgrade));
+
+    return () => {
+      cleanupListeners.forEach((d) => d());
+    };
+  }, [previewToken, publicRoot, port]);
+
+  // Start/stop the server whenever the
+  // containing component is mounted/unmounted.
+  useEffect(() => {
+    proxyServer.current.listen(port);
+    console.log(`⬣ Listening at http://localhost:${port}`);
+
+    return () => {
+      proxyServer.current.close();
+    };
+  }, [port]);
+}
+
+function createHandleAssetsRequest(
+  assetPath: string,
+  handleRequest: RequestListener
+) {
+  const handleAsset = serveStatic(assetPath, {
+    cacheControl: false,
+  });
+  return (request: IncomingMessage, response: ServerResponse) => {
+    handleAsset(request, response, () => {
+      handleRequest(request, response);
+    });
+  };
+}
+
+/** A Set of headers we want to remove from HTTP/1 requests. */
 const HTTP1_HEADERS = new Set([
   "host",
   "connection",


### PR DESCRIPTION
Closes #205.

This PR refactors how we setup the proxy server between the developer and the edge preview service during `wrangler dev`. Of note, we start the server immediately. We also buffers requests/streams and hold on to them when starting/refreshing the token. This means a developer should never see `ERR_CONNECTION_REFUSED` error page, or have an older worker respond after making a change to the code. And when the token does get refreshed, we flush said streams/requests with the newer values, making the iteration process a lot smoother and predictable.