### PR TITLE
refactor: enable TypeScript strict-null checks

### DIFF
--- a/.changeset/quiet-pianos-try.md
+++ b/.changeset/quiet-pianos-try.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+refactor: enable TypeScript strict-null checks
+
+The codebase is now strict-null compliant and the CI checks will fail if a PR tries to introduce code that is not.

--- a/packages/wrangler/pages/functions/filepath-routing.ts
+++ b/packages/wrangler/pages/functions/filepath-routing.ts
@@ -157,7 +157,9 @@ export async function generateConfigFromFileTree({
 export function compareRoutes(a: string, b: string) {
   function parseRoutePath(routePath: string): [string | null, string[]] {
     const parts = routePath.split(" ", 2);
-    const segmentedPath = parts.pop();
+    // split() will guarantee at least one element.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const segmentedPath = parts.pop()!;
     const method = parts.pop() ?? null;
 
     const segments = segmentedPath.slice(1).split("/").filter(Boolean);

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -15,7 +15,7 @@ describe("Dev component", () => {
       accountId: "some-account-id",
       public: "some/public/path",
     });
-    expect(lastFrame().split("\n").slice(0, 2).join("\n"))
+    expect(lastFrame()?.split("\n").slice(0, 2).join("\n"))
       .toMatchInlineSnapshot(`
       "Something went wrong:
       Error: You cannot use the service worker format with a \`public\` directory."

--- a/packages/wrangler/src/cfetch/internal.ts
+++ b/packages/wrangler/src/cfetch/internal.ts
@@ -40,7 +40,7 @@ export async function fetchInternal<ResponseType>(
   }
 }
 
-function cloneHeaders(headers: HeadersInit): HeadersInit {
+function cloneHeaders(headers: HeadersInit | undefined): HeadersInit {
   return { ...headers };
 }
 

--- a/packages/wrangler/src/inspect.ts
+++ b/packages/wrangler/src/inspect.ts
@@ -470,8 +470,10 @@ function logConsoleMessage(evt: Protocol.Runtime.ConsoleAPICalledEvent): void {
             case "map":
               args.push(
                 "{\n" +
-                  ro.preview.entries
-                    .map(({ key, value }) => {
+                  // Maps always have entries
+                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                  ro.preview
+                    .entries!.map(({ key, value }) => {
                       return `  ${key?.description ?? "<unknown>"} => ${
                         value.description
                       }`;
@@ -485,8 +487,10 @@ function logConsoleMessage(evt: Protocol.Runtime.ConsoleAPICalledEvent): void {
             case "set":
               args.push(
                 "{ " +
-                  ro.preview.entries
-                    .map(({ value }) => {
+                  // Sets always have entries
+                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                  ro.preview
+                    .entries!.map(({ value }) => {
                       return `${value.description}`;
                     })
                     .join(", ") +

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -155,7 +155,9 @@ export default async function publish(props: Props): Promise<void> {
   const entryPointExports = entryPoints[0].exports;
   const resolvedEntryPointPath = path.resolve(
     destination.path,
-    entryPoints[0].entryPoint
+    // We know that entryPoint is not null because we filtered out those without above.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    entryPoints[0].entryPoint!
   );
   const { format } = props;
   const bundle = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "lib": ["esnext"],
     "jsx": "react",
     "resolveJsonModule": true,
-    "incremental": true
+    "incremental": true,
+    "strictNullChecks": true
   },
   "exclude": ["node_modules/", "packages/*/vendor", "packages/*/*-dist"]
 }


### PR DESCRIPTION
The codebase is now strict-null compliant and the CI checks will fail if a PR tries to introduce code that is not.