### PR TITLE
feature: add more types that get logged via `console` methods

### DIFF
--- a/.changeset/strange-melons-provide.md
+++ b/.changeset/strange-melons-provide.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+feature: add more types that get logged via `console` methods
+
+This PR adds more special logic for some data types that get logged via `console` methods. Types like `Promise`, `Date`, `WeakMaps`, and some more, now get logged correctly (or at least, better than they used to).
+
+This PR also fixes a sinister bug - the `type` of the `ConsoleAPICalled` events don't match 1:1 with actual console methods (eg: `console.warn` message type is `warning`). This PR adds a mapping between those types and method names. Some methods don't seem to have a message type, I'm not sure why, but we'll get to them later.

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -569,7 +569,7 @@ function useWorker(props: {
       if (!startedRef.current) {
         startedRef.current = true;
       } else {
-        console.log("⎔ Detected changes, restarting server...");
+        console.log("⎔ Detected changes, restarted server.");
       }
 
       const assets = await syncAssets(


### PR DESCRIPTION
This PR adds more special logic for some data types that get logged via `console` methods. Types like `Promise`, `Date`, `WeakMaps`, and some more, now get logged correctly (or at least, better than they used to).

This PR also fixes a sinister bug - the `type` of the `ConsoleAPICalled` events don't match 1:1 with actual console methods (eg: `console.warn` message type is `warning`). This PR adds a mapping between those types and method names. Some methods don't seem to have a message type, I'm not sure why, but we'll get to them later.