### PR TITLE
polish: Added Wrangler TOML fields

### DIFF
--- a/.changeset/silly-students-add.md
+++ b/.changeset/silly-students-add.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+polish: Added Wrangler TOML fields
+Additional field to get projects ready to publish as soon as possible.
+It will check if the Worker is named, if not then it defaults to using the parent directory name.

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -101,6 +101,20 @@ describe("wrangler", () => {
       await runWrangler("init");
       const parsed = TOML.parse(await fsp.readFile("./wrangler.toml", "utf-8"));
       expect(typeof parsed.compatibility_date).toBe("string");
+      expect(parsed.name).toContain("wrangler-tests");
+      expect(fs.existsSync("./package.json")).toBe(false);
+      expect(fs.existsSync("./tsconfig.json")).toBe(false);
+    });
+
+    it("should create a named Worker wrangler.toml", async () => {
+      mockConfirm({
+        text: "No package.json found. Would you like to create one?",
+        result: false,
+      });
+      await runWrangler("init my-worker");
+      const parsed = TOML.parse(await fsp.readFile("./wrangler.toml", "utf-8"));
+      expect(typeof parsed.compatibility_date).toBe("string");
+      expect(parsed.name).toBe("my-worker");
       expect(fs.existsSync("./package.json")).toBe(false);
       expect(fs.existsSync("./tsconfig.json")).toBe(false);
     });

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -205,7 +205,10 @@ export async function main(argv: string[]): Promise<void> {
         try {
           await writeFile(
             destination,
-            `compatibility_date = "${compatibilityDate}"` + "\n"
+            TOML.stringify({
+              name: args.name || path.basename(path.resolve(process.cwd())),
+              compatibility_date: compatibilityDate,
+            }) + "\n"
           );
           console.log(`✨ Successfully created wrangler.toml`);
           // TODO: suggest next steps?


### PR DESCRIPTION
Added additional fields to get projects ready to publish as soon as possible.
- The name will check if the Worker is named if not defaults to the parent directory name.
- The workers_dev field is now initialized default true

partial #399