### PR TITLE
Fixed broken routing on Windows

### DIFF
--- a/.changeset/tall-worms-suffer.md
+++ b/.changeset/tall-worms-suffer.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fixed paths not working on Windows, see #92

--- a/packages/wrangler/pages/functions/filepath-routing.ts
+++ b/packages/wrangler/pages/functions/filepath-routing.ts
@@ -103,7 +103,7 @@ export async function generateConfigFromFileTree({
                 routePath = "";
               }
 
-              routePath = `${baseURL}/${routePath}`;
+              routePath = `${baseURL}/${routePath}`.replace(/\\/g, "/");
 
               routePath = routePath.replace(/\[\[(.+)]]/g, ":$1*"); // transform [[id]] => :id*
               routePath = routePath.replace(/\[(.+)]/g, ":$1"); // transform [id] => :id

--- a/packages/wrangler/pages/functions/filepath-routing.ts
+++ b/packages/wrangler/pages/functions/filepath-routing.ts
@@ -103,7 +103,7 @@ export async function generateConfigFromFileTree({
                 routePath = "";
               }
 
-              routePath = `${baseURL}/${routePath}`.replace(/\\/g, "/");
+              routePath = `${baseURL}/${routePath}`;
 
               routePath = routePath.replace(/\[\[(.+)]]/g, ":$1*"); // transform [[id]] => :id*
               routePath = routePath.replace(/\[(.+)]/g, ":$1"); // transform [id] => :id


### PR DESCRIPTION
On Windows, routes keeping coming out with single backslashes delimiters, which break everything. Added a regex to convert `\` to `/`. See #92.
NOTE: I don't know if this messes with any Unix path escaping.