### PR TITLE
fix: wait for port to be available before creating a dev server

### DIFF
--- a/.changeset/calm-bananas-obey.md
+++ b/.changeset/calm-bananas-obey.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: wait for port to be available before creating a dev server
+
+When we run `wrangler dev`, we start a server on a port (defaulting to 8787). We do this separately for both local and edge modes. However, when switching between the two with the `l` hotkey, we don't 'wait' for the previous server to stop before starting the next one. This can crash the process, and we don't want that (of course). So we introduce a helper function `waitForPortToBeAvailable()` that waits for a port to be available before returning. This is used in both the local and edge modes, and prevents the bug right now, where switching between edge - local - edge crashes the process.
+
+(This isn't a complete fix, and we can still cause errors by very rapidly switching between the two modes. A proper long term fix for the future would probably be to hoist the proxy server hook above the `<Remote/>` and `<Local/>` components, and use a single instance throughout. But that requires a deeper refactor, and isn't critical at the moment.)

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -24,7 +24,7 @@ import type { CfWorkerInit } from "./api/worker";
 
 import useInspector from "./inspect";
 import makeModuleCollector from "./module-collection";
-import { usePreviewServer } from "./proxy";
+import { usePreviewServer, waitForPortToBeAvailable } from "./proxy";
 import type { AssetPaths } from "./sites";
 import { syncAssets } from "./sites";
 import { getAPIToken } from "./user";
@@ -226,6 +226,8 @@ function useLocalWorker(props: {
         // TODO: a much better error message here, with what to do next
         return;
       }
+
+      await waitForPortToBeAvailable(port, { retryPeriod: 200, timeout: 2000 });
 
       console.log("⎔ Starting a local server...");
       // TODO: just use execa for this


### PR DESCRIPTION
When we run `wrangler dev`, we start a server on a port (defaulting to 8787). We do this separately for both local and edge modes. However, when switching between the two with the `l` hotkey, we don't 'wait' for the previous server to stop before starting the next one. This can crash the process, and we don't want that (of course). So we introduce a helper function `waitForPortToBeAvailable()` that waits for a port to be available before returning. This is used in both the local and edge modes, and prevents the bug right now, where switching between edge - local - edge crashes the process.

(This isn't a complete fix, and we can still cause errors by very rapidly switching between the two modes. A proper long term fix for the future would probably be to hoist the proxy server hook above the `<Remote/>` and `<Local/>` components, and use a single instance throughout. But that requires a deeper refactor, and isn't critical at the moment.)