### PR TITLE
feat: Add support for "json" bindings

### DIFF
--- a/.changeset/green-carrots-scream.md
+++ b/.changeset/green-carrots-scream.md
@@ -1,0 +1,12 @@
+---
+"wrangler": patch
+---
+
+feat: Add support for "json" bindings
+
+Did you know? We have support for "json" bindings! Here are a few examples:
+
+[vars]
+text = "plain ol' string"
+count = 1
+complex = { enabled = true, id = 123 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,7 +27,7 @@
     "websockets",
     "xxhash"
   ],
-  "cSpell.ignoreWords": ["yxxx"],
+  "cSpell.ignoreWords": ["TESTWASMNAME", "yxxx"],
   "eslint.runtime": "node",
   "files.trimTrailingWhitespace": false
 }

--- a/packages/wrangler/src/api/form_data.ts
+++ b/packages/wrangler/src/api/form_data.ts
@@ -42,6 +42,7 @@ export interface WorkerMetadata {
   bindings: (
     | { type: "kv_namespace"; name: string; namespace_id: string }
     | { type: "plain_text"; name: string; text: string }
+    | { type: "json"; name: string; json: unknown }
     | { type: "wasm_module"; name: string; part: string }
     | {
         type: "durable_object_namespace";
@@ -95,7 +96,11 @@ export function toFormData(worker: CfWorkerInit): FormData {
   );
 
   Object.entries(bindings.vars || {})?.forEach(([key, value]) => {
-    metadataBindings.push({ name: key, type: "plain_text", text: value });
+    if (typeof value === "string") {
+      metadataBindings.push({ name: key, type: "plain_text", text: value });
+    } else {
+      metadataBindings.push({ name: key, type: "json", json: value });
+    }
   });
 
   for (const [name, filePath] of Object.entries(bindings.wasm_modules || {})) {

--- a/packages/wrangler/src/api/worker.ts
+++ b/packages/wrangler/src/api/worker.ts
@@ -71,7 +71,7 @@ export interface CfModule {
  * A map of variable names to values.
  */
 interface CfVars {
-  [key: string]: string;
+  [key: string]: unknown;
 }
 
 /**

--- a/packages/wrangler/src/config.ts
+++ b/packages/wrangler/src/config.ts
@@ -154,15 +154,14 @@ export type Config = {
 
   /**
    * A map of environment variables to set when deploying your worker.
-   * Of note, they can only be strings. Which is unfortunate, really.
-   * (TODO: verify that they can only be strings?)
+   *
    * NB: these are not inherited, and HAVE to  be duplicated across all environments.
    *
    * @default `{}`
    * @optional
    * @inherited false
    */
-  vars?: { [key: string]: string };
+  vars?: { [key: string]: unknown };
 
   /**
    * A list of durable objects that your worker should be bound to.

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -52,6 +52,7 @@ const fgGreenColor = "\x1b[32m";
 // a set of binding types that are known to be supported by wrangler
 const knownBindings = [
   "plain_text",
+  "json",
   "kv_namespace",
   "durable_object_namespace",
 ];


### PR DESCRIPTION
We've had support for "json" bindings for a long time, but never added them to wrangler1.. oops! This is nice because you can include complex values, and you don't need to use things like `parseInteger(env.variable)` in your code.

```toml
# wrangler.toml
[vars]
text = "plain ol' string"
count = 1
complex = { enabled = true, id = 123 }
```
/cc @mrbbot Since you probably didn't know this existed! 😅 