### PR TITLE
fix: prevent infinite loop when fetching a list of results

### DIFF
--- a/.changeset/brown-chefs-own.md
+++ b/.changeset/brown-chefs-own.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: prevent infinite loop when fetching a list of results
+
+When fetching a list of results from cloudflare APIs (e.g. when fetching a list of keys in a kv namespace), the api returns a `cursor` that a consumer should use to get the next 'page' of results. It appears this cursor can also be a blank string (while we'd only account for it to be `undefined`). By only accounting for it to be `undefined`, we were infinitely looping through the same page of results and never terminating. This PR fixes it by letting it be a blank string (and `null`, for good measure)

--- a/packages/wrangler/src/cfetch/index.ts
+++ b/packages/wrangler/src/cfetch/index.ts
@@ -106,5 +106,6 @@ function throwFetchError(
 }
 
 function hasCursor(result_info: unknown): result_info is { cursor: string } {
-  return (result_info as { cursor: string } | undefined)?.cursor !== undefined;
+  const cursor = (result_info as { cursor: string } | undefined)?.cursor;
+  return cursor !== undefined && cursor !== null && cursor !== "";
 }


### PR DESCRIPTION
When fetching a list of results from cloudflare APIs (e.g. when fetching a list of keys in a kv namespace), the api returns a `cursor` that a consumer should use to get the next 'page' of results. It appears this cursor can also be a blank string (while we'd only account for it to be `undefined`). By only accounting for it to be `undefined`, we were infinitely looping through the same page of results and never terminating. This PR fixes it by letting it be a blank string (and `null`, for good measure)