### PR TITLE
fix: pages advanced mode usage

### DIFF
--- a/.changeset/many-eggs-deny.md
+++ b/.changeset/many-eggs-deny.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: pages advanced mode usage
+
+Previously in pages projects using advanced mode (a single `_worker.js` or `--script-path` file rather than a `./functions` folder), calling `pages dev` would quit without an error and not launch miniflare.
+
+This change fixes that and enables `pages dev` to be used with pages projects in advanced mode.

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -828,6 +828,8 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
             scriptPath,
           };
         } else {
+          scriptReadyResolve();
+
           const scriptPath =
             directory !== undefined
               ? join(directory, singleWorkerScriptPath)
@@ -850,7 +852,6 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
               }
             }`,
             };
-            scriptReadyResolve();
           }
         }
 


### PR DESCRIPTION
When setting up a project using pages in advanced mode (using a `_worker.js` file), wrangler 2 just quits with no error.

This is because `await scriptReadyPromise;` on line 866 only ever resolves when there are functions in a functions directory.

This PR fix's the issue by calling `scriptReadyResolve()` outside of the `if (existsSync(scriptPath))` condition.