### PR TITLE
fix: hide `wrangler pages functions` in the main help menu

### DIFF
--- a/.changeset/dry-panthers-lie.md
+++ b/.changeset/dry-panthers-lie.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: hide `wrangler pages functions` in the main help menu
+
+This hides `wrangler pages functions` in the main help menu, since it's only intended for internal usage right now. It still "works", so nothing changes in that regard. We'll bring this back when we have a broader story in wrangler for functions.

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -966,7 +966,9 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
         }
       }
     )
-    .command("functions", "Cloudflare Pages Functions", (yargs) =>
+    .command("functions", false, (yargs) =>
+      // we hide this command from help output because
+      // it's not meant to be used directly right now
       yargs.command(
         "build [directory]",
         "Compile a folder of Cloudflare Pages Functions into a single Worker",


### PR DESCRIPTION
This hides `wrangler pages functions` in the main help menu, since it's only intended for internal usage right now. It still "works", so nothing changes in that regard. We will bring this back when we have a broader story in wrangler for functions.