### PR TITLE
Fix silent failure when browser open doesn't work

### DIFF
--- a/.changeset/tricky-lemons-warn.md
+++ b/.changeset/tricky-lemons-warn.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: appropriately fail silently when the open browser command doesn't work

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -935,7 +935,7 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
         try {
           // `startServer` might throw if user code contains errors
           const server = await miniflare.startServer();
-          console.log(`Serving at http://127.0.0.1:${port}/`, { wait: true });
+          console.log(`Serving at http://127.0.0.1:${port}/`);
 
           if (process.env.BROWSER !== "none") {
             const childProcess = await open(`http://127.0.0.1:${port}/`);

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -940,7 +940,7 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
           if (process.env.BROWSER !== "none") {
             const childProcess = await open(`http://127.0.0.1:${port}/`);
             // fail silently if the open command doesn't work (e.g. in GitHub Codespaces)
-            childProcess.on("error", (err) => {});
+            childProcess.on("error", (_err) => {});
           }
 
           if (directory !== undefined && liveReload) {

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -940,7 +940,7 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
           if (process.env.BROWSER !== "none") {
             const childProcess = await open(`http://127.0.0.1:${port}/`);
             // fail silently if the open command doesn't work (e.g. in GitHub Codespaces)
-            childProcess.on('error', (err) => {})
+            childProcess.on("error", (err) => {});
           }
 
           if (directory !== undefined && liveReload) {

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -935,12 +935,12 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
         try {
           // `startServer` might throw if user code contains errors
           const server = await miniflare.startServer();
-          console.log(`Serving at http://127.0.0.1:${port}/`);
+          console.log(`Serving at http://127.0.0.1:${port}/`, { wait: true });
 
           if (process.env.BROWSER !== "none") {
-            try {
-              await open(`http://127.0.0.1:${port}/`);
-            } catch {}
+            const childProcess = await open(`http://127.0.0.1:${port}/`);
+            // fail silently if the open command doesn't work (e.g. in GitHub Codespaces)
+            childProcess.on('error', (err) => {})
           }
 
           if (directory !== undefined && liveReload) {


### PR DESCRIPTION
The solution in #211 doesn't work, because the error is thrown by the child process returned by the `open` function, not by the `open` itself.

Tested with GitHub Codespaces.