### PR TITLE
refactor: use esbuild's message formatting for cleaner error messages

### DIFF
--- a/.changeset/poor-beers-deny.md
+++ b/.changeset/poor-beers-deny.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+refactor: use esbuild's message formatting for cleaner error messages
+
+This is the first step in making a standard format for error messages. For now, this uses esbuild's error formatting, which is nice and colored, but we could decide to customize our own later. Moreover, we should use the `parseJSON`, `parseTOML`, and `readFile` utilities so there are pretty errors for any configuration.

--- a/packages/wrangler/src/__tests__/parse.test.ts
+++ b/packages/wrangler/src/__tests__/parse.test.ts
@@ -12,6 +12,7 @@ describe("formatMessage", () => {
     // No color and skip emojis at the start.
     return formatMessage(input, false).substring(2);
   };
+
   it("should format message without location", () => {
     expect(
       format({
@@ -24,6 +25,7 @@ describe("formatMessage", () => {
       "
     `);
   });
+
   it("should format message with location", () => {
     expect(
       format({
@@ -46,6 +48,7 @@ describe("formatMessage", () => {
       "
     `);
   });
+
   it("should format message with location and notes", () => {
     expect(
       format({
@@ -84,6 +87,7 @@ describe("parseTOML", () => {
   it("should parse toml that is empty", () => {
     expect(parseTOML("")).toStrictEqual({});
   });
+
   it("should parse toml with basic values", () => {
     expect(
       parseTOML(`
@@ -95,6 +99,7 @@ describe("parseTOML", () => {
       version: 1,
     });
   });
+
   it("should parse toml with complex values", () => {
     expect(
       parseTOML(`
@@ -118,6 +123,7 @@ describe("parseTOML", () => {
       version: 1,
     });
   });
+
   it("should fail to parse toml with invalid string", () => {
     try {
       parseTOML(`name = 'fail"`);
@@ -138,6 +144,7 @@ describe("parseTOML", () => {
       });
     }
   });
+
   it("should fail to parse toml with invalid header", () => {
     try {
       parseTOML(`\n[name`, "config.toml");
@@ -164,6 +171,7 @@ describe("parseJSON", () => {
   it("should parse json that is empty", () => {
     expect(parseJSON("{}")).toStrictEqual({});
   });
+
   it("should parse json with basic values", () => {
     expect(
       parseJSON(`
@@ -176,6 +184,7 @@ describe("parseJSON", () => {
       version: 1,
     });
   });
+
   it("should parse json with complex values", () => {
     expect(
       parseJSON(
@@ -195,6 +204,7 @@ describe("parseJSON", () => {
       },
     });
   });
+
   it("should fail to parse json with invalid string", () => {
     try {
       parseJSON(`\n{\n"version" "1\n}\n`);
@@ -215,6 +225,7 @@ describe("parseJSON", () => {
       });
     }
   });
+
   it("should fail to parse json with invalid number", () => {
     const file = "config.json",
       fileText = `{\n\t"a":{\n\t\t"b":{\n\t\t\t"c":[012345]\n}\n}\n}`;
@@ -249,6 +260,7 @@ describe("indexLocation", () => {
       lineText: "",
     });
   });
+
   it("should calculate location from multi-line input", () => {
     const file = "package.json",
       fileText = `\n{\n\t"hello":"world"\n}\n`;
@@ -260,6 +272,7 @@ describe("indexLocation", () => {
       lineText: `\t"hello":"world"`,
     });
   });
+
   it("should calculate location when index is out of bounds", () => {
     const fileText = `\n\n\n\n`;
     expect(indexLocation({ fileText }, 10)).toStrictEqual({
@@ -284,6 +297,7 @@ describe("searchLocation", () => {
       lineText: `name = 'coolthing'`,
     });
   });
+
   it("should calculate location from multi-line match", () => {
     const fileText = `\n{"versions":[\n\t"1.2.3",\n\t"1.2.4",\n\t"1.2.5"\n]}\n`;
     expect(searchLocation({ fileText }, "1.2.4")).toStrictEqual({
@@ -294,6 +308,7 @@ describe("searchLocation", () => {
       lineText: `\t"1.2.4",`,
     });
   });
+
   it("should calculate location from no match", () => {
     const fileText = `\n{}\n`;
     expect(searchLocation({ fileText }, "apple")).toStrictEqual({

--- a/packages/wrangler/src/__tests__/parse.test.ts
+++ b/packages/wrangler/src/__tests__/parse.test.ts
@@ -1,0 +1,272 @@
+import {
+  formatMessage,
+  searchLocation,
+  indexLocation,
+  parseJSON,
+  parseTOML,
+} from "../parse";
+
+describe("formatMessage", () => {
+  test.each([
+    {
+      title: "should format message without location",
+      message: {
+        text: "Invalid argument",
+      },
+      output:
+        "\x1B[31m✘ \x1B[41;31m[\x1B[41;97mERROR\x1B[41;31m]\x1B[0m \x1B[1mInvalid argument\x1B[0m\n\n",
+    },
+    {
+      title: "should format message with location",
+      message: {
+        text: "Missing property: main",
+        location: {
+          file: "package.json",
+          line: 1,
+          column: 0,
+          lineText: "{}",
+        },
+      },
+      output:
+        "\x1B[31m✘ \x1B[41;31m[\x1B[41;97mERROR\x1B[41;31m]\x1B[0m \x1B[1mMissing property: main\x1B[0m\n" +
+        "\n    package.json:1:0:\n\x1B[37m      1 │ \x1B[32m\x1B[37m{}\n        ╵ \x1B[32m^\x1B[0m\n\n",
+    },
+    {
+      title: "should format message with location and notes",
+      message: {
+        text: "Invalid property: type",
+        location: {
+          file: "package.toml",
+          line: 3,
+          column: 8,
+          length: 7,
+          lineText: "type = 'modular'",
+          suggestion: "Did you mean 'module'?",
+        },
+        notes: [
+          {
+            text: "There are two acceptable types: 'module' and 'commonjs'",
+          },
+        ],
+      },
+      output:
+        "\x1B[31m✘ \x1B[41;31m[\x1B[41;97mERROR\x1B[41;31m]\x1B[0m \x1B[1mInvalid property: type\x1B[0m\n" +
+        "\n    package.toml:3:8:\n\x1B[37m      3 │ type = '\x1B[32mmodular\x1B[37m'\n        │         " +
+        "\x1B[32m~~~~~~~\x1B[37m\n        ╵         \x1B[32mDid you mean 'module'?\x1B[0m\n\n  " +
+        "There are two acceptable types: 'module' and 'commonjs'\n\n",
+    },
+  ])("$title", ({ message, output }) => {
+    expect(formatMessage(message)).toBe(output);
+  });
+});
+
+describe("parseTOML", () => {
+  test.each([
+    {
+      title: "should parse toml that is empty",
+      toml: "",
+      json: {},
+    },
+    {
+      title: "should parse toml with basic values",
+      toml: "name = 'basic'\nversion = 1",
+      json: {
+        name: "basic",
+        version: 1,
+      },
+    },
+    {
+      title: "should parse toml with complex values",
+      toml: "name = 'complex'\n\tversion = 2\n[owner]\nname = ['tim']\nalive = true\n[owner.dog]\nexists = true",
+      json: {
+        name: "complex",
+        version: 2,
+        owner: {
+          name: ["tim"],
+          alive: true,
+          dog: {
+            exists: true,
+          },
+        },
+      },
+    },
+  ])("$title", ({ toml, json }) => {
+    expect(parseTOML(toml)).toStrictEqual(json);
+  });
+  test.each([
+    {
+      title: "should fail to parse toml with invalid string",
+      toml: "\n\n\tname = 'fail",
+      error: {
+        text: "Unterminated string",
+        location: {
+          file: "config.toml",
+          lineText: "\tname = 'fail",
+          line: 3,
+          column: 12,
+        },
+      },
+    },
+    {
+      title: "should fail to parse toml with invalid header",
+      toml: "[name",
+      error: {
+        text: "Key ended without value",
+        location: {
+          file: "config.toml",
+          lineText: "[name",
+          line: 1,
+          column: 5,
+        },
+      },
+    },
+  ])("$title", async ({ toml, error }) => {
+    await expect(async () =>
+      parseTOML(toml, "config.toml")
+    ).rejects.toMatchObject({
+      detail: error,
+    });
+  });
+});
+
+describe("parseJSON", () => {
+  test.each([
+    {
+      title: "should parse json that is empty",
+      text: "{}",
+      json: {},
+    },
+    {
+      title: "should parse json with basic values",
+      text: `{\n"name" : "basic",\n"version": 1\n}`,
+      json: {
+        name: "basic",
+        version: 1,
+      },
+    },
+    {
+      title: "should parse json with complex values",
+      text: `{\n\t"name":"complex",\n\t"spec":{\n\t\t"uptime":[1,2.5,3],\n\t\t"ok":true\n\t}\n}`,
+      json: {
+        name: "complex",
+        spec: {
+          uptime: [1, 2.5, 3],
+          ok: true,
+        },
+      },
+    },
+  ])("$title", ({ text, json }) => {
+    expect(parseJSON(text)).toStrictEqual(json);
+  });
+  test.each([
+    {
+      title: "should fail to parse json with invalid string",
+      json: `\n{\n"version" "1\n}\n`,
+      error: {
+        text: "Unexpected string",
+        location: {
+          file: "config.json",
+          lineText: `"version" "1`,
+          line: 3,
+          column: 9,
+        },
+      },
+    },
+    {
+      title: "should fail to parse json with invalid number",
+      json: `{\n\t"a":{\n\t\t"b":{\n\t\t\t"c":[012345]\n}\n}\n}`,
+      error: {
+        text: "Unexpected number",
+        location: {
+          file: "config.json",
+          lineText: `\t\t\t"c":[012345]`,
+          line: 4,
+          column: 8,
+        },
+      },
+    },
+  ])("$title", async ({ json, error }) => {
+    await expect(async () =>
+      parseJSON(json, "config.json")
+    ).rejects.toMatchObject({
+      detail: error,
+    });
+  });
+});
+
+describe("indexLocation", () => {
+  test.each([
+    {
+      title: "should calculate location from one-line input",
+      input: "",
+      index: 1,
+      location: {
+        line: 1,
+        column: 0,
+        lineText: "",
+      },
+    },
+    {
+      title: "should calculate location from multi-line input",
+      input: `\n{\n\t"hello":"world"\n}\n`,
+      index: 11,
+      location: {
+        line: 3,
+        column: 7,
+        lineText: `\t"hello":"world"`,
+      },
+    },
+    {
+      title: "should calculate location when index is out of bounds",
+      input: "\n\n\n\n",
+      index: 10,
+      location: {
+        line: 5,
+        column: 0,
+        lineText: undefined,
+      },
+    },
+  ])("$title", ({ input, index, location }) => {
+    expect(indexLocation(input, index)).toStrictEqual(location);
+  });
+});
+
+describe("searchLocation", () => {
+  test.each([
+    {
+      title: "should calculate location from one-line match",
+      input: "name = 'coolthing'",
+      search: "coolthing",
+      location: {
+        line: 1,
+        column: 8,
+        length: 9,
+        lineText: "name = 'coolthing'",
+      },
+    },
+    {
+      title: "should calculate location from multi-line match",
+      input: `\n{"versions":[\n\t"1.2.3",\n\t"1.2.4",\n\t"1.2.5"\n]}\n`,
+      search: "1.2.4",
+      location: {
+        line: 4,
+        column: 2,
+        length: 5,
+        lineText: `\t"1.2.4",`,
+      },
+    },
+    {
+      title: "should calculate location from no match",
+      input: "\n{}\n",
+      search: "apple",
+      location: {
+        line: 3,
+        column: 0,
+        length: undefined,
+        lineText: undefined,
+      },
+    },
+  ])("$title", ({ input, search, location }) => {
+    expect(searchLocation(input, search)).toStrictEqual(location);
+  });
+});

--- a/packages/wrangler/src/cfetch/index.ts
+++ b/packages/wrangler/src/cfetch/index.ts
@@ -1,4 +1,5 @@
 import { URLSearchParams } from "node:url";
+import { ParseError } from "../parse";
 import { fetchInternal } from "./internal";
 import type { RequestInit } from "undici";
 
@@ -81,11 +82,12 @@ function throwFetchError(
   resource: string,
   response: FetchResult<unknown>
 ): never {
-  response.messages.forEach((message) => console.warn(message));
-  const errors = response.errors
-    .map((error) => `- ${error.code}: ${error.message}`)
-    .join("\n");
-  const error = new Error(`Failed to fetch ${resource}:\n${errors}`);
+  const error = new ParseError({
+    text: "Received a bad response from the API",
+    notes: response.errors.map((err) => ({
+      text: err.code ? `${err.message} [code: ${err.code}]` : err.message,
+    })),
+  });
   // add the first error code directly to this error
   // so consumers can use it for specific behaviour
   const code = response.errors[0]?.code;

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -218,7 +218,6 @@ main = "${path.join(
       // fail silently, usually means require.resolve threw MODULE_NOT_FOUND
     }
     if (fileExists === false) {
-      // TODO(soon): use `readFile` instead.
       throw new Error(`Could not resolve "${file}".`);
     }
   }

--- a/packages/wrangler/src/parse.ts
+++ b/packages/wrangler/src/parse.ts
@@ -1,0 +1,178 @@
+import { readFile as readFile_ } from "node:fs/promises";
+import TOML from "@iarna/toml";
+import { formatMessagesSync } from "esbuild";
+import type { PartialMessage, Location } from "esbuild";
+
+/**
+ * Formats a message using esbuild's pretty-print algorithm.
+ */
+export function formatMessage(
+  message: PartialMessage,
+  kind: "warning" | "error" = "error",
+  label?: string
+): string {
+  const lines = formatMessagesSync([message], {
+    color: true,
+    kind: kind,
+    terminalWidth: process.stderr.columns,
+  });
+  if (label) {
+    lines[0] = lines[0].replace(
+      kind.toUpperCase(),
+      `${label.toUpperCase()} ${kind.toUpperCase()}`
+    );
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Formats and prints a message to stderr.
+ */
+export function printMessage(
+  message: PartialMessage,
+  kind?: "warning" | "error",
+  label?: string
+): void {
+  const text = formatMessage(message, kind, label);
+  process.stderr.write(text);
+}
+
+/**
+ * An error that's thrown when something fails to parse.
+ */
+export class ParseError extends Error {
+  readonly detail: PartialMessage;
+
+  constructor(message: PartialMessage) {
+    super(message.text);
+    this.name = this.constructor.name;
+    this.detail = message;
+    if (!this.detail.notes) {
+      this.detail.notes = [];
+    }
+  }
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * A wrapper around `TOML.parse` that throws a friendly error.
+ */
+export function parseTOML(input: string, file?: string): any {
+  try {
+    return TOML.parse(input);
+  } catch (err) {
+    const { name, message, line, col } = err;
+    if (name !== "TomlError") {
+      throw err;
+    }
+    // Errors from the TOML parser are formatted as "... at row 1, col 3".
+    // Since the formatter already formats the line and column, the message can be truncated.
+    const text = message.split(" at row ", 2)[0];
+    const lineText = input.split("\n")[line];
+    const location = { file, lineText, line: line + 1, column: col - 2 };
+    throw new ParseError({ text, location });
+  }
+}
+
+/**
+ * A wrapper around `JSON.parse` that throws a friendly error.
+ */
+export function parseJSON(input: string, file?: string): any {
+  try {
+    return JSON.parse(input);
+  } catch (err) {
+    const { message } = err;
+    const index = message.lastIndexOf(" in JSON at position "); // length = 21
+    if (index < 0) {
+      throw err;
+    }
+    const text = message.substring(0, index);
+    const position = parseInt(message.substring(index + 21));
+    const location = indexLocation(input, position, { file });
+    throw new ParseError({ text, location });
+  }
+}
+
+/**
+ * Reads a file and parses it based on its type.
+ */
+export async function readFile(
+  file: string,
+  type?: "json" | "toml"
+): Promise<any> {
+  let content;
+  try {
+    content = await readFile_(file, { encoding: "utf-8" });
+  } catch (err) {
+    // TODO: cleanup common Node.js errors that can be confusing (e.g. ENOENT)
+    throw new ParseError({
+      text: err.message,
+      location: {
+        file,
+      },
+    });
+  }
+  if (type === "json") {
+    return parseJSON(content, file);
+  }
+  if (type === "toml") {
+    return parseTOML(content, file);
+  }
+  return content;
+}
+
+/**
+ * Calculates the line and column location from an index.
+ */
+export function indexLocation(
+  input: string,
+  index: number,
+  extra?: Partial<Location>
+): Partial<Location> {
+  let lineText,
+    line = 0,
+    column = 0,
+    cursor = 0;
+  for (const content of input.split("\n")) {
+    line++;
+    cursor += content.length + 1;
+    if (cursor >= index) {
+      lineText = content;
+      column = content.length - (cursor - index);
+      break;
+    }
+  }
+  return { lineText, line, column, ...extra };
+}
+
+/**
+ * Guesses the line and column location of a search query.
+ */
+export function searchLocation(
+  input: string,
+  search: string,
+  extra?: Partial<Location>
+): Partial<Location> {
+  let lineText,
+    length,
+    line = 0,
+    column = 0;
+  for (const content of input.split("\n")) {
+    line++;
+    const index = content.indexOf(search);
+    if (index >= 0) {
+      lineText = content;
+      column = index;
+      length = search.length;
+      break;
+    }
+  }
+  return { lineText, line, column, length, ...extra };
+}
+
+process.on("uncaughtException", (err) => {
+  if (err instanceof ParseError) {
+    printMessage(err.detail, "error");
+  }
+});


### PR DESCRIPTION
This is the beginning of more standard error messages in wrangler. For now, it outputs these errors for TOML and JSON parsing errors. 

<img width="483" alt="Screen Shot 2022-02-08 at 11 00 03 AM" src="https://user-images.githubusercontent.com/3238291/153056955-8392981b-80e3-40ba-b9e4-2a6f33f9c46e.png">
<img width="483" alt="Screen Shot 2022-02-08 at 10 59 38 AM" src="https://user-images.githubusercontent.com/3238291/153056942-ab25d2a6-37d1-4736-af69-314dbafc74ba.png">
