### PR TITLE
Upgrade `miniflare` to `2.1.0`

### DIFF
--- a/.changeset/early-seahorses-impress.md
+++ b/.changeset/early-seahorses-impress.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Upgrade `miniflare` to [`2.1.0`](https://github.com/cloudflare/miniflare/releases/tag/v2.1.0) 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2492,12 +2492,12 @@
       }
     },
     "node_modules/@miniflare/cache": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.0.0.tgz",
-      "integrity": "sha512-Luk/MmRKZPy481b+3wKVYKL/kMwM/X9Tl6Wxj1XrE/P3x4SwZNGI6w0kIxHMYSlBy8OsQJso/XDPu1jJhIltJQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.1.0.tgz",
+      "integrity": "sha512-U/lLt+HcIVxvb6FTUBSR/Q34zavnmFa06wCDYu3HrZqxRN3Y3mp80USy+9a0PsS2g7YofP//yXQl40TKxRq3uQ==",
       "dependencies": {
-        "@miniflare/core": "2.0.0",
-        "@miniflare/shared": "2.0.0",
+        "@miniflare/core": "2.1.0",
+        "@miniflare/shared": "2.1.0",
         "http-cache-semantics": "^4.1.0",
         "undici": "4.12.1"
       },
@@ -2506,11 +2506,11 @@
       }
     },
     "node_modules/@miniflare/cli-parser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.0.0.tgz",
-      "integrity": "sha512-GYPWk/qXr19/4c5nmhBzl0RcyPnXFtYNQoWnys/v6rAWCEBzKROBVh3tInrvO7v2jyDYWYfbOnbCf9ZxZDSRSQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.1.0.tgz",
+      "integrity": "sha512-jYX0gtNwPOg/Vm0/0bJEZQZ7aCXpD/LpTuxZFB5SSxoetCmMAWr3EYi2b+cVc5uAqKySNWuCGsQ97Bpla/Najw==",
       "dependencies": {
-        "@miniflare/shared": "2.0.0",
+        "@miniflare/shared": "2.1.0",
         "kleur": "^4.1.4"
       },
       "engines": {
@@ -2518,12 +2518,13 @@
       }
     },
     "node_modules/@miniflare/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-w37nbFzlp6R2TL0WG8m5iaZWK4BKdDkoACEnc9kQaaBEYI1HRne1rjzT+8DqgrrFqBjDIa+7cT6tn74eGer7Dg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-1vFX6vuttgZFTDg5REwi1MbbEITtyXXxZkuwvXrEfE1SAfj/KKn5wdQtKiZesoU/eJ5J80ggeysUagwNGuDemg==",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/shared": "2.0.0",
+        "@miniflare/shared": "2.1.0",
+        "@miniflare/watcher": "2.1.0",
         "busboy": "^0.3.1",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
@@ -2532,14 +2533,6 @@
       },
       "engines": {
         "node": ">=16.7"
-      },
-      "peerDependencies": {
-        "@miniflare/watcher": "2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@miniflare/watcher": {
-          "optional": true
-        }
       }
     },
     "node_modules/@miniflare/core/node_modules/dotenv": {
@@ -2551,13 +2544,13 @@
       }
     },
     "node_modules/@miniflare/durable-objects": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.0.0.tgz",
-      "integrity": "sha512-xu1wFcQ4XXwqOr/Z2QCARgbeau7SujtVV7LDPcWs8LWBYteEsFwl96mpoDv/ho2Zk67xUMK3TIvGakBbnQWsjQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.1.0.tgz",
+      "integrity": "sha512-r4KLXHCQEP/LW6DGjIKWdZQltS7rq9gfPOm32ruLVTEuvuLGzQU5m4H1K6IRvtD+WqVkX3xZbo6i5up1ulhM8A==",
       "dependencies": {
-        "@miniflare/core": "2.0.0",
-        "@miniflare/shared": "2.0.0",
-        "@miniflare/storage-memory": "2.0.0",
+        "@miniflare/core": "2.1.0",
+        "@miniflare/shared": "2.1.0",
+        "@miniflare/storage-memory": "2.1.0",
         "undici": "4.12.1"
       },
       "engines": {
@@ -2565,12 +2558,12 @@
       }
     },
     "node_modules/@miniflare/html-rewriter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.0.0.tgz",
-      "integrity": "sha512-GFfrYsswtp8ZvDsJ2UybdpKYqclS4TMX7i9YvQMBUBolS7ovdEa0+UoWsDyHmw/iRjJI+mcov5IRQImrC8HFOw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.1.0.tgz",
+      "integrity": "sha512-IUewfaN0H+AQAOYL0GcRIT9VShEG6Khl95MU6aK+LqINzZdieTw/fKZHszlV84+HPJPUNYa2jtwYRnKOI4wDbQ==",
       "dependencies": {
-        "@miniflare/core": "2.0.0",
-        "@miniflare/shared": "2.0.0",
+        "@miniflare/core": "2.1.0",
+        "@miniflare/shared": "2.1.0",
         "html-rewriter-wasm": "^0.3.2",
         "undici": "4.12.1"
       },
@@ -2579,15 +2572,15 @@
       }
     },
     "node_modules/@miniflare/http-server": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.0.0.tgz",
-      "integrity": "sha512-moIpSSYOpLUZ2RjYOXO+mZMKOzOKuxHfF8V9pDdtQ/s9kF9CjyPUNG2TKBcfhKFmdWFdhxdUm+fbHo2DOVytRw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.1.0.tgz",
+      "integrity": "sha512-4Ijhgx1X7znpMca6xGDZvigDN7+qtkEbPQFxl8ptKhGvDXLb3lP2UMkz7Ee7myV5H4Oauj4RpD6B6zmSj3p5zA==",
       "dependencies": {
-        "@miniflare/core": "2.0.0",
-        "@miniflare/shared": "2.0.0",
-        "@miniflare/web-sockets": "2.0.0",
+        "@miniflare/core": "2.1.0",
+        "@miniflare/shared": "2.1.0",
+        "@miniflare/web-sockets": "2.1.0",
         "kleur": "^4.1.4",
-        "selfsigned": "^1.10.11",
+        "selfsigned": "^2.0.0",
         "undici": "4.12.1",
         "ws": "^8.2.2",
         "youch": "^2.2.2"
@@ -2597,34 +2590,34 @@
       }
     },
     "node_modules/@miniflare/kv": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.0.0.tgz",
-      "integrity": "sha512-f087ATCuFPQR3ZgLKt5kIeRYFdwt2pCNfRPb5pNf5t8tI1xT5O1IacC13WLo6nCO0uBfCovUQV11mGdSuDpG7w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.1.0.tgz",
+      "integrity": "sha512-/XhibgDUIFjUlaBjztSMvvj96JuLGOt+vlPQKViGoeAyk7PItk4VfBYxaQjMWAiaPEDUkdhZD3P1CvIP/9Colw==",
       "dependencies": {
-        "@miniflare/shared": "2.0.0"
+        "@miniflare/shared": "2.1.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/runner-vm": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.0.0.tgz",
-      "integrity": "sha512-2kFTS+IhtoZjsDRyIba2xQWG0B73KaJGaymmk5cYjXqBML1DA9C7nxpkiJbbEDdAGG0hQRD7ILSe3M4gCQ51Bg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.1.0.tgz",
+      "integrity": "sha512-LvF6RqPgkA+kSgRZiu8NEANFhlTATfEFYEJtPZiwRYchXIXpLpiOQ+Zi0yglBM9HFeLG50iuT3z/CKmv2T1oSw==",
       "dependencies": {
-        "@miniflare/shared": "2.0.0"
+        "@miniflare/shared": "2.1.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/scheduler": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.0.0.tgz",
-      "integrity": "sha512-H0gUrvhSb6XeSUpOcr0vuuFVxciE4LIKQB/vgVLPjYULQqvU85ZZU1/hocYxJ35f9h8U7iK13FUzORfwj5EBbA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.1.0.tgz",
+      "integrity": "sha512-C75U4wvZNNPWdUdmLThNflq6kSi4jPpSeoAZ+UVDyxVlivw4IMLL9Xy7sbmlyTzPuQ79zsH8RI0RpEJyN7DJUQ==",
       "dependencies": {
-        "@miniflare/core": "2.0.0",
-        "@miniflare/shared": "2.0.0",
+        "@miniflare/core": "2.1.0",
+        "@miniflare/shared": "2.1.0",
         "cron-schedule": "^3.0.4"
       },
       "engines": {
@@ -2632,9 +2625,9 @@
       }
     },
     "node_modules/@miniflare/shared": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.0.0.tgz",
-      "integrity": "sha512-cWLl8qvYueQ4Kgx1m9ve1m9lCVL2/rnaBQ21jxb8CS5zQ6csMBIrvA0pCDfRK6YeAY76ScNM0uO6aiRW7easEA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.1.0.tgz",
+      "integrity": "sha512-ad7ofHntHTiPWtN8rDlvNS/o5TGnQDH5ncHAYmMtQl50Lsf8XFpBrQjaqjrwSKiRacHi09ipr9C+qxP04QU7Qw==",
       "dependencies": {
         "ignore": "^5.1.8",
         "kleur": "^4.1.4"
@@ -2644,59 +2637,59 @@
       }
     },
     "node_modules/@miniflare/sites": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.0.0.tgz",
-      "integrity": "sha512-uG4bEPfcc1OLToiOXHNZrjU0aoUyugUu5q+mUGwR2ApCHbt/bRv6FZVxOSQWZcbzVYGujnk9vGAALVg/hwd0Hw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.1.0.tgz",
+      "integrity": "sha512-hZpN+XPhiR92+BuAaZeZRBasYvFNZA3aZA1bMIGhAAgilAEI4mLzAE7iYCiOBS0R/zgrxoYhoc4rVKnVcTcZjw==",
       "dependencies": {
-        "@miniflare/kv": "2.0.0",
-        "@miniflare/shared": "2.0.0",
-        "@miniflare/storage-file": "2.0.0"
+        "@miniflare/kv": "2.1.0",
+        "@miniflare/shared": "2.1.0",
+        "@miniflare/storage-file": "2.1.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/storage-file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.0.0.tgz",
-      "integrity": "sha512-ADWmq7OLjQDgAaOiTBfUn44VDxTt2gqsHrr00KIXGdaVVU6R1HS8VryRCx4o/1w23p31ySSez2+h2g5rWB4WQg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.1.0.tgz",
+      "integrity": "sha512-82WyImf2BFzkhZNqWIUelTKBB27wqTB2N/zCAWnpmjWu6BSTXmxaUcYwVqB90eUebdNpSqREnhp3hLPT6JePRw==",
       "dependencies": {
-        "@miniflare/shared": "2.0.0",
-        "@miniflare/storage-memory": "2.0.0"
+        "@miniflare/shared": "2.1.0",
+        "@miniflare/storage-memory": "2.1.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/storage-memory": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.0.0.tgz",
-      "integrity": "sha512-bWN0HvjnWwCDfBhlMXNC1ir9BceUA+LvWqmCDQcrY8K8nm+hH1/DU1TtSjGDnmAELNV5Rv1b0OwmhYkyNlq+nQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.1.0.tgz",
+      "integrity": "sha512-C2XsqJ0vfWM6MfcTMOgNz5Qmzq0NEfkLiR9siZUdcR0ULRHU8y4eoN2yk+Po9covpwByDqrbd5Viqe0RAgXN0Q==",
       "dependencies": {
-        "@miniflare/shared": "2.0.0"
+        "@miniflare/shared": "2.1.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/watcher": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.0.0.tgz",
-      "integrity": "sha512-0B7w1B1d4hHVyLPznDuGxxwDku4wxLjPXqcIcVZhQmIK1+IaRwx/qJ5PolAwLTaqkLaYA7K/WlY8aumDa/VLsQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.1.0.tgz",
+      "integrity": "sha512-S/sTxi470bRildWL0t7PnPZge/6HO5KL7I5YSw7U4Srle/maojlaq2tiTaSfcloSJVkFeNm0thghudOOHUJGHQ==",
       "dependencies": {
-        "@miniflare/shared": "2.0.0"
+        "@miniflare/shared": "2.1.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/web-sockets": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.0.0.tgz",
-      "integrity": "sha512-mU/Fw0a3/giJRbhOJVEsvm8Wlau2vVK241vI5K2VRjT6S5w9XGeog7ohBPtbTDYjkB0gdmZX/9KPQVBidJgB8Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.1.0.tgz",
+      "integrity": "sha512-x5KRzS1iXv9+giLfLN3/ZPfcTxwX55LnMRn1A0GdTU119A482EOyvnzOjnCzz73IlghUqv9UPZnLV26tfzfInA==",
       "dependencies": {
-        "@miniflare/core": "2.0.0",
-        "@miniflare/shared": "2.0.0",
+        "@miniflare/core": "2.1.0",
+        "@miniflare/shared": "2.1.0",
         "undici": "4.12.1",
         "ws": "^8.2.2"
       },
@@ -11201,25 +11194,24 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.0.0.tgz",
-      "integrity": "sha512-vjaVGh8PPT5wsMs+XkTUEeg0S7Yrl4LAHY5/mwoocI+Z8iCCHTECEAB/Ioymh5Z3pnczj1AZ99DPMFBTXRI29A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.1.0.tgz",
+      "integrity": "sha512-DR6V/UTNd7Uo8OS6SuT+pxdf52sRDX8ZS9cDq5RSRwT7qrYnpC55E//M8bLSFCqAsokjvyDb0zI19/Wdi86hmw==",
       "dependencies": {
-        "@miniflare/cache": "2.0.0",
-        "@miniflare/cli-parser": "2.0.0",
-        "@miniflare/core": "2.0.0",
-        "@miniflare/durable-objects": "2.0.0",
-        "@miniflare/html-rewriter": "2.0.0",
-        "@miniflare/http-server": "2.0.0",
-        "@miniflare/kv": "2.0.0",
-        "@miniflare/runner-vm": "2.0.0",
-        "@miniflare/scheduler": "2.0.0",
-        "@miniflare/shared": "2.0.0",
-        "@miniflare/sites": "2.0.0",
-        "@miniflare/storage-file": "2.0.0",
-        "@miniflare/storage-memory": "2.0.0",
-        "@miniflare/watcher": "2.0.0",
-        "@miniflare/web-sockets": "2.0.0",
+        "@miniflare/cache": "2.1.0",
+        "@miniflare/cli-parser": "2.1.0",
+        "@miniflare/core": "2.1.0",
+        "@miniflare/durable-objects": "2.1.0",
+        "@miniflare/html-rewriter": "2.1.0",
+        "@miniflare/http-server": "2.1.0",
+        "@miniflare/kv": "2.1.0",
+        "@miniflare/runner-vm": "2.1.0",
+        "@miniflare/scheduler": "2.1.0",
+        "@miniflare/shared": "2.1.0",
+        "@miniflare/sites": "2.1.0",
+        "@miniflare/storage-file": "2.1.0",
+        "@miniflare/storage-memory": "2.1.0",
+        "@miniflare/web-sockets": "2.1.0",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
@@ -11232,12 +11224,15 @@
         "node": ">=16.7"
       },
       "peerDependencies": {
-        "@miniflare/storage-redis": "2.0.0",
+        "@miniflare/storage-redis": "2.1.0",
         "cron-schedule": "^3.0.4",
         "ioredis": "^4.27.9"
       },
       "peerDependenciesMeta": {
         "@miniflare/storage-redis": {
+          "optional": true
+        },
+        "cron-schedule": {
           "optional": true
         },
         "ioredis": {
@@ -11376,11 +11371,11 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
+      "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==",
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/node-int64": {
@@ -13033,11 +13028,14 @@
       }
     },
     "node_modules/selfsigned": {
-      "version": "1.10.11",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.11.tgz",
-      "integrity": "sha512-aVmbPOfViZqOZPgRBT0+3u4yZFHpmnIghLMlAcb5/xhp5ZtB/RVnKhz5vl2M32CLXAqR4kha9zfhNg0Lf/sxKA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.0.0.tgz",
+      "integrity": "sha512-cUdFiCbKoa1mZ6osuJs2uDHrs0k0oprsKveFiiaBKCNq3SYyb5gs2HxhQyDNLCmL51ZZThqi4YNDpCK6GOP1iQ==",
       "dependencies": {
-        "node-forge": "^0.10.0"
+        "node-forge": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/semiver": {
@@ -15146,7 +15144,7 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "esbuild": "0.14.1",
-        "miniflare": "2.0.0",
+        "miniflare": "2.1.0",
         "path-to-regexp": "^6.2.0",
         "semiver": "^1.1.0"
       },
@@ -17338,32 +17336,33 @@
       }
     },
     "@miniflare/cache": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.0.0.tgz",
-      "integrity": "sha512-Luk/MmRKZPy481b+3wKVYKL/kMwM/X9Tl6Wxj1XrE/P3x4SwZNGI6w0kIxHMYSlBy8OsQJso/XDPu1jJhIltJQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.1.0.tgz",
+      "integrity": "sha512-U/lLt+HcIVxvb6FTUBSR/Q34zavnmFa06wCDYu3HrZqxRN3Y3mp80USy+9a0PsS2g7YofP//yXQl40TKxRq3uQ==",
       "requires": {
-        "@miniflare/core": "2.0.0",
-        "@miniflare/shared": "2.0.0",
+        "@miniflare/core": "2.1.0",
+        "@miniflare/shared": "2.1.0",
         "http-cache-semantics": "^4.1.0",
         "undici": "4.12.1"
       }
     },
     "@miniflare/cli-parser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.0.0.tgz",
-      "integrity": "sha512-GYPWk/qXr19/4c5nmhBzl0RcyPnXFtYNQoWnys/v6rAWCEBzKROBVh3tInrvO7v2jyDYWYfbOnbCf9ZxZDSRSQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.1.0.tgz",
+      "integrity": "sha512-jYX0gtNwPOg/Vm0/0bJEZQZ7aCXpD/LpTuxZFB5SSxoetCmMAWr3EYi2b+cVc5uAqKySNWuCGsQ97Bpla/Najw==",
       "requires": {
-        "@miniflare/shared": "2.0.0",
+        "@miniflare/shared": "2.1.0",
         "kleur": "^4.1.4"
       }
     },
     "@miniflare/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-w37nbFzlp6R2TL0WG8m5iaZWK4BKdDkoACEnc9kQaaBEYI1HRne1rjzT+8DqgrrFqBjDIa+7cT6tn74eGer7Dg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-1vFX6vuttgZFTDg5REwi1MbbEITtyXXxZkuwvXrEfE1SAfj/KKn5wdQtKiZesoU/eJ5J80ggeysUagwNGuDemg==",
       "requires": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/shared": "2.0.0",
+        "@miniflare/shared": "2.1.0",
+        "@miniflare/watcher": "2.1.0",
         "busboy": "^0.3.1",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
@@ -17379,119 +17378,119 @@
       }
     },
     "@miniflare/durable-objects": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.0.0.tgz",
-      "integrity": "sha512-xu1wFcQ4XXwqOr/Z2QCARgbeau7SujtVV7LDPcWs8LWBYteEsFwl96mpoDv/ho2Zk67xUMK3TIvGakBbnQWsjQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.1.0.tgz",
+      "integrity": "sha512-r4KLXHCQEP/LW6DGjIKWdZQltS7rq9gfPOm32ruLVTEuvuLGzQU5m4H1K6IRvtD+WqVkX3xZbo6i5up1ulhM8A==",
       "requires": {
-        "@miniflare/core": "2.0.0",
-        "@miniflare/shared": "2.0.0",
-        "@miniflare/storage-memory": "2.0.0",
+        "@miniflare/core": "2.1.0",
+        "@miniflare/shared": "2.1.0",
+        "@miniflare/storage-memory": "2.1.0",
         "undici": "4.12.1"
       }
     },
     "@miniflare/html-rewriter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.0.0.tgz",
-      "integrity": "sha512-GFfrYsswtp8ZvDsJ2UybdpKYqclS4TMX7i9YvQMBUBolS7ovdEa0+UoWsDyHmw/iRjJI+mcov5IRQImrC8HFOw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.1.0.tgz",
+      "integrity": "sha512-IUewfaN0H+AQAOYL0GcRIT9VShEG6Khl95MU6aK+LqINzZdieTw/fKZHszlV84+HPJPUNYa2jtwYRnKOI4wDbQ==",
       "requires": {
-        "@miniflare/core": "2.0.0",
-        "@miniflare/shared": "2.0.0",
+        "@miniflare/core": "2.1.0",
+        "@miniflare/shared": "2.1.0",
         "html-rewriter-wasm": "^0.3.2",
         "undici": "4.12.1"
       }
     },
     "@miniflare/http-server": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.0.0.tgz",
-      "integrity": "sha512-moIpSSYOpLUZ2RjYOXO+mZMKOzOKuxHfF8V9pDdtQ/s9kF9CjyPUNG2TKBcfhKFmdWFdhxdUm+fbHo2DOVytRw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.1.0.tgz",
+      "integrity": "sha512-4Ijhgx1X7znpMca6xGDZvigDN7+qtkEbPQFxl8ptKhGvDXLb3lP2UMkz7Ee7myV5H4Oauj4RpD6B6zmSj3p5zA==",
       "requires": {
-        "@miniflare/core": "2.0.0",
-        "@miniflare/shared": "2.0.0",
-        "@miniflare/web-sockets": "2.0.0",
+        "@miniflare/core": "2.1.0",
+        "@miniflare/shared": "2.1.0",
+        "@miniflare/web-sockets": "2.1.0",
         "kleur": "^4.1.4",
-        "selfsigned": "^1.10.11",
+        "selfsigned": "^2.0.0",
         "undici": "4.12.1",
         "ws": "^8.2.2",
         "youch": "^2.2.2"
       }
     },
     "@miniflare/kv": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.0.0.tgz",
-      "integrity": "sha512-f087ATCuFPQR3ZgLKt5kIeRYFdwt2pCNfRPb5pNf5t8tI1xT5O1IacC13WLo6nCO0uBfCovUQV11mGdSuDpG7w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.1.0.tgz",
+      "integrity": "sha512-/XhibgDUIFjUlaBjztSMvvj96JuLGOt+vlPQKViGoeAyk7PItk4VfBYxaQjMWAiaPEDUkdhZD3P1CvIP/9Colw==",
       "requires": {
-        "@miniflare/shared": "2.0.0"
+        "@miniflare/shared": "2.1.0"
       }
     },
     "@miniflare/runner-vm": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.0.0.tgz",
-      "integrity": "sha512-2kFTS+IhtoZjsDRyIba2xQWG0B73KaJGaymmk5cYjXqBML1DA9C7nxpkiJbbEDdAGG0hQRD7ILSe3M4gCQ51Bg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.1.0.tgz",
+      "integrity": "sha512-LvF6RqPgkA+kSgRZiu8NEANFhlTATfEFYEJtPZiwRYchXIXpLpiOQ+Zi0yglBM9HFeLG50iuT3z/CKmv2T1oSw==",
       "requires": {
-        "@miniflare/shared": "2.0.0"
+        "@miniflare/shared": "2.1.0"
       }
     },
     "@miniflare/scheduler": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.0.0.tgz",
-      "integrity": "sha512-H0gUrvhSb6XeSUpOcr0vuuFVxciE4LIKQB/vgVLPjYULQqvU85ZZU1/hocYxJ35f9h8U7iK13FUzORfwj5EBbA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.1.0.tgz",
+      "integrity": "sha512-C75U4wvZNNPWdUdmLThNflq6kSi4jPpSeoAZ+UVDyxVlivw4IMLL9Xy7sbmlyTzPuQ79zsH8RI0RpEJyN7DJUQ==",
       "requires": {
-        "@miniflare/core": "2.0.0",
-        "@miniflare/shared": "2.0.0",
+        "@miniflare/core": "2.1.0",
+        "@miniflare/shared": "2.1.0",
         "cron-schedule": "^3.0.4"
       }
     },
     "@miniflare/shared": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.0.0.tgz",
-      "integrity": "sha512-cWLl8qvYueQ4Kgx1m9ve1m9lCVL2/rnaBQ21jxb8CS5zQ6csMBIrvA0pCDfRK6YeAY76ScNM0uO6aiRW7easEA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.1.0.tgz",
+      "integrity": "sha512-ad7ofHntHTiPWtN8rDlvNS/o5TGnQDH5ncHAYmMtQl50Lsf8XFpBrQjaqjrwSKiRacHi09ipr9C+qxP04QU7Qw==",
       "requires": {
         "ignore": "^5.1.8",
         "kleur": "^4.1.4"
       }
     },
     "@miniflare/sites": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.0.0.tgz",
-      "integrity": "sha512-uG4bEPfcc1OLToiOXHNZrjU0aoUyugUu5q+mUGwR2ApCHbt/bRv6FZVxOSQWZcbzVYGujnk9vGAALVg/hwd0Hw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.1.0.tgz",
+      "integrity": "sha512-hZpN+XPhiR92+BuAaZeZRBasYvFNZA3aZA1bMIGhAAgilAEI4mLzAE7iYCiOBS0R/zgrxoYhoc4rVKnVcTcZjw==",
       "requires": {
-        "@miniflare/kv": "2.0.0",
-        "@miniflare/shared": "2.0.0",
-        "@miniflare/storage-file": "2.0.0"
+        "@miniflare/kv": "2.1.0",
+        "@miniflare/shared": "2.1.0",
+        "@miniflare/storage-file": "2.1.0"
       }
     },
     "@miniflare/storage-file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.0.0.tgz",
-      "integrity": "sha512-ADWmq7OLjQDgAaOiTBfUn44VDxTt2gqsHrr00KIXGdaVVU6R1HS8VryRCx4o/1w23p31ySSez2+h2g5rWB4WQg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.1.0.tgz",
+      "integrity": "sha512-82WyImf2BFzkhZNqWIUelTKBB27wqTB2N/zCAWnpmjWu6BSTXmxaUcYwVqB90eUebdNpSqREnhp3hLPT6JePRw==",
       "requires": {
-        "@miniflare/shared": "2.0.0",
-        "@miniflare/storage-memory": "2.0.0"
+        "@miniflare/shared": "2.1.0",
+        "@miniflare/storage-memory": "2.1.0"
       }
     },
     "@miniflare/storage-memory": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.0.0.tgz",
-      "integrity": "sha512-bWN0HvjnWwCDfBhlMXNC1ir9BceUA+LvWqmCDQcrY8K8nm+hH1/DU1TtSjGDnmAELNV5Rv1b0OwmhYkyNlq+nQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.1.0.tgz",
+      "integrity": "sha512-C2XsqJ0vfWM6MfcTMOgNz5Qmzq0NEfkLiR9siZUdcR0ULRHU8y4eoN2yk+Po9covpwByDqrbd5Viqe0RAgXN0Q==",
       "requires": {
-        "@miniflare/shared": "2.0.0"
+        "@miniflare/shared": "2.1.0"
       }
     },
     "@miniflare/watcher": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.0.0.tgz",
-      "integrity": "sha512-0B7w1B1d4hHVyLPznDuGxxwDku4wxLjPXqcIcVZhQmIK1+IaRwx/qJ5PolAwLTaqkLaYA7K/WlY8aumDa/VLsQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.1.0.tgz",
+      "integrity": "sha512-S/sTxi470bRildWL0t7PnPZge/6HO5KL7I5YSw7U4Srle/maojlaq2tiTaSfcloSJVkFeNm0thghudOOHUJGHQ==",
       "requires": {
-        "@miniflare/shared": "2.0.0"
+        "@miniflare/shared": "2.1.0"
       }
     },
     "@miniflare/web-sockets": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.0.0.tgz",
-      "integrity": "sha512-mU/Fw0a3/giJRbhOJVEsvm8Wlau2vVK241vI5K2VRjT6S5w9XGeog7ohBPtbTDYjkB0gdmZX/9KPQVBidJgB8Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.1.0.tgz",
+      "integrity": "sha512-x5KRzS1iXv9+giLfLN3/ZPfcTxwX55LnMRn1A0GdTU119A482EOyvnzOjnCzz73IlghUqv9UPZnLV26tfzfInA==",
       "requires": {
-        "@miniflare/core": "2.0.0",
-        "@miniflare/shared": "2.0.0",
+        "@miniflare/core": "2.1.0",
+        "@miniflare/shared": "2.1.0",
         "undici": "4.12.1",
         "ws": "^8.2.2"
       }
@@ -23726,25 +23725,24 @@
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
     },
     "miniflare": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.0.0.tgz",
-      "integrity": "sha512-vjaVGh8PPT5wsMs+XkTUEeg0S7Yrl4LAHY5/mwoocI+Z8iCCHTECEAB/Ioymh5Z3pnczj1AZ99DPMFBTXRI29A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.1.0.tgz",
+      "integrity": "sha512-DR6V/UTNd7Uo8OS6SuT+pxdf52sRDX8ZS9cDq5RSRwT7qrYnpC55E//M8bLSFCqAsokjvyDb0zI19/Wdi86hmw==",
       "requires": {
-        "@miniflare/cache": "2.0.0",
-        "@miniflare/cli-parser": "2.0.0",
-        "@miniflare/core": "2.0.0",
-        "@miniflare/durable-objects": "2.0.0",
-        "@miniflare/html-rewriter": "2.0.0",
-        "@miniflare/http-server": "2.0.0",
-        "@miniflare/kv": "2.0.0",
-        "@miniflare/runner-vm": "2.0.0",
-        "@miniflare/scheduler": "2.0.0",
-        "@miniflare/shared": "2.0.0",
-        "@miniflare/sites": "2.0.0",
-        "@miniflare/storage-file": "2.0.0",
-        "@miniflare/storage-memory": "2.0.0",
-        "@miniflare/watcher": "2.0.0",
-        "@miniflare/web-sockets": "2.0.0",
+        "@miniflare/cache": "2.1.0",
+        "@miniflare/cli-parser": "2.1.0",
+        "@miniflare/core": "2.1.0",
+        "@miniflare/durable-objects": "2.1.0",
+        "@miniflare/html-rewriter": "2.1.0",
+        "@miniflare/http-server": "2.1.0",
+        "@miniflare/kv": "2.1.0",
+        "@miniflare/runner-vm": "2.1.0",
+        "@miniflare/scheduler": "2.1.0",
+        "@miniflare/shared": "2.1.0",
+        "@miniflare/sites": "2.1.0",
+        "@miniflare/storage-file": "2.1.0",
+        "@miniflare/storage-memory": "2.1.0",
+        "@miniflare/web-sockets": "2.1.0",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
@@ -23844,9 +23842,9 @@
       }
     },
     "node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
+      "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -25031,11 +25029,11 @@
       }
     },
     "selfsigned": {
-      "version": "1.10.11",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.11.tgz",
-      "integrity": "sha512-aVmbPOfViZqOZPgRBT0+3u4yZFHpmnIghLMlAcb5/xhp5ZtB/RVnKhz5vl2M32CLXAqR4kha9zfhNg0Lf/sxKA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.0.0.tgz",
+      "integrity": "sha512-cUdFiCbKoa1mZ6osuJs2uDHrs0k0oprsKveFiiaBKCNq3SYyb5gs2HxhQyDNLCmL51ZZThqi4YNDpCK6GOP1iQ==",
       "requires": {
-        "node-forge": "^0.10.0"
+        "node-forge": "^1.2.0"
       }
     },
     "semiver": {
@@ -26544,7 +26542,7 @@
         "ink-testing-library": "^2.1.0",
         "ink-text-input": "^4.0.2",
         "mime": "^3.0.0",
-        "miniflare": "2.0.0",
+        "miniflare": "2.1.0",
         "node-fetch": "^3.1.0",
         "open": "^8.4.0",
         "path-to-regexp": "^6.2.0",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -37,7 +37,7 @@
   ],
   "dependencies": {
     "esbuild": "0.14.1",
-    "miniflare": "2.0.0",
+    "miniflare": "2.1.0",
     "path-to-regexp": "^6.2.0",
     "semiver": "^1.1.0"
   },


### PR DESCRIPTION
Hey! 👋 This PR upgrades `miniflare` to version `2.1.0`. This is mostly just bug fixes from the `2.0.0` release. See the [full changelog here](https://github.com/cloudflare/miniflare/releases/tag/v2.1.0).