### PR TITLE
fix: use entrypoint specified in esbuild's metafile as source for building the worker

### DIFF
--- a/.changeset/popular-weeks-march.md
+++ b/.changeset/popular-weeks-march.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: use entrypoint specified in esbuuild's metafile as source for building the worker
+
+When we pass a non-js file as entry to esbuild, it generates a `.js` file. (which, that's the whole job of esbuild, haha). So, given `<source>/index.ts`, it'll generate `<destination>/index.js`. However, when we try to 'find' the matching file to pass on as an input to creating the actual worker, we try to use the original file name inside the destination directory. At this point, the extension has changed, so it doesn't find the file, and hence we get the error that looks like `ENOENT: no such file or directory, open '/var/folders/3f/fwp6mt7n13bfnkd5vl3jmh1w0000gp/T/tmp-61545-4Y5kwyNI8DGU/src/worker.ts'`
+
+The actual path to the destination file is actually the key of the block in `metafile.outputs` that matches the given output.entryPoint, so this PR simply rewrites the logic to use that instead.

--- a/.changeset/popular-weeks-march.md
+++ b/.changeset/popular-weeks-march.md
@@ -4,6 +4,6 @@
 
 fix: use entrypoint specified in esbuuild's metafile as source for building the worker
 
-When we pass a non-js file as entry to esbuild, it generates a `.js` file. (which, that's the whole job of esbuild, haha). So, given `<source>/index.ts`, it'll generate `<destination>/index.js`. However, when we try to 'find' the matching file to pass on as an input to creating the actual worker, we try to use the original file name inside the destination directory. At this point, the extension has changed, so it doesn't find the file, and hence we get the error that looks like `ENOENT: no such file or directory, open '/var/folders/3f/fwp6mt7n13bfnkd5vl3jmh1w0000gp/T/tmp-61545-4Y5kwyNI8DGU/src/worker.ts'`
+When we pass a non-js file as entry to esbuild, it generates a `.js` file. (which, is the whole job of esbuild, haha). So, given `<source>/index.ts`, it'll generate `<destination>/index.js`. However, when we try to 'find' the matching file to pass on as an input to creating the actual worker, we try to use the original file name inside the destination directory. At this point, the extension has changed, so it doesn't find the file, and hence we get the error that looks like `ENOENT: no such file or directory, open '/var/folders/3f/fwp6mt7n13bfnkd5vl3jmh1w0000gp/T/tmp-61545-4Y5kwyNI8DGU/src/worker.ts'`
 
 The actual path to the destination file is actually the key of the block in `metafile.outputs` that matches the given output.entryPoint, so this PR simply rewrites the logic to use that instead.

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -140,8 +140,8 @@ export default async function publish(props: Props): Promise<void> {
   // result.metafile is defined because of the `metafile: true` option above.
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const metafile = result.metafile!;
-  const entryPoints = Object.values(metafile.outputs).filter(
-    (output) => output.entryPoint !== undefined
+  const entryPoints = Object.entries(metafile.outputs).filter(
+    ([_path, output]) => output.entryPoint !== undefined
   );
   assert(
     entryPoints.length > 0,
@@ -153,13 +153,8 @@ export default async function publish(props: Props): Promise<void> {
     "More than one entry-point found for generated bundle." +
       listEntryPoints(entryPoints)
   );
-  const entryPointExports = entryPoints[0].exports;
-  const resolvedEntryPointPath = path.resolve(
-    destination.path,
-    // We know that entryPoint is not null because we filtered out those without above.
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    entryPoints[0].entryPoint!
-  );
+  const entryPointExports = entryPoints[0][1].exports;
+  const resolvedEntryPointPath = entryPoints[0][0];
   const { format } = props;
   const bundle = {
     type: entryPointExports.length > 0 ? "esm" : "commonjs",
@@ -378,8 +373,10 @@ export default async function publish(props: Props): Promise<void> {
   }
 }
 
-function listEntryPoints(outputs: ValueOf<Metafile["outputs"]>[]): string {
-  return outputs.map((output) => output.entryPoint).join("\n");
+function listEntryPoints(
+  outputs: [string, ValueOf<Metafile["outputs"]>][]
+): string {
+  return outputs.map(([_input, output]) => output.entryPoint).join("\n");
 }
 
 type ValueOf<T> = T[keyof T];


### PR DESCRIPTION
When we pass a non-js file as entry to esbuild, it generates a `.js` file. (which, that's the whole job of esbuild, haha). So, given `<source>/index.ts`, it'll generate `<destination>/index.js`. However, when we try to 'find' the matching file to pass on as an input to creating the actual worker, we try to use the original file name inside the destination directory. At this point, the extension has changed, so it doesn't find the file, and hence we get the error that looks like `ENOENT: no such file or directory, open '/var/folders/3f/fwp6mt7n13bfnkd5vl3jmh1w0000gp/T/tmp-61545-4Y5kwyNI8DGU/src/worker.ts'`

The actual path to the destination file is actually the key of the block in `metafile.outputs` that matches the given `output.entryPoint`, so this PR simply rewrites the logic to use that instead.

fixes https://github.com/cloudflare/wrangler2/issues/288