### PR TITLE
polish: `package.json` tweaks

### DIFF
--- a/.changeset/orange-hats-yell.md
+++ b/.changeset/orange-hats-yell.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+---
+
+feat: add scripts to package.json & autogenerate name value when initializing a project
+To get wrangler init projects up and running with good ergonomics for deploying and development,
+added default scripts "start" & "deploy" with assumed TS or JS files in generated ./src/index.
+The name property is now derived from user input on `init <name>` or parent directory if no input is provided.

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -217,9 +217,10 @@ export async function main(argv: string[]): Promise<void> {
       }
 
       let pathToPackageJson = await findUp("package.json");
+      let shouldCreatePackageJson = false;
       if (!pathToPackageJson) {
         // If no package.json exists, ask to create one
-        const shouldCreatePackageJson = await confirm(
+        shouldCreatePackageJson = await confirm(
           "No package.json found. Would you like to create one?"
         );
         if (shouldCreatePackageJson) {
@@ -227,7 +228,7 @@ export async function main(argv: string[]): Promise<void> {
             "./package.json",
             JSON.stringify(
               {
-                name: "worker",
+                name: args.name || path.basename(path.resolve(process.cwd())),
                 version: "0.0.0",
                 devDependencies: {
                   wrangler: wranglerVersion,
@@ -333,6 +334,47 @@ export async function main(argv: string[]): Promise<void> {
         }
       }
 
+      const packageJsonContent = JSON.parse(
+        await readFile(pathToPackageJson, "utf-8")
+      );
+      const shouldWritePackageJsonScripts =
+        !packageJsonContent.scripts?.start &&
+        !packageJsonContent.scripts?.deploy &&
+        shouldCreatePackageJson;
+      async function writePackageJsonScripts(
+        isWritingScripts: boolean,
+        packagePath: string,
+        scriptPath: string
+      ) {
+        if (isWritingScripts) {
+          await writeFile(
+            packagePath,
+            JSON.stringify(
+              {
+                ...packageJsonContent,
+                scripts: {
+                  ...packageJsonContent.scripts,
+                  start: `wrangler dev ${scriptPath}`,
+                  deploy: `wrangler publish ${scriptPath}`,
+                },
+              },
+              null,
+              "  "
+            ) + "\n"
+          );
+          console.log(`To start developing on your worker, run npm start.`);
+          console.log(
+            `To publish your worker on to the internet, run npm run deploy.`
+          );
+        } else {
+          console.log(
+            `To start developing on your worker, npx wrangler dev ${scriptPath}`
+          );
+          console.log(
+            `To publish your worker on to the internet, npx wrangler publish ${scriptPath}`
+          );
+        }
+      }
       if (isTypescriptProject) {
         if (!fs.existsSync("./src/index.ts")) {
           const shouldCreateSource = await confirm(
@@ -347,6 +389,13 @@ export async function main(argv: string[]): Promise<void> {
                 "utf-8"
               )
             );
+
+            await writePackageJsonScripts(
+              shouldWritePackageJsonScripts,
+              pathToPackageJson,
+              "src/index.ts"
+            );
+
             console.log(`✨ Created src/index.ts`);
           }
         }
@@ -364,6 +413,13 @@ export async function main(argv: string[]): Promise<void> {
                 "utf-8"
               )
             );
+
+            await writePackageJsonScripts(
+              shouldWritePackageJsonScripts,
+              pathToPackageJson,
+              "src/index.js"
+            );
+
             console.log(`✨ Created src/index.js`);
           }
         }


### PR DESCRIPTION
To get wrangler init projects up and running with good ergonomics for deploying and development,
added default scripts "start" & "deploy" with assumed TS or JS files in generated ./src/index.
The name property is now derived from user input on `init <name>` or parent directory if no input is provided. 


partial #399 