### PR TITLE
fix: publishes from `experimental-wasm` branch

### DIFF
--- a/.github/workflows/experimental-wasm-release.yml
+++ b/.github/workflows/experimental-wasm-release.yml
@@ -38,3 +38,4 @@ jobs:
         run: npm publish --tag wasm
         env:
           NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+        working-directory: packages/wrangler


### PR DESCRIPTION
I missed a configuration field, this should fix it.