### PR TITLE
fix: incorrect script name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,6 @@ jobs:
       # In the Sentry project there is a concept of a filesystem which if they are all referencing root can be used to determine the correct location of the sourcemap.z
       # The unmodified released version of the sourcemap is done in the Create Version PR or Publish to NPM two steps above.
       - name: SourceMapping Rewrite & Sentry Upload
-        run: node .github/sentry-upload.js
+        run: node .github/sourcemap-url.js
       - run: npx sentry-cli --auth-token ${{ secrets.SENTRY_AUTH_TOKEN }} releases --org ${{ secrets.SENTRY_ORG }} --project ${{ secrets.SENTRY_PROJECT}} files "wrangler@$WRANGLER_VERSION" upload-sourcemaps ./wrangler-dist --url-prefix /
         working-directory: packages/wrangler


### PR DESCRIPTION
In the Release GH Workflow the old filename was still used for sourcemap URL remapping. 