### PR TITLE
refactor: use xxhash-wasm for better compatibility with Windows

### DIFF
--- a/.changeset/sixty-fishes-doubt.md
+++ b/.changeset/sixty-fishes-doubt.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+refactor: use xxhash-wasm for better compatibility with Windows
+
+The previous xxhash package we were using required a build step, which relied upon tooling that was not always available on Window.
+
+This version is a portable WASM package.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15166,14 +15166,10 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
-    "node_modules/xxhash-addon": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/xxhash-addon/-/xxhash-addon-1.4.0.tgz",
-      "integrity": "sha512-n3Ml0Vgvy7jMYJBlQIoFLjYxXNZQ5CbzW8E2Ynq2QCUpWMqCouooW7j02+7Oud5FijBuSrjQNuN/fCiz1SHN+w==",
-      "hasInstallScript": true,
-      "engines": {
-        "node": ">=8.6.0 <9.0.0 || >=10.0.0"
-      }
+    "node_modules/xxhash-wasm": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.0.1.tgz",
+      "integrity": "sha512-Lc9CTvDrH2vRoiaUzz25q7lRaviMhz90pkx6YxR9EPYtF99yOJnv2cB+CQ0hp/TLoqrUsk8z/W2EN31T568Azw=="
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -15292,7 +15288,7 @@
         "miniflare": "2.2.0",
         "path-to-regexp": "^6.2.0",
         "semiver": "^1.1.0",
-        "xxhash-addon": "^1.4.0"
+        "xxhash-wasm": "^1.0.1"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
@@ -26607,7 +26603,7 @@
         "tmp-promise": "^3.0.3",
         "undici": "4.13.0",
         "ws": "^8.3.0",
-        "xxhash-addon": "^1.4.0",
+        "xxhash-wasm": "*",
         "yargs": "^17.3.0"
       },
       "dependencies": {
@@ -26684,10 +26680,10 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
-    "xxhash-addon": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/xxhash-addon/-/xxhash-addon-1.4.0.tgz",
-      "integrity": "sha512-n3Ml0Vgvy7jMYJBlQIoFLjYxXNZQ5CbzW8E2Ynq2QCUpWMqCouooW7j02+7Oud5FijBuSrjQNuN/fCiz1SHN+w=="
+    "xxhash-wasm": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.0.1.tgz",
+      "integrity": "sha512-Lc9CTvDrH2vRoiaUzz25q7lRaviMhz90pkx6YxR9EPYtF99yOJnv2cB+CQ0hp/TLoqrUsk8z/W2EN31T568Azw=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -40,7 +40,7 @@
     "miniflare": "2.2.0",
     "path-to-regexp": "^6.2.0",
     "semiver": "^1.1.0",
-    "xxhash-addon": "^1.4.0"
+    "xxhash-wasm": "^1.0.1"
   },
   "optionalDependencies": {
     "fsevents": "~2.3.2"

--- a/packages/wrangler/scripts/bundle.ts
+++ b/packages/wrangler/scripts/bundle.ts
@@ -12,13 +12,7 @@ async function run() {
     platform: "node",
     format: "cjs",
     // minify: true, // TODO: enable this again
-    external: [
-      "fsevents",
-      "esbuild",
-      "miniflare",
-      "@miniflare/core",
-      "xxhash-addon",
-    ], // todo - bundle miniflare too
+    external: ["fsevents", "esbuild", "miniflare", "@miniflare/core"], // todo - bundle miniflare too
     sourcemap: true,
     inject: [path.join(__dirname, "../import_meta_url.js")],
     define: {


### PR DESCRIPTION
The previous xxhash package we were using required a build step, which relied upon tooling that was not always available on Window.

This version is a portable WASM package.