### PR TITLE
chore: upgrade `miniflare` to `2.2.0`

### DIFF
--- a/.changeset/cyan-fireants-study.md
+++ b/.changeset/cyan-fireants-study.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Upgrade `miniflare` to [`2.2.0`](https://github.com/cloudflare/miniflare/releases/tag/v2.2.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2493,12 +2493,12 @@
       }
     },
     "node_modules/@miniflare/cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.1.0.tgz",
-      "integrity": "sha512-U/lLt+HcIVxvb6FTUBSR/Q34zavnmFa06wCDYu3HrZqxRN3Y3mp80USy+9a0PsS2g7YofP//yXQl40TKxRq3uQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.2.0.tgz",
+      "integrity": "sha512-N6b4V6fp4V0ljUHWs6+wVAvT94/SUCp6+pn3wnizjnYQhDE9ns8KJHu6zOTi+OkZUezjdUDJK0dqQXIKC/23XA==",
       "dependencies": {
-        "@miniflare/core": "2.1.0",
-        "@miniflare/shared": "2.1.0",
+        "@miniflare/core": "2.2.0",
+        "@miniflare/shared": "2.2.0",
         "http-cache-semantics": "^4.1.0",
         "undici": "4.12.1"
       },
@@ -2507,11 +2507,11 @@
       }
     },
     "node_modules/@miniflare/cli-parser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.1.0.tgz",
-      "integrity": "sha512-jYX0gtNwPOg/Vm0/0bJEZQZ7aCXpD/LpTuxZFB5SSxoetCmMAWr3EYi2b+cVc5uAqKySNWuCGsQ97Bpla/Najw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.2.0.tgz",
+      "integrity": "sha512-AeP3hZOQ7/dBosCPh/iL7cwgdUi5EfHA0unGsFULaxuCwBb3RkQd5WAq4gzzgHywsFRIQ0+5/j9Mk1wHG2AkJA==",
       "dependencies": {
-        "@miniflare/shared": "2.1.0",
+        "@miniflare/shared": "2.2.0",
         "kleur": "^4.1.4"
       },
       "engines": {
@@ -2519,13 +2519,13 @@
       }
     },
     "node_modules/@miniflare/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-1vFX6vuttgZFTDg5REwi1MbbEITtyXXxZkuwvXrEfE1SAfj/KKn5wdQtKiZesoU/eJ5J80ggeysUagwNGuDemg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-CJwYhyXQ7si0ALZ4wB/vFAo0sHcyaMR7A8oQb6HaZ8XKhaKkzA8BmPutMvYVikiW+oRJP3YRcJGuVKibL3TSgA==",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/shared": "2.1.0",
-        "@miniflare/watcher": "2.1.0",
+        "@miniflare/shared": "2.2.0",
+        "@miniflare/watcher": "2.2.0",
         "busboy": "^0.3.1",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
@@ -2545,13 +2545,13 @@
       }
     },
     "node_modules/@miniflare/durable-objects": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.1.0.tgz",
-      "integrity": "sha512-r4KLXHCQEP/LW6DGjIKWdZQltS7rq9gfPOm32ruLVTEuvuLGzQU5m4H1K6IRvtD+WqVkX3xZbo6i5up1ulhM8A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.2.0.tgz",
+      "integrity": "sha512-iIRritqTBiTvX5dHPYswc3a6qzi3LPilbFE2HGjHMbqHi+/C4yX9SMfxCU4/6NcXc9xWjMGtJYBk+hgOW+Mvow==",
       "dependencies": {
-        "@miniflare/core": "2.1.0",
-        "@miniflare/shared": "2.1.0",
-        "@miniflare/storage-memory": "2.1.0",
+        "@miniflare/core": "2.2.0",
+        "@miniflare/shared": "2.2.0",
+        "@miniflare/storage-memory": "2.2.0",
         "undici": "4.12.1"
       },
       "engines": {
@@ -2559,13 +2559,13 @@
       }
     },
     "node_modules/@miniflare/html-rewriter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.1.0.tgz",
-      "integrity": "sha512-IUewfaN0H+AQAOYL0GcRIT9VShEG6Khl95MU6aK+LqINzZdieTw/fKZHszlV84+HPJPUNYa2jtwYRnKOI4wDbQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.2.0.tgz",
+      "integrity": "sha512-20qic3swy5bXg63Q96oHBKxHWp5d5GSn2HCZYXlHtODHeVbI/1lYQoD12b9EmE2i+jUZfCJjlinmjonXGyyL+A==",
       "dependencies": {
-        "@miniflare/core": "2.1.0",
-        "@miniflare/shared": "2.1.0",
-        "html-rewriter-wasm": "^0.3.2",
+        "@miniflare/core": "2.2.0",
+        "@miniflare/shared": "2.2.0",
+        "html-rewriter-wasm": "^0.4.0",
         "undici": "4.12.1"
       },
       "engines": {
@@ -2573,13 +2573,13 @@
       }
     },
     "node_modules/@miniflare/http-server": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.1.0.tgz",
-      "integrity": "sha512-4Ijhgx1X7znpMca6xGDZvigDN7+qtkEbPQFxl8ptKhGvDXLb3lP2UMkz7Ee7myV5H4Oauj4RpD6B6zmSj3p5zA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.2.0.tgz",
+      "integrity": "sha512-nx7xEXKYvPyUpu2HFigD+UEgclipMQzGdTKtm4t6JzsOGYys7Lj7kGjryYaQVtbbJvPKIxqSaViFQDk/QSdosg==",
       "dependencies": {
-        "@miniflare/core": "2.1.0",
-        "@miniflare/shared": "2.1.0",
-        "@miniflare/web-sockets": "2.1.0",
+        "@miniflare/core": "2.2.0",
+        "@miniflare/shared": "2.2.0",
+        "@miniflare/web-sockets": "2.2.0",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
         "undici": "4.12.1",
@@ -2591,34 +2591,34 @@
       }
     },
     "node_modules/@miniflare/kv": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.1.0.tgz",
-      "integrity": "sha512-/XhibgDUIFjUlaBjztSMvvj96JuLGOt+vlPQKViGoeAyk7PItk4VfBYxaQjMWAiaPEDUkdhZD3P1CvIP/9Colw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.2.0.tgz",
+      "integrity": "sha512-x2iUskcNEX74AfDhcZDKMTchNn3hUQyxDrzuDSHOv0vWRxDctmqYh5VxZVUGiaFvrbNN2+XgkgxXNY6TxrsfNQ==",
       "dependencies": {
-        "@miniflare/shared": "2.1.0"
+        "@miniflare/shared": "2.2.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/runner-vm": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.1.0.tgz",
-      "integrity": "sha512-LvF6RqPgkA+kSgRZiu8NEANFhlTATfEFYEJtPZiwRYchXIXpLpiOQ+Zi0yglBM9HFeLG50iuT3z/CKmv2T1oSw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.2.0.tgz",
+      "integrity": "sha512-x58BxIsAB6LcYgqTNVfxTsKFCu4G3Xiuj1k+3ZQ4b8v8TZjuZ3iOJcsrYU0PlbW5JpnRA8IH/mkiFRb/MrLtaQ==",
       "dependencies": {
-        "@miniflare/shared": "2.1.0"
+        "@miniflare/shared": "2.2.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/scheduler": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.1.0.tgz",
-      "integrity": "sha512-C75U4wvZNNPWdUdmLThNflq6kSi4jPpSeoAZ+UVDyxVlivw4IMLL9Xy7sbmlyTzPuQ79zsH8RI0RpEJyN7DJUQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.2.0.tgz",
+      "integrity": "sha512-OqfeSfxEfG3XA6D33C3dUxTUIy425n+BbZe15D2SdfvqUBeBobzOAAp0FbCQiZ5USsDY/zSIu98iSclqPxAn5w==",
       "dependencies": {
-        "@miniflare/core": "2.1.0",
-        "@miniflare/shared": "2.1.0",
+        "@miniflare/core": "2.2.0",
+        "@miniflare/shared": "2.2.0",
         "cron-schedule": "^3.0.4"
       },
       "engines": {
@@ -2626,9 +2626,9 @@
       }
     },
     "node_modules/@miniflare/shared": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.1.0.tgz",
-      "integrity": "sha512-ad7ofHntHTiPWtN8rDlvNS/o5TGnQDH5ncHAYmMtQl50Lsf8XFpBrQjaqjrwSKiRacHi09ipr9C+qxP04QU7Qw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.2.0.tgz",
+      "integrity": "sha512-ikz3nkBexVQ16Ioi6naAzK6Spj5O7lUcqIihMLCQKTAAdC252EL0QrBRxHV9MlvkypVNj6MqkoL4E6HcyuCo6g==",
       "dependencies": {
         "ignore": "^5.1.8",
         "kleur": "^4.1.4"
@@ -2638,59 +2638,59 @@
       }
     },
     "node_modules/@miniflare/sites": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.1.0.tgz",
-      "integrity": "sha512-hZpN+XPhiR92+BuAaZeZRBasYvFNZA3aZA1bMIGhAAgilAEI4mLzAE7iYCiOBS0R/zgrxoYhoc4rVKnVcTcZjw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.2.0.tgz",
+      "integrity": "sha512-UpD5xGqEnwHZ0slvAp+8N60LX1WezXTZVLI599KGIXuthEVkRLgk8PwujabmHisicDoyC3nxITeDExq0DY9G/w==",
       "dependencies": {
-        "@miniflare/kv": "2.1.0",
-        "@miniflare/shared": "2.1.0",
-        "@miniflare/storage-file": "2.1.0"
+        "@miniflare/kv": "2.2.0",
+        "@miniflare/shared": "2.2.0",
+        "@miniflare/storage-file": "2.2.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/storage-file": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.1.0.tgz",
-      "integrity": "sha512-82WyImf2BFzkhZNqWIUelTKBB27wqTB2N/zCAWnpmjWu6BSTXmxaUcYwVqB90eUebdNpSqREnhp3hLPT6JePRw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.2.0.tgz",
+      "integrity": "sha512-DzBbUmPadDw+nAG31Yn60d1Jg6ksHmXasfnd1g7Whe/D0leFRAsvcEJyVaojzlnuxTabtZAsLMoUjsofvnThzA==",
       "dependencies": {
-        "@miniflare/shared": "2.1.0",
-        "@miniflare/storage-memory": "2.1.0"
+        "@miniflare/shared": "2.2.0",
+        "@miniflare/storage-memory": "2.2.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/storage-memory": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.1.0.tgz",
-      "integrity": "sha512-C2XsqJ0vfWM6MfcTMOgNz5Qmzq0NEfkLiR9siZUdcR0ULRHU8y4eoN2yk+Po9covpwByDqrbd5Viqe0RAgXN0Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.2.0.tgz",
+      "integrity": "sha512-1Ze2ZGwRFzH+6lLu6hZMTwGYTNioIT07QXvz3ZS/ilpg++cWUtqy2yHnajdJgcnNDNNQ4iVGladC2GNezrLbHg==",
       "dependencies": {
-        "@miniflare/shared": "2.1.0"
+        "@miniflare/shared": "2.2.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/watcher": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.1.0.tgz",
-      "integrity": "sha512-S/sTxi470bRildWL0t7PnPZge/6HO5KL7I5YSw7U4Srle/maojlaq2tiTaSfcloSJVkFeNm0thghudOOHUJGHQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.2.0.tgz",
+      "integrity": "sha512-Myaztj1QaL1IaB04uBLKY8hE1kFtvB65cnKdJPOgjFxIgFzNyqybjlBjxx01Q6vymboFTPrl1Q5+g7fsW3lmfQ==",
       "dependencies": {
-        "@miniflare/shared": "2.1.0"
+        "@miniflare/shared": "2.2.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/web-sockets": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.1.0.tgz",
-      "integrity": "sha512-x5KRzS1iXv9+giLfLN3/ZPfcTxwX55LnMRn1A0GdTU119A482EOyvnzOjnCzz73IlghUqv9UPZnLV26tfzfInA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.2.0.tgz",
+      "integrity": "sha512-/GHYuTq6m28udequw4E8IpcFmcEheAcVQ3oZyAvY0ub0by8v4WzYuougiizqYylyQZ0KXyLg8SmPeBNChe82Zw==",
       "dependencies": {
-        "@miniflare/core": "2.1.0",
-        "@miniflare/shared": "2.1.0",
+        "@miniflare/core": "2.2.0",
+        "@miniflare/shared": "2.2.0",
         "undici": "4.12.1",
         "ws": "^8.2.2"
       },
@@ -6688,9 +6688,9 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
     },
     "node_modules/html-rewriter-wasm": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/html-rewriter-wasm/-/html-rewriter-wasm-0.3.2.tgz",
-      "integrity": "sha512-b+pOh+bs00uRVNIZoTgGBREjUKN47pchTNwkxKuP4ecQTFcOA6KJIW+jjvjjXrkSRURZsideLxFKqX7hnxdegQ=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/html-rewriter-wasm/-/html-rewriter-wasm-0.4.0.tgz",
+      "integrity": "sha512-x3keWzQCFIXTEIuBsF9oDcxg64ZuufuJRDimkTYGB9jwayLCB9KZ8ENsfDdTtUr+G47Gt07g0s10yCjZw2KtXg=="
     },
     "node_modules/http-cache-semantics": {
       "version": "4.1.0",
@@ -11250,24 +11250,24 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.1.0.tgz",
-      "integrity": "sha512-DR6V/UTNd7Uo8OS6SuT+pxdf52sRDX8ZS9cDq5RSRwT7qrYnpC55E//M8bLSFCqAsokjvyDb0zI19/Wdi86hmw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.2.0.tgz",
+      "integrity": "sha512-azOKDz9RfyWfDZY4u1k+GaaRuBApfgrRoz99sK/U7ngm0pxL0YRNuHPFSHwezAxw1Oz+KQpwtPClCE0zs7Rqgg==",
       "dependencies": {
-        "@miniflare/cache": "2.1.0",
-        "@miniflare/cli-parser": "2.1.0",
-        "@miniflare/core": "2.1.0",
-        "@miniflare/durable-objects": "2.1.0",
-        "@miniflare/html-rewriter": "2.1.0",
-        "@miniflare/http-server": "2.1.0",
-        "@miniflare/kv": "2.1.0",
-        "@miniflare/runner-vm": "2.1.0",
-        "@miniflare/scheduler": "2.1.0",
-        "@miniflare/shared": "2.1.0",
-        "@miniflare/sites": "2.1.0",
-        "@miniflare/storage-file": "2.1.0",
-        "@miniflare/storage-memory": "2.1.0",
-        "@miniflare/web-sockets": "2.1.0",
+        "@miniflare/cache": "2.2.0",
+        "@miniflare/cli-parser": "2.2.0",
+        "@miniflare/core": "2.2.0",
+        "@miniflare/durable-objects": "2.2.0",
+        "@miniflare/html-rewriter": "2.2.0",
+        "@miniflare/http-server": "2.2.0",
+        "@miniflare/kv": "2.2.0",
+        "@miniflare/runner-vm": "2.2.0",
+        "@miniflare/scheduler": "2.2.0",
+        "@miniflare/shared": "2.2.0",
+        "@miniflare/sites": "2.2.0",
+        "@miniflare/storage-file": "2.2.0",
+        "@miniflare/storage-memory": "2.2.0",
+        "@miniflare/web-sockets": "2.2.0",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
@@ -11280,7 +11280,7 @@
         "node": ">=16.7"
       },
       "peerDependencies": {
-        "@miniflare/storage-redis": "2.1.0",
+        "@miniflare/storage-redis": "2.2.0",
         "cron-schedule": "^3.0.4",
         "ioredis": "^4.27.9"
       },
@@ -15335,7 +15335,7 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "esbuild": "0.14.1",
-        "miniflare": "2.1.0",
+        "miniflare": "2.2.0",
         "path-to-regexp": "^6.2.0",
         "semiver": "^1.1.0"
       },
@@ -17527,33 +17527,33 @@
       }
     },
     "@miniflare/cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.1.0.tgz",
-      "integrity": "sha512-U/lLt+HcIVxvb6FTUBSR/Q34zavnmFa06wCDYu3HrZqxRN3Y3mp80USy+9a0PsS2g7YofP//yXQl40TKxRq3uQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.2.0.tgz",
+      "integrity": "sha512-N6b4V6fp4V0ljUHWs6+wVAvT94/SUCp6+pn3wnizjnYQhDE9ns8KJHu6zOTi+OkZUezjdUDJK0dqQXIKC/23XA==",
       "requires": {
-        "@miniflare/core": "2.1.0",
-        "@miniflare/shared": "2.1.0",
+        "@miniflare/core": "2.2.0",
+        "@miniflare/shared": "2.2.0",
         "http-cache-semantics": "^4.1.0",
         "undici": "4.12.1"
       }
     },
     "@miniflare/cli-parser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.1.0.tgz",
-      "integrity": "sha512-jYX0gtNwPOg/Vm0/0bJEZQZ7aCXpD/LpTuxZFB5SSxoetCmMAWr3EYi2b+cVc5uAqKySNWuCGsQ97Bpla/Najw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.2.0.tgz",
+      "integrity": "sha512-AeP3hZOQ7/dBosCPh/iL7cwgdUi5EfHA0unGsFULaxuCwBb3RkQd5WAq4gzzgHywsFRIQ0+5/j9Mk1wHG2AkJA==",
       "requires": {
-        "@miniflare/shared": "2.1.0",
+        "@miniflare/shared": "2.2.0",
         "kleur": "^4.1.4"
       }
     },
     "@miniflare/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-1vFX6vuttgZFTDg5REwi1MbbEITtyXXxZkuwvXrEfE1SAfj/KKn5wdQtKiZesoU/eJ5J80ggeysUagwNGuDemg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-CJwYhyXQ7si0ALZ4wB/vFAo0sHcyaMR7A8oQb6HaZ8XKhaKkzA8BmPutMvYVikiW+oRJP3YRcJGuVKibL3TSgA==",
       "requires": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/shared": "2.1.0",
-        "@miniflare/watcher": "2.1.0",
+        "@miniflare/shared": "2.2.0",
+        "@miniflare/watcher": "2.2.0",
         "busboy": "^0.3.1",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
@@ -17569,35 +17569,35 @@
       }
     },
     "@miniflare/durable-objects": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.1.0.tgz",
-      "integrity": "sha512-r4KLXHCQEP/LW6DGjIKWdZQltS7rq9gfPOm32ruLVTEuvuLGzQU5m4H1K6IRvtD+WqVkX3xZbo6i5up1ulhM8A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.2.0.tgz",
+      "integrity": "sha512-iIRritqTBiTvX5dHPYswc3a6qzi3LPilbFE2HGjHMbqHi+/C4yX9SMfxCU4/6NcXc9xWjMGtJYBk+hgOW+Mvow==",
       "requires": {
-        "@miniflare/core": "2.1.0",
-        "@miniflare/shared": "2.1.0",
-        "@miniflare/storage-memory": "2.1.0",
+        "@miniflare/core": "2.2.0",
+        "@miniflare/shared": "2.2.0",
+        "@miniflare/storage-memory": "2.2.0",
         "undici": "4.12.1"
       }
     },
     "@miniflare/html-rewriter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.1.0.tgz",
-      "integrity": "sha512-IUewfaN0H+AQAOYL0GcRIT9VShEG6Khl95MU6aK+LqINzZdieTw/fKZHszlV84+HPJPUNYa2jtwYRnKOI4wDbQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.2.0.tgz",
+      "integrity": "sha512-20qic3swy5bXg63Q96oHBKxHWp5d5GSn2HCZYXlHtODHeVbI/1lYQoD12b9EmE2i+jUZfCJjlinmjonXGyyL+A==",
       "requires": {
-        "@miniflare/core": "2.1.0",
-        "@miniflare/shared": "2.1.0",
-        "html-rewriter-wasm": "^0.3.2",
+        "@miniflare/core": "2.2.0",
+        "@miniflare/shared": "2.2.0",
+        "html-rewriter-wasm": "^0.4.0",
         "undici": "4.12.1"
       }
     },
     "@miniflare/http-server": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.1.0.tgz",
-      "integrity": "sha512-4Ijhgx1X7znpMca6xGDZvigDN7+qtkEbPQFxl8ptKhGvDXLb3lP2UMkz7Ee7myV5H4Oauj4RpD6B6zmSj3p5zA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.2.0.tgz",
+      "integrity": "sha512-nx7xEXKYvPyUpu2HFigD+UEgclipMQzGdTKtm4t6JzsOGYys7Lj7kGjryYaQVtbbJvPKIxqSaViFQDk/QSdosg==",
       "requires": {
-        "@miniflare/core": "2.1.0",
-        "@miniflare/shared": "2.1.0",
-        "@miniflare/web-sockets": "2.1.0",
+        "@miniflare/core": "2.2.0",
+        "@miniflare/shared": "2.2.0",
+        "@miniflare/web-sockets": "2.2.0",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
         "undici": "4.12.1",
@@ -17606,82 +17606,82 @@
       }
     },
     "@miniflare/kv": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.1.0.tgz",
-      "integrity": "sha512-/XhibgDUIFjUlaBjztSMvvj96JuLGOt+vlPQKViGoeAyk7PItk4VfBYxaQjMWAiaPEDUkdhZD3P1CvIP/9Colw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.2.0.tgz",
+      "integrity": "sha512-x2iUskcNEX74AfDhcZDKMTchNn3hUQyxDrzuDSHOv0vWRxDctmqYh5VxZVUGiaFvrbNN2+XgkgxXNY6TxrsfNQ==",
       "requires": {
-        "@miniflare/shared": "2.1.0"
+        "@miniflare/shared": "2.2.0"
       }
     },
     "@miniflare/runner-vm": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.1.0.tgz",
-      "integrity": "sha512-LvF6RqPgkA+kSgRZiu8NEANFhlTATfEFYEJtPZiwRYchXIXpLpiOQ+Zi0yglBM9HFeLG50iuT3z/CKmv2T1oSw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.2.0.tgz",
+      "integrity": "sha512-x58BxIsAB6LcYgqTNVfxTsKFCu4G3Xiuj1k+3ZQ4b8v8TZjuZ3iOJcsrYU0PlbW5JpnRA8IH/mkiFRb/MrLtaQ==",
       "requires": {
-        "@miniflare/shared": "2.1.0"
+        "@miniflare/shared": "2.2.0"
       }
     },
     "@miniflare/scheduler": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.1.0.tgz",
-      "integrity": "sha512-C75U4wvZNNPWdUdmLThNflq6kSi4jPpSeoAZ+UVDyxVlivw4IMLL9Xy7sbmlyTzPuQ79zsH8RI0RpEJyN7DJUQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.2.0.tgz",
+      "integrity": "sha512-OqfeSfxEfG3XA6D33C3dUxTUIy425n+BbZe15D2SdfvqUBeBobzOAAp0FbCQiZ5USsDY/zSIu98iSclqPxAn5w==",
       "requires": {
-        "@miniflare/core": "2.1.0",
-        "@miniflare/shared": "2.1.0",
+        "@miniflare/core": "2.2.0",
+        "@miniflare/shared": "2.2.0",
         "cron-schedule": "^3.0.4"
       }
     },
     "@miniflare/shared": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.1.0.tgz",
-      "integrity": "sha512-ad7ofHntHTiPWtN8rDlvNS/o5TGnQDH5ncHAYmMtQl50Lsf8XFpBrQjaqjrwSKiRacHi09ipr9C+qxP04QU7Qw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.2.0.tgz",
+      "integrity": "sha512-ikz3nkBexVQ16Ioi6naAzK6Spj5O7lUcqIihMLCQKTAAdC252EL0QrBRxHV9MlvkypVNj6MqkoL4E6HcyuCo6g==",
       "requires": {
         "ignore": "^5.1.8",
         "kleur": "^4.1.4"
       }
     },
     "@miniflare/sites": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.1.0.tgz",
-      "integrity": "sha512-hZpN+XPhiR92+BuAaZeZRBasYvFNZA3aZA1bMIGhAAgilAEI4mLzAE7iYCiOBS0R/zgrxoYhoc4rVKnVcTcZjw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.2.0.tgz",
+      "integrity": "sha512-UpD5xGqEnwHZ0slvAp+8N60LX1WezXTZVLI599KGIXuthEVkRLgk8PwujabmHisicDoyC3nxITeDExq0DY9G/w==",
       "requires": {
-        "@miniflare/kv": "2.1.0",
-        "@miniflare/shared": "2.1.0",
-        "@miniflare/storage-file": "2.1.0"
+        "@miniflare/kv": "2.2.0",
+        "@miniflare/shared": "2.2.0",
+        "@miniflare/storage-file": "2.2.0"
       }
     },
     "@miniflare/storage-file": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.1.0.tgz",
-      "integrity": "sha512-82WyImf2BFzkhZNqWIUelTKBB27wqTB2N/zCAWnpmjWu6BSTXmxaUcYwVqB90eUebdNpSqREnhp3hLPT6JePRw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.2.0.tgz",
+      "integrity": "sha512-DzBbUmPadDw+nAG31Yn60d1Jg6ksHmXasfnd1g7Whe/D0leFRAsvcEJyVaojzlnuxTabtZAsLMoUjsofvnThzA==",
       "requires": {
-        "@miniflare/shared": "2.1.0",
-        "@miniflare/storage-memory": "2.1.0"
+        "@miniflare/shared": "2.2.0",
+        "@miniflare/storage-memory": "2.2.0"
       }
     },
     "@miniflare/storage-memory": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.1.0.tgz",
-      "integrity": "sha512-C2XsqJ0vfWM6MfcTMOgNz5Qmzq0NEfkLiR9siZUdcR0ULRHU8y4eoN2yk+Po9covpwByDqrbd5Viqe0RAgXN0Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.2.0.tgz",
+      "integrity": "sha512-1Ze2ZGwRFzH+6lLu6hZMTwGYTNioIT07QXvz3ZS/ilpg++cWUtqy2yHnajdJgcnNDNNQ4iVGladC2GNezrLbHg==",
       "requires": {
-        "@miniflare/shared": "2.1.0"
+        "@miniflare/shared": "2.2.0"
       }
     },
     "@miniflare/watcher": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.1.0.tgz",
-      "integrity": "sha512-S/sTxi470bRildWL0t7PnPZge/6HO5KL7I5YSw7U4Srle/maojlaq2tiTaSfcloSJVkFeNm0thghudOOHUJGHQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.2.0.tgz",
+      "integrity": "sha512-Myaztj1QaL1IaB04uBLKY8hE1kFtvB65cnKdJPOgjFxIgFzNyqybjlBjxx01Q6vymboFTPrl1Q5+g7fsW3lmfQ==",
       "requires": {
-        "@miniflare/shared": "2.1.0"
+        "@miniflare/shared": "2.2.0"
       }
     },
     "@miniflare/web-sockets": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.1.0.tgz",
-      "integrity": "sha512-x5KRzS1iXv9+giLfLN3/ZPfcTxwX55LnMRn1A0GdTU119A482EOyvnzOjnCzz73IlghUqv9UPZnLV26tfzfInA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.2.0.tgz",
+      "integrity": "sha512-/GHYuTq6m28udequw4E8IpcFmcEheAcVQ3oZyAvY0ub0by8v4WzYuougiizqYylyQZ0KXyLg8SmPeBNChe82Zw==",
       "requires": {
-        "@miniflare/core": "2.1.0",
-        "@miniflare/shared": "2.1.0",
+        "@miniflare/core": "2.2.0",
+        "@miniflare/shared": "2.2.0",
         "undici": "4.12.1",
         "ws": "^8.2.2"
       }
@@ -20613,9 +20613,9 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
     },
     "html-rewriter-wasm": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/html-rewriter-wasm/-/html-rewriter-wasm-0.3.2.tgz",
-      "integrity": "sha512-b+pOh+bs00uRVNIZoTgGBREjUKN47pchTNwkxKuP4ecQTFcOA6KJIW+jjvjjXrkSRURZsideLxFKqX7hnxdegQ=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/html-rewriter-wasm/-/html-rewriter-wasm-0.4.0.tgz",
+      "integrity": "sha512-x3keWzQCFIXTEIuBsF9oDcxg64ZuufuJRDimkTYGB9jwayLCB9KZ8ENsfDdTtUr+G47Gt07g0s10yCjZw2KtXg=="
     },
     "http-cache-semantics": {
       "version": "4.1.0",
@@ -23958,24 +23958,24 @@
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
     },
     "miniflare": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.1.0.tgz",
-      "integrity": "sha512-DR6V/UTNd7Uo8OS6SuT+pxdf52sRDX8ZS9cDq5RSRwT7qrYnpC55E//M8bLSFCqAsokjvyDb0zI19/Wdi86hmw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.2.0.tgz",
+      "integrity": "sha512-azOKDz9RfyWfDZY4u1k+GaaRuBApfgrRoz99sK/U7ngm0pxL0YRNuHPFSHwezAxw1Oz+KQpwtPClCE0zs7Rqgg==",
       "requires": {
-        "@miniflare/cache": "2.1.0",
-        "@miniflare/cli-parser": "2.1.0",
-        "@miniflare/core": "2.1.0",
-        "@miniflare/durable-objects": "2.1.0",
-        "@miniflare/html-rewriter": "2.1.0",
-        "@miniflare/http-server": "2.1.0",
-        "@miniflare/kv": "2.1.0",
-        "@miniflare/runner-vm": "2.1.0",
-        "@miniflare/scheduler": "2.1.0",
-        "@miniflare/shared": "2.1.0",
-        "@miniflare/sites": "2.1.0",
-        "@miniflare/storage-file": "2.1.0",
-        "@miniflare/storage-memory": "2.1.0",
-        "@miniflare/web-sockets": "2.1.0",
+        "@miniflare/cache": "2.2.0",
+        "@miniflare/cli-parser": "2.2.0",
+        "@miniflare/core": "2.2.0",
+        "@miniflare/durable-objects": "2.2.0",
+        "@miniflare/html-rewriter": "2.2.0",
+        "@miniflare/http-server": "2.2.0",
+        "@miniflare/kv": "2.2.0",
+        "@miniflare/runner-vm": "2.2.0",
+        "@miniflare/scheduler": "2.2.0",
+        "@miniflare/shared": "2.2.0",
+        "@miniflare/sites": "2.2.0",
+        "@miniflare/storage-file": "2.2.0",
+        "@miniflare/storage-memory": "2.2.0",
+        "@miniflare/web-sockets": "2.2.0",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
@@ -26868,7 +26868,7 @@
         "ink-testing-library": "^2.1.0",
         "ink-text-input": "^4.0.2",
         "mime": "^3.0.0",
-        "miniflare": "2.1.0",
+        "miniflare": "2.2.0",
         "node-fetch": "^3.1.0",
         "open": "^8.4.0",
         "path-to-regexp": "^6.2.0",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -37,7 +37,7 @@
   ],
   "dependencies": {
     "esbuild": "0.14.1",
-    "miniflare": "2.1.0",
+    "miniflare": "2.2.0",
     "path-to-regexp": "^6.2.0",
     "semiver": "^1.1.0"
   },


### PR DESCRIPTION
Hey! 👋 This PR upgrades `miniflare` to version `2.2.0`. This contains some new `HTMLRewriter` stuff and a few more bug fixes. See the [full changelog here](https://github.com/cloudflare/miniflare/releases/tag/v2.2.0).