### PR TITLE
Fix Pages Functions routing for windows path separator

### DIFF
--- a/packages/wrangler/pages/functions/routes.ts
+++ b/packages/wrangler/pages/functions/routes.ts
@@ -147,7 +147,7 @@ export const routes = [
   ${routes
     .map(
       (route) => `  {
-      routePath: "${route.routePath}",
+      routePath: "${route.routePath.replace(/\\/g, '/')}",
       methods: ${JSON.stringify(route.methods)},
       middlewares: [${route.middlewares.join(", ")}],
       modules: [${route.modules.join(", ")}],


### PR DESCRIPTION
I've used the temporary fix proposed as a starting point on issue #51 to address pages function routing on windows . The issue is that windows paths use the backslash separator, which is carried over to routes, making them unusable. Feel free to propose a better solution.