### PR TITLE
chore: upgrade `miniflare` to `2.3.0`

### DIFF
--- a/.changeset/nine-toes-impress.md
+++ b/.changeset/nine-toes-impress.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Upgrade `miniflare` to [`2.3.0`](https://github.com/cloudflare/miniflare/releases/tag/v2.3.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2244,30 +2244,25 @@
       }
     },
     "node_modules/@miniflare/cache": {
-      "version": "2.2.0",
-      "license": "MIT",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.3.0.tgz",
+      "integrity": "sha512-lOf3WVtrs0ac7KOtsQ+JOGHWR90zsqqJbolE+Wt4hIZuvM2U3t1RD2Ms7U20J301msVIsBAd02IL57H95LXQtQ==",
       "dependencies": {
-        "@miniflare/core": "2.2.0",
-        "@miniflare/shared": "2.2.0",
+        "@miniflare/core": "2.3.0",
+        "@miniflare/shared": "2.3.0",
         "http-cache-semantics": "^4.1.0",
-        "undici": "4.12.1"
+        "undici": "4.13.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
-    "node_modules/@miniflare/cache/node_modules/undici": {
-      "version": "4.12.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.18"
-      }
-    },
     "node_modules/@miniflare/cli-parser": {
-      "version": "2.2.0",
-      "license": "MIT",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.3.0.tgz",
+      "integrity": "sha512-yQzU+OBBvWshr9qVxAe6bWXJLNfpmLYrfkfR3u+rPOo2LYnccWg0f/8jtxrXM1TIyu+tCOJGqCODpO//XtrwWw==",
       "dependencies": {
-        "@miniflare/shared": "2.2.0",
+        "@miniflare/shared": "2.3.0",
         "kleur": "^4.1.4"
       },
       "engines": {
@@ -2275,17 +2270,18 @@
       }
     },
     "node_modules/@miniflare/core": {
-      "version": "2.2.0",
-      "license": "MIT",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Dltb3p+Uq5Lx53DuInckHYaDoMrBq49HE/p/oUDXmzHmQy7EAM6v+nJGKmiM9Uen4OqyqsmlmPWqntSMjaX7Jg==",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/shared": "2.2.0",
-        "@miniflare/watcher": "2.2.0",
+        "@miniflare/shared": "2.3.0",
+        "@miniflare/watcher": "2.3.0",
         "busboy": "^0.3.1",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
         "set-cookie-parser": "^2.4.8",
-        "undici": "4.12.1"
+        "undici": "4.13.0"
       },
       "engines": {
         "node": ">=16.7"
@@ -2293,68 +2289,51 @@
     },
     "node_modules/@miniflare/core/node_modules/dotenv": {
       "version": "10.0.0",
-      "license": "BSD-2-Clause",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
       "engines": {
         "node": ">=10"
       }
     },
-    "node_modules/@miniflare/core/node_modules/undici": {
-      "version": "4.12.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.18"
-      }
-    },
     "node_modules/@miniflare/durable-objects": {
-      "version": "2.2.0",
-      "license": "MIT",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.3.0.tgz",
+      "integrity": "sha512-YuzxBBu9xBU3xxD4TzGdeVVMXrE76AWJE4MIqkJR5UmASqayyv//cApGw3+C01NHe07cpbrTM1QTgFo2eBncwQ==",
       "dependencies": {
-        "@miniflare/core": "2.2.0",
-        "@miniflare/shared": "2.2.0",
-        "@miniflare/storage-memory": "2.2.0",
-        "undici": "4.12.1"
+        "@miniflare/core": "2.3.0",
+        "@miniflare/shared": "2.3.0",
+        "@miniflare/storage-memory": "2.3.0",
+        "undici": "4.13.0"
       },
       "engines": {
         "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/durable-objects/node_modules/undici": {
-      "version": "4.12.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.18"
       }
     },
     "node_modules/@miniflare/html-rewriter": {
-      "version": "2.2.0",
-      "license": "MIT",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.3.0.tgz",
+      "integrity": "sha512-cyWhmQgzhtRlBeg0mxP5FmAq/75ChuLwWQlhokx88XkGnteuh0/DOk3OxIMaveF2oDHKmIlLFgSlzv4NbT1Mng==",
       "dependencies": {
-        "@miniflare/core": "2.2.0",
-        "@miniflare/shared": "2.2.0",
-        "html-rewriter-wasm": "^0.4.0",
-        "undici": "4.12.1"
+        "@miniflare/core": "2.3.0",
+        "@miniflare/shared": "2.3.0",
+        "html-rewriter-wasm": "^0.4.1",
+        "undici": "4.13.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
-    "node_modules/@miniflare/html-rewriter/node_modules/undici": {
-      "version": "4.12.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.18"
-      }
-    },
     "node_modules/@miniflare/http-server": {
-      "version": "2.2.0",
-      "license": "MIT",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.3.0.tgz",
+      "integrity": "sha512-jTzsRuro3yWVb4T85znBGw1w+ydimgi2PJvHrTuGFKDjFam+R037fGH+HZCAjAgPiBHTroXfkeSXypJLXbQBEg==",
       "dependencies": {
-        "@miniflare/core": "2.2.0",
-        "@miniflare/shared": "2.2.0",
-        "@miniflare/web-sockets": "2.2.0",
+        "@miniflare/core": "2.3.0",
+        "@miniflare/shared": "2.3.0",
+        "@miniflare/web-sockets": "2.3.0",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
-        "undici": "4.12.1",
+        "undici": "4.13.0",
         "ws": "^8.2.2",
         "youch": "^2.2.2"
       },
@@ -2362,16 +2341,10 @@
         "node": ">=16.7"
       }
     },
-    "node_modules/@miniflare/http-server/node_modules/undici": {
-      "version": "4.12.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.18"
-      }
-    },
     "node_modules/@miniflare/http-server/node_modules/ws": {
-      "version": "8.4.2",
-      "license": "MIT",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -2389,31 +2362,34 @@
       }
     },
     "node_modules/@miniflare/kv": {
-      "version": "2.2.0",
-      "license": "MIT",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.3.0.tgz",
+      "integrity": "sha512-m0zu5sRoaFDm+WVTnLRrz8+77b6eVxQN7cLN6ZQiKP3Nd8cAggPdaIIef8dVksWbPvOW9DztoUVZTB1v9EOaLA==",
       "dependencies": {
-        "@miniflare/shared": "2.2.0"
+        "@miniflare/shared": "2.3.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/runner-vm": {
-      "version": "2.2.0",
-      "license": "MIT",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.3.0.tgz",
+      "integrity": "sha512-/aB997YodNcRFxtlnvEn4BJSIqKXRw29FexOqCWwWv+b7XQkTTxd4IfSocIFi6du3265gp85icqP/hxsLAQBVg==",
       "dependencies": {
-        "@miniflare/shared": "2.2.0"
+        "@miniflare/shared": "2.3.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/scheduler": {
-      "version": "2.2.0",
-      "license": "MIT",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.3.0.tgz",
+      "integrity": "sha512-Er80srMNXbxqGbYXtiZkD8UlveHsw4cpwcytQgsEJCHG7/48vC/rpmtN0zKOWFEHifaOUvHhURZRJu+S2E4Stg==",
       "dependencies": {
-        "@miniflare/core": "2.2.0",
-        "@miniflare/shared": "2.2.0",
+        "@miniflare/core": "2.3.0",
+        "@miniflare/shared": "2.3.0",
         "cron-schedule": "^3.0.4"
       },
       "engines": {
@@ -2421,8 +2397,9 @@
       }
     },
     "node_modules/@miniflare/shared": {
-      "version": "2.2.0",
-      "license": "MIT",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.3.0.tgz",
+      "integrity": "sha512-TvCSUe1op5AKINx3zHSSdfAbdoV3eSF3MzeVQA4+1NmtuefY8cjujQCdILeAxg3oPbHXaZkc7j1zZ13rYdvwGQ==",
       "dependencies": {
         "ignore": "^5.1.8",
         "kleur": "^4.1.4"
@@ -2432,71 +2409,70 @@
       }
     },
     "node_modules/@miniflare/sites": {
-      "version": "2.2.0",
-      "license": "MIT",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.3.0.tgz",
+      "integrity": "sha512-WkRBxQbf6k/eS1D/D1mw30Zs253TFeIkWFh8HQ8Z36Kdt79rNVezT9YmRpahUfvYXmubTquV5JftNOAhvbOJXA==",
       "dependencies": {
-        "@miniflare/kv": "2.2.0",
-        "@miniflare/shared": "2.2.0",
-        "@miniflare/storage-file": "2.2.0"
+        "@miniflare/kv": "2.3.0",
+        "@miniflare/shared": "2.3.0",
+        "@miniflare/storage-file": "2.3.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/storage-file": {
-      "version": "2.2.0",
-      "license": "MIT",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.3.0.tgz",
+      "integrity": "sha512-1rda/MC0R8wVC6N7Na2EdSGNAZv6o/yugp7Z+GikJ1vbgi1+9soAczDzFtaq4jrBzAkCFOMT79DgkSKSl59vxg==",
       "dependencies": {
-        "@miniflare/shared": "2.2.0",
-        "@miniflare/storage-memory": "2.2.0"
+        "@miniflare/shared": "2.3.0",
+        "@miniflare/storage-memory": "2.3.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/storage-memory": {
-      "version": "2.2.0",
-      "license": "MIT",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.3.0.tgz",
+      "integrity": "sha512-cMqQK9neRySchoNUVhQYOmLFrYkAjT5V113Wfxmsz93dladQ1/mXOsndqPrlb+5hhnwbw4Ns67nyzkHUe9sX/g==",
       "dependencies": {
-        "@miniflare/shared": "2.2.0"
+        "@miniflare/shared": "2.3.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/watcher": {
-      "version": "2.2.0",
-      "license": "MIT",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.3.0.tgz",
+      "integrity": "sha512-G0ZE9WHIcdR2TlPXwwQabULDIMZ9LujfC0tn+yXmPXKxgWoJWcWFmUbkhVDcOJzkIz2TAhRlLbW11n8nChUHFQ==",
       "dependencies": {
-        "@miniflare/shared": "2.2.0"
+        "@miniflare/shared": "2.3.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/web-sockets": {
-      "version": "2.2.0",
-      "license": "MIT",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.3.0.tgz",
+      "integrity": "sha512-3xcPG1vfiMb2obVC4jNtS5VzUxzM1rdUrWPCG86gpZaHky0xC1U7Tp+eFdxQFTty99HPYrrVKXl1ww2h1LGWRA==",
       "dependencies": {
-        "@miniflare/core": "2.2.0",
-        "@miniflare/shared": "2.2.0",
-        "undici": "4.12.1",
+        "@miniflare/core": "2.3.0",
+        "@miniflare/shared": "2.3.0",
+        "undici": "4.13.0",
         "ws": "^8.2.2"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
-    "node_modules/@miniflare/web-sockets/node_modules/undici": {
-      "version": "4.12.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.18"
-      }
-    },
     "node_modules/@miniflare/web-sockets/node_modules/ws": {
-      "version": "8.4.2",
-      "license": "MIT",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -3054,7 +3030,8 @@
     },
     "node_modules/@types/stack-trace": {
       "version": "0.0.29",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/stack-trace/-/stack-trace-0.0.29.tgz",
+      "integrity": "sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g=="
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -3909,6 +3886,8 @@
     },
     "node_modules/busboy": {
       "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
+      "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
       "dependencies": {
         "dicer": "0.3.0"
       },
@@ -4589,7 +4568,8 @@
     },
     "node_modules/cron-schedule": {
       "version": "3.0.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/cron-schedule/-/cron-schedule-3.0.4.tgz",
+      "integrity": "sha512-wEspID2dNPfWyh7t2ZvE4Izunzk20QacZg8oZcqfTrN1j5kImj0CEYT3ZGZo+KqGQUgRc9tKlEJmY4uFVt4ccA=="
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
@@ -4909,6 +4889,8 @@
     },
     "node_modules/dicer": {
       "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
+      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
       "dependencies": {
         "streamsearch": "0.1.2"
       },
@@ -7240,8 +7222,9 @@
       "license": "MIT"
     },
     "node_modules/html-rewriter-wasm": {
-      "version": "0.4.0",
-      "license": "BSD-3-Clause"
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/html-rewriter-wasm/-/html-rewriter-wasm-0.4.1.tgz",
+      "integrity": "sha512-lNovG8CMCCmcVB1Q7xggMSf7tqPCijZXaH4gL6iE8BFghdQCbaY5Met9i1x2Ex8m/cZHDUtXK9H6/znKamRP8Q=="
     },
     "node_modules/http-cache-semantics": {
       "version": "4.1.0",
@@ -12284,27 +12267,28 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "2.2.0",
-      "license": "MIT",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.3.0.tgz",
+      "integrity": "sha512-0lK4Df+jfqLDSDDgj4AOJffb1G6sN7XvB5QGUaquEakW+qPdurydyNhFKcFKBgpk4ozN6WTmB2x802iPXQcJJQ==",
       "dependencies": {
-        "@miniflare/cache": "2.2.0",
-        "@miniflare/cli-parser": "2.2.0",
-        "@miniflare/core": "2.2.0",
-        "@miniflare/durable-objects": "2.2.0",
-        "@miniflare/html-rewriter": "2.2.0",
-        "@miniflare/http-server": "2.2.0",
-        "@miniflare/kv": "2.2.0",
-        "@miniflare/runner-vm": "2.2.0",
-        "@miniflare/scheduler": "2.2.0",
-        "@miniflare/shared": "2.2.0",
-        "@miniflare/sites": "2.2.0",
-        "@miniflare/storage-file": "2.2.0",
-        "@miniflare/storage-memory": "2.2.0",
-        "@miniflare/web-sockets": "2.2.0",
+        "@miniflare/cache": "2.3.0",
+        "@miniflare/cli-parser": "2.3.0",
+        "@miniflare/core": "2.3.0",
+        "@miniflare/durable-objects": "2.3.0",
+        "@miniflare/html-rewriter": "2.3.0",
+        "@miniflare/http-server": "2.3.0",
+        "@miniflare/kv": "2.3.0",
+        "@miniflare/runner-vm": "2.3.0",
+        "@miniflare/scheduler": "2.3.0",
+        "@miniflare/shared": "2.3.0",
+        "@miniflare/sites": "2.3.0",
+        "@miniflare/storage-file": "2.3.0",
+        "@miniflare/storage-memory": "2.3.0",
+        "@miniflare/web-sockets": "2.3.0",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
-        "undici": "4.12.1"
+        "undici": "4.13.0"
       },
       "bin": {
         "miniflare": "bootstrap.js"
@@ -12313,7 +12297,7 @@
         "node": ">=16.7"
       },
       "peerDependencies": {
-        "@miniflare/storage-redis": "2.2.0",
+        "@miniflare/storage-redis": "2.3.0",
         "cron-schedule": "^3.0.4",
         "ioredis": "^4.27.9"
       },
@@ -12327,13 +12311,6 @@
         "ioredis": {
           "optional": true
         }
-      }
-    },
-    "node_modules/miniflare/node_modules/undici": {
-      "version": "4.12.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.18"
       }
     },
     "node_modules/minimatch": {
@@ -12474,7 +12451,8 @@
     },
     "node_modules/mustache": {
       "version": "4.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
       "bin": {
         "mustache": "bin/mustache"
       }
@@ -12549,7 +12527,8 @@
     },
     "node_modules/node-forge": {
       "version": "1.2.1",
-      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
+      "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==",
       "engines": {
         "node": ">= 6.13.0"
       }
@@ -14321,7 +14300,8 @@
     },
     "node_modules/selfsigned": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.0.0.tgz",
+      "integrity": "sha512-cUdFiCbKoa1mZ6osuJs2uDHrs0k0oprsKveFiiaBKCNq3SYyb5gs2HxhQyDNLCmL51ZZThqi4YNDpCK6GOP1iQ==",
       "dependencies": {
         "node-forge": "^1.2.0"
       },
@@ -14925,7 +14905,8 @@
     },
     "node_modules/stack-trace": {
       "version": "0.0.10",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "engines": {
         "node": "*"
       }
@@ -15052,6 +15033,8 @@
     },
     "node_modules/streamsearch": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -15751,7 +15734,6 @@
     },
     "node_modules/undici": {
       "version": "4.13.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.18"
@@ -16415,7 +16397,8 @@
     },
     "node_modules/youch": {
       "version": "2.2.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-2.2.2.tgz",
+      "integrity": "sha512-/FaCeG3GkuJwaMR34GHVg0l8jCbafZLHiFowSjqLlqhC6OMyf2tPJBu8UirF7/NI9X/R5ai4QfEKUCOxMAGxZQ==",
       "dependencies": {
         "@types/stack-trace": "0.0.29",
         "cookie": "^0.4.1",
@@ -16534,7 +16517,7 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "esbuild": "0.14.14",
-        "miniflare": "2.2.0",
+        "miniflare": "2.3.0",
         "path-to-regexp": "^6.2.0",
         "semiver": "^1.1.0",
         "xxhash-wasm": "^1.0.1"
@@ -18404,165 +18387,177 @@
       }
     },
     "@miniflare/cache": {
-      "version": "2.2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.3.0.tgz",
+      "integrity": "sha512-lOf3WVtrs0ac7KOtsQ+JOGHWR90zsqqJbolE+Wt4hIZuvM2U3t1RD2Ms7U20J301msVIsBAd02IL57H95LXQtQ==",
       "requires": {
-        "@miniflare/core": "2.2.0",
-        "@miniflare/shared": "2.2.0",
+        "@miniflare/core": "2.3.0",
+        "@miniflare/shared": "2.3.0",
         "http-cache-semantics": "^4.1.0",
-        "undici": "4.12.1"
-      },
-      "dependencies": {
-        "undici": {
-          "version": "4.12.1"
-        }
+        "undici": "4.13.0"
       }
     },
     "@miniflare/cli-parser": {
-      "version": "2.2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.3.0.tgz",
+      "integrity": "sha512-yQzU+OBBvWshr9qVxAe6bWXJLNfpmLYrfkfR3u+rPOo2LYnccWg0f/8jtxrXM1TIyu+tCOJGqCODpO//XtrwWw==",
       "requires": {
-        "@miniflare/shared": "2.2.0",
+        "@miniflare/shared": "2.3.0",
         "kleur": "^4.1.4"
       }
     },
     "@miniflare/core": {
-      "version": "2.2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Dltb3p+Uq5Lx53DuInckHYaDoMrBq49HE/p/oUDXmzHmQy7EAM6v+nJGKmiM9Uen4OqyqsmlmPWqntSMjaX7Jg==",
       "requires": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/shared": "2.2.0",
-        "@miniflare/watcher": "2.2.0",
+        "@miniflare/shared": "2.3.0",
+        "@miniflare/watcher": "2.3.0",
         "busboy": "^0.3.1",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
         "set-cookie-parser": "^2.4.8",
-        "undici": "4.12.1"
+        "undici": "4.13.0"
       },
       "dependencies": {
         "dotenv": {
-          "version": "10.0.0"
-        },
-        "undici": {
-          "version": "4.12.1"
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
         }
       }
     },
     "@miniflare/durable-objects": {
-      "version": "2.2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.3.0.tgz",
+      "integrity": "sha512-YuzxBBu9xBU3xxD4TzGdeVVMXrE76AWJE4MIqkJR5UmASqayyv//cApGw3+C01NHe07cpbrTM1QTgFo2eBncwQ==",
       "requires": {
-        "@miniflare/core": "2.2.0",
-        "@miniflare/shared": "2.2.0",
-        "@miniflare/storage-memory": "2.2.0",
-        "undici": "4.12.1"
-      },
-      "dependencies": {
-        "undici": {
-          "version": "4.12.1"
-        }
+        "@miniflare/core": "2.3.0",
+        "@miniflare/shared": "2.3.0",
+        "@miniflare/storage-memory": "2.3.0",
+        "undici": "4.13.0"
       }
     },
     "@miniflare/html-rewriter": {
-      "version": "2.2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.3.0.tgz",
+      "integrity": "sha512-cyWhmQgzhtRlBeg0mxP5FmAq/75ChuLwWQlhokx88XkGnteuh0/DOk3OxIMaveF2oDHKmIlLFgSlzv4NbT1Mng==",
       "requires": {
-        "@miniflare/core": "2.2.0",
-        "@miniflare/shared": "2.2.0",
-        "html-rewriter-wasm": "^0.4.0",
-        "undici": "4.12.1"
-      },
-      "dependencies": {
-        "undici": {
-          "version": "4.12.1"
-        }
+        "@miniflare/core": "2.3.0",
+        "@miniflare/shared": "2.3.0",
+        "html-rewriter-wasm": "^0.4.1",
+        "undici": "4.13.0"
       }
     },
     "@miniflare/http-server": {
-      "version": "2.2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.3.0.tgz",
+      "integrity": "sha512-jTzsRuro3yWVb4T85znBGw1w+ydimgi2PJvHrTuGFKDjFam+R037fGH+HZCAjAgPiBHTroXfkeSXypJLXbQBEg==",
       "requires": {
-        "@miniflare/core": "2.2.0",
-        "@miniflare/shared": "2.2.0",
-        "@miniflare/web-sockets": "2.2.0",
+        "@miniflare/core": "2.3.0",
+        "@miniflare/shared": "2.3.0",
+        "@miniflare/web-sockets": "2.3.0",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
-        "undici": "4.12.1",
+        "undici": "4.13.0",
         "ws": "^8.2.2",
         "youch": "^2.2.2"
       },
       "dependencies": {
-        "undici": {
-          "version": "4.12.1"
-        },
         "ws": {
-          "version": "8.4.2",
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+          "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
           "requires": {}
         }
       }
     },
     "@miniflare/kv": {
-      "version": "2.2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.3.0.tgz",
+      "integrity": "sha512-m0zu5sRoaFDm+WVTnLRrz8+77b6eVxQN7cLN6ZQiKP3Nd8cAggPdaIIef8dVksWbPvOW9DztoUVZTB1v9EOaLA==",
       "requires": {
-        "@miniflare/shared": "2.2.0"
+        "@miniflare/shared": "2.3.0"
       }
     },
     "@miniflare/runner-vm": {
-      "version": "2.2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.3.0.tgz",
+      "integrity": "sha512-/aB997YodNcRFxtlnvEn4BJSIqKXRw29FexOqCWwWv+b7XQkTTxd4IfSocIFi6du3265gp85icqP/hxsLAQBVg==",
       "requires": {
-        "@miniflare/shared": "2.2.0"
+        "@miniflare/shared": "2.3.0"
       }
     },
     "@miniflare/scheduler": {
-      "version": "2.2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.3.0.tgz",
+      "integrity": "sha512-Er80srMNXbxqGbYXtiZkD8UlveHsw4cpwcytQgsEJCHG7/48vC/rpmtN0zKOWFEHifaOUvHhURZRJu+S2E4Stg==",
       "requires": {
-        "@miniflare/core": "2.2.0",
-        "@miniflare/shared": "2.2.0",
+        "@miniflare/core": "2.3.0",
+        "@miniflare/shared": "2.3.0",
         "cron-schedule": "^3.0.4"
       }
     },
     "@miniflare/shared": {
-      "version": "2.2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.3.0.tgz",
+      "integrity": "sha512-TvCSUe1op5AKINx3zHSSdfAbdoV3eSF3MzeVQA4+1NmtuefY8cjujQCdILeAxg3oPbHXaZkc7j1zZ13rYdvwGQ==",
       "requires": {
         "ignore": "^5.1.8",
         "kleur": "^4.1.4"
       }
     },
     "@miniflare/sites": {
-      "version": "2.2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.3.0.tgz",
+      "integrity": "sha512-WkRBxQbf6k/eS1D/D1mw30Zs253TFeIkWFh8HQ8Z36Kdt79rNVezT9YmRpahUfvYXmubTquV5JftNOAhvbOJXA==",
       "requires": {
-        "@miniflare/kv": "2.2.0",
-        "@miniflare/shared": "2.2.0",
-        "@miniflare/storage-file": "2.2.0"
+        "@miniflare/kv": "2.3.0",
+        "@miniflare/shared": "2.3.0",
+        "@miniflare/storage-file": "2.3.0"
       }
     },
     "@miniflare/storage-file": {
-      "version": "2.2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.3.0.tgz",
+      "integrity": "sha512-1rda/MC0R8wVC6N7Na2EdSGNAZv6o/yugp7Z+GikJ1vbgi1+9soAczDzFtaq4jrBzAkCFOMT79DgkSKSl59vxg==",
       "requires": {
-        "@miniflare/shared": "2.2.0",
-        "@miniflare/storage-memory": "2.2.0"
+        "@miniflare/shared": "2.3.0",
+        "@miniflare/storage-memory": "2.3.0"
       }
     },
     "@miniflare/storage-memory": {
-      "version": "2.2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.3.0.tgz",
+      "integrity": "sha512-cMqQK9neRySchoNUVhQYOmLFrYkAjT5V113Wfxmsz93dladQ1/mXOsndqPrlb+5hhnwbw4Ns67nyzkHUe9sX/g==",
       "requires": {
-        "@miniflare/shared": "2.2.0"
+        "@miniflare/shared": "2.3.0"
       }
     },
     "@miniflare/watcher": {
-      "version": "2.2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.3.0.tgz",
+      "integrity": "sha512-G0ZE9WHIcdR2TlPXwwQabULDIMZ9LujfC0tn+yXmPXKxgWoJWcWFmUbkhVDcOJzkIz2TAhRlLbW11n8nChUHFQ==",
       "requires": {
-        "@miniflare/shared": "2.2.0"
+        "@miniflare/shared": "2.3.0"
       }
     },
     "@miniflare/web-sockets": {
-      "version": "2.2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.3.0.tgz",
+      "integrity": "sha512-3xcPG1vfiMb2obVC4jNtS5VzUxzM1rdUrWPCG86gpZaHky0xC1U7Tp+eFdxQFTty99HPYrrVKXl1ww2h1LGWRA==",
       "requires": {
-        "@miniflare/core": "2.2.0",
-        "@miniflare/shared": "2.2.0",
-        "undici": "4.12.1",
+        "@miniflare/core": "2.3.0",
+        "@miniflare/shared": "2.3.0",
+        "undici": "4.13.0",
         "ws": "^8.2.2"
       },
       "dependencies": {
-        "undici": {
-          "version": "4.12.1"
-        },
         "ws": {
-          "version": "8.4.2",
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+          "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
           "requires": {}
         }
       }
@@ -18973,7 +18968,9 @@
       "dev": true
     },
     "@types/stack-trace": {
-      "version": "0.0.29"
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/stack-trace/-/stack-trace-0.0.29.tgz",
+      "integrity": "sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g=="
     },
     "@types/stack-utils": {
       "version": "2.0.1"
@@ -19448,6 +19445,8 @@
     },
     "busboy": {
       "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
+      "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
       "requires": {
         "dicer": "0.3.0"
       }
@@ -19863,7 +19862,9 @@
       "version": "file:packages/create-workers-app"
     },
     "cron-schedule": {
-      "version": "3.0.4"
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/cron-schedule/-/cron-schedule-3.0.4.tgz",
+      "integrity": "sha512-wEspID2dNPfWyh7t2ZvE4Izunzk20QacZg8oZcqfTrN1j5kImj0CEYT3ZGZo+KqGQUgRc9tKlEJmY4uFVt4ccA=="
     },
     "cross-env": {
       "version": "7.0.3",
@@ -20056,6 +20057,8 @@
     },
     "dicer": {
       "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
+      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
       "requires": {
         "streamsearch": "0.1.2"
       }
@@ -21457,7 +21460,9 @@
       "version": "2.0.2"
     },
     "html-rewriter-wasm": {
-      "version": "0.4.0"
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/html-rewriter-wasm/-/html-rewriter-wasm-0.4.1.tgz",
+      "integrity": "sha512-lNovG8CMCCmcVB1Q7xggMSf7tqPCijZXaH4gL6iE8BFghdQCbaY5Met9i1x2Ex8m/cZHDUtXK9H6/znKamRP8Q=="
     },
     "http-cache-semantics": {
       "version": "4.1.0"
@@ -24536,31 +24541,28 @@
       "version": "1.0.1"
     },
     "miniflare": {
-      "version": "2.2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.3.0.tgz",
+      "integrity": "sha512-0lK4Df+jfqLDSDDgj4AOJffb1G6sN7XvB5QGUaquEakW+qPdurydyNhFKcFKBgpk4ozN6WTmB2x802iPXQcJJQ==",
       "requires": {
-        "@miniflare/cache": "2.2.0",
-        "@miniflare/cli-parser": "2.2.0",
-        "@miniflare/core": "2.2.0",
-        "@miniflare/durable-objects": "2.2.0",
-        "@miniflare/html-rewriter": "2.2.0",
-        "@miniflare/http-server": "2.2.0",
-        "@miniflare/kv": "2.2.0",
-        "@miniflare/runner-vm": "2.2.0",
-        "@miniflare/scheduler": "2.2.0",
-        "@miniflare/shared": "2.2.0",
-        "@miniflare/sites": "2.2.0",
-        "@miniflare/storage-file": "2.2.0",
-        "@miniflare/storage-memory": "2.2.0",
-        "@miniflare/web-sockets": "2.2.0",
+        "@miniflare/cache": "2.3.0",
+        "@miniflare/cli-parser": "2.3.0",
+        "@miniflare/core": "2.3.0",
+        "@miniflare/durable-objects": "2.3.0",
+        "@miniflare/html-rewriter": "2.3.0",
+        "@miniflare/http-server": "2.3.0",
+        "@miniflare/kv": "2.3.0",
+        "@miniflare/runner-vm": "2.3.0",
+        "@miniflare/scheduler": "2.3.0",
+        "@miniflare/shared": "2.3.0",
+        "@miniflare/sites": "2.3.0",
+        "@miniflare/storage-file": "2.3.0",
+        "@miniflare/storage-memory": "2.3.0",
+        "@miniflare/web-sockets": "2.3.0",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
-        "undici": "4.12.1"
-      },
-      "dependencies": {
-        "undici": {
-          "version": "4.12.1"
-        }
+        "undici": "4.13.0"
       }
     },
     "minimatch": {
@@ -24647,7 +24649,9 @@
       "version": "2.1.2"
     },
     "mustache": {
-      "version": "4.2.0"
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -24698,7 +24702,9 @@
       }
     },
     "node-forge": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
+      "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w=="
     },
     "node-int64": {
       "version": "0.4.0"
@@ -25824,6 +25830,8 @@
     },
     "selfsigned": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.0.0.tgz",
+      "integrity": "sha512-cUdFiCbKoa1mZ6osuJs2uDHrs0k0oprsKveFiiaBKCNq3SYyb5gs2HxhQyDNLCmL51ZZThqi4YNDpCK6GOP1iQ==",
       "requires": {
         "node-forge": "^1.2.0"
       }
@@ -26247,7 +26255,9 @@
       }
     },
     "stack-trace": {
-      "version": "0.0.10"
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "stack-utils": {
       "version": "2.0.5",
@@ -26331,7 +26341,9 @@
       }
     },
     "streamsearch": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
     "string_decoder": {
       "version": "1.1.1",
@@ -26763,8 +26775,7 @@
       }
     },
     "undici": {
-      "version": "4.13.0",
-      "dev": true
+      "version": "4.13.0"
     },
     "unified": {
       "version": "10.1.1",
@@ -27093,7 +27104,7 @@
         "ink-text-input": "^4.0.2",
         "jest-fetch-mock": "^3.0.3",
         "mime": "^3.0.0",
-        "miniflare": "2.2.0",
+        "miniflare": "2.3.0",
         "open": "^8.4.0",
         "path-to-regexp": "^6.2.0",
         "react": "^17.0.2",
@@ -27409,6 +27420,8 @@
     },
     "youch": {
       "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-2.2.2.tgz",
+      "integrity": "sha512-/FaCeG3GkuJwaMR34GHVg0l8jCbafZLHiFowSjqLlqhC6OMyf2tPJBu8UirF7/NI9X/R5ai4QfEKUCOxMAGxZQ==",
       "requires": {
         "@types/stack-trace": "0.0.29",
         "cookie": "^0.4.1",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -37,7 +37,7 @@
   ],
   "dependencies": {
     "esbuild": "0.14.14",
-    "miniflare": "2.2.0",
+    "miniflare": "2.3.0",
     "path-to-regexp": "^6.2.0",
     "semiver": "^1.1.0",
     "xxhash-wasm": "^1.0.1"


### PR DESCRIPTION
Hey! 👋 This PR upgrades `miniflare` to version `2.3.0`. See the [full changelog here](https://github.com/cloudflare/miniflare/releases/tag/v2.3.0). Closes https://github.com/cloudflare/wrangler2/issues/394.