### PR TITLE
Refactor `inspector` code to pass strict-null checks

### DIFF
--- a/.changeset/ten-cooks-warn.md
+++ b/.changeset/ten-cooks-warn.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Refactor inspector code to ensure that strict-null types pass


### PR DESCRIPTION
Some simple strict-null fixes but also a refactor to use react memo hooks in inspector code.

Previously the proxy server and websocket server were created in ref hooks.
But this prevented TypeScript from understanding that they were always defined when needed.
By using memo hooks we get this typing for free; and also can lean on react to handle recreating them as needed.