### PR TITLE
refactor: tidy up the typings of the build result in dev

### DIFF
--- a/.changeset/clever-turtles-shake.md
+++ b/.changeset/clever-turtles-shake.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+---
+
+refactor: tidy up the typings of the build result in dev
+
+In #262 some of the strict null fixes were removed to resolve a regression.
+This refactor re-applies these fixes in a way that avoids that problem.

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -441,7 +441,7 @@ function useEsbuild(props: {
   const { entry, destination, staticRoot, jsxFactory, jsxFragment } = props;
   const [bundle, setBundle] = useState<EsbuildBundle>();
   useEffect(() => {
-    let result: esbuild.BuildResult;
+    let result: esbuild.BuildResult | undefined;
     async function build() {
       if (!destination || !entry) return;
       const moduleCollector = makeModuleCollector();
@@ -508,9 +508,7 @@ function useEsbuild(props: {
       // so this is a no-op error handler
     });
     return () => {
-      if (result && result.stop) {
-        result.stop();
-      }
+      result?.stop?.();
     };
   }, [entry, destination, staticRoot, jsxFactory, jsxFragment]);
   return bundle;


### PR DESCRIPTION
In #262 some of the strict null fixes were removed to resolve a regression.
This refactor re-applies these fixes in a way that avoids that problem.