### PR TITLE
chore: remove `experimental_services` from configuration

### DIFF
--- a/.changeset/long-penguins-guess.md
+++ b/.changeset/long-penguins-guess.md
@@ -1,0 +1,27 @@
+---
+"wrangler": patch
+---
+
+chore: remove `experimental_services` from configuration
+
+Now that we have `[[unsafe.bindings]]` (as of https://github.com/cloudflare/wrangler2/pull/411), we should use that for experimental features. This removes support for `[experimental_services]`, and adds a helpful message for how to rewrite their configuration.
+
+This error is temporary, until the internal teams that were using this rewrite their configs. We'll remove it before GA.
+
+What the error looks like -
+
+```
+Error: The "experimental_services" field is no longer supported. Instead, use [[unsafe.bindings]] to enable experimental features. Add this to your wrangler.toml:
+
+[[unsafe.bindings]]
+name = "SomeService"
+type = "service"
+service = "some-service"
+environment = "staging"
+
+[[unsafe.bindings]]
+name = "SomeOtherService"
+type = "service"
+service = "some-other-service"
+environment = "qa"
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -27690,7 +27690,7 @@
         "@iarna/toml": "^2.2.5",
         "@sentry/cli": "^1.71.0",
         "@sentry/integrations": "^6.17.6",
-        "@sentry/node": "*",
+        "@sentry/node": "^6.17.6",
         "@types/estree": "^0.0.50",
         "@types/mime": "^2.0.3",
         "@types/prompts": "^2.0.14",

--- a/packages/wrangler/src/api/form_data.ts
+++ b/packages/wrangler/src/api/form_data.ts
@@ -43,12 +43,6 @@ export interface WorkerMetadata {
         class_name: string;
         script_name?: string;
       }
-    | {
-        type: "service";
-        name: string;
-        service: string;
-        environment: string;
-      }
   )[];
 }
 
@@ -140,15 +134,6 @@ export function toFormData(worker: CfWorkerInit): FormData {
       }
     }
   }
-
-  bindings.services?.forEach(({ name, service, environment }) => {
-    metadataBindings.push({
-      name,
-      type: "service",
-      service,
-      environment,
-    });
-  });
 
   if (bindings.unsafe) {
     // @ts-expect-error unsafe bindings don't need to match a specific type here

--- a/packages/wrangler/src/api/worker.ts
+++ b/packages/wrangler/src/api/worker.ts
@@ -99,15 +99,6 @@ interface CfDurableObject {
   script_name?: string;
 }
 
-/**
- * A Service.
- */
-interface CfService {
-  name: string;
-  service: string;
-  environment: string;
-}
-
 interface CfUnsafeBinding {
   name: string;
   type: string;
@@ -147,7 +138,6 @@ export interface CfWorkerInit {
     kv_namespaces?: CfKvNamespace[];
     wasm_modules?: CfWasmModuleBindings;
     durable_objects?: { bindings: CfDurableObject[] };
-    services?: CfService[];
     unsafe?: CfUnsafeBinding[];
   };
   migrations: undefined | CfDurableObjectMigrations;

--- a/packages/wrangler/src/config.ts
+++ b/packages/wrangler/src/config.ts
@@ -209,6 +209,7 @@ export type Config = {
    *
    * @default `[]`
    * @optional
+   * @deprecated DO NOT USE. We'd added this to test the new service binding system, but the proper way to test experimental features is to use `unsafe.bindings` configuration.
    * @inherited false
    */
   experimental_services?: {
@@ -569,7 +570,7 @@ export function normaliseAndValidateEnvironmentsConfig(config: Config) {
     }
 
     // Warn if there is a "required" field in the top level config that has not been specified specified in the environment.
-    // These required fields are `vars`, `durable_objects`, `kv_namespaces` and `experimental_services`.
+    // These required fields are `vars`, `durable_objects`, and `kv_namespaces`.
     // Each of them has different characteristics that need to be checked.
 
     // `vars` is just an object
@@ -639,32 +640,6 @@ export function normaliseAndValidateEnvironmentsConfig(config: Config) {
               `In your configuration, there is a kv_namespaces with binding "${bindingName}" at the top level, but not on "env.${envKey}".\n` +
                 `This is not what you probably want, since "kv_namespaces" is not inherited by environments.\n` +
                 `Please add a binding for "${bindingName}" to "env.${envKey}.kv_namespaces".`
-            );
-          }
-        }
-      }
-    }
-
-    // `experimental_services` contains an array of namespace bindings
-    if (config.experimental_services !== undefined) {
-      if (environment.experimental_services === undefined) {
-        console.warn(
-          `In your configuration, "experimental_services" exists at the top level, but not on "env.${envKey}".\n` +
-            `This is not what you probably want, since "experimental_services" is not inherited by environments.\n` +
-            `Please add "experimental_services" to "env.${envKey}".`
-        );
-      } else {
-        const envBindingNames = new Set(
-          environment.experimental_services.map((service) => service.name)
-        );
-        for (const bindingName of config.experimental_services.map(
-          (service) => service.name
-        )) {
-          if (!envBindingNames.has(bindingName)) {
-            console.warn(
-              `In your configuration, there is a experimental_services with binding name "${bindingName}" at the top level, but not on "env.${envKey}".\n` +
-                `This is not what you probably want, since "experimental_services" is not inherited by environments.\n` +
-                `Please add a service for "${bindingName}" to "env.${envKey}.experimental_services".`
             );
           }
         }

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -254,7 +254,6 @@ export default async function publish(props: Props): Promise<void> {
       vars: envRootObj.vars,
       wasm_modules: config.wasm_modules,
       durable_objects: envRootObj.durable_objects,
-      services: envRootObj.experimental_services,
       unsafe: envRootObj.unsafe?.bindings,
     };
 


### PR DESCRIPTION
Now that we have `[[unsafe.bindings]]` (as of https://github.com/cloudflare/wrangler2/pull/411), we should use that for experimental features. This removes support for `[experimental_services]`, and adds a helpful message for how to rewrite their configuration.

This error is temporary, until the internal teams that were using this rewrite their configs. We'll remove it before GA.

What the error looks like -

```
Error: The "experimental_services" field is no longer supported. Instead, use [[unsafe.bindings]] to enable experimental features. Add this to your wrangler.toml:

[[unsafe.bindings]]
name = "SomeService"
type = "service"
service = "some-service"
environment = "staging"

[[unsafe.bindings]]
name = "SomeOtherService"
type = "service"
service = "some-other-service"
environment = "qa"
```

cc @ObsidianMinor 