### PR TITLE
Non interactive mode

### DIFF
--- a/.changeset/two-coins-compare.md
+++ b/.changeset/two-coins-compare.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Disabled local persistence by default & added --experimental-enable-local-persistence flag

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "printWidth": 80,
+  "singleQuote": false,
+  "semi": true
+}

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -44,6 +44,7 @@ function renderDev({
   compatibilityFlags,
   usageModel,
   buildCommand = {},
+  enableLocalPersistence = false,
 }: Partial<DevProps>) {
   return render(
     <Dev
@@ -62,6 +63,7 @@ function renderDev({
       compatibilityFlags={compatibilityFlags}
       usageModel={usageModel}
       bindings={bindings}
+      enableLocalPersistence={enableLocalPersistence}
     />
   );
 }

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -4,7 +4,7 @@ import { spawn } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import path from "node:path";
-import { Box, Text, useApp, useInput } from "ink";
+import { Box, Text, useApp, useInput, useStdin } from "ink";
 import { watch } from "chokidar";
 import clipboardy from "clipboardy";
 import commandExists from "command-exists";
@@ -82,45 +82,93 @@ function Dev(props: DevProps): JSX.Element {
     );
   }
 
+  const { isRawModeSupported } = useStdin();
+
+  if (isRawModeSupported) {
+    return (
+      <InteractiveDev
+        bundle={bundle}
+        local={props.initialMode === "local"}
+        port={port}
+        apiToken={apiToken}
+        name={props.name}
+        format={props.format}
+        bindings={props.bindings}
+        public={props.public}
+        assetPaths={props.assetPaths}
+        enableLocalPersistence={props.enableLocalPersistence}
+        accountId={props.accountId}
+        compatibilityDate={props.compatibilityDate}
+        compatibilityFlags={props.compatibilityFlags}
+        usageModel={props.usageModel}
+      />
+    );
+  } else {
+    return (
+      <DevSession
+        bundle={bundle}
+        local={props.initialMode === "local"}
+        port={port}
+        apiToken={apiToken}
+        name={props.name}
+        format={props.format}
+        bindings={props.bindings}
+        public={props.public}
+        assetPaths={props.assetPaths}
+        enableLocalPersistence={props.enableLocalPersistence}
+        accountId={props.accountId}
+        compatibilityDate={props.compatibilityDate}
+        compatibilityFlags={props.compatibilityFlags}
+        usageModel={props.usageModel}
+      />
+    );
+  }
+}
+
+function InteractiveDev(props: {
+  name: string | undefined;
+  bundle: EsbuildBundle | undefined;
+  local: boolean;
+  port: number;
+  format: CfScriptFormat;
+  bindings: CfWorkerInit["bindings"];
+  public: undefined | string;
+  assetPaths: undefined | AssetPaths;
+  enableLocalPersistence: boolean;
+  accountId: undefined | string;
+  apiToken: undefined | string;
+  compatibilityDate: string | undefined;
+  compatibilityFlags: undefined | string[];
+  usageModel: undefined | "bundled" | "unbound";
+}) {
   const toggles = useHotkeys(
     {
-      local: props.initialMode === "local",
+      local: props.local,
       tunnel: false,
     },
-    port
+    props.port
   );
 
   useTunnel(toggles.tunnel);
 
   return (
     <>
-      {toggles.local ? (
-        <Local
-          name={props.name}
-          bundle={bundle}
-          format={props.format}
-          bindings={props.bindings}
-          site={props.assetPaths}
-          public={props.public}
-          port={port}
-          enableLocalPersistence={props.enableLocalPersistence}
-        />
-      ) : (
-        <Remote
-          name={props.name}
-          bundle={bundle}
-          format={props.format}
-          accountId={props.accountId}
-          apiToken={apiToken}
-          bindings={props.bindings}
-          assetPaths={props.assetPaths}
-          public={props.public}
-          port={port}
-          compatibilityDate={props.compatibilityDate}
-          compatibilityFlags={props.compatibilityFlags}
-          usageModel={props.usageModel}
-        />
-      )}
+      <DevSession
+        name={props.name}
+        format={props.format}
+        bindings={props.bindings}
+        public={props.public}
+        assetPaths={props.assetPaths}
+        enableLocalPersistence={props.enableLocalPersistence}
+        accountId={props.accountId}
+        compatibilityDate={props.compatibilityDate}
+        compatibilityFlags={props.compatibilityFlags}
+        usageModel={props.usageModel}
+        apiToken={props.apiToken}
+        port={props.port}
+        bundle={props.bundle}
+        local={props.local}
+      />
       <Box borderStyle="round" paddingLeft={1} paddingRight={1}>
         <Text>
           {`B to open a browser, D to open Devtools, S to ${
@@ -131,6 +179,51 @@ function Dev(props: DevProps): JSX.Element {
         </Text>
       </Box>
     </>
+  );
+}
+
+function DevSession(props: {
+  name: string | undefined;
+  bundle: EsbuildBundle | undefined;
+  local: boolean;
+  port: number;
+  format: CfScriptFormat;
+  bindings: CfWorkerInit["bindings"];
+  public: undefined | string;
+  assetPaths: undefined | AssetPaths;
+  enableLocalPersistence: boolean;
+  accountId: undefined | string;
+  apiToken: undefined | string;
+  compatibilityDate: string | undefined;
+  compatibilityFlags: undefined | string[];
+  usageModel: undefined | "bundled" | "unbound";
+}) {
+  return props.local ? (
+    <Local
+      name={props.name}
+      bundle={props.bundle}
+      format={props.format}
+      bindings={props.bindings}
+      site={props.assetPaths}
+      public={props.public}
+      port={props.port}
+      enableLocalPersistence={props.enableLocalPersistence}
+    />
+  ) : (
+    <Remote
+      name={props.name}
+      bundle={props.bundle}
+      format={props.format}
+      accountId={props.accountId}
+      apiToken={props.apiToken}
+      bindings={props.bindings}
+      assetPaths={props.assetPaths}
+      public={props.public}
+      port={props.port}
+      compatibilityDate={props.compatibilityDate}
+      compatibilityFlags={props.compatibilityFlags}
+      usageModel={props.usageModel}
+    />
   );
 }
 

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -40,6 +40,7 @@ export type DevProps = {
   initialMode: "local" | "remote";
   jsxFactory: undefined | string;
   jsxFragment: undefined | string;
+  enableLocalPersistence: boolean;
   bindings: CfWorkerInit["bindings"];
   public: undefined | string;
   assetPaths: undefined | AssetPaths;
@@ -102,6 +103,7 @@ function Dev(props: DevProps): JSX.Element {
           site={props.assetPaths}
           public={props.public}
           port={port}
+          enableLocalPersistence={props.enableLocalPersistence}
         />
       ) : (
         <Remote
@@ -184,6 +186,7 @@ function Local(props: {
   public: undefined | string;
   site: undefined | AssetPaths;
   port: number;
+  enableLocalPersistence: boolean;
 }) {
   const { inspectorUrl } = useLocalWorker({
     name: props.name,
@@ -191,6 +194,7 @@ function Local(props: {
     format: props.format,
     bindings: props.bindings,
     port: props.port,
+    enableLocalPersistence: props.enableLocalPersistence,
   });
   useInspector({ inspectorUrl, port: 9229, logToTerminal: false });
   return null;
@@ -202,6 +206,7 @@ function useLocalWorker(props: {
   format: CfScriptFormat;
   bindings: CfWorkerInit["bindings"];
   port: number;
+  enableLocalPersistence: boolean;
 }) {
   // TODO: pass vars via command line
   const { bundle, format, bindings, port } = props;
@@ -238,9 +243,9 @@ function useLocalWorker(props: {
         path.join(__dirname, "../miniflare-config-stubs/package.empty.json"),
         "--port",
         port.toString(),
-        "--kv-persist",
-        "--cache-persist",
-        "--do-persist",
+        ...(props.enableLocalPersistence
+          ? ["--kv-persist", "--cache-persist", "--do-persist"]
+          : []),
         ...Object.entries(bindings.vars || {}).flatMap(([key, value]) => {
           return ["--binding", `${key}=${value}`];
         }),

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -541,6 +541,10 @@ export async function main(argv: string[]): Promise<void> {
         .option("jsx-fragment", {
           describe: "The function that is called for each JSX fragment",
           type: "string",
+        })
+        .option("experimental-enable-local-persistence", {
+          describe: "Enable persistence for this session (only for local mode)",
+          type: "boolean",
         });
     },
     async (args) => {
@@ -608,6 +612,9 @@ export async function main(argv: string[]): Promise<void> {
           initialMode={args.local ? "local" : "remote"}
           jsxFactory={args["jsx-factory"] || envRootObj?.jsx_factory}
           jsxFragment={args["jsx-fragment"] || envRootObj?.jsx_fragment}
+          enableLocalPersistence={
+            args["experimental-enable-local-persistence"] || false
+          }
           accountId={config.account_id}
           assetPaths={getAssetPaths(
             config,


### PR DESCRIPTION
Proof of concept (stacks on top of #321) to let Wrangler2 run from within a test (should fix #322 and #170). Diff is a little wonky (that's a lotta props) but it does work:

```
> @holodb/example-1@ dev /Users/glen/src/projects/holodb/examples/1-simple
> wrangler dev --local src/worker.ts "--port" "1983"

Debugger listening on ws://127.0.0.1:9229/7c84629d-55da-4466-92a9-bed23a667ac4
For help, see: https://nodejs.org/en/docs/inspector

Debugger attached.

⎔ Starting a local server...
⬣ Listening at http://localhost:1983



[mf:inf] Worker reloaded! (447.55KiB)

[mf:inf] Listening on :1983

[mf:inf] - http://127.0.0.1:1983
[mf:inf] - http://192.0.2.2:1983

[mf:inf] - http://192.168.1.115:1983
[mf:inf] - http://192.168.1.92:1983
[mf:inf] - http://172.16.0.2:1983


 PASS  examples/1-simple.spec.ts (5.441 s)
  ● Console

    console.log
      {
        createUser: {
          id: 'e9ff69f2d17a06dd2541e87ea389969f4d9b338907cef8feff28399ea1abb9f6'
        }
      }

      at Object.<anonymous> (examples/1-simple.spec.ts:37:13)


Test Suites: 2 passed, 2 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        5.853 s, estimated 6 s
Ran all test suites.
POST /graphql 200 OK (46.33ms)


⎔ Shutting down local server.
```

Just FYI, this is the code example I'm using to execute it. Works pretty well!

```ts
const background_jobs: Function[] = []

describe(`Example`, () => {
  test('Sets up wrangler local dev', async () => {
    const { pid, promise } = await shellac.bg`
      in ${exampleDir} {
        $$ pnpm dev -- --port ${PORT}
      }
    `

    background_jobs.push(() => Promise.all([shellac`$$ kill -SIGINT -${pid}`, promise]))
  })

  // do tests here...

  afterAll(async () => {
    let close_job: Function | undefined
    while ((close_job = background_jobs.shift())) {
      await close_job()
    }
  })
})
```