### PR TITLE
fix: don't report intentional errors

### DIFF
--- a/.changeset/silent-bananas-compete.md
+++ b/.changeset/silent-bananas-compete.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: don't report intentional errors
+
+We shouldn't be reporting intentional errors, only exceptions. This removes reporting for all caught errors for now, until we filter all known errors, and then bring back reporting for unknown errors. We also remove a stray `console.warn()`.

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -29,7 +29,6 @@ import { getPackageManager } from "./package-manager";
 import { pages } from "./pages";
 import publish from "./publish";
 import { createR2Bucket, deleteR2Bucket, listR2Buckets } from "./r2";
-import { reportError } from "./reporting";
 import { getAssetPaths } from "./sites";
 import { createTail } from "./tail";
 import {
@@ -2416,7 +2415,6 @@ export async function main(argv: string[]): Promise<void> {
         "If you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new."
       );
     }
-    await reportError(e, "indexCatch");
     throw e;
   }
 }

--- a/packages/wrangler/src/reporting.ts
+++ b/packages/wrangler/src/reporting.ts
@@ -56,7 +56,6 @@ function exceptionTransaction(error: Error, origin = "") {
     op: origin,
     name: error.name,
   });
-  console.warn(error);
   captureException(error);
   transaction.finish();
 }


### PR DESCRIPTION
We shouldn't be reporting intentional errors, only exceptions. This removes reporting for all caought errors for now, until we filter all known errors, and then bring back reporting for unknown errors. We also remove a stray `console.warn()`.