### PR TITLE
chore: replace `node-fetch` with `undici`

### DIFF
--- a/.changeset/rare-eggs-bathe.md
+++ b/.changeset/rare-eggs-bathe.md
@@ -1,0 +1,19 @@
+---
+"wrangler": patch
+---
+
+chore: replace `node-fetch` with `undici`
+
+There are several reasons to replace `node-fetch` with `undici`:
+
+- `undici`'s `fetch()` implementation is set to become node's standard `fetch()` implementation, which means we can just remove the dependency in the future (or optionally load it depending on which version of node is being used)
+- `node-fetch` pollutes the global type space with a number of standard types
+- we already bundle `undici` via `miniflare`/pages, so this means our bundle size could ostensibly become smaller.
+
+This replaces `node-fetch` with `undici`.
+
+- All instances of `import fetch from "node-fetch"` are replaced with `import {fetch} from "undici"`
+- `undici` also comes with spec compliant forms of `FormData` and `File`, so we could also remove `formdata-node` in `form_data.ts`
+- All the global types that were injected by `node-fetch` are now imported from `undici` (as well as some mistaken ones from `node:url`)
+- NOTE: this also turns on `skipLibCheck` in `tsconfig.json`. Some dependencies oddly depend on browser globals like `Request`, `Response` (like `@miniflare/core`, `jest-fetch-mock`, etc), which now fail because `node-fetch` isn't injecting those globals anymore. So we enable `skipLibCheck` to bypass them. (I'd thought `skipLibCheck` completely ignores 'third party' types, but that's not true - it still uses the module graph to scan types. So we're still typesafe. We should enable `strict` sometime to avoid `any`s, but that's for later.)
+- The bundle size isn't smaller because we're bundling 2 different versions of `undici`, but we'll fix that by separately upping the version of `undici` that miniflare bundles.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4435,15 +4435,6 @@
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.6.5.tgz",
       "integrity": "sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A=="
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -5973,38 +5964,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.4.tgz",
-      "integrity": "sha512-Eq5Xv5+VlSrYWEqKrusxY1C3Hm/hjeAsCGVG3ft7pZahlUAChpGZT/Ms1WmSLnEAisEXszjzu/s+ce6HZB2VHA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
-    "node_modules/fetch-blob/node_modules/web-streams-polyfill": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
-      "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -6136,31 +6095,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/formdata-node": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.3.2.tgz",
-      "integrity": "sha512-k7lYJyzDOSL6h917favP8j1L0/wNyylzU+x+1w4p5haGVHNlP58dbpdJhiCUsDbWsa9HwEtLp89obQgXl2e0qg==",
-      "dev": true,
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.1"
-      },
-      "engines": {
-        "node": ">= 12.20"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/fragment-cache": {
@@ -11212,25 +11146,6 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
     "node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -14778,15 +14693,6 @@
         "defaults": "^1.0.3"
       }
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.1.tgz",
-      "integrity": "sha512-3ux37gEX670UUphBF9AMCq8XM6iQ8Ac6A+DSRRjDoRBm1ufCkaCDdNVbaqq60PsEkdNlLKrGtv/YBP4EJXqNtQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
@@ -15178,7 +15084,6 @@
         "faye-websocket": "^0.11.4",
         "finalhandler": "^1.1.2",
         "find-up": "^6.2.0",
-        "formdata-node": "^4.3.1",
         "ignore": "^5.2.0",
         "ink": "^3.2.0",
         "ink-select-input": "^4.2.1",
@@ -15187,14 +15092,13 @@
         "ink-text-input": "^4.0.2",
         "jest-fetch-mock": "^3.0.3",
         "mime": "^3.0.0",
-        "node-fetch": "3.1.1",
         "open": "^8.4.0",
         "react": "^17.0.2",
         "react-error-boundary": "^3.1.4",
         "serve-static": "^1.14.1",
         "signal-exit": "^3.0.6",
         "tmp-promise": "^3.0.3",
-        "undici": "^4.11.1",
+        "undici": "4.13.0",
         "ws": "^8.3.0",
         "yargs": "^17.3.0"
       },
@@ -15205,22 +15109,13 @@
         "fsevents": "~2.3.2"
       }
     },
-    "packages/wrangler/node_modules/node-fetch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.1.1.tgz",
-      "integrity": "sha512-SMk+vKgU77PYotRdWzqZGTZeuFKlsJ0hu4KPviQKkfY+N3vn2MIzr0rvpnYpR8MtB3IEuhlEcuOLbGvLRlA+yg==",
+    "packages/wrangler/node_modules/undici": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-4.13.0.tgz",
+      "integrity": "sha512-8lk8S/f2V0VUNGf2scU2b+KI2JSzEQLdCyRNRF3XmHu+5jectlSDaPSBCXAHFaUlt1rzngzOBVDgJS9/Gue/KA==",
       "dev": true,
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.3",
-        "formdata-polyfill": "^4.0.10"
-      },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
+        "node": ">=12.18"
       }
     }
   },
@@ -18584,12 +18479,6 @@
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.6.5.tgz",
       "integrity": "sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A=="
     },
-    "data-uri-to-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
-      "dev": true
-    },
     "data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -19685,24 +19574,6 @@
         "bser": "2.1.1"
       }
     },
-    "fetch-blob": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.4.tgz",
-      "integrity": "sha512-Eq5Xv5+VlSrYWEqKrusxY1C3Hm/hjeAsCGVG3ft7pZahlUAChpGZT/Ms1WmSLnEAisEXszjzu/s+ce6HZB2VHA==",
-      "dev": true,
-      "requires": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "dependencies": {
-        "web-streams-polyfill": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
-          "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
-          "dev": true
-        }
-      }
-    },
     "figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -19806,25 +19677,6 @@
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
-      }
-    },
-    "formdata-node": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.3.2.tgz",
-      "integrity": "sha512-k7lYJyzDOSL6h917favP8j1L0/wNyylzU+x+1w4p5haGVHNlP58dbpdJhiCUsDbWsa9HwEtLp89obQgXl2e0qg==",
-      "dev": true,
-      "requires": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.1"
-      }
-    },
-    "formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
-      "requires": {
-        "fetch-blob": "^3.1.2"
       }
     },
     "fragment-cache": {
@@ -23520,12 +23372,6 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
-    "node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "dev": true
-    },
     "node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -26190,12 +26036,6 @@
         "defaults": "^1.0.3"
       }
     },
-    "web-streams-polyfill": {
-      "version": "4.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.1.tgz",
-      "integrity": "sha512-3ux37gEX670UUphBF9AMCq8XM6iQ8Ac6A+DSRRjDoRBm1ufCkaCDdNVbaqq60PsEkdNlLKrGtv/YBP4EJXqNtQ==",
-      "dev": true
-    },
     "webidl-conversions": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
@@ -26310,7 +26150,6 @@
         "faye-websocket": "^0.11.4",
         "finalhandler": "^1.1.2",
         "find-up": "^6.2.0",
-        "formdata-node": "^4.3.1",
         "fsevents": "~2.3.2",
         "ignore": "^5.2.0",
         "ink": "^3.2.0",
@@ -26321,7 +26160,6 @@
         "jest-fetch-mock": "^3.0.3",
         "mime": "^3.0.0",
         "miniflare": "2.2.0",
-        "node-fetch": "3.1.1",
         "open": "^8.4.0",
         "path-to-regexp": "^6.2.0",
         "react": "^17.0.2",
@@ -26330,22 +26168,17 @@
         "serve-static": "^1.14.1",
         "signal-exit": "^3.0.6",
         "tmp-promise": "^3.0.3",
-        "undici": "^4.11.1",
+        "undici": "4.13.0",
         "ws": "^8.3.0",
         "xxhash-addon": "^1.4.0",
         "yargs": "^17.3.0"
       },
       "dependencies": {
-        "node-fetch": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.1.1.tgz",
-          "integrity": "sha512-SMk+vKgU77PYotRdWzqZGTZeuFKlsJ0hu4KPviQKkfY+N3vn2MIzr0rvpnYpR8MtB3IEuhlEcuOLbGvLRlA+yg==",
-          "dev": true,
-          "requires": {
-            "data-uri-to-buffer": "^4.0.0",
-            "fetch-blob": "^3.1.3",
-            "formdata-polyfill": "^4.0.10"
-          }
+        "undici": {
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/undici/-/undici-4.13.0.tgz",
+          "integrity": "sha512-8lk8S/f2V0VUNGf2scU2b+KI2JSzEQLdCyRNRF3XmHu+5jectlSDaPSBCXAHFaUlt1rzngzOBVDgJS9/Gue/KA==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "root": true,
     "ignorePatterns": [
       "packages/*/vendor",
-      "packages/*/*-dist"
+      "packages/*/*-dist",
+      "packages/wrangler/pages/functions/template-worker.ts"
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -65,7 +65,6 @@
     "faye-websocket": "^0.11.4",
     "finalhandler": "^1.1.2",
     "find-up": "^6.2.0",
-    "formdata-node": "^4.3.1",
     "ignore": "^5.2.0",
     "ink": "^3.2.0",
     "ink-select-input": "^4.2.1",
@@ -74,14 +73,13 @@
     "ink-text-input": "^4.0.2",
     "jest-fetch-mock": "^3.0.3",
     "mime": "^3.0.0",
-    "node-fetch": "3.1.1",
     "open": "^8.4.0",
     "react": "^17.0.2",
     "react-error-boundary": "^3.1.4",
     "serve-static": "^1.14.1",
     "signal-exit": "^3.0.6",
     "tmp-promise": "^3.0.3",
-    "undici": "^4.11.1",
+    "undici": "4.13.0",
     "ws": "^8.3.0",
     "yargs": "^17.3.0"
   },
@@ -111,7 +109,7 @@
     "testTimeout": 30000,
     "testRegex": ".*.(test|spec)\\.[jt]sx?$",
     "transformIgnorePatterns": [
-      "node_modules/(?!node-fetch|fetch-blob|find-up|locate-path|p-locate|p-limit|yocto-queue|path-exists|data-uri-to-buffer|formdata-polyfill|execa|strip-final-newline|npm-run-path|path-key|onetime|mimic-fn|human-signals|is-stream)"
+      "node_modules/(?!find-up|locate-path|p-locate|p-limit|yocto-queue|path-exists|execa|strip-final-newline|npm-run-path|path-key|onetime|mimic-fn|human-signals|is-stream)"
     ],
     "moduleNameMapper": {
       "clipboardy": "<rootDir>/src/__tests__/clipboardy-mock.js"

--- a/packages/wrangler/src/__tests__/jest.setup.ts
+++ b/packages/wrangler/src/__tests__/jest.setup.ts
@@ -3,7 +3,12 @@ import { confirm, prompt } from "../dialogs";
 import { fetchInternal } from "../cfetch/internal";
 import fetchMock from "jest-fetch-mock";
 
-jest.mock("node-fetch", () => jest.requireActual("jest-fetch-mock"));
+jest.mock("undici", () => {
+  return {
+    ...jest.requireActual("undici"),
+    fetch: jest.requireActual("jest-fetch-mock"),
+  };
+});
 fetchMock.doMock(() => {
   // Any un-mocked fetches should throw
   throw new Error("Unexpected fetch request");

--- a/packages/wrangler/src/__tests__/mock-cfetch.ts
+++ b/packages/wrangler/src/__tests__/mock-cfetch.ts
@@ -1,5 +1,5 @@
-import type { RequestInit } from "node-fetch";
-import { URLSearchParams } from "node:url";
+import type { RequestInit } from "undici";
+import { URL, URLSearchParams } from "node:url";
 import { pathToRegexp } from "path-to-regexp";
 import { CF_API_BASE_URL } from "../cfetch";
 import type { FetchResult } from "../cfetch";

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -9,6 +9,7 @@ import { mockConsoleMethods } from "./mock-console";
 import type { Config } from "../config";
 import * as TOML from "@iarna/toml";
 import type { WorkerMetadata } from "../api/form_data";
+import type { FormData, File } from "undici";
 
 describe("publish", () => {
   runInTempDir();

--- a/packages/wrangler/src/api/form_data.ts
+++ b/packages/wrangler/src/api/form_data.ts
@@ -4,7 +4,7 @@ import type {
   CfModule,
   CfDurableObjectMigrations,
 } from "./worker.js";
-import { FormData, Blob } from "formdata-node";
+import { FormData, File } from "undici";
 
 export function toMimeType(type: CfModuleType): string {
   switch (type) {
@@ -23,11 +23,10 @@ export function toMimeType(type: CfModuleType): string {
   }
 }
 
-function toModule(module: CfModule, entryType: CfModuleType): Blob {
+function toModule(module: CfModule, entryType: CfModuleType): File {
   const { type: moduleType, content } = module;
   const type = toMimeType(moduleType ?? entryType);
-
-  return new Blob([content], { type });
+  return new File([content], module.name, { type });
 }
 
 export interface WorkerMetadata {
@@ -127,8 +126,8 @@ export function toFormData(worker: CfWorkerInit): FormData {
 
   for (const module of [main].concat(modules || [])) {
     const { name } = module;
-    const blob = toModule(module, main.type ?? "esm");
-    formData.set(name, blob, name);
+    const file = toModule(module, main.type ?? "esm");
+    formData.set(name, file);
   }
 
   return formData;

--- a/packages/wrangler/src/api/preview.ts
+++ b/packages/wrangler/src/api/preview.ts
@@ -1,4 +1,5 @@
-import fetch from "node-fetch";
+import { URL } from "node:url";
+import { fetch } from "undici";
 import { fetchResult } from "../cfetch";
 import { toFormData } from "./form_data";
 import type { CfAccount, CfWorkerInit } from "./worker";
@@ -108,7 +109,6 @@ export async function previewToken(
 
   const { preview_token } = await fetchResult<{ preview_token: string }>(url, {
     method: "POST",
-    // @ts-expect-error TODO: fix this
     body: formData,
     headers: {
       "cf-preview-upload-config-token": value,

--- a/packages/wrangler/src/api/worker.ts
+++ b/packages/wrangler/src/api/worker.ts
@@ -1,6 +1,6 @@
 import type { CfPreviewToken } from "./preview";
 import { previewToken } from "./preview";
-import fetch from "node-fetch";
+import { fetch } from "undici";
 
 /**
  * A Cloudflare account.
@@ -53,7 +53,7 @@ export interface CfModule {
    *   }
    * }
    */
-  content: string | BufferSource;
+  content: string | Buffer;
   /**
    * The module type.
    *

--- a/packages/wrangler/src/cfetch/index.ts
+++ b/packages/wrangler/src/cfetch/index.ts
@@ -1,5 +1,5 @@
-import type { RequestInit } from "node-fetch";
-import { URLSearchParams } from "url";
+import type { RequestInit } from "undici";
+import { URLSearchParams } from "node:url";
 import { fetchInternal } from "./internal";
 
 // Check out https://api.cloudflare.com/ for API docs.

--- a/packages/wrangler/src/cfetch/internal.ts
+++ b/packages/wrangler/src/cfetch/internal.ts
@@ -1,6 +1,7 @@
-import fetch from "node-fetch";
-import type { RequestInit, HeadersInit } from "node-fetch";
+import { fetch } from "undici";
+import type { RequestInit, HeadersInit } from "undici";
 import { getAPIToken, loginOrRefreshIfRequired } from "../user";
+import type { URLSearchParams } from "node:url";
 
 export const CF_API_BASE_URL =
   process.env.CF_API_BASE_URL || "https://api.cloudflare.com/client/v4";

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -9,7 +9,7 @@ import { watch } from "chokidar";
 import clipboardy from "clipboardy";
 import commandExists from "command-exists";
 import { execaCommand } from "execa";
-import fetch from "node-fetch";
+import { fetch } from "undici";
 import open from "open";
 import React, { useState, useEffect, useRef } from "react";
 import { withErrorBoundary, useErrorHandler } from "react-error-boundary";

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -1146,8 +1146,8 @@ export async function main(argv: string[]): Promise<void> {
                   `/accounts/${config.account_id}/workers/scripts/${scriptName}`,
                   {
                     method: "PUT",
-                    // @ts-expect-error TODO: fix this error!
                     body: toFormData({
+                      name: scriptName,
                       main: {
                         name: scriptName,
                         content: `export default { fetch() {} }`,
@@ -1159,6 +1159,10 @@ export async function main(argv: string[]): Promise<void> {
                         durable_objects: { bindings: [] },
                       },
                       modules: [],
+                      migrations: undefined,
+                      compatibility_date: undefined,
+                      compatibility_flags: undefined,
+                      usage_model: undefined,
                     }),
                   }
                 );

--- a/packages/wrangler/src/inspect.ts
+++ b/packages/wrangler/src/inspect.ts
@@ -5,6 +5,7 @@ import type { IncomingMessage, Server, ServerResponse } from "http";
 import { createServer } from "http";
 import { useEffect, useRef, useState } from "react";
 import { version } from "../package.json";
+import { URL } from "node:url";
 
 import type Protocol from "devtools-protocol";
 

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -12,6 +12,7 @@ import type { Config } from "./config";
 import makeModuleCollector from "./module-collection";
 import type { AssetPaths } from "./sites";
 import { syncAssets } from "./sites";
+import { URLSearchParams } from "node:url";
 
 type CfScriptFormat = undefined | "modules" | "service-worker";
 
@@ -302,7 +303,6 @@ export default async function publish(props: Props): Promise<void> {
     workerUrl,
     {
       method: "PUT",
-      // @ts-expect-error: TODO: fix this type error!
       body: toFormData(worker),
     },
     new URLSearchParams({ available_on_subdomains: "true" })

--- a/packages/wrangler/src/user.tsx
+++ b/packages/wrangler/src/user.tsx
@@ -209,7 +209,7 @@ import React from "react";
 import { render, Text } from "ink";
 import Table from "ink-table";
 import SelectInput from "ink-select-input";
-import fetch from "node-fetch";
+import { fetch } from "undici";
 import { webcrypto as crypto } from "node:crypto";
 import { TextEncoder } from "node:util";
 import open from "open";
@@ -223,7 +223,7 @@ import TOML from "@iarna/toml";
 import assert from "node:assert";
 import type { ParsedUrlQuery } from "node:querystring";
 import { CF_API_BASE_URL } from "./cfetch";
-import type { Response } from "node-fetch";
+import type { Response } from "undici";
 
 /**
  * An implementation of rfc6749#section-4.1 and rfc7636.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,13 @@
     "jsx": "react",
     "resolveJsonModule": true,
     "incremental": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "skipLibCheck": true
   },
-  "exclude": ["node_modules/", "packages/*/vendor", "packages/*/*-dist"]
+  "exclude": [
+    "node_modules/",
+    "packages/*/vendor",
+    "packages/*/*-dist",
+    "packages/wrangler/pages/functions/template-worker.ts"
+  ]
 }


### PR DESCRIPTION
There are several reasons to replace `node-fetch` with `undici`:

- `undici`'s `fetch()` implementation is set to become node's standard `fetch()` implementation, which means we can just remove the dependency in the future (or optionally load it depending on which version of node is being used)
- `node-fetch` pollutes the global type space with a number of standard types
- we already bundle `undici` via `miniflare`/pages, so this means our bundle size could ostensibly become smaller.

This replaces `node-fetch` with `undici`.

- All instances of `import fetch from "node-fetch"` are replaced with `import {fetch} from "undici"`
- `undici` also comes with spec compliant forms of `FormData` and `File`, so we could also remove `formdata-node` in `form_data.ts`
- All the global types that were injected by `node-fetch` are now imported from `undici` (as well as some mistaken ones from `node:url`)
- NOTE: this also turns on `skipLibCheck` in `tsconfig.json`. Some dependencies oddly depend on browser globals like `Request`, `Response` (like `@miniflare/core`, `jest-fetch-mock`, etc), which now fail because `node-fetch` isn't injecting those globals anymore. So we enable `skipLibCheck` to bypass them. (I'd thought `skipLibCheck` completely ignores 'third party' types, but that's not true - it still uses the module graph to scan types. So we're still typesafe. We should enable `strict` sometime to avoid `any`s, but that's for later.)
- The bundle size isn't smaller because we're bundling 2 different versions of `undici`, but we'll fix that by separately upping the version of `undici` that miniflare bundles.