### PR TITLE
feat: support for raw "unsafe bindings"

### DIFF
--- a/.changeset/healthy-cooks-perform.md
+++ b/.changeset/healthy-cooks-perform.md
@@ -1,0 +1,10 @@
+---
+"wrangler": patch
+---
+
+feat: unsafe-bindings
+
+Adds support for "unsafe bindings", that is, bindings that aren't supported by wrangler, but are
+desired when uploading a Worker to Cloudflare. This allows you to use beta features before
+official support is added to wrangler, while also letting you migrate to proper support for the
+feature when desired. Note: these bindings may not work everywhere, and may break at any time.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,5 +28,6 @@
     "xxhash"
   ],
   "cSpell.ignoreWords": ["yxxx"],
-  "eslint.runtime": "node"
+  "eslint.runtime": "node",
+  "files.trimTrailingWhitespace": false
 }

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -32,15 +32,15 @@ describe("publish", () => {
       await runWrangler("publish ./index");
 
       expect(std.out).toMatchInlineSnapshot(`
-              "Uploaded
-              test-name
-              (TIMINGS)
-              Deployed
-              test-name
-              (TIMINGS)
-               
-              test-name.test-sub-domain.workers.dev"
-          `);
+        "Uploaded
+        test-name
+        (TIMINGS)
+        Deployed
+        test-name
+        (TIMINGS)
+         
+        test-name.test-sub-domain.workers.dev"
+      `);
       expect(std.err).toMatchInlineSnapshot(`""`);
     });
 
@@ -53,15 +53,15 @@ describe("publish", () => {
       await runWrangler("publish ./index");
 
       expect(std.out).toMatchInlineSnapshot(`
-              "Uploaded
-              test-name
-              (TIMINGS)
-              Deployed
-              test-name
-              (TIMINGS)
-               
-              test-name.test-sub-domain.workers.dev"
-          `);
+        "Uploaded
+        test-name
+        (TIMINGS)
+        Deployed
+        test-name
+        (TIMINGS)
+         
+        test-name.test-sub-domain.workers.dev"
+      `);
       expect(std.err).toMatchInlineSnapshot(`""`);
     });
 
@@ -74,15 +74,15 @@ describe("publish", () => {
       await runWrangler("publish");
 
       expect(std.out).toMatchInlineSnapshot(`
-              "Uploaded
-              test-name
-              (TIMINGS)
-              Deployed
-              test-name
-              (TIMINGS)
-               
-              test-name.test-sub-domain.workers.dev"
-          `);
+        "Uploaded
+        test-name
+        (TIMINGS)
+        Deployed
+        test-name
+        (TIMINGS)
+         
+        test-name.test-sub-domain.workers.dev"
+      `);
       expect(std.err).toMatchInlineSnapshot(`""`);
     });
 
@@ -150,15 +150,15 @@ describe("publish", () => {
       await runWrangler("publish index.ts");
 
       expect(std.out).toMatchInlineSnapshot(`
-              "Uploaded
-              test-name
-              (TIMINGS)
-              Deployed
-              test-name
-              (TIMINGS)
-               
-              test-name.test-sub-domain.workers.dev"
-          `);
+        "Uploaded
+        test-name
+        (TIMINGS)
+        Deployed
+        test-name
+        (TIMINGS)
+         
+        test-name.test-sub-domain.workers.dev"
+      `);
       expect(std.err).toMatchInlineSnapshot(`""`);
     });
 
@@ -173,15 +173,15 @@ describe("publish", () => {
       await runWrangler("publish index.ts");
 
       expect(std.out).toMatchInlineSnapshot(`
-              "Uploaded
-              test-name
-              (TIMINGS)
-              Deployed
-              test-name
-              (TIMINGS)
-               
-              test-name.test-sub-domain.workers.dev"
-          `);
+        "Uploaded
+        test-name
+        (TIMINGS)
+        Deployed
+        test-name
+        (TIMINGS)
+         
+        test-name.test-sub-domain.workers.dev"
+      `);
       expect(std.err).toMatchInlineSnapshot(`""`);
     });
 
@@ -224,15 +224,15 @@ export default{
       await runWrangler("publish ./src/index.js");
 
       expect(std.out).toMatchInlineSnapshot(`
-              "Uploaded
-              test-name
-              (TIMINGS)
-              Deployed
-              test-name
-              (TIMINGS)
-               
-              test-name.test-sub-domain.workers.dev"
-          `);
+        "Uploaded
+        test-name
+        (TIMINGS)
+        Deployed
+        test-name
+        (TIMINGS)
+         
+        test-name.test-sub-domain.workers.dev"
+      `);
       expect(std.err).toMatchInlineSnapshot(`""`);
     });
 
@@ -248,15 +248,15 @@ export default{
       await runWrangler("publish ./src/index.js");
 
       expect(std.out).toMatchInlineSnapshot(`
-              "Uploaded
-              test-name
-              (TIMINGS)
-              Deployed
-              test-name
-              (TIMINGS)
-               
-              test-name.test-sub-domain.workers.dev"
-          `);
+        "Uploaded
+        test-name
+        (TIMINGS)
+        Deployed
+        test-name
+        (TIMINGS)
+         
+        test-name.test-sub-domain.workers.dev"
+      `);
       expect(std.err).toMatchInlineSnapshot(`""`);
     });
 
@@ -634,17 +634,17 @@ export default{
       await runWrangler("publish --site-include file-1.txt");
 
       expect(std.out).toMatchInlineSnapshot(`
-              "reading assets/file-1.txt...
-              uploading as assets/file-1.2ca234f380.txt...
-              Uploaded
-              test-name
-              (TIMINGS)
-              Deployed
-              test-name
-              (TIMINGS)
-               
-              test-name.test-sub-domain.workers.dev"
-          `);
+        "reading assets/file-1.txt...
+        uploading as assets/file-1.2ca234f380.txt...
+        Uploaded
+        test-name
+        (TIMINGS)
+        Deployed
+        test-name
+        (TIMINGS)
+         
+        test-name.test-sub-domain.workers.dev"
+      `);
       expect(std.err).toMatchInlineSnapshot(`""`);
     });
 
@@ -677,17 +677,17 @@ export default{
       await runWrangler("publish --site-exclude file-2.txt");
 
       expect(std.out).toMatchInlineSnapshot(`
-              "reading assets/file-1.txt...
-              uploading as assets/file-1.2ca234f380.txt...
-              Uploaded
-              test-name
-              (TIMINGS)
-              Deployed
-              test-name
-              (TIMINGS)
-               
-              test-name.test-sub-domain.workers.dev"
-          `);
+        "reading assets/file-1.txt...
+        uploading as assets/file-1.2ca234f380.txt...
+        Uploaded
+        test-name
+        (TIMINGS)
+        Deployed
+        test-name
+        (TIMINGS)
+         
+        test-name.test-sub-domain.workers.dev"
+      `);
       expect(std.err).toMatchInlineSnapshot(`""`);
     });
 
@@ -721,17 +721,17 @@ export default{
       await runWrangler("publish");
 
       expect(std.out).toMatchInlineSnapshot(`
-              "reading assets/file-1.txt...
-              uploading as assets/file-1.2ca234f380.txt...
-              Uploaded
-              test-name
-              (TIMINGS)
-              Deployed
-              test-name
-              (TIMINGS)
-               
-              test-name.test-sub-domain.workers.dev"
-          `);
+        "reading assets/file-1.txt...
+        uploading as assets/file-1.2ca234f380.txt...
+        Uploaded
+        test-name
+        (TIMINGS)
+        Deployed
+        test-name
+        (TIMINGS)
+         
+        test-name.test-sub-domain.workers.dev"
+      `);
       expect(std.err).toMatchInlineSnapshot(`""`);
     });
 
@@ -765,17 +765,17 @@ export default{
       await runWrangler("publish");
 
       expect(std.out).toMatchInlineSnapshot(`
-              "reading assets/file-1.txt...
-              uploading as assets/file-1.2ca234f380.txt...
-              Uploaded
-              test-name
-              (TIMINGS)
-              Deployed
-              test-name
-              (TIMINGS)
-               
-              test-name.test-sub-domain.workers.dev"
-          `);
+        "reading assets/file-1.txt...
+        uploading as assets/file-1.2ca234f380.txt...
+        Uploaded
+        test-name
+        (TIMINGS)
+        Deployed
+        test-name
+        (TIMINGS)
+         
+        test-name.test-sub-domain.workers.dev"
+      `);
       expect(std.err).toMatchInlineSnapshot(`""`);
     });
 
@@ -809,17 +809,17 @@ export default{
       await runWrangler("publish --site-include file-1.txt");
 
       expect(std.out).toMatchInlineSnapshot(`
-              "reading assets/file-1.txt...
-              uploading as assets/file-1.2ca234f380.txt...
-              Uploaded
-              test-name
-              (TIMINGS)
-              Deployed
-              test-name
-              (TIMINGS)
-               
-              test-name.test-sub-domain.workers.dev"
-          `);
+        "reading assets/file-1.txt...
+        uploading as assets/file-1.2ca234f380.txt...
+        Uploaded
+        test-name
+        (TIMINGS)
+        Deployed
+        test-name
+        (TIMINGS)
+         
+        test-name.test-sub-domain.workers.dev"
+      `);
       expect(std.err).toMatchInlineSnapshot(`""`);
     });
 
@@ -853,17 +853,17 @@ export default{
       await runWrangler("publish --site-exclude file-2.txt");
 
       expect(std.out).toMatchInlineSnapshot(`
-              "reading assets/file-1.txt...
-              uploading as assets/file-1.2ca234f380.txt...
-              Uploaded
-              test-name
-              (TIMINGS)
-              Deployed
-              test-name
-              (TIMINGS)
-               
-              test-name.test-sub-domain.workers.dev"
-          `);
+        "reading assets/file-1.txt...
+        uploading as assets/file-1.2ca234f380.txt...
+        Uploaded
+        test-name
+        (TIMINGS)
+        Deployed
+        test-name
+        (TIMINGS)
+         
+        test-name.test-sub-domain.workers.dev"
+      `);
       expect(std.err).toMatchInlineSnapshot(`""`);
     });
 
@@ -1212,6 +1212,90 @@ export default{
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
       expect(std.warn).toMatchInlineSnapshot(`""`);
+    });
+  });
+
+  describe("unsafe bindings", () => {
+    it("should warn if using unsafe bindings", async () => {
+      writeWranglerToml({
+        unsafe: {
+          bindings: [
+            {
+              name: "my-binding",
+              type: "binding-type",
+              param: "binding-param",
+            },
+          ],
+        },
+      });
+      writeWorkerSource();
+      mockSubDomainRequest();
+      mockUploadWorkerRequest({
+        expectedBindings: [
+          {
+            name: "my-binding",
+            type: "binding-type",
+            param: "binding-param",
+          },
+        ],
+      });
+
+      await runWrangler("publish index.js");
+      expect(std.out).toMatchInlineSnapshot(`
+        "Uploaded
+        test-name
+        (TIMINGS)
+        Deployed
+        test-name
+        (TIMINGS)
+         
+        test-name.test-sub-domain.workers.dev"
+      `);
+      expect(std.err).toMatchInlineSnapshot(`""`);
+      expect(std.warn).toMatchInlineSnapshot(
+        `"'unsafe' fields are experimental and may change or break at any time."`
+      );
+    });
+    it("should warn if using unsafe bindings already handled by wrangler", async () => {
+      writeWranglerToml({
+        unsafe: {
+          bindings: [
+            {
+              name: "my-binding",
+              type: "plain_text",
+              text: "text",
+            },
+          ],
+        },
+      });
+      writeWorkerSource();
+      mockSubDomainRequest();
+      mockUploadWorkerRequest({
+        expectedBindings: [
+          {
+            name: "my-binding",
+            type: "plain_text",
+            text: "text",
+          },
+        ],
+      });
+
+      await runWrangler("publish index.js");
+      expect(std.out).toMatchInlineSnapshot(`
+        "Uploaded
+        test-name
+        (TIMINGS)
+        Deployed
+        test-name
+        (TIMINGS)
+         
+        test-name.test-sub-domain.workers.dev"
+      `);
+      expect(std.err).toMatchInlineSnapshot(`""`);
+      expect(std.warn).toMatchInlineSnapshot(`
+        "'unsafe' fields are experimental and may change or break at any time.
+        Raw 'plain_text' bindings are not directly supported by wrangler. Consider migrating to a format for 'plain_text' bindings that is supported by wrangler for optimal support: https://developers.cloudflare.com/workers/cli-wrangler/configuration"
+      `);
     });
   });
 });

--- a/packages/wrangler/src/api/form_data.ts
+++ b/packages/wrangler/src/api/form_data.ts
@@ -122,6 +122,11 @@ export function toFormData(worker: CfWorkerInit): FormData {
     });
   });
 
+  if (bindings.unsafe) {
+    // @ts-expect-error unsafe bindings don't need to match a specific type here
+    metadataBindings.push(...bindings.unsafe);
+  }
+
   const metadata: WorkerMetadata = {
     ...(main.type !== "commonjs"
       ? { main_module: main.name }

--- a/packages/wrangler/src/api/worker.ts
+++ b/packages/wrangler/src/api/worker.ts
@@ -108,6 +108,11 @@ interface CfService {
   environment: string;
 }
 
+interface CfUnsafeBinding {
+  name: string;
+  type: string;
+}
+
 export interface CfDurableObjectMigrations {
   old_tag?: string;
   new_tag: string;
@@ -143,6 +148,7 @@ export interface CfWorkerInit {
     wasm_modules?: CfWasmModuleBindings;
     durable_objects?: { bindings: CfDurableObject[] };
     services?: CfService[];
+    unsafe?: CfUnsafeBinding[];
   };
   migrations: undefined | CfDurableObjectMigrations;
   compatibility_date: string | undefined;

--- a/packages/wrangler/src/config.ts
+++ b/packages/wrangler/src/config.ts
@@ -232,6 +232,28 @@ export type Config = {
   };
 
   /**
+   * "Unsafe" tables for features that aren't directly supported by wrangler.
+   * NB: these are not inherited, and HAVE to be duplicated across all environments.
+   *
+   * @default `[]`
+   * @optional
+   * @inherited false
+   */
+  unsafe?: {
+    /**
+     * A set of bindings that should be put into a Worker's upload metadata without changes. These
+     * can be used to implement bindings for features that haven't released and aren't supported
+     * directly by wrangler or miniflare.
+     */
+    bindings?: {
+      name: string;
+      type: string;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      [key: string]: any;
+    }[];
+  };
+
+  /**
    * A list of migrations that should be uploaded with your Worker.
    * These define changes in your Durable Object declarations.
    * More details at https://developers.cloudflare.com/workers/learning/using-durable-objects#configuring-durable-object-classes-with-migrations

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -255,6 +255,7 @@ export default async function publish(props: Props): Promise<void> {
       wasm_modules: config.wasm_modules,
       durable_objects: envRootObj.durable_objects,
       services: envRootObj.experimental_services,
+      unsafe: envRootObj.unsafe?.bindings,
     };
 
     const workerType = bundle.type === "esm" ? "esm" : "commonjs";


### PR DESCRIPTION
Implements support for raw bindings as described in #358 

Raw bindings can be defined in the `unsafe.bindings` table array in wrangler.toml as -

[[unsafe.bindings]]
name = "my-binding"
type = "binding-type"

The TOML table will then be directly inserted into the metadata upload for a Worker in JSON format as though it were a binding made by wrangler itself. Note, these bindings cannot be detected by tools like miniflare, so support for specific binding types is sparse and limited.