### PR TITLE
fix: align publishing sites asset keys with Wrangler 1 

### DIFF
--- a/.changeset/quiet-steaks-smoke.md
+++ b/.changeset/quiet-steaks-smoke.md
@@ -1,0 +1,10 @@
+---
+"wrangler": patch
+---
+
+fix: align publishing sites asset keys with Wrangler 1
+
+- Use the same hashing strategy for asset keys (xxhash64)
+- Include the full path (from cwd) in the asset key
+- Match include and exclude patterns against full path (from cwd)
+- Validate that the asset key is not over 512 bytes long

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,7 +23,8 @@
     "weakmap",
     "weakset",
     "webassemblymemory",
-    "websockets"
+    "websockets",
+    "xxhash"
   ],
   "cSpell.ignoreWords": ["yxxx"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "typescript": "^4.5.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=16.7.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -15213,6 +15213,15 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
+    "node_modules/xxhash-addon": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/xxhash-addon/-/xxhash-addon-1.4.0.tgz",
+      "integrity": "sha512-n3Ml0Vgvy7jMYJBlQIoFLjYxXNZQ5CbzW8E2Ynq2QCUpWMqCouooW7j02+7Oud5FijBuSrjQNuN/fCiz1SHN+w==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=8.6.0 <9.0.0 || >=10.0.0"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -15337,7 +15346,8 @@
         "esbuild": "0.14.1",
         "miniflare": "2.2.0",
         "path-to-regexp": "^6.2.0",
-        "semiver": "^1.1.0"
+        "semiver": "^1.1.0",
+        "xxhash-addon": "^1.4.0"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
@@ -26863,7 +26873,7 @@
         "find-up": "^6.2.0",
         "formdata-node": "^4.3.1",
         "fsevents": "~2.3.2",
-        "ignore": "*",
+        "ignore": "^5.2.0",
         "ink": "^3.2.0",
         "ink-select-input": "^4.2.1",
         "ink-table": "^3.0.0",
@@ -26882,6 +26892,7 @@
         "tmp-promise": "^3.0.3",
         "undici": "^4.11.1",
         "ws": "^8.3.0",
+        "xxhash-addon": "^1.4.0",
         "yargs": "^17.3.0"
       },
       "dependencies": {
@@ -27087,6 +27098,11 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+    },
+    "xxhash-addon": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/xxhash-addon/-/xxhash-addon-1.4.0.tgz",
+      "integrity": "sha512-n3Ml0Vgvy7jMYJBlQIoFLjYxXNZQ5CbzW8E2Ynq2QCUpWMqCouooW7j02+7Oud5FijBuSrjQNuN/fCiz1SHN+w=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -39,7 +39,8 @@
     "esbuild": "0.14.1",
     "miniflare": "2.2.0",
     "path-to-regexp": "^6.2.0",
-    "semiver": "^1.1.0"
+    "semiver": "^1.1.0",
+    "xxhash-addon": "^1.4.0"
   },
   "optionalDependencies": {
     "fsevents": "~2.3.2"

--- a/packages/wrangler/scripts/bundle.ts
+++ b/packages/wrangler/scripts/bundle.ts
@@ -12,7 +12,13 @@ async function run() {
     platform: "node",
     format: "cjs",
     // minify: true, // TODO: enable this again
-    external: ["fsevents", "esbuild", "miniflare", "@miniflare/core"], // todo - bundle miniflare too
+    external: [
+      "fsevents",
+      "esbuild",
+      "miniflare",
+      "@miniflare/core",
+      "xxhash-addon",
+    ], // todo - bundle miniflare too
     sourcemap: true,
     inject: [path.join(__dirname, "../import_meta_url.js")],
     define: {


### PR DESCRIPTION
Builds on top of #270.

- Use the same hashing strategy for asset keys (xxhash64)
- Include the full path (from cwd) in the asset key
- Match include and exclude patterns against full path (from cwd)
- Validate that the asset key is not over 512 bytes long