### PR TITLE
fix: propagate api errors to the terminal correctly.

### DIFF
--- a/.changeset/tall-cheetahs-juggle.md
+++ b/.changeset/tall-cheetahs-juggle.md
@@ -1,0 +1,12 @@
+---
+"wrangler": patch
+---
+
+fix: propagate api errors to the terminal correctly
+
+Any errors embedded in the response from the Cloudflare API were being lost, because `fetchInternal()` would throw on a non-200 response. This PR fixes that behaviour:
+
+- It doesn't throw on non-200 responses
+- It first gets the response text with `.text()` and converts it to an object with `JSON.parse`, so in case the api returns a non json response, we don't lose response we were sent.
+
+Unfortunately, because of the nature of this abstraction, we do lose the response `status` code and `statusText`, but maybe that's acceptable since we have richer error information in the payload. I considered logging the code and text to the terminal, but that may make it noisy.

--- a/packages/wrangler/src/cfetch/index.ts
+++ b/packages/wrangler/src/cfetch/index.ts
@@ -94,9 +94,17 @@ function throwFetchError(
   const errors = response.errors
     .map((error) => `${error.code}: ${error.message}`)
     .join("\n");
-  throw new Error(`Failed to fetch ${resource} - ${errors}`);
+  const error = new Error(`Failed to fetch ${resource} - \n${errors}`);
+  // add the first error code directly to this error
+  // so consumers can use it for specific behaviour
+  const code = response.errors[0]?.code;
+  if (code) {
+    //@ts-expect-error non-standard property on Error
+    error.code = code;
+  }
+  throw error;
 }
 
 function hasCursor(result_info: unknown): result_info is { cursor: string } {
-  return (result_info as { cursor } | undefined)?.cursor !== undefined;
+  return (result_info as { cursor: string } | undefined)?.cursor !== undefined;
 }

--- a/packages/wrangler/src/cfetch/internal.ts
+++ b/packages/wrangler/src/cfetch/internal.ts
@@ -31,11 +31,13 @@ export async function fetchInternal<ResponseType>(
     headers,
   });
 
-  if (response.ok) {
-    return (await response.json()) as ResponseType;
-  } else {
+  const jsonText = await response.text();
+  try {
+    const json = JSON.parse(jsonText);
+    return json as ResponseType;
+  } catch (e) {
     throw new Error(
-      `Failed to fetch ${resource} - ${response.status}: ${response.statusText}`
+      `Failed to fetch ${resource} - ${response.status}: ${response.statusText}\nInvalid JSON response:\n${jsonText}`
     );
   }
 }


### PR DESCRIPTION
Any errors embedded in the response from the Cloudflare API were being lost, because `fetchInternal()` would throw on a non-200 response. This PR fixes that behaviour:
- It doesn't throw on non-200 responses
- It first gets the response text with `.text()` and converts it to an object with `JSON.parse`, so in case the api returns a non json response, we don't lose response we were sent.

Unfortunately, because of the nature of this abstraction, we do lose the response `status` code and `statusText`, but maybe that's acceptable since we have richer error information in the payload. I considered logging the code and text to the terminal, but that may make it noisy.

Before: (note the generic http error message)
![image](https://user-images.githubusercontent.com/18808/150840426-0471dc01-83b4-4af3-b87c-98e432bc8bbe.png)

After: (note the cloudflare error code and message)
![image](https://user-images.githubusercontent.com/18808/150840475-a1be6439-3a25-43ad-8cac-df5929c3a83e.png)

