### PR TITLE
fix: Config should be resolved relative to the entrypoint

### DIFF
--- a/.changeset/calm-numbers-shout.md
+++ b/.changeset/calm-numbers-shout.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: Config should be resolved relative to the entrypoint
+
+During `dev` and `publish`, we should resolve `wrangler.toml` starting from the entrypoint, and then working up from there. Currently, we start from the directory from which we call `wrangler`, this changes that behaviour to start from the entrypoint instead.
+
+(To implement this, I made one big change: Inside commands, we now have to explicitly read configuration from a path, instead of expecting it to 'arrive' coerced into a configuration object.)

--- a/packages/wrangler/src/kv.tsx
+++ b/packages/wrangler/src/kv.tsx
@@ -7,7 +7,6 @@ type KvArgs = {
   "namespace-id"?: string;
   env?: string;
   preview?: boolean;
-  config?: Config;
 };
 
 /**
@@ -153,13 +152,10 @@ export async function deleteBulkKeyValue(
   );
 }
 
-export function getNamespaceId({
-  preview,
-  binding,
-  config,
-  "namespace-id": namespaceId,
-  env,
-}: KvArgs): string {
+export function getNamespaceId(
+  { preview, binding, "namespace-id": namespaceId, env }: KvArgs,
+  config: Config
+): string {
   // nice
   if (namespaceId) {
     return namespaceId;
@@ -189,19 +185,21 @@ export function getNamespaceId({
     }
 
     // TODO: either a bespoke arg type for this function to avoid `undefined`s or an `EnvOrConfig` type
-    return getNamespaceId({
-      binding,
-      "namespace-id": namespaceId,
-      env: undefined,
-      preview,
-      config: {
+    return getNamespaceId(
+      {
+        binding,
+        "namespace-id": namespaceId,
+        env: undefined,
+        preview,
+      },
+      {
         env: undefined,
         build: undefined,
         name: undefined,
         account_id: undefined,
         ...config.env[env],
-      },
-    });
+      }
+    );
   }
 
   // there's no KV namespaces


### PR DESCRIPTION
During `dev` and `publish`, we should resolve `wrangler.toml` starting from the entrypoint, and then working up from there. Currently, we start from the directory from which we call `wrangler`, this changes that behaviour to start from the entrypoint instead.

(To implement this, I made one big change: Inside commands, we now have to explicitly read configuration from a path, instead of expecting it to 'arrive' coerced into a configuration object.)

Fixes #440. 