### PR TITLE
fix: pass worker name to syncAssets in `dev`

### DIFF
--- a/.changeset/bright-needles-dance.md
+++ b/.changeset/bright-needles-dance.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: pass worker name to syncAssets in `dev`
+
+This fix passes the correct worker name to `syncAssets` during `wrangler dev`. This function uses the name to create the backing kv store for a Workers Sites definition, so it's important we get the name right.
+
+I also fixed the lint warning introduced in https://github.com/cloudflare/wrangler2/pull/321, to pass `props.enableLocalPersistence` as a dependency in the `useEffect` call that starts the "local" mode dev server.

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -324,6 +324,7 @@ function useLocalWorker(props: {
     bindings.durable_objects?.bindings,
     bindings.kv_namespaces,
     bindings.vars,
+    props.enableLocalPersistence,
   ]);
   return { inspectorUrl };
 }
@@ -580,7 +581,7 @@ function useWorker(props: {
 
       const assets = await syncAssets(
         accountId,
-        path.basename(bundle.path),
+        name || path.basename(bundle.path),
         assetPaths,
         true
       ); // TODO: cancellable?


### PR DESCRIPTION
This fix passes the correct worker name to `syncAssets` during `wrangler dev`. This function uses the name to create the backing kv store for a Workers Sites definition, so it's important we get the name right.

I also fixed the lint warning introduced in https://github.com/cloudflare/wrangler2/pull/321, to pass `props.enableLocalPersistence` as a dependency in the `useEffect` call that starts the "local" mode dev server.