### PR TITLE
add `--yes` flag to `wrangler init`

### DIFF
--- a/.changeset/olive-maps-promise.md
+++ b/.changeset/olive-maps-promise.md
@@ -1,0 +1,10 @@
+---
+"wrangler": patch
+---
+
+feat: add `--yes` with alias `--y` flag as automatic answer to all prompts and run `wrangler init` non-interactively.
+generated during setup:
+
+- package.json
+- TypeScript, which includes tsconfig.json & `@cloudflare/workers-types`
+- Template "hello world" Worker at src/index.ts

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -716,6 +716,26 @@ describe("wrangler", () => {
       expect(tsconfigJson.compilerOptions).toEqual({});
     });
 
+    it("should initialize with no interactive prompts if `--yes` is used", async () => {
+      await runWrangler("init --yes");
+
+      expect(fs.existsSync("./src/index.js")).toBe(false);
+      expect(fs.existsSync("./src/index.ts")).toBe(true);
+      expect(fs.existsSync("./tsconfig.json")).toBe(true);
+      expect(fs.existsSync("./package.json")).toBe(true);
+      expect(fs.existsSync("./wrangler.toml")).toBe(true);
+    });
+
+    it("should initialize with no interactive prompts if `--y` is used", async () => {
+      await runWrangler("init -y");
+
+      expect(fs.existsSync("./src/index.js")).toBe(false);
+      expect(fs.existsSync("./src/index.ts")).toBe(true);
+      expect(fs.existsSync("./tsconfig.json")).toBe(true);
+      expect(fs.existsSync("./package.json")).toBe(true);
+      expect(fs.existsSync("./wrangler.toml")).toBe(true);
+    });
+
     it("should error if `--type` is used", async () => {
       await expect(
         runWrangler("init --type")


### PR DESCRIPTION
Add `--yes` with alias `--y` flag as automatic answer to all prompts and run `wrangler init` non-interactively.
generated during setup:
- package.json
- TypeScript, which includes tsconfig.json & @cloudflare/workers-types
- Template "hello world" Worker at src/index.ts

resolves #446 