### PR TITLE
fix: description for `kv:bulk delete <filename>`

### DIFF
--- a/.changeset/serious-coins-provide.md
+++ b/.changeset/serious-coins-provide.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: description for `kv:bulk delete <filename>`
+
+The description for the `kv:bulk delete` command was wrong, it was probably copied earlier from the `kv:bulk put` command. This PR fixes the mistake.

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -1855,11 +1855,11 @@ export async function main(argv: string[]): Promise<void> {
         )
         .command(
           "delete <filename>",
-          "Upload multiple key-value pairs to a namespace",
+          "Delete multiple key-value pairs from a namespace",
           (yargs) => {
             return yargs
               .positional("filename", {
-                describe: `The JSON file of key-value pairs to upload, in form ["key1", "key2", ...]`,
+                describe: `The JSON file of keys to delete, in the form ["key1", "key2", ...]`,
                 type: "string",
               })
               .option("binding", {


### PR DESCRIPTION
The description for the `kv:bulk delete` command was wrong, it was probably copied earlier from the `kv:bulk put` command. This PR fixes the mistake.