### PR TITLE
fix: warn if the `site.entry-point` configuration is found during publishing

### DIFF
--- a/.changeset/lovely-elephants-reflect.md
+++ b/.changeset/lovely-elephants-reflect.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: warn if the `site.entry-point` configuration is found during publishing
+
+Also updates the message and adds a test for the error when there is no entry-point specified.
+
+Fixes #282

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -494,6 +494,14 @@ export async function main(argv: string[]): Promise<void> {
         );
       }
 
+      if (config.site?.["entry-point"]) {
+        console.warn(
+          "Deprecation notice: The `site.entry-point` config field is no longer used.\n" +
+            "The entry-point is specified via the command line (e.g. `wrangler dev path/to/script`).\n" +
+            "Please remove the `site.entry-point` field from the `wrangler.toml` file."
+        );
+      }
+
       if (!args.local) {
         // -- snip, extract --
         const loggedIn = await loginOrRefreshIfRequired();

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -78,13 +78,25 @@ export default async function publish(props: Props): Promise<void> {
     'You need to provide a name when publishing a worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`'
   );
 
+  if (config.site?.["entry-point"]) {
+    console.warn(
+      "Deprecation notice: The `site.entry-point` config field is no longer used.\n" +
+        "The entry-point should be specified via the command line (e.g. `wrangler publish path/to/script`) or the `build.upload.main` config field.\n" +
+        "Please remove the `site.entry-point` field from the `wrangler.toml` file."
+    );
+  }
+
   let file: string;
   if (props.script) {
     // If the script name comes from the command line it is relative to the current working directory.
     file = path.resolve(props.script);
   } else {
     // If the script name comes from the config, then it is relative to the wrangler.toml file.
-    assert(build?.upload?.main, "missing main file");
+    if (build?.upload?.main === undefined) {
+      throw new Error(
+        "Missing entry-point: The entry-point should be specified via the command line (e.g. `wrangler publish path/to/script`) or the `build.upload.main` config field."
+      );
+    }
     file = path.resolve(path.dirname(__path__), build.upload.main);
   }
 


### PR DESCRIPTION
Is it enough to log a warning? Or should we throw a `new DeprecationError()`?

Fixes #282