### PR TITLE
fix: `kv:key get`

### DIFF
--- a/.changeset/early-lies-sniff.md
+++ b/.changeset/early-lies-sniff.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: `kv:key get`
+
+The api for fetching a kv value, unlike every other cloudflare api, returns just the raw value as a string (as opposed to the `FetchResult`-style json). However, our fetch utility tries to convert every api response to json before parsing it further. This leads to bugs like https://github.com/cloudflare/wrangler2/issues/359. The fix is to special case for `kv:key get`.
+
+Fixes https://github.com/cloudflare/wrangler2/issues/359.

--- a/packages/wrangler/src/__tests__/jest.setup.ts
+++ b/packages/wrangler/src/__tests__/jest.setup.ts
@@ -1,7 +1,7 @@
 import fetchMock from "jest-fetch-mock";
-import { fetchInternal } from "../cfetch/internal";
+import { fetchInternal, fetchKVGetValue } from "../cfetch/internal";
 import { confirm, prompt } from "../dialogs";
-import { mockFetchInternal } from "./helpers/mock-cfetch";
+import { mockFetchInternal, mockFetchKVGetValue } from "./helpers/mock-cfetch";
 
 jest.mock("undici", () => {
   return {
@@ -16,6 +16,7 @@ fetchMock.doMock(() => {
 
 jest.mock("../cfetch/internal");
 (fetchInternal as jest.Mock).mockImplementation(mockFetchInternal);
+(fetchKVGetValue as jest.Mock).mockImplementation(mockFetchKVGetValue);
 
 jest.mock("../dialogs");
 

--- a/packages/wrangler/src/cfetch/index.ts
+++ b/packages/wrangler/src/cfetch/index.ts
@@ -18,16 +18,7 @@ export interface FetchResult<ResponseType = unknown> {
   result_info?: unknown;
 }
 
-/**
- * Make a fetch request for a raw JSON value.
- */
-export async function fetchRaw<ResponseType>(
-  resource: string,
-  init: RequestInit = {},
-  queryParams?: URLSearchParams
-): Promise<ResponseType> {
-  return fetchInternal<ResponseType>(resource, init, queryParams);
-}
+export { fetchKVGetValue } from "./internal";
 
 /**
  * Make a fetch request, and extract the `result` from the JSON response.

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -10,7 +10,7 @@ import onExit from "signal-exit";
 import makeCLI from "yargs";
 import { version as wranglerVersion } from "../package.json";
 import { toFormData } from "./api/form_data";
-import { fetchResult, fetchRaw } from "./cfetch";
+import { fetchResult } from "./cfetch";
 import { normaliseAndValidateEnvironmentsConfig } from "./config";
 import Dev from "./dev";
 import { confirm, prompt } from "./dialogs";
@@ -23,6 +23,7 @@ import {
   deleteBulkKeyValue,
   createNamespace,
   isValidNamespaceBinding,
+  getKeyValue,
 } from "./kv";
 import { npm } from "./npm-installer";
 import { pages } from "./pages";
@@ -1755,13 +1756,11 @@ export async function main(argv: string[]): Promise<void> {
                 }
               }
               // -- snip, end --
-            }
 
-            console.log(
-              await fetchRaw(
-                `/accounts/${config.account_id}/storage/kv/namespaces/${namespaceId}/values/${key}`
-              )
-            );
+              console.log(
+                await getKeyValue(config.account_id, namespaceId, key)
+              );
+            }
           }
         )
         .command(

--- a/packages/wrangler/src/kv.tsx
+++ b/packages/wrangler/src/kv.tsx
@@ -1,5 +1,5 @@
 import { URLSearchParams } from "node:url";
-import { fetchListResult, fetchResult } from "./cfetch";
+import { fetchListResult, fetchResult, fetchKVGetValue } from "./cfetch";
 import type { Config } from "./config";
 
 type KvArgs = {
@@ -113,6 +113,14 @@ export async function putKeyValue(
     { method: "PUT", body: value },
     searchParams
   );
+}
+
+export async function getKeyValue(
+  accountId: string,
+  namespaceId: string,
+  key: string
+): Promise<string> {
+  return await fetchKVGetValue(accountId, namespaceId, key);
 }
 
 export async function putBulkKeyValue(


### PR DESCRIPTION
The api for fetching a kv value, unlike every other cloudflare api, returns just the raw value as a string (as opposed to the `FetchResult`-style json). However, our fetch utility tries to convert every api response to json before parsing it further. This leads to bugs like https://github.com/cloudflare/wrangler2/issues/359. The fix is to special case for `kv:key get`.

Fixes https://github.com/cloudflare/wrangler2/issues/359.