### PR TITLE
Fix wrangler pages dev failing to start for just static assets

### DIFF
--- a/.changeset/poor-actors-join.md
+++ b/.changeset/poor-actors-join.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fixes `wrangler pages dev` failing to start for just a folder of static assets (no functions)

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -850,6 +850,7 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
               }
             }`,
             };
+            scriptReadyResolve();
           }
         }
 


### PR DESCRIPTION
With https://github.com/cloudflare/wrangler2/commit/8ff55376ffb8f9db24d56fef6ee2c6bd5cc0527d, we introduced a ready promise to ensure Miniflare had a script to run with `wrangler pages dev`.

This PR resolves that promise when providing a static script (in the case of no functions folder or Worker script being provided).