### PR TITLE
chore: add `eslint-plugin-import`

### DIFF
--- a/.changeset/silly-apes-rush.md
+++ b/.changeset/silly-apes-rush.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+---
+
+chore: add eslint-plugin-import
+
+- This adds `eslint-plugin-import` to enforce ordering of imports, and configuration for the same in `package.json`.
+- I also run `npm run check:lint -- --fix` to apply the configured order in our whole codebase.
+- This also needs a setting in `.vscode/settings.json` to prevent spurious warnings inside vscode. You'll probably have to restart your IDE for this to take effect. (re: https://github.com/import-js/eslint-plugin-import/issues/2377#issuecomment-1024800026)
+
+(I'd also like to enforce using `node:` prefixes for node builtin modules, but that can happen later. For now I manually added the prefixes wherever they were missing. It's not functionally any different, but imo it helps the visual grouping.)

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,5 +26,6 @@
     "websockets",
     "xxhash"
   ],
-  "cSpell.ignoreWords": ["yxxx"]
+  "cSpell.ignoreWords": ["yxxx"],
+  "eslint.runtime": "node"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "esbuild-jest": "0.5.0",
         "esbuild-register": "^3.2.0",
         "eslint": "^7.32.0",
+        "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-react": "^7.27.1",
         "eslint-plugin-react-hooks": "^4.3.0",
         "ioredis": "^4.28.2",
@@ -2825,6 +2826,11 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
     },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
+    },
     "node_modules/@types/mime": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
@@ -3413,6 +3419,22 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz",
+      "integrity": "sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.flatmap": {
@@ -5220,6 +5242,186 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
+      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "resolve": "^1.20.0"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/resolve": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "dependencies": {
+        "is-core-module": "^2.8.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz",
+      "integrity": "sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "find-up": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "dependencies": {
+        "locate-path": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dependencies": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dependencies": {
+        "p-try": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dependencies": {
+        "p-limit": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.25.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz",
+      "integrity": "sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==",
+      "dependencies": {
+        "array-includes": "^3.1.4",
+        "array.prototype.flat": "^1.2.5",
+        "debug": "^2.6.9",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-module-utils": "^2.7.2",
+        "has": "^1.0.3",
+        "is-core-module": "^2.8.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.5",
+        "resolve": "^1.20.0",
+        "tsconfig-paths": "^3.12.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/eslint-plugin-import/node_modules/resolve": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "dependencies": {
+        "is-core-module": "^2.8.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/eslint-plugin-react": {
@@ -14255,6 +14457,36 @@
         "node": ">=8"
       }
     },
+    "node_modules/tsconfig-paths": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
+      "integrity": "sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.0",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/json5": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -17300,6 +17532,11 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
     },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
+    },
     "@types/mime": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
@@ -17699,6 +17936,16 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+    },
+    "array.prototype.flat": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz",
+      "integrity": "sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0"
+      }
     },
     "array.prototype.flatmap": {
       "version": "1.2.5",
@@ -19107,6 +19354,150 @@
           "version": "0.20.2",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
+        }
+      }
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
+      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
+      "requires": {
+        "debug": "^3.2.7",
+        "resolve": "^1.20.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "resolve": {
+          "version": "1.22.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+          "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+          "requires": {
+            "is-core-module": "^2.8.1",
+            "path-parse": "^1.0.7",
+            "supports-preserve-symlinks-flag": "^1.0.0"
+          }
+        }
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz",
+      "integrity": "sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==",
+      "requires": {
+        "debug": "^3.2.7",
+        "find-up": "^2.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+        }
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.25.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz",
+      "integrity": "sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==",
+      "requires": {
+        "array-includes": "^3.1.4",
+        "array.prototype.flat": "^1.2.5",
+        "debug": "^2.6.9",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-module-utils": "^2.7.2",
+        "has": "^1.0.3",
+        "is-core-module": "^2.8.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.5",
+        "resolve": "^1.20.0",
+        "tsconfig-paths": "^3.12.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "resolve": {
+          "version": "1.22.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+          "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+          "requires": {
+            "is-core-module": "^2.8.1",
+            "path-parse": "^1.0.7",
+            "supports-preserve-symlinks-flag": "^1.0.0"
+          }
         }
       }
     },
@@ -25697,6 +26088,32 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
       "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw=="
+    },
+    "tsconfig-paths": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
+      "integrity": "sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==",
+      "requires": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+        }
+      }
     },
     "tslib": {
       "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "esbuild-jest": "0.5.0",
     "esbuild-register": "^3.2.0",
     "eslint": "^7.32.0",
+    "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-react": "^7.27.1",
     "eslint-plugin-react-hooks": "^4.3.0",
     "ioredis": "^4.28.2",
@@ -60,7 +61,8 @@
     "plugins": [
       "@typescript-eslint",
       "eslint-plugin-react",
-      "eslint-plugin-react-hooks"
+      "eslint-plugin-react-hooks",
+      "import"
     ],
     "settings": {
       "react": {
@@ -77,7 +79,8 @@
           "eslint:recommended",
           "plugin:@typescript-eslint/recommended",
           "plugin:react/recommended",
-          "plugin:react-hooks/recommended"
+          "plugin:react-hooks/recommended",
+          "plugin:import/typescript"
         ],
         "rules": {
           "@typescript-eslint/consistent-type-imports": [
@@ -94,6 +97,24 @@
             "warn",
             {
               "argsIgnorePattern": "^_"
+            }
+          ],
+          "import/order": [
+            "warn",
+            {
+              "groups": [
+                "builtin",
+                "external",
+                "internal",
+                "parent",
+                "sibling",
+                "index",
+                "object",
+                "type"
+              ],
+              "alphabetize": {
+                "order": "asc"
+              }
             }
           ]
         }

--- a/packages/wrangler/bin/wrangler.js
+++ b/packages/wrangler/bin/wrangler.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-const { spawn } = require("child_process");
-const { join } = require("path");
+const { spawn } = require("node:child_process");
+const { join } = require("node:path");
 const semiver = require("semiver");
 
 const MIN_NODE_VERSION = "16.7.0";

--- a/packages/wrangler/pages/functions/buildWorker.ts
+++ b/packages/wrangler/pages/functions/buildWorker.ts
@@ -1,4 +1,4 @@
-import path from "path";
+import path from "node:path";
 import { build } from "esbuild";
 
 type Options = {

--- a/packages/wrangler/pages/functions/filepath-routing.ts
+++ b/packages/wrangler/pages/functions/filepath-routing.ts
@@ -1,8 +1,8 @@
-import path from "path";
-import fs from "fs/promises";
-import { transform } from "esbuild";
+import fs from "node:fs/promises";
+import path from "node:path";
 import * as acorn from "acorn";
 import * as acornWalk from "acorn-walk";
+import { transform } from "esbuild";
 import type { Config, RouteConfig } from "./routes";
 import type { ExportNamedDeclaration, Identifier } from "estree";
 

--- a/packages/wrangler/pages/functions/routes.ts
+++ b/packages/wrangler/pages/functions/routes.ts
@@ -1,5 +1,5 @@
-import path from "path";
-import fs from "fs/promises";
+import fs from "node:fs/promises";
+import path from "node:path";
 import { isValidIdentifier, normalizeIdentifier } from "./identifiers";
 
 export const HTTP_METHODS = [

--- a/packages/wrangler/scripts/bundle.ts
+++ b/packages/wrangler/scripts/bundle.ts
@@ -1,5 +1,5 @@
+import path from "node:path";
 import { build } from "esbuild";
-import path from "path";
 
 // the expectation is that this is being run from the project root
 

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -1,10 +1,10 @@
+import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as TOML from "@iarna/toml";
-import { mockConfirm } from "./mock-dialogs";
-import { runWrangler } from "./run-wrangler";
-import { runInTempDir } from "./run-in-tmp";
 import { mockConsoleMethods } from "./mock-console";
-import * as fs from "node:fs";
+import { mockConfirm } from "./mock-dialogs";
+import { runInTempDir } from "./run-in-tmp";
+import { runWrangler } from "./run-wrangler";
 
 describe("wrangler", () => {
   runInTempDir();

--- a/packages/wrangler/src/__tests__/jest.setup.ts
+++ b/packages/wrangler/src/__tests__/jest.setup.ts
@@ -1,7 +1,7 @@
-import { mockFetchInternal } from "./mock-cfetch";
-import { confirm, prompt } from "../dialogs";
-import { fetchInternal } from "../cfetch/internal";
 import fetchMock from "jest-fetch-mock";
+import { fetchInternal } from "../cfetch/internal";
+import { confirm, prompt } from "../dialogs";
+import { mockFetchInternal } from "./mock-cfetch";
 
 jest.mock("undici", () => {
   return {

--- a/packages/wrangler/src/__tests__/kv.test.ts
+++ b/packages/wrangler/src/__tests__/kv.test.ts
@@ -1,14 +1,14 @@
-import { writeFileSync } from "fs";
-import type { KVNamespaceInfo } from "../kv";
+import { writeFileSync } from "node:fs";
 import {
   setMockResponse,
   setMockRawResponse,
   unsetAllMocks,
 } from "./mock-cfetch";
-import { runWrangler } from "./run-wrangler";
-import { runInTempDir } from "./run-in-tmp";
 import { mockConsoleMethods } from "./mock-console";
 import { mockKeyListRequest } from "./mock-kv";
+import { runInTempDir } from "./run-in-tmp";
+import { runWrangler } from "./run-wrangler";
+import type { KVNamespaceInfo } from "../kv";
 
 describe("wrangler", () => {
   runInTempDir();

--- a/packages/wrangler/src/__tests__/logout.test.ts
+++ b/packages/wrangler/src/__tests__/logout.test.ts
@@ -1,12 +1,12 @@
+import { existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { existsSync } from "node:fs";
 import fetchMock from "jest-fetch-mock";
-import { runWrangler } from "./run-wrangler";
-import { runInTempDir } from "./run-in-tmp";
 import { initialise } from "../user";
 import { mockConsoleMethods } from "./mock-console";
 import { writeUserConfig } from "./mock-user";
+import { runInTempDir } from "./run-in-tmp";
+import { runWrangler } from "./run-wrangler";
 
 const ORIGINAL_CF_API_TOKEN = process.env.CF_API_TOKEN;
 const ORIGINAL_CF_ACCOUNT_ID = process.env.CF_ACCOUNT_ID;

--- a/packages/wrangler/src/__tests__/mock-cfetch.ts
+++ b/packages/wrangler/src/__tests__/mock-cfetch.ts
@@ -1,8 +1,8 @@
-import type { RequestInit } from "undici";
 import { URL, URLSearchParams } from "node:url";
 import { pathToRegexp } from "path-to-regexp";
 import { CF_API_BASE_URL } from "../cfetch";
 import type { FetchResult } from "../cfetch";
+import type { RequestInit } from "undici";
 
 /**
  * The signature of the function that will handle a mock request.

--- a/packages/wrangler/src/__tests__/mock-user.ts
+++ b/packages/wrangler/src/__tests__/mock-user.ts
@@ -1,6 +1,6 @@
-import path from "path";
-import os from "os";
 import { mkdirSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 export function writeUserConfig(
   oauth_token?: string,

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -1,14 +1,14 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { KVNamespaceInfo } from "../kv";
-import { mockKeyListRequest } from "./mock-kv";
+import * as TOML from "@iarna/toml";
 import { setMockResponse, unsetAllMocks } from "./mock-cfetch";
+import { mockConsoleMethods } from "./mock-console";
+import { mockKeyListRequest } from "./mock-kv";
 import { runInTempDir } from "./run-in-tmp";
 import { runWrangler } from "./run-wrangler";
-import { mockConsoleMethods } from "./mock-console";
-import type { Config } from "../config";
-import * as TOML from "@iarna/toml";
 import type { WorkerMetadata } from "../api/form_data";
+import type { Config } from "../config";
+import type { KVNamespaceInfo } from "../kv";
 import type { FormData, File } from "undici";
 
 describe("publish", () => {

--- a/packages/wrangler/src/__tests__/run-in-tmp.ts
+++ b/packages/wrangler/src/__tests__/run-in-tmp.ts
@@ -1,6 +1,6 @@
+import * as fs from "node:fs";
 import os from "node:os";
 import * as path from "node:path";
-import * as fs from "fs";
 
 const originalCwd = process.cwd();
 

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -1,8 +1,8 @@
 import { setMockResponse, unsetAllMocks } from "./mock-cfetch";
-import { runWrangler } from "./run-wrangler";
-import { runInTempDir } from "./run-in-tmp";
-import { mockConfirm, mockPrompt } from "./mock-dialogs";
 import { mockConsoleMethods } from "./mock-console";
+import { mockConfirm, mockPrompt } from "./mock-dialogs";
+import { runInTempDir } from "./run-in-tmp";
+import { runWrangler } from "./run-wrangler";
 
 describe("wrangler secret", () => {
   const std = mockConsoleMethods();

--- a/packages/wrangler/src/__tests__/whoami.test.tsx
+++ b/packages/wrangler/src/__tests__/whoami.test.tsx
@@ -1,11 +1,11 @@
-import React from "react";
 import { render } from "ink-testing-library";
-import type { UserInfo } from "../whoami";
-import { getUserInfo, WhoAmI } from "../whoami";
-import { runInTempDir } from "./run-in-tmp";
-import { setMockResponse } from "./mock-cfetch";
+import React from "react";
 import { initialise } from "../user";
+import { getUserInfo, WhoAmI } from "../whoami";
+import { setMockResponse } from "./mock-cfetch";
 import { writeUserConfig } from "./mock-user";
+import { runInTempDir } from "./run-in-tmp";
+import type { UserInfo } from "../whoami";
 
 const ORIGINAL_CF_API_TOKEN = process.env.CF_API_TOKEN;
 const ORIGINAL_CF_ACCOUNT_ID = process.env.CF_ACCOUNT_ID;

--- a/packages/wrangler/src/api/form_data.ts
+++ b/packages/wrangler/src/api/form_data.ts
@@ -1,10 +1,10 @@
+import { FormData, File } from "undici";
 import type {
   CfWorkerInit,
   CfModuleType,
   CfModule,
   CfDurableObjectMigrations,
 } from "./worker.js";
-import { FormData, File } from "undici";
 
 export function toMimeType(type: CfModuleType): string {
   switch (type) {

--- a/packages/wrangler/src/api/worker.ts
+++ b/packages/wrangler/src/api/worker.ts
@@ -1,6 +1,6 @@
-import type { CfPreviewToken } from "./preview";
-import { previewToken } from "./preview";
 import { fetch } from "undici";
+import { previewToken } from "./preview";
+import type { CfPreviewToken } from "./preview";
 
 /**
  * A Cloudflare account.

--- a/packages/wrangler/src/cfetch/index.ts
+++ b/packages/wrangler/src/cfetch/index.ts
@@ -1,6 +1,6 @@
-import type { RequestInit } from "undici";
 import { URLSearchParams } from "node:url";
 import { fetchInternal } from "./internal";
+import type { RequestInit } from "undici";
 
 // Check out https://api.cloudflare.com/ for API docs.
 

--- a/packages/wrangler/src/cfetch/internal.ts
+++ b/packages/wrangler/src/cfetch/internal.ts
@@ -1,7 +1,7 @@
 import { fetch } from "undici";
-import type { RequestInit, HeadersInit } from "undici";
 import { getAPIToken, loginOrRefreshIfRequired } from "../user";
 import type { URLSearchParams } from "node:url";
+import type { RequestInit, HeadersInit } from "undici";
 
 export const CF_API_BASE_URL =
   process.env.CF_API_BASE_URL || "https://api.cloudflare.com/client/v4";

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -1,33 +1,32 @@
-import * as esbuild from "esbuild";
 import assert from "node:assert";
 import { spawn } from "node:child_process";
-import { readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { Box, Text, useApp, useInput } from "ink";
 import { watch } from "chokidar";
 import clipboardy from "clipboardy";
 import commandExists from "command-exists";
+import * as esbuild from "esbuild";
 import { execaCommand } from "execa";
-import { fetch } from "undici";
+import { Box, Text, useApp, useInput } from "ink";
 import open from "open";
 import React, { useState, useEffect, useRef } from "react";
 import { withErrorBoundary, useErrorHandler } from "react-error-boundary";
 import onExit from "signal-exit";
 import tmp from "tmp-promise";
-import type { DirectoryResult } from "tmp-promise";
+import { fetch } from "undici";
 
-import type { CfPreviewToken } from "./api/preview";
-import type { CfModule } from "./api/worker";
 import { createWorker } from "./api/worker";
-import type { CfWorkerInit } from "./api/worker";
 
 import useInspector from "./inspect";
 import makeModuleCollector from "./module-collection";
 import { usePreviewServer, waitForPortToBeAvailable } from "./proxy";
-import type { AssetPaths } from "./sites";
 import { syncAssets } from "./sites";
 import { getAPIToken } from "./user";
+import type { CfPreviewToken } from "./api/preview";
+import type { CfModule, CfWorkerInit } from "./api/worker";
+import type { AssetPaths } from "./sites";
+import type { DirectoryResult } from "tmp-promise";
 
 type CfScriptFormat = undefined | "modules" | "service-worker";
 

--- a/packages/wrangler/src/dialogs.tsx
+++ b/packages/wrangler/src/dialogs.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import { useState } from "react";
 import { Box, Text, useInput, render } from "ink";
 import TextInput from "ink-text-input";
+import * as React from "react";
+import { useState } from "react";
 type ConfirmProps = {
   text: string;
   onConfirm: (answer: boolean) => void;

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -1,25 +1,20 @@
-import React from "react";
-import { render } from "ink";
-import Dev from "./dev";
-import { readFile } from "node:fs/promises";
-import makeCLI from "yargs";
-import type Yargs from "yargs";
-import { findUp } from "find-up";
+import * as fs from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path/posix";
+import { setTimeout } from "node:timers/promises";
 import TOML from "@iarna/toml";
-import { normaliseAndValidateEnvironmentsConfig } from "./config";
-import type { Config } from "./config";
-import { getAssetPaths } from "./sites";
-import { confirm, prompt } from "./dialogs";
+import { execa } from "execa";
+import { findUp } from "find-up";
+import { render } from "ink";
+import React from "react";
+import onExit from "signal-exit";
+import makeCLI from "yargs";
 import { version as wranglerVersion } from "../package.json";
-import {
-  login,
-  logout,
-  listScopes,
-  initialise as initialiseUserConfig,
-  loginOrRefreshIfRequired,
-  getAccountId,
-  validateScopeKeys,
-} from "./user";
+import { toFormData } from "./api/form_data";
+import { fetchResult, fetchRaw } from "./cfetch";
+import { normaliseAndValidateEnvironmentsConfig } from "./config";
+import Dev from "./dev";
+import { confirm, prompt } from "./dialogs";
 import {
   getNamespaceId,
   listNamespaces,
@@ -30,22 +25,23 @@ import {
   createNamespace,
   isValidNamespaceBinding,
 } from "./kv";
-
 import { pages } from "./pages";
-
-import { fetchResult, fetchRaw } from "./cfetch";
-
 import publish from "./publish";
-import path from "path/posix";
-import { writeFile } from "node:fs/promises";
-import { toFormData } from "./api/form_data";
-
+import { getAssetPaths } from "./sites";
 import { createTail } from "./tail";
-import onExit from "signal-exit";
-import { setTimeout } from "node:timers/promises";
-import * as fs from "node:fs";
-import { execa } from "execa";
+import {
+  login,
+  logout,
+  listScopes,
+  initialise as initialiseUserConfig,
+  loginOrRefreshIfRequired,
+  getAccountId,
+  validateScopeKeys,
+} from "./user";
+
 import { whoami } from "./whoami";
+import type { Config } from "./config";
+import type Yargs from "yargs";
 
 const resetColor = "\x1b[0m";
 const fgGreenColor = "\x1b[32m";

--- a/packages/wrangler/src/inspect.ts
+++ b/packages/wrangler/src/inspect.ts
@@ -1,13 +1,13 @@
-import assert from "assert";
-import type { MessageEvent } from "ws";
-import WebSocket, { WebSocketServer } from "ws";
-import type { IncomingMessage, Server, ServerResponse } from "http";
-import { createServer } from "http";
-import { useEffect, useRef, useState } from "react";
-import { version } from "../package.json";
+import assert from "node:assert";
+import { createServer } from "node:http";
 import { URL } from "node:url";
 
+import { useEffect, useRef, useState } from "react";
+import WebSocket, { WebSocketServer } from "ws";
+import { version } from "../package.json";
 import type Protocol from "devtools-protocol";
+import type { IncomingMessage, Server, ServerResponse } from "node:http";
+import type { MessageEvent } from "ws";
 
 /**
  * `useInspector` is a hook for debugging Workers applications

--- a/packages/wrangler/src/kv.tsx
+++ b/packages/wrangler/src/kv.tsx
@@ -1,6 +1,6 @@
 import { URLSearchParams } from "node:url";
-import type { Config } from "./config";
 import { fetchListResult, fetchResult } from "./cfetch";
+import type { Config } from "./config";
 
 type KvArgs = {
   binding?: string;

--- a/packages/wrangler/src/module-collection.ts
+++ b/packages/wrangler/src/module-collection.ts
@@ -1,8 +1,8 @@
+import crypto from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 import type { CfModule } from "./api/worker";
 import type esbuild from "esbuild";
-import path from "node:path";
-import { readFile } from "node:fs/promises";
-import crypto from "node:crypto";
 
 // This is a combination of an esbuild plugin and a mutable array
 // that we use to collect module references from source code.

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -1,25 +1,25 @@
 /* eslint-disable no-shadow */
 
-import type { BuilderCallback } from "yargs";
-import { join } from "path";
-import { tmpdir } from "os";
-import { existsSync, lstatSync, readFileSync, writeFileSync } from "fs";
-import { execSync, spawn } from "child_process";
-import { URL } from "url";
+import { execSync, spawn } from "node:child_process";
+import { existsSync, lstatSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { URL } from "node:url";
+import { watch } from "chokidar";
 import { getType } from "mime";
 import open from "open";
-import { watch } from "chokidar";
-import type { BuildResult } from "esbuild";
 import { buildWorker } from "../pages/functions/buildWorker";
-import type { Config } from "../pages/functions/routes";
-import { writeRoutesModule } from "../pages/functions/routes";
 import { generateConfigFromFileTree } from "../pages/functions/filepath-routing";
+import { writeRoutesModule } from "../pages/functions/routes";
+import type { Config } from "../pages/functions/routes";
+import type { Headers, Request, fetch } from "@miniflare/core";
+import type { BuildResult } from "esbuild";
+import type { MiniflareOptions } from "miniflare";
+import type { BuilderCallback } from "yargs";
 
 // Defer importing miniflare until we really need it. This takes ~0.5s
 // and also modifies some `stream/web` and `undici` prototypes, so we
 // don't want to do this if pages commands aren't being called.
-import type { Headers, Request, fetch } from "@miniflare/core";
-import type { MiniflareOptions } from "miniflare";
 
 const EXIT_CALLBACKS: (() => void)[] = [];
 const EXIT = (message?: string, code?: number) => {

--- a/packages/wrangler/src/proxy.ts
+++ b/packages/wrangler/src/proxy.ts
@@ -1,6 +1,9 @@
-import { connect } from "node:http2";
-import type { ClientHttp2Session, ServerHttp2Stream } from "node:http2";
 import { createServer } from "node:http";
+import { connect } from "node:http2";
+import WebSocket from "faye-websocket";
+import { useEffect, useRef, useState } from "react";
+import serveStatic from "serve-static";
+import type { CfPreviewToken } from "./api/preview";
 import type {
   IncomingHttpHeaders,
   RequestListener,
@@ -8,10 +11,7 @@ import type {
   ServerResponse,
   Server,
 } from "node:http";
-import WebSocket from "faye-websocket";
-import serveStatic from "serve-static";
-import type { CfPreviewToken } from "./api/preview";
-import { useEffect, useRef, useState } from "react";
+import type { ClientHttp2Session, ServerHttp2Stream } from "node:http2";
 
 /**
  * `usePreviewServer` is a React hook that creates a local development

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -1,18 +1,18 @@
 import assert from "node:assert";
-import path from "node:path";
 import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { URLSearchParams } from "node:url";
 import * as esbuild from "esbuild";
-import type { Metafile } from "esbuild";
 import { execaCommand } from "execa";
 import tmp from "tmp-promise";
-import type { CfWorkerInit } from "./api/worker";
 import { toFormData } from "./api/form_data";
 import { fetchResult } from "./cfetch";
-import type { Config } from "./config";
 import makeModuleCollector from "./module-collection";
-import type { AssetPaths } from "./sites";
 import { syncAssets } from "./sites";
-import { URLSearchParams } from "node:url";
+import type { CfWorkerInit } from "./api/worker";
+import type { Config } from "./config";
+import type { AssetPaths } from "./sites";
+import type { Metafile } from "esbuild";
 
 type CfScriptFormat = undefined | "modules" | "service-worker";
 

--- a/packages/wrangler/src/sites.tsx
+++ b/packages/wrangler/src/sites.tsx
@@ -1,14 +1,14 @@
-import * as path from "node:path";
 import { readdir, readFile, stat } from "node:fs/promises";
+import * as path from "node:path";
 import ignore from "ignore";
 import { XXHash64 } from "xxhash-addon";
-import type { Config } from "./config";
 import {
   createNamespace,
   listNamespaceKeys,
   listNamespaces,
   putBulkKeyValue,
 } from "./kv";
+import type { Config } from "./config";
 
 /** Paths to always ignore. */
 const ALWAYS_IGNORE = ["node_modules"];

--- a/packages/wrangler/src/user.tsx
+++ b/packages/wrangler/src/user.tsx
@@ -205,24 +205,24 @@
    limitations under the License.
   */
 
-import React from "react";
-import { render, Text } from "ink";
-import Table from "ink-table";
-import SelectInput from "ink-select-input";
-import { fetch } from "undici";
+import assert from "node:assert";
 import { webcrypto as crypto } from "node:crypto";
-import { TextEncoder } from "node:util";
-import open from "open";
-import url from "node:url";
-import http from "node:http";
 import { readFile, writeFile, rm, mkdir } from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
 import path from "node:path";
 import process from "node:process";
-import os from "node:os";
+import url from "node:url";
+import { TextEncoder } from "node:util";
 import TOML from "@iarna/toml";
-import assert from "node:assert";
-import type { ParsedUrlQuery } from "node:querystring";
+import { render, Text } from "ink";
+import SelectInput from "ink-select-input";
+import Table from "ink-table";
+import open from "open";
+import React from "react";
+import { fetch } from "undici";
 import { CF_API_BASE_URL } from "./cfetch";
+import type { ParsedUrlQuery } from "node:querystring";
 import type { Response } from "undici";
 
 /**


### PR DESCRIPTION
- This adds `eslint-plugin-import` to enforce ordering of imports, and configuration for the same in `package.json`.
- I also run `npm run check:lint -- --fix` to apply the configured order in our whole codebase.
- This also needs a setting in `.vscode/settings.json` to prevent spurious warnings inside vscode. You'll probably have to restart your IDE for this to take effect. (re: https://github.com/import-js/eslint-plugin-import/issues/2377#issuecomment-1024800026)

(I'd also like to enforce using `node:` prefixes for node builtin modules, but that can happen later. For now I manually added the prefixes wherever they were missing. It's not functionally any different, but imo it helps the visual grouping.)