### PR TITLE
chore: run typechecks in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "scripts": {
     "check": "run-p check:* --aggregate-output -l",
-    "check:type": "npm run check:test --workspaces --if-present",
+    "check:type": "npm run check:type --workspaces --if-present",
     "check:lint": "eslint \"packages/**/*.[tj]s?(x)\" --cache --cache-strategy content",
     "check:format": "prettier packages/** --check --ignore-unknown",
     "prebuild-and-test": "npm run build",


### PR DESCRIPTION
We were accidentally not running any typechecking in CI, this fixes that by calling the right command for all workspaces.