### PR TITLE
fix: correctly handle entry-point path when publishing 

### DIFF
--- a/.changeset/heavy-paws-relate.md
+++ b/.changeset/heavy-paws-relate.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+---
+
+fix: correctly handle entry-point path when publishing
+
+The `publish` command was failing when the entry-point was specified in the wrangler.toml file and the entry-point imported another file.
+
+This was because we were using the `metafile.inputs` to guess the entry-point file path. But the order in which the source-files were added to this object was not well defined, and so we could end up failing to find a match.
+
+This fix avoids this by using the fact that the `metadata.outputs` object will only contain one element that has the `entrypoint` property - and then using that as the entry-point path. For runtime safety, we now assert that there cannot be zero or multiple such elements.

--- a/.changeset/young-horses-jam.md
+++ b/.changeset/young-horses-jam.md
@@ -1,0 +1,13 @@
+---
+"wrangler": patch
+---
+
+chore: add test-watch script to the wrangler workspace
+
+Watch the files in the wrangler workspace, and run the tests when anything changes:
+
+```sh
+> npm run test-watch -w wrangler
+```
+
+This will also run all the tests in a single process (rather than in parallel shards) and will increase the test-timeout to 50 seconds, which is helpful when debugging.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,8 +135,9 @@ Tests in a workspace are executed, by [Jest](https://jestjs.io/), which is confi
   ```
 - Watch the files in a specific workspace (e.g. wrangler), and run the tests when anything changes
   ```sh
-  > npm run test -w wrangler -- --watch
+  > npm run test-watch -w wrangler
   ```
+  This will also run all the tests in a single process (rather than in parallel shards) and will increase the test-timeout to 50 seconds, which is helpful when debugging.
 
 ## Steps For Making Changes
 

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -97,7 +97,8 @@
     "bundle": "node -r esbuild-register scripts/bundle.ts",
     "build": "npm run clean && npm run bundle",
     "start": "npm run bundle && NODE_OPTIONS=--enable-source-maps ./bin/wrangler.js",
-    "test": "CF_API_TOKEN=some-api-token CF_ACCOUNT_ID=some-account-id jest --silent=false --verbose=true"
+    "test": "CF_API_TOKEN=some-api-token CF_ACCOUNT_ID=some-account-id jest --silent=false --verbose=true",
+    "test-watch": "npm run test -- --runInBand --testTimeout=50000 --watch"
   },
   "engines": {
     "node": ">=16.7.0"

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -1,0 +1,102 @@
+import * as fs from "node:fs";
+import { setMockResponse } from "./mock-cfetch";
+import { runInTempDir } from "./run-in-tmp";
+import { runWrangler } from "./run-wrangler";
+
+describe("publish", () => {
+  runInTempDir();
+
+  it("should be able to use `index` with no extension as the entry-point", async () => {
+    writeWranglerToml();
+    writeEsmWorkerSource();
+    mockUploadWorkerRequest();
+    mockSubDomainRequest();
+
+    const { stdout, stderr, error } = await runWrangler("publish ./index");
+
+    expect(stdout).toMatchInlineSnapshot(`
+      "Uploaded
+      test-name
+      (0.00 sec)
+      Deployed
+      test-name
+      (0.00 sec)
+       
+      test-name.test-sub-domain.workers.dev"
+    `);
+    expect(stderr).toMatchInlineSnapshot(`""`);
+    expect(error).toMatchInlineSnapshot(`undefined`);
+  });
+
+  it("should be able to use the `build.upload.main` config as the entry-point for ESM sources", async () => {
+    writeWranglerToml("./index.js");
+    writeEsmWorkerSource();
+    mockUploadWorkerRequest();
+    mockSubDomainRequest();
+
+    const { stdout, stderr, error } = await runWrangler("publish");
+
+    expect(stdout).toMatchInlineSnapshot(`
+      "Uploaded
+      test-name
+      (0.00 sec)
+      Deployed
+      test-name
+      (0.00 sec)
+       
+      test-name.test-sub-domain.workers.dev"
+    `);
+    expect(stderr).toMatchInlineSnapshot(`""`);
+    expect(error).toMatchInlineSnapshot(`undefined`);
+  });
+});
+
+/** Write a mock wrangler.toml file to disk. */
+function writeWranglerToml(main?: string) {
+  fs.writeFileSync(
+    "./wrangler.toml",
+    [
+      `compatibility_date = "2022-01-12"`,
+      `name = "test-name"`,
+      main !== undefined ? `[build.upload]\nmain = "${main}"` : "",
+    ].join("\n"),
+    "utf-8"
+  );
+}
+
+/** Write a mock Worker script to disk. */
+function writeEsmWorkerSource() {
+  fs.writeFileSync(
+    "index.js",
+    [
+      `import { foo } from "./another";`,
+      `export default {`,
+      `  async fetch(request) {`,
+      `    return new Response('Hello' + foo);`,
+      `  },`,
+      `};`,
+    ].join("\n")
+  );
+  fs.writeFileSync("another.js", `export const foo = 100;`);
+}
+
+/** Create a mock handler for the request to upload a worker script. */
+function mockUploadWorkerRequest(available_on_subdomain = true) {
+  setMockResponse(
+    "/accounts/:accountId/workers/scripts/:scriptName",
+    "PUT",
+    ([_url, accountId, scriptName], _init, queryParams) => {
+      expect(accountId).toEqual("some-account-id");
+      expect(scriptName).toEqual("test-name");
+      expect(queryParams.get("available_on_subdomains")).toEqual("true");
+      return { available_on_subdomain };
+    }
+  );
+}
+
+/** Create a mock handler the request for the account's subdomain. */
+function mockSubDomainRequest(subdomain = "test-sub-domain") {
+  setMockResponse("/accounts/:accountId/workers/subdomain", () => {
+    return { subdomain };
+  });
+}


### PR DESCRIPTION
The `publish` command was failing when the entry-point was specified in the wrangler.toml file and the entry-point imported another file.

This was because we were using the `metafile.inputs` to guess the entry-point file path. But the order in which the source-files were added to this object was not well defined, and so we could end up failing to find a match.

This fix avoids this by using the fact that the `metadata.outputs` object will only contain one element that has the `entrypoint` property - and then using that as the entry-point path. For runtime safety, we now assert that there cannot be zero or multiple such elements.

Fixes #252