### PR TITLE
fix: add `example-remix-pages-app` artifacts to `.prettierignore`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,6 @@
 packages/wrangler/vendor/
 packages/wrangler/wrangler-dist/
 packages/example-worker-app/dist/
+packages/example-remix-pages-app/build
+packages/example-remix-pages-app/public/
 packages/prerelease-registry/_worker.js


### PR DESCRIPTION
To avoid `npm run check` from failing locally.

![image](https://user-images.githubusercontent.com/18808/152602648-b226d362-f031-4154-af25-9ec5905a0a6f.png)
