### PR TITLE
refactor: implement a renderToString() helper for static Ink components

### DIFF
--- a/.changeset/odd-scissors-destroy.md
+++ b/.changeset/odd-scissors-destroy.md
@@ -1,0 +1,12 @@
+---
+"wrangler": patch
+---
+
+refactor: implement a `renderToString()` helper for static Ink components
+
+This change enables simpler testing of some Ink components.
+When an Ink component is used only to statically generate some output, we can now use the `renderToString()` method to render the output to a string, which can be sent to the logger.
+
+This cannot be used for interactive or dynamic components.
+
+The change also updates the whoami command and its tests to demonstrate use of `renderToString()`.

--- a/packages/wrangler/src/__tests__/login.test.ts
+++ b/packages/wrangler/src/__tests__/login.test.ts
@@ -1,0 +1,40 @@
+import { runWrangler } from "./run-wrangler";
+import { initialise } from "../user";
+import { mockConsoleMethods } from "./mock-console";
+
+describe("login", () => {
+  const std = mockConsoleMethods();
+
+  describe("--scopes-list", () => {
+    it("should display a list of available scopes", async () => {
+      await initialise();
+      await runWrangler("login --scopes-list");
+      expect(std.out).toContain("Available scopes:");
+      expect(std.out).toMatch(/Scope .* Description/);
+      expect(std.out).toMatch(
+        / account:read .* See your account info such as account details, analytics, and memberships\. /
+      );
+      expect(std.out).toMatch(
+        / user:read .* See your user info such as name, email address, and account memberships\. /
+      );
+      expect(std.out).toMatch(
+        / workers:write .* See and change Cloudflare Workers data such as zones, KV storage, namespaces, scripts, and routes\. /
+      );
+      expect(std.out).toMatch(
+        / workers_kv:write .* See and change Cloudflare Workers KV Storage data such as keys and namespaces\. /
+      );
+      expect(std.out).toMatch(
+        / workers_routes:write .* See and change Cloudflare Workers data such as filters and routes\. /
+      );
+      expect(std.out).toMatch(
+        / workers_scripts:write .* See and change Cloudflare Workers scripts, durable objects, subdomains, triggers, and tail data\. /
+      );
+      expect(std.out).toMatch(
+        / workers_tail:read .* See Cloudflare Workers tail and script data\. /
+      );
+      expect(std.out).toMatch(
+        / zone:read .* Grants read level access to account zone\. /
+      );
+    });
+  });
+});

--- a/packages/wrangler/src/__tests__/mock-console.ts
+++ b/packages/wrangler/src/__tests__/mock-console.ts
@@ -7,6 +7,9 @@ let logSpy: jest.SpyInstance,
   errorSpy: jest.SpyInstance,
   warnSpy: jest.SpyInstance;
 
+// Store the actual current number of columns, because we will override this when mocking the console.
+const originalColumns = process.stdout.columns;
+
 const std = {
   get out() {
     return logSpy.mock.calls.flat(2).join("\n");
@@ -19,16 +22,26 @@ const std = {
   },
 };
 
-export function mockConsoleMethods() {
+/**
+ * Mock out the console.xxx methods, capturing their calls via spies.
+ *
+ * The spies can be accessed via the returned object.
+ * Set the `columns` argument to ensure that Ink components are rendered in a suitably wide format.
+ */
+export function mockConsoleMethods({
+  columns = 500,
+}: { columns?: number } = {}) {
   beforeEach(() => {
     logSpy = jest.spyOn(console, "log").mockImplementation();
     errorSpy = jest.spyOn(console, "error").mockImplementation();
     warnSpy = jest.spyOn(console, "warn").mockImplementation();
+    process.stdout.columns = columns;
   });
   afterEach(() => {
     logSpy.mockRestore();
     errorSpy.mockRestore();
     warnSpy.mockRestore();
+    process.stdout.columns = originalColumns;
   });
   return std;
 }

--- a/packages/wrangler/src/__tests__/whoami.test.tsx
+++ b/packages/wrangler/src/__tests__/whoami.test.tsx
@@ -1,19 +1,18 @@
-import React from "react";
 import os from "node:os";
 import path from "node:path";
-import { render } from "ink-testing-library";
-import type { UserInfo } from "../whoami";
-import { getUserInfo, WhoAmI } from "../whoami";
 import { runInTempDir } from "./run-in-tmp";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { setMockResponse } from "./mock-cfetch";
 import { initialise } from "../user";
+import { runWrangler } from "./run-wrangler";
+import { mockConsoleMethods } from "./mock-console";
 
 const ORIGINAL_CF_API_TOKEN = process.env.CF_API_TOKEN;
 const ORIGINAL_CF_ACCOUNT_ID = process.env.CF_ACCOUNT_ID;
 
-describe("getUserInfo()", () => {
+describe("whoami", () => {
   runInTempDir({ homedir: "./home" });
+  const std = mockConsoleMethods();
 
   beforeEach(() => {
     // Clear the environment variables, so we can control them in the tests
@@ -27,17 +26,27 @@ describe("getUserInfo()", () => {
     process.env.CF_ACCOUNT_ID = ORIGINAL_CF_ACCOUNT_ID;
   });
 
-  it("should return undefined if there is no config file", async () => {
+  it("should log a 'not authenticated' message if there is no config file", async () => {
     await initialise();
-    const userInfo = await getUserInfo();
-    expect(userInfo).toBeUndefined();
+    await runWrangler("whoami");
+    expect(std.out).toMatchInlineSnapshot(`
+      "Getting User settings...
+      You are not authenticated. Please run \`wrangler login\`.
+      "
+    `);
+    expect(std.err).toMatchInlineSnapshot(`""`);
   });
 
-  it("should return undefined if there is an empty config file", async () => {
+  it("should log a 'not authenticated' message if there is an empty config file", async () => {
     writeUserConfig();
     await initialise();
-    const userInfo = await getUserInfo();
-    expect(userInfo).toBeUndefined();
+    await runWrangler("whoami");
+    expect(std.out).toMatchInlineSnapshot(`
+      "Getting User settings...
+      You are not authenticated. Please run \`wrangler login\`.
+      "
+    `);
+    expect(std.err).toMatchInlineSnapshot(`""`);
   });
 
   it("should return the user's email and accounts if authenticated via config token", async () => {
@@ -54,51 +63,16 @@ describe("getUserInfo()", () => {
     });
 
     await initialise();
-    const userInfo = await getUserInfo();
-
-    expect(userInfo).toEqual({
-      authType: "OAuth",
-      apiToken: "some-oauth-token",
-      email: "user@example.com",
-      accounts: [
-        { name: "Account One", id: "account-1" },
-        { name: "Account Two", id: "account-2" },
-        { name: "Account Three", id: "account-3" },
-      ],
-    });
-  });
-});
-
-describe("WhoAmI component", () => {
-  it("should return undefined if there is no user", async () => {
-    const { lastFrame } = render(<WhoAmI user={undefined}></WhoAmI>);
-
-    expect(lastFrame()).toMatchInlineSnapshot(
-      `"You are not authenticated. Please run \`wrangler login\`."`
-    );
-  });
-
-  it("should display the user's email and accounts", async () => {
-    const user: UserInfo = {
-      authType: "OAuth",
-      apiToken: "some-oauth-token",
-      email: "user@example.com",
-      accounts: [
-        { name: "Account One", id: "account-1" },
-        { name: "Account Two", id: "account-2" },
-        { name: "Account Three", id: "account-3" },
-      ],
-    };
-
-    const { lastFrame } = render(<WhoAmI user={user}></WhoAmI>);
-
-    expect(lastFrame()).toContain(
+    await runWrangler("whoami");
+    expect(std.out).toContain("Getting User settings...");
+    expect(std.out).toContain(
       "You are logged in with an OAuth Token, associated with the email 'user@example.com'!"
     );
-    expect(lastFrame()).toMatch(/Account Name .+ Account ID/);
-    expect(lastFrame()).toMatch(/Account One .+ account-1/);
-    expect(lastFrame()).toMatch(/Account Two .+ account-2/);
-    expect(lastFrame()).toMatch(/Account Three .+ account-3/);
+    expect(std.out).toMatch(/Account Name .+ Account ID/);
+    expect(std.out).toMatch(/Account One .+ account-1/);
+    expect(std.out).toMatch(/Account Two .+ account-2/);
+    expect(std.out).toMatch(/Account Three .+ account-3/);
+    expect(std.err).toMatchInlineSnapshot(`""`);
   });
 });
 

--- a/packages/wrangler/src/render-helpers.ts
+++ b/packages/wrangler/src/render-helpers.ts
@@ -1,0 +1,32 @@
+import EventEmitter from "node:events";
+import { render } from "ink";
+import type { ReactElement } from "react";
+
+/**
+ * Render the given ink.js `Component` to a string.
+ *
+ * It should only be used for components that will static render output based on their properties.
+ */
+export function renderToString(Component: ReactElement) {
+  const stdout = new CaptureStd();
+  render(Component, {
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    patchConsole: false,
+  });
+
+  return stdout.output;
+}
+
+/**
+ * This class is passed to the ink.js `render()` to capture its output into a string.
+ *
+ * Each new rendering will overwrite the content being captured.
+ */
+class CaptureStd extends EventEmitter {
+  output = "";
+  columns = process.stdout.columns;
+
+  write(str: string) {
+    this.output = str;
+  }
+}

--- a/packages/wrangler/src/user.tsx
+++ b/packages/wrangler/src/user.tsx
@@ -224,6 +224,7 @@ import assert from "node:assert";
 import type { ParsedUrlQuery } from "node:querystring";
 import { CF_API_BASE_URL } from "./cfetch";
 import type { Response } from "node-fetch";
+import { renderToString } from "./render-helpers";
 
 /**
  * An implementation of rfc6749#section-4.1 and rfc7636.
@@ -943,7 +944,7 @@ export function listScopes(): void {
     Scope: scope,
     Description: Scopes[scope],
   }));
-  render(<Table data={data} />);
+  console.log(renderToString(<Table data={data} />));
   // TODO: maybe a good idea to show usage here
 }
 

--- a/packages/wrangler/src/whoami.tsx
+++ b/packages/wrangler/src/whoami.tsx
@@ -1,13 +1,14 @@
-import { Text, render } from "ink";
+import { Text } from "ink";
 import Table from "ink-table";
 import React from "react";
 import { fetchListResult, fetchResult } from "./cfetch";
+import { renderToString } from "./render-helpers";
 import { getAPIToken } from "./user";
 
 export async function whoami() {
   console.log("Getting User settings...");
   const user = await getUserInfo();
-  render(<WhoAmI user={user}></WhoAmI>);
+  console.log(renderToString(<WhoAmI user={user}></WhoAmI>));
 }
 
 export function WhoAmI({ user }: { user: UserInfo | undefined }) {


### PR DESCRIPTION
This change enables simpler testing of some Ink components.
When an Ink component is used only to statically generate some output, we can now use the `renderToString()` method to render the output to a string, which can be sent to the logger.

This cannot be used for interactive or dynamic components.

The change also updates the whoami command and its tests to demonstrate use of `renderToString()` and uses `renderToString()` to list the available auth scopes in the `login` command.