### PR TITLE
Fix Pages Functions path routing on Windows

### DIFF
--- a/.changeset/funny-peas-call.md
+++ b/.changeset/funny-peas-call.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fixed Pages Functions path routing on Windows

--- a/packages/wrangler/pages/functions/filepath-routing.ts
+++ b/packages/wrangler/pages/functions/filepath-routing.ts
@@ -93,7 +93,8 @@ export async function generateConfigFromFileTree({
 
               let routePath = path
                 .relative(baseDir, filepath)
-                .slice(0, -ext.length);
+                .slice(0, -ext.length)
+                .replaceAll(path.win32.sep, "/");
 
               if (isIndexFile || isMiddlewareFile) {
                 routePath = path.dirname(routePath);


### PR DESCRIPTION
This fixes an issue pointed out in #50 #51 where Pages Functions routes weren't properly routing due to Windows path separators being `\\` instead of `/`. Tested this change on both Windows and Linux.

### Before:
`functions\api\example.js` -> `/apiexample`
`functions\api\[[path]].js` -> `/api:path*`

### After:
`functions\api\example.js` -> `/api/example`
`functions\api\[[path]].js` -> `/api/:path*`

Edit: This might be good to go ahead and push out for Windows users. But I really like #331 as a more permanent fix to issues like this.