### PR TITLE
DO NOT MERGE maintenance: bundle miniflare

### DIFF
--- a/.changeset/mighty-cooks-peel.md
+++ b/.changeset/mighty-cooks-peel.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+maintenance: bundle miniflare
+
+This bundles miniflare into the wrangler package. We already bundled most other dependencies, this adds miniflare as well. Of note, it's actually bundling miniflare _twice_, once into the main bundle, and once separately as a cli to be called with `wrangler dev` as local mode. We could optimise this in the future as a separate package. Regardless, I expect this to anyway install fewer dependencies (naturally, because it's not a nested dep anymore) and roughly be the same size for download, so it should be a faster install.

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules/
 wrangler-dist/
+miniflare-dist/
 packages/wrangler/wrangler.toml
 tsconfig.tsbuildinfo
 .eslintcache

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 packages/wrangler/vendor/
 packages/wrangler/wrangler-dist/
+packages/wrangler/miniflare-dist/
 packages/example-worker-app/dist/

--- a/package-lock.json
+++ b/package-lock.json
@@ -849,7 +849,8 @@
     "node_modules/@iarna/toml": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
-      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+      "dev": true
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -2473,6 +2474,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.2.0.tgz",
       "integrity": "sha512-N6b4V6fp4V0ljUHWs6+wVAvT94/SUCp6+pn3wnizjnYQhDE9ns8KJHu6zOTi+OkZUezjdUDJK0dqQXIKC/23XA==",
+      "dev": true,
       "dependencies": {
         "@miniflare/core": "2.2.0",
         "@miniflare/shared": "2.2.0",
@@ -2487,6 +2489,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.2.0.tgz",
       "integrity": "sha512-AeP3hZOQ7/dBosCPh/iL7cwgdUi5EfHA0unGsFULaxuCwBb3RkQd5WAq4gzzgHywsFRIQ0+5/j9Mk1wHG2AkJA==",
+      "dev": true,
       "dependencies": {
         "@miniflare/shared": "2.2.0",
         "kleur": "^4.1.4"
@@ -2499,6 +2502,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.2.0.tgz",
       "integrity": "sha512-CJwYhyXQ7si0ALZ4wB/vFAo0sHcyaMR7A8oQb6HaZ8XKhaKkzA8BmPutMvYVikiW+oRJP3YRcJGuVKibL3TSgA==",
+      "dev": true,
       "dependencies": {
         "@iarna/toml": "^2.2.5",
         "@miniflare/shared": "2.2.0",
@@ -2517,6 +2521,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
       "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -2525,6 +2530,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.2.0.tgz",
       "integrity": "sha512-iIRritqTBiTvX5dHPYswc3a6qzi3LPilbFE2HGjHMbqHi+/C4yX9SMfxCU4/6NcXc9xWjMGtJYBk+hgOW+Mvow==",
+      "dev": true,
       "dependencies": {
         "@miniflare/core": "2.2.0",
         "@miniflare/shared": "2.2.0",
@@ -2539,6 +2545,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.2.0.tgz",
       "integrity": "sha512-20qic3swy5bXg63Q96oHBKxHWp5d5GSn2HCZYXlHtODHeVbI/1lYQoD12b9EmE2i+jUZfCJjlinmjonXGyyL+A==",
+      "dev": true,
       "dependencies": {
         "@miniflare/core": "2.2.0",
         "@miniflare/shared": "2.2.0",
@@ -2553,6 +2560,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.2.0.tgz",
       "integrity": "sha512-nx7xEXKYvPyUpu2HFigD+UEgclipMQzGdTKtm4t6JzsOGYys7Lj7kGjryYaQVtbbJvPKIxqSaViFQDk/QSdosg==",
+      "dev": true,
       "dependencies": {
         "@miniflare/core": "2.2.0",
         "@miniflare/shared": "2.2.0",
@@ -2571,6 +2579,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.2.0.tgz",
       "integrity": "sha512-x2iUskcNEX74AfDhcZDKMTchNn3hUQyxDrzuDSHOv0vWRxDctmqYh5VxZVUGiaFvrbNN2+XgkgxXNY6TxrsfNQ==",
+      "dev": true,
       "dependencies": {
         "@miniflare/shared": "2.2.0"
       },
@@ -2582,6 +2591,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.2.0.tgz",
       "integrity": "sha512-x58BxIsAB6LcYgqTNVfxTsKFCu4G3Xiuj1k+3ZQ4b8v8TZjuZ3iOJcsrYU0PlbW5JpnRA8IH/mkiFRb/MrLtaQ==",
+      "dev": true,
       "dependencies": {
         "@miniflare/shared": "2.2.0"
       },
@@ -2593,6 +2603,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.2.0.tgz",
       "integrity": "sha512-OqfeSfxEfG3XA6D33C3dUxTUIy425n+BbZe15D2SdfvqUBeBobzOAAp0FbCQiZ5USsDY/zSIu98iSclqPxAn5w==",
+      "dev": true,
       "dependencies": {
         "@miniflare/core": "2.2.0",
         "@miniflare/shared": "2.2.0",
@@ -2606,6 +2617,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.2.0.tgz",
       "integrity": "sha512-ikz3nkBexVQ16Ioi6naAzK6Spj5O7lUcqIihMLCQKTAAdC252EL0QrBRxHV9MlvkypVNj6MqkoL4E6HcyuCo6g==",
+      "dev": true,
       "dependencies": {
         "ignore": "^5.1.8",
         "kleur": "^4.1.4"
@@ -2618,6 +2630,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.2.0.tgz",
       "integrity": "sha512-UpD5xGqEnwHZ0slvAp+8N60LX1WezXTZVLI599KGIXuthEVkRLgk8PwujabmHisicDoyC3nxITeDExq0DY9G/w==",
+      "dev": true,
       "dependencies": {
         "@miniflare/kv": "2.2.0",
         "@miniflare/shared": "2.2.0",
@@ -2631,6 +2644,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.2.0.tgz",
       "integrity": "sha512-DzBbUmPadDw+nAG31Yn60d1Jg6ksHmXasfnd1g7Whe/D0leFRAsvcEJyVaojzlnuxTabtZAsLMoUjsofvnThzA==",
+      "dev": true,
       "dependencies": {
         "@miniflare/shared": "2.2.0",
         "@miniflare/storage-memory": "2.2.0"
@@ -2643,6 +2657,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.2.0.tgz",
       "integrity": "sha512-1Ze2ZGwRFzH+6lLu6hZMTwGYTNioIT07QXvz3ZS/ilpg++cWUtqy2yHnajdJgcnNDNNQ4iVGladC2GNezrLbHg==",
+      "dev": true,
       "dependencies": {
         "@miniflare/shared": "2.2.0"
       },
@@ -2654,6 +2669,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.2.0.tgz",
       "integrity": "sha512-Myaztj1QaL1IaB04uBLKY8hE1kFtvB65cnKdJPOgjFxIgFzNyqybjlBjxx01Q6vymboFTPrl1Q5+g7fsW3lmfQ==",
+      "dev": true,
       "dependencies": {
         "@miniflare/shared": "2.2.0"
       },
@@ -2665,6 +2681,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.2.0.tgz",
       "integrity": "sha512-/GHYuTq6m28udequw4E8IpcFmcEheAcVQ3oZyAvY0ub0by8v4WzYuougiizqYylyQZ0KXyLg8SmPeBNChe82Zw==",
+      "dev": true,
       "dependencies": {
         "@miniflare/core": "2.2.0",
         "@miniflare/shared": "2.2.0",
@@ -2904,7 +2921,8 @@
     "node_modules/@types/stack-trace": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/stack-trace/-/stack-trace-0.0.29.tgz",
-      "integrity": "sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g=="
+      "integrity": "sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g==",
+      "dev": true
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -3767,6 +3785,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
       "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
+      "dev": true,
       "dependencies": {
         "dicer": "0.3.0"
       },
@@ -4336,6 +4355,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
       "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -4355,7 +4375,8 @@
     "node_modules/cron-schedule": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/cron-schedule/-/cron-schedule-3.0.4.tgz",
-      "integrity": "sha512-wEspID2dNPfWyh7t2ZvE4Izunzk20QacZg8oZcqfTrN1j5kImj0CEYT3ZGZo+KqGQUgRc9tKlEJmY4uFVt4ccA=="
+      "integrity": "sha512-wEspID2dNPfWyh7t2ZvE4Izunzk20QacZg8oZcqfTrN1j5kImj0CEYT3ZGZo+KqGQUgRc9tKlEJmY4uFVt4ccA==",
+      "dev": true
     },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
@@ -4634,6 +4655,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
       "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
+      "dev": true,
       "dependencies": {
         "streamsearch": "0.1.2"
       },
@@ -6509,7 +6531,8 @@
     "node_modules/http-cache-semantics": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "dev": true
     },
     "node_modules/http-errors": {
       "version": "1.8.1",
@@ -10723,6 +10746,7 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
       "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -11076,6 +11100,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.2.0.tgz",
       "integrity": "sha512-azOKDz9RfyWfDZY4u1k+GaaRuBApfgrRoz99sK/U7ngm0pxL0YRNuHPFSHwezAxw1Oz+KQpwtPClCE0zs7Rqgg==",
+      "dev": true,
       "dependencies": {
         "@miniflare/cache": "2.2.0",
         "@miniflare/cli-parser": "2.2.0",
@@ -11177,6 +11202,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
       "bin": {
         "mustache": "bin/mustache"
       }
@@ -11273,6 +11299,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
       "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==",
+      "dev": true,
       "engines": {
         "node": ">= 6.13.0"
       }
@@ -13056,6 +13083,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.0.0.tgz",
       "integrity": "sha512-cUdFiCbKoa1mZ6osuJs2uDHrs0k0oprsKveFiiaBKCNq3SYyb5gs2HxhQyDNLCmL51ZZThqi4YNDpCK6GOP1iQ==",
+      "dev": true,
       "dependencies": {
         "node-forge": "^1.2.0"
       },
@@ -13159,7 +13187,8 @@
     "node_modules/set-cookie-parser": {
       "version": "2.4.8",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz",
-      "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg=="
+      "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==",
+      "dev": true
     },
     "node_modules/set-value": {
       "version": "2.0.1",
@@ -13734,6 +13763,7 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -13871,6 +13901,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
+      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -14599,6 +14630,7 @@
       "version": "4.12.1",
       "resolved": "https://registry.npmjs.org/undici/-/undici-4.12.1.tgz",
       "integrity": "sha512-MSfap7YiQJqTPP12C11PFRs9raZuVicDbwsZHTjB0a8+SsCqt7KdUis54f373yf7ZFhJzAkGJLaKm0202OIxHg==",
+      "dev": true,
       "engines": {
         "node": ">=12.18"
       }
@@ -14986,6 +15018,7 @@
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
       "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
+      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -15123,6 +15156,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/youch/-/youch-2.2.2.tgz",
       "integrity": "sha512-/FaCeG3GkuJwaMR34GHVg0l8jCbafZLHiFowSjqLlqhC6OMyf2tPJBu8UirF7/NI9X/R5ai4QfEKUCOxMAGxZQ==",
+      "dev": true,
       "dependencies": {
         "@types/stack-trace": "0.0.29",
         "cookie": "^0.4.1",
@@ -15149,7 +15183,7 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "esbuild": "0.14.14",
-        "miniflare": "2.2.0",
+        "html-rewriter-wasm": "0.4.0",
         "path-to-regexp": "^6.2.0",
         "semiver": "^1.1.0",
         "xxhash-addon": "^1.4.0"
@@ -15187,6 +15221,7 @@
         "ink-text-input": "^4.0.2",
         "jest-fetch-mock": "^3.0.3",
         "mime": "^3.0.0",
+        "miniflare": "2.2.0",
         "node-fetch": "3.1.1",
         "open": "^8.4.0",
         "react": "^17.0.2",
@@ -15873,7 +15908,8 @@
     "@iarna/toml": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
-      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+      "dev": true
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -17111,6 +17147,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.2.0.tgz",
       "integrity": "sha512-N6b4V6fp4V0ljUHWs6+wVAvT94/SUCp6+pn3wnizjnYQhDE9ns8KJHu6zOTi+OkZUezjdUDJK0dqQXIKC/23XA==",
+      "dev": true,
       "requires": {
         "@miniflare/core": "2.2.0",
         "@miniflare/shared": "2.2.0",
@@ -17122,6 +17159,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.2.0.tgz",
       "integrity": "sha512-AeP3hZOQ7/dBosCPh/iL7cwgdUi5EfHA0unGsFULaxuCwBb3RkQd5WAq4gzzgHywsFRIQ0+5/j9Mk1wHG2AkJA==",
+      "dev": true,
       "requires": {
         "@miniflare/shared": "2.2.0",
         "kleur": "^4.1.4"
@@ -17131,6 +17169,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.2.0.tgz",
       "integrity": "sha512-CJwYhyXQ7si0ALZ4wB/vFAo0sHcyaMR7A8oQb6HaZ8XKhaKkzA8BmPutMvYVikiW+oRJP3YRcJGuVKibL3TSgA==",
+      "dev": true,
       "requires": {
         "@iarna/toml": "^2.2.5",
         "@miniflare/shared": "2.2.0",
@@ -17145,7 +17184,8 @@
         "dotenv": {
           "version": "10.0.0",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+          "dev": true
         }
       }
     },
@@ -17153,6 +17193,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.2.0.tgz",
       "integrity": "sha512-iIRritqTBiTvX5dHPYswc3a6qzi3LPilbFE2HGjHMbqHi+/C4yX9SMfxCU4/6NcXc9xWjMGtJYBk+hgOW+Mvow==",
+      "dev": true,
       "requires": {
         "@miniflare/core": "2.2.0",
         "@miniflare/shared": "2.2.0",
@@ -17164,6 +17205,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.2.0.tgz",
       "integrity": "sha512-20qic3swy5bXg63Q96oHBKxHWp5d5GSn2HCZYXlHtODHeVbI/1lYQoD12b9EmE2i+jUZfCJjlinmjonXGyyL+A==",
+      "dev": true,
       "requires": {
         "@miniflare/core": "2.2.0",
         "@miniflare/shared": "2.2.0",
@@ -17175,6 +17217,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.2.0.tgz",
       "integrity": "sha512-nx7xEXKYvPyUpu2HFigD+UEgclipMQzGdTKtm4t6JzsOGYys7Lj7kGjryYaQVtbbJvPKIxqSaViFQDk/QSdosg==",
+      "dev": true,
       "requires": {
         "@miniflare/core": "2.2.0",
         "@miniflare/shared": "2.2.0",
@@ -17190,6 +17233,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.2.0.tgz",
       "integrity": "sha512-x2iUskcNEX74AfDhcZDKMTchNn3hUQyxDrzuDSHOv0vWRxDctmqYh5VxZVUGiaFvrbNN2+XgkgxXNY6TxrsfNQ==",
+      "dev": true,
       "requires": {
         "@miniflare/shared": "2.2.0"
       }
@@ -17198,6 +17242,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.2.0.tgz",
       "integrity": "sha512-x58BxIsAB6LcYgqTNVfxTsKFCu4G3Xiuj1k+3ZQ4b8v8TZjuZ3iOJcsrYU0PlbW5JpnRA8IH/mkiFRb/MrLtaQ==",
+      "dev": true,
       "requires": {
         "@miniflare/shared": "2.2.0"
       }
@@ -17206,6 +17251,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.2.0.tgz",
       "integrity": "sha512-OqfeSfxEfG3XA6D33C3dUxTUIy425n+BbZe15D2SdfvqUBeBobzOAAp0FbCQiZ5USsDY/zSIu98iSclqPxAn5w==",
+      "dev": true,
       "requires": {
         "@miniflare/core": "2.2.0",
         "@miniflare/shared": "2.2.0",
@@ -17216,6 +17262,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.2.0.tgz",
       "integrity": "sha512-ikz3nkBexVQ16Ioi6naAzK6Spj5O7lUcqIihMLCQKTAAdC252EL0QrBRxHV9MlvkypVNj6MqkoL4E6HcyuCo6g==",
+      "dev": true,
       "requires": {
         "ignore": "^5.1.8",
         "kleur": "^4.1.4"
@@ -17225,6 +17272,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.2.0.tgz",
       "integrity": "sha512-UpD5xGqEnwHZ0slvAp+8N60LX1WezXTZVLI599KGIXuthEVkRLgk8PwujabmHisicDoyC3nxITeDExq0DY9G/w==",
+      "dev": true,
       "requires": {
         "@miniflare/kv": "2.2.0",
         "@miniflare/shared": "2.2.0",
@@ -17235,6 +17283,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.2.0.tgz",
       "integrity": "sha512-DzBbUmPadDw+nAG31Yn60d1Jg6ksHmXasfnd1g7Whe/D0leFRAsvcEJyVaojzlnuxTabtZAsLMoUjsofvnThzA==",
+      "dev": true,
       "requires": {
         "@miniflare/shared": "2.2.0",
         "@miniflare/storage-memory": "2.2.0"
@@ -17244,6 +17293,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.2.0.tgz",
       "integrity": "sha512-1Ze2ZGwRFzH+6lLu6hZMTwGYTNioIT07QXvz3ZS/ilpg++cWUtqy2yHnajdJgcnNDNNQ4iVGladC2GNezrLbHg==",
+      "dev": true,
       "requires": {
         "@miniflare/shared": "2.2.0"
       }
@@ -17252,6 +17302,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.2.0.tgz",
       "integrity": "sha512-Myaztj1QaL1IaB04uBLKY8hE1kFtvB65cnKdJPOgjFxIgFzNyqybjlBjxx01Q6vymboFTPrl1Q5+g7fsW3lmfQ==",
+      "dev": true,
       "requires": {
         "@miniflare/shared": "2.2.0"
       }
@@ -17260,6 +17311,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.2.0.tgz",
       "integrity": "sha512-/GHYuTq6m28udequw4E8IpcFmcEheAcVQ3oZyAvY0ub0by8v4WzYuougiizqYylyQZ0KXyLg8SmPeBNChe82Zw==",
+      "dev": true,
       "requires": {
         "@miniflare/core": "2.2.0",
         "@miniflare/shared": "2.2.0",
@@ -17486,7 +17538,8 @@
     "@types/stack-trace": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/stack-trace/-/stack-trace-0.0.29.tgz",
-      "integrity": "sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g=="
+      "integrity": "sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g==",
+      "dev": true
     },
     "@types/stack-utils": {
       "version": "2.0.1",
@@ -18067,6 +18120,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
       "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
+      "dev": true,
       "requires": {
         "dicer": "0.3.0"
       }
@@ -18498,7 +18552,8 @@
     "cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "dev": true
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -18511,7 +18566,8 @@
     "cron-schedule": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/cron-schedule/-/cron-schedule-3.0.4.tgz",
-      "integrity": "sha512-wEspID2dNPfWyh7t2ZvE4Izunzk20QacZg8oZcqfTrN1j5kImj0CEYT3ZGZo+KqGQUgRc9tKlEJmY4uFVt4ccA=="
+      "integrity": "sha512-wEspID2dNPfWyh7t2ZvE4Izunzk20QacZg8oZcqfTrN1j5kImj0CEYT3ZGZo+KqGQUgRc9tKlEJmY4uFVt4ccA==",
+      "dev": true
     },
     "cross-fetch": {
       "version": "3.1.5",
@@ -18732,6 +18788,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
       "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
+      "dev": true,
       "requires": {
         "streamsearch": "0.1.2"
       }
@@ -20074,7 +20131,8 @@
     "http-cache-semantics": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "dev": true
     },
     "http-errors": {
       "version": "1.8.1",
@@ -23164,7 +23222,8 @@
     "kleur": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
-      "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA=="
+      "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
+      "dev": true
     },
     "leven": {
       "version": "3.1.0",
@@ -23424,6 +23483,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.2.0.tgz",
       "integrity": "sha512-azOKDz9RfyWfDZY4u1k+GaaRuBApfgrRoz99sK/U7ngm0pxL0YRNuHPFSHwezAxw1Oz+KQpwtPClCE0zs7Rqgg==",
+      "dev": true,
       "requires": {
         "@miniflare/cache": "2.2.0",
         "@miniflare/cli-parser": "2.2.0",
@@ -23490,7 +23550,8 @@
     "mustache": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
-      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -23558,7 +23619,8 @@
     "node-forge": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
-      "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w=="
+      "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==",
+      "dev": true
     },
     "node-int64": {
       "version": "0.4.0",
@@ -24836,6 +24898,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.0.0.tgz",
       "integrity": "sha512-cUdFiCbKoa1mZ6osuJs2uDHrs0k0oprsKveFiiaBKCNq3SYyb5gs2HxhQyDNLCmL51ZZThqi4YNDpCK6GOP1iQ==",
+      "dev": true,
       "requires": {
         "node-forge": "^1.2.0"
       }
@@ -24922,7 +24985,8 @@
     "set-cookie-parser": {
       "version": "2.4.8",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz",
-      "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg=="
+      "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==",
+      "dev": true
     },
     "set-value": {
       "version": "2.0.1",
@@ -25401,7 +25465,8 @@
     "stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true
     },
     "stack-utils": {
       "version": "2.0.5",
@@ -25510,7 +25575,8 @@
     "streamsearch": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
+      "dev": true
     },
     "string-length": {
       "version": "4.0.2",
@@ -26042,7 +26108,8 @@
     "undici": {
       "version": "4.12.1",
       "resolved": "https://registry.npmjs.org/undici/-/undici-4.12.1.tgz",
-      "integrity": "sha512-MSfap7YiQJqTPP12C11PFRs9raZuVicDbwsZHTjB0a8+SsCqt7KdUis54f373yf7ZFhJzAkGJLaKm0202OIxHg=="
+      "integrity": "sha512-MSfap7YiQJqTPP12C11PFRs9raZuVicDbwsZHTjB0a8+SsCqt7KdUis54f373yf7ZFhJzAkGJLaKm0202OIxHg==",
+      "dev": true
     },
     "union-value": {
       "version": "1.0.1",
@@ -26312,6 +26379,7 @@
         "find-up": "^6.2.0",
         "formdata-node": "^4.3.1",
         "fsevents": "~2.3.2",
+        "html-rewriter-wasm": "0.4.0",
         "ignore": "^5.2.0",
         "ink": "^3.2.0",
         "ink-select-input": "^4.2.1",
@@ -26412,6 +26480,7 @@
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
       "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
+      "dev": true,
       "requires": {}
     },
     "xml-name-validator": {
@@ -26508,6 +26577,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/youch/-/youch-2.2.2.tgz",
       "integrity": "sha512-/FaCeG3GkuJwaMR34GHVg0l8jCbafZLHiFowSjqLlqhC6OMyf2tPJBu8UirF7/NI9X/R5ai4QfEKUCOxMAGxZQ==",
+      "dev": true,
       "requires": {
         "@types/stack-trace": "0.0.29",
         "cookie": "^0.4.1",

--- a/packages/example-worker-app/src/index.js
+++ b/packages/example-worker-app/src/index.js
@@ -1,6 +1,6 @@
 import { now } from "./dep";
 export default {
-  fetch(request) {
+  async fetch(request) {
     console.log(
       request.method,
       request.url,
@@ -8,7 +8,15 @@ export default {
       request.cf
     );
 
-    return new Response(`${request.url} ${now()}`);
+    const catFacts = await fetch("https://cat-fact.herokuapp.com/facts");
+
+    return new Response(
+      `${request.url} ${now()}\n ${JSON.stringify(
+        await catFacts.json(),
+        null,
+        "  "
+      )}`
+    );
   },
 };
 

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -37,7 +37,7 @@
   ],
   "dependencies": {
     "esbuild": "0.14.14",
-    "miniflare": "2.2.0",
+    "html-rewriter-wasm": "0.4.0",
     "path-to-regexp": "^6.2.0",
     "semiver": "^1.1.0",
     "xxhash-addon": "^1.4.0"
@@ -74,6 +74,7 @@
     "ink-text-input": "^4.0.2",
     "jest-fetch-mock": "^3.0.3",
     "mime": "^3.0.0",
+    "miniflare": "2.2.0",
     "node-fetch": "3.1.1",
     "open": "^8.4.0",
     "react": "^17.0.2",
@@ -91,6 +92,7 @@
     "pages",
     "miniflare-config-stubs",
     "wrangler-dist",
+    "miniflare-dist",
     "static-asset-facade.js",
     "vendor",
     "import_meta_url.js"

--- a/packages/wrangler/scripts/bundle.ts
+++ b/packages/wrangler/scripts/bundle.ts
@@ -4,6 +4,19 @@ import path from "path";
 // the expectation is that this is being run from the project root
 
 async function run() {
+  // miniflare cli for `wrangler dev --local`
+  await build({
+    entryPoints: ["miniflare/cli"],
+    bundle: true,
+    platform: "node",
+    outdir: "./miniflare-dist",
+    minify: true,
+    format: "cjs",
+    target: "esnext",
+    // html-rewriter-wasm has a wasm dependency and expects to have the .wasm file in the same output folder. Further, it also expects an asyncify.js file in the same folder, which esbuild doesn't bundle because it's required using require(String.raw`./asyncify.js`). So we mark it as an external right now, and we'll revisit it later.
+    external: ["@miniflare/storage-redis", "html-rewriter-wasm"],
+  });
+
   // main cli
   await build({
     entryPoints: ["./src/cli.ts"],
@@ -11,14 +24,14 @@ async function run() {
     outdir: "./wrangler-dist",
     platform: "node",
     format: "cjs",
-    // minify: true, // TODO: enable this again
     external: [
       "fsevents",
       "esbuild",
-      "miniflare",
-      "@miniflare/core",
       "xxhash-addon",
-    ], // todo - bundle miniflare too
+      "@miniflare/storage-redis",
+      // html-rewriter-wasm has a wasm dependency and expects to have the .wasm file in the same output folder. Further, it also expects an asyncify.js file in the same folder, which esbuild doesn't bundle because it's required using require(String.raw`./asyncify.js`). So we mark it as an external right now, and we'll revisit it later.
+      "html-rewriter-wasm",
+    ],
     sourcemap: true,
     inject: [path.join(__dirname, "../import_meta_url.js")],
     define: {

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -243,7 +243,7 @@ function useLocalWorker(props: {
       local.current = spawn("node", [
         "--experimental-vm-modules",
         "--inspect",
-        require.resolve("miniflare/cli"),
+        path.join(__dirname, "../miniflare-dist/cli.js"),
         bundle.path,
         "--watch",
         "--wrangler-config",


### PR DESCRIPTION
This bundles miniflare into the wrangler package. We already bundled most other dependencies, this adds miniflare as well. Of note, it's actually bundling miniflare _twice_, once into the main bundle, and once separately as a cli to be called with `wrangler dev` as local mode. We could optimise this in the future as a separate package. Regardless, I expect this to anyway install fewer dependencies (naturally, because it's not a nested dep anymore) and roughly be the same size for download, so it should be a faster install.

I _don't_ think this should break anything else. This would've been a good usecase for the arbitrary npm publishes, haha. Anyway, we can test the alpha after we land this.  

Closes https://github.com/cloudflare/wrangler2/issues/66