### PR TITLE
Add experimental support for wrangler dev/publish file.wasm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -734,6 +734,11 @@
       "version": "3.3.1",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@cloudflare/workers-wasi": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-wasi/-/workers-wasi-0.0.5.tgz",
+      "integrity": "sha512-Gxu2tt2YY8tRgN7vfY8mSW0Md5wUj5+gb5eYrqsGRM+qJn9jx+ButL6BteLluDe5vlEkxQ69LagEMHjE58O7iQ=="
+    },
     "node_modules/@cnakazawa/watch": {
       "version": "1.0.4",
       "license": "Apache-2.0",
@@ -16842,6 +16847,7 @@
       "version": "0.0.16",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
+        "@cloudflare/workers-wasi": "0.0.5",
         "esbuild": "0.14.14",
         "miniflare": "2.3.0",
         "path-to-regexp": "^6.2.0",
@@ -17726,6 +17732,11 @@
     },
     "@cloudflare/workers-types": {
       "version": "3.3.1"
+    },
+    "@cloudflare/workers-wasi": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-wasi/-/workers-wasi-0.0.5.tgz",
+      "integrity": "sha512-Gxu2tt2YY8tRgN7vfY8mSW0Md5wUj5+gb5eYrqsGRM+qJn9jx+ButL6BteLluDe5vlEkxQ69LagEMHjE58O7iQ=="
     },
     "@cnakazawa/watch": {
       "version": "1.0.4",
@@ -27687,6 +27698,7 @@
       "version": "file:packages/wrangler",
       "requires": {
         "@babel/types": "^7.16.0",
+        "@cloudflare/workers-wasi": "0.0.5",
         "@iarna/toml": "^2.2.5",
         "@sentry/cli": "^1.71.0",
         "@sentry/integrations": "^6.17.6",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "esbuild": "0.14.14",
     "miniflare": "2.3.0",
+    "@cloudflare/workers-wasi": "0.0.5",
     "path-to-regexp": "^6.2.0",
     "semiver": "^1.1.0",
     "xxhash-wasm": "^1.0.1"

--- a/packages/wrangler/scripts/bundle.ts
+++ b/packages/wrangler/scripts/bundle.ts
@@ -12,7 +12,13 @@ async function run() {
     platform: "node",
     format: "cjs",
     // minify: true, // TODO: enable this again
-    external: ["fsevents", "esbuild", "miniflare", "@miniflare/core"], // todo - bundle miniflare too
+    external: [
+      "@cloudflare/workers-wasi",
+      "fsevents",
+      "esbuild",
+      "miniflare",
+      "@miniflare/core",
+    ], // todo - bundle miniflare too
     sourcemap: true,
     inject: [path.join(__dirname, "../import_meta_url.js")],
     define: {

--- a/packages/wrangler/src/guess-worker-format.ts
+++ b/packages/wrangler/src/guess-worker-format.ts
@@ -16,6 +16,10 @@ export default async function guessWorkerFormat(
   entry: Entry,
   hint: CfScriptFormat | undefined
 ): Promise<CfScriptFormat> {
+  if (entry.file.endsWith(".wasm")) {
+    return "modules";
+  }
+
   const result = await build({
     entryPoints: [entry.file],
     absWorkingDir: entry.directory,

--- a/packages/wrangler/src/wasi.ts
+++ b/packages/wrangler/src/wasi.ts
@@ -1,0 +1,79 @@
+import { realpath, writeFile } from "node:fs/promises";
+import path from "node:path";
+import tmp from "tmp-promise";
+
+function makeEntrypoint(wasmPath: string, modulePath: string): string {
+  const name = path.basename(wasmPath);
+
+  // Allow setting cli arguments by putting WRANGLER_EXPERIMENTAL_WASM_ARGS=foo=bar,baz in wrangler
+  // environment, e.g., WRANGLER_EXPERIMENTAL_WASM_ARGS=foo=bar,baz -> hello.wasm foo=bar baz
+  const argsPrefix = "WRANGLER_EXPERIMENTAL_WASM_ARGS";
+  const args = process.env[argsPrefix]?.split(",") ?? [];
+
+  // Allow setting env variables by putting WRANGLER_EXPERIMENTAL_WASM_ENV_xyz in wrangler
+  // environment, e.g., WRANGLER_EXPERIMENTAL_WASM_ENV_FOO=baz -> FOO=baz
+  const envPrefix = "WRANGLER_EXPERIMENTAL_WASM_ENV_";
+  const env = Object.fromEntries(
+    Object.entries(process.env)
+      .filter(([k, _v]) => {
+        return k.startsWith(envPrefix);
+      })
+      .map(([k, v]) => {
+        return [k.substring(envPrefix.length), v];
+      })
+  );
+
+  // Allow setting the response content type variables by putting WRANGLER_WASM_RESPONSE_CONTENT_TYPE
+  // in wrangler environment, eg. WRANGLER_EXPERIMENTAL_WASM_RESPONSE_CONTENT_TYPE=application/zstd
+  const responseContentTypeKey =
+    "WRANGLER_EXPERIMENTAL_WASM_RESPONSE_CONTENT_TYPE";
+  const contentType = process.env[responseContentTypeKey]
+    ? { "content-type": process.env[responseContentTypeKey] }
+    : {};
+
+  return `
+import { WASI } from '${modulePath}';
+import wasm from '${wasmPath}';
+export default {
+  async fetch(request, environment, context) {
+    const stdout = new TransformStream()
+    const wasi = new WASI({
+       args: ${JSON.stringify([name, ...args])},
+       env: ${JSON.stringify(env)},
+       stdout: stdout.writable,
+       stdin: request.body,
+       streamStdio: false
+    });
+    const instance = new WebAssembly.Instance(wasm, {
+       wasi_snapshot_preview1: wasi.wasiImport,
+    });
+    const promise = wasi.start(instance);
+    const response = new Response(stdout.readable, {
+      headers: {
+        ...${JSON.stringify(contentType)}
+      }
+    })
+    context.waitUntil(promise)
+    return response
+  }
+}
+`;
+}
+
+export async function wrapIfWasmEntrypoint(
+  entrypoint: string
+): Promise<string> {
+  if (path.extname(entrypoint) !== ".wasm") {
+    return entrypoint;
+  }
+  const scratch = await realpath((await tmp.dir({ unsafeCleanup: true })).path);
+
+  // We want to ship '@cloudflare/workers-wasi' with wrangler and include from the generated
+  // bundle, so we mark as external in the wrangler build process and ask node for the path
+  const absModulePath = require.resolve("@cloudflare/workers-wasi");
+  const importPath = path.relative(scratch, entrypoint);
+  const modulePath = path.relative(scratch, absModulePath);
+  const generated = path.join(scratch, "index.mjs");
+  await writeFile(generated, makeEntrypoint(importPath, modulePath));
+  return path.relative(process.cwd(), generated);
+}


### PR DESCRIPTION
  Allow wrangler to work with simple with WebAssembly programs that
  operate on stdin/stdout by generating a js shim that uses
  '@cloudflare/wasi'

  Example:
      cargo new hello_wasm
      cd ./hello_wasm
      cargo build --target wasm32-wasi --release
      wrangler dev target/wasm32-wasi/release/hello_wasm.wasm
      curl http://localhost:8787
        Hello, world!