### PR TITLE
chore: remove trailing whitespace from snapshot tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,5 +29,5 @@
   ],
   "cSpell.ignoreWords": ["TESTWASMNAME", "yxxx"],
   "eslint.runtime": "node",
-  "files.trimTrailingWhitespace": false
+  "files.trimTrailingWhitespace": true
 }

--- a/packages/wrangler/src/__tests__/helpers/mock-console.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-console.ts
@@ -9,16 +9,18 @@ let logSpy: jest.SpyInstance,
 
 const std = {
   get out() {
-    return normalizeSlashes(stripTimings(logSpy.mock.calls.flat(2).join("\n")));
+    return stripTrailingWhitespace(
+      normalizeSlashes(stripTimings(logSpy.mock.calls.flat(2).join("\n")))
+    );
   },
   get err() {
-    return normalizeSlashes(
-      stripTimings(errorSpy.mock.calls.flat(2).join("\n"))
+    return stripTrailingWhitespace(
+      normalizeSlashes(stripTimings(errorSpy.mock.calls.flat(2).join("\n")))
     );
   },
   get warn() {
-    return normalizeSlashes(
-      stripTimings(warnSpy.mock.calls.flat(2).join("\n"))
+    return stripTrailingWhitespace(
+      normalizeSlashes(stripTimings(warnSpy.mock.calls.flat(2).join("\n")))
     );
   },
 };
@@ -53,4 +55,8 @@ export function normalizeSlashes(str: string): string {
  */
 export function stripTimings(stdout: string): string {
   return stdout.replace(/\(\d+\.\d+ sec\)/g, "(TIMINGS)");
+}
+
+export function stripTrailingWhitespace(str: string): string {
+  return str.replace(/[^\S\n]+\n/g, "\n");
 }

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -401,13 +401,13 @@ describe("wrangler", () => {
       expect(packageJson.name).toContain("wrangler-tests");
       expect(packageJson.version).toEqual("0.0.0");
       expect(std.out).toMatchInlineSnapshot(`
-      "✨ Successfully created wrangler.toml
-      ✨ Created package.json
-      ✨ Created tsconfig.json, installed @cloudflare/workers-types into devDependencies
-      To start developing on your worker, run npm start.
-      To publish your worker on to the internet, run npm run deploy.
-      ✨ Created src/index.ts"
-      `);
+              "✨ Successfully created wrangler.toml
+              ✨ Created package.json
+              ✨ Created tsconfig.json, installed @cloudflare/workers-types into devDependencies
+              To start developing on your worker, run npm start.
+              To publish your worker on to the internet, run npm run deploy.
+              ✨ Created src/index.ts"
+            `);
     });
 
     it("should not overwrite package.json scripts for a typescript project", async () => {
@@ -445,12 +445,12 @@ describe("wrangler", () => {
       expect(packageJson.scripts.start).toBe("test-start");
       expect(packageJson.scripts.deploy).toBe("test-deploy");
       expect(std.out).toMatchInlineSnapshot(`
-      "✨ Successfully created wrangler.toml
-      ✨ Created tsconfig.json, installed @cloudflare/workers-types into devDependencies
-      To start developing on your worker, npx wrangler dev src/index.ts
-      To publish your worker on to the internet, npx wrangler publish src/index.ts
-      ✨ Created src/index.ts"
-      `);
+              "✨ Successfully created wrangler.toml
+              ✨ Created tsconfig.json, installed @cloudflare/workers-types into devDependencies
+              To start developing on your worker, npx wrangler dev src/index.ts
+              To publish your worker on to the internet, npx wrangler publish src/index.ts
+              ✨ Created src/index.ts"
+            `);
     });
 
     it("should add missing scripts for a non-ts project with .js extension", async () => {
@@ -487,12 +487,12 @@ describe("wrangler", () => {
       expect(packageJson.name).toContain("wrangler-tests");
       expect(packageJson.version).toEqual("0.0.0");
       expect(std.out).toMatchInlineSnapshot(`
-      "✨ Successfully created wrangler.toml
-      ✨ Created package.json
-      To start developing on your worker, run npm start.
-      To publish your worker on to the internet, run npm run deploy.
-      ✨ Created src/index.js"
-      `);
+              "✨ Successfully created wrangler.toml
+              ✨ Created package.json
+              To start developing on your worker, run npm start.
+              To publish your worker on to the internet, run npm run deploy.
+              ✨ Created src/index.js"
+            `);
     });
 
     it("should not overwrite package.json scripts for a non-ts project with .js extension", async () => {
@@ -530,11 +530,11 @@ describe("wrangler", () => {
       expect(packageJson.scripts.start).toBe("test-start");
       expect(packageJson.scripts.deploy).toBe("test-deploy");
       expect(std.out).toMatchInlineSnapshot(`
-      "✨ Successfully created wrangler.toml
-      To start developing on your worker, npx wrangler dev src/index.js
-      To publish your worker on to the internet, npx wrangler publish src/index.js
-      ✨ Created src/index.js"
-      `);
+              "✨ Successfully created wrangler.toml
+              To start developing on your worker, npx wrangler dev src/index.js
+              To publish your worker on to the internet, npx wrangler publish src/index.js
+              ✨ Created src/index.js"
+            `);
     });
 
     it("should not offer to create a worker in a non-ts project if a file already exists at the location", async () => {

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -38,7 +38,7 @@ describe("publish", () => {
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -59,7 +59,7 @@ describe("publish", () => {
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -80,7 +80,7 @@ describe("publish", () => {
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -107,7 +107,7 @@ describe("publish", () => {
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -136,7 +136,7 @@ describe("publish", () => {
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -156,7 +156,7 @@ describe("publish", () => {
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -179,7 +179,7 @@ describe("publish", () => {
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -209,7 +209,7 @@ export default{
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -230,7 +230,7 @@ export default{
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -254,7 +254,7 @@ export default{
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -328,7 +328,7 @@ export default{
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -396,7 +396,7 @@ export default{
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -448,7 +448,7 @@ export default{
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -502,7 +502,7 @@ export default{
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -553,7 +553,7 @@ export default{
         Deployed
         test-name (some-env)
         (TIMINGS)
-         
+
         some-env.test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -599,7 +599,7 @@ export default{
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -642,7 +642,7 @@ export default{
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -685,7 +685,7 @@ export default{
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -729,7 +729,7 @@ export default{
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -773,7 +773,7 @@ export default{
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -817,7 +817,7 @@ export default{
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -861,7 +861,7 @@ export default{
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -907,7 +907,7 @@ export default{
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -957,7 +957,7 @@ export default{
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -1074,7 +1074,7 @@ export default{
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -1104,7 +1104,7 @@ export default{
           Deployed
           test-name
           (TIMINGS)
-           
+
           test-name.test-sub-domain.workers.dev"
         `);
         expect(std.err).toMatchInlineSnapshot(`""`);
@@ -1139,7 +1139,7 @@ export default{
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -1207,7 +1207,7 @@ export default{
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -1241,7 +1241,7 @@ export default{
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -1280,7 +1280,7 @@ export default{
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -1321,7 +1321,7 @@ export default{
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -1361,7 +1361,7 @@ export default{
         Deployed
         test-name
         (TIMINGS)
-         
+
         test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);

--- a/packages/wrangler/src/user.tsx
+++ b/packages/wrangler/src/user.tsx
@@ -1,6 +1,6 @@
 /* Based heavily on code from https://github.com/BitySA/oauth2-auth-code-pkce */
 
-/* 
+/*
 
                                  Apache License
                            Version 2.0, January 2004


### PR DESCRIPTION
Previously the snapshots were capturing blank lines that only contained whitespace,
which was conflicting with VS Code settings that wanted to remove trailing whitespace.

Now we strip this whitespace before checking snapshots so it does not appear in our
test files, and we can safely turn on `trimTrailingWhitespace` in the VS Code settings.

See https://github.com/cloudflare/wrangler2/pull/411/files#r802597313