### PR TITLE
chore: run jest `--onlyChanged` in CI

### DIFF
--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -67,4 +67,4 @@ jobs:
         run: npm install
 
       - name: Run build and test
-        run: npm run build-and-test
+        run: npm run build-and-test:ci

--- a/package.json
+++ b/package.json
@@ -35,8 +35,10 @@
     "check:lint": "eslint packages/** --cache --cache-strategy content",
     "check:format": "prettier packages/** --check",
     "build-and-test": "run-p build test --aggregate-output -l",
+    "build-and-test:ci": "run-p build test:ci --aggregate-output -l",
     "build": "npm run build --workspace=wrangler",
     "test": "npm run test --workspaces --if-present",
+    "test:ci": "npm run test:ci --workspaces --if-present",
     "prettify": "prettier packages/** --write"
   },
   "engines": {

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -100,6 +100,7 @@
     "build": "npm run clean && npm run bundle",
     "start": "npm run bundle && NODE_OPTIONS=--enable-source-maps ./bin/wrangler.js",
     "test": "CF_API_TOKEN=some-api-token CF_ACCOUNT_ID=some-account-id jest --silent=false --verbose=true",
+    "test:ci": "CF_API_TOKEN=some-api-token CF_ACCOUNT_ID=some-account-id jest --onlyChanged --silent=false --verbose=true",
     "test-watch": "npm run test -- --runInBand --testTimeout=50000 --watch"
   },
   "engines": {


### PR DESCRIPTION
This PR runs jest with the `--onlyChanged` flag in CI. This *may* make tests faster, at least in some cases. Let's see.