### PR TITLE
fix: do not publish to workers.dev if workers_dev is false

### DIFF
--- a/.changeset/rich-fans-shake.md
+++ b/.changeset/rich-fans-shake.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+---
+
+fix: do not publish to workers.dev if workers_dev is false
+
+Previously we always published to the workers.dev subdomain, ignoring the `workers_dev` setting in the `wrangler.toml` configuration.
+
+Now we respect this configuration setting, and also disable an current workers.dev subdomain worker when we publish and `workers_dev` is `false`.
+
+Fixes #410

--- a/.changeset/sour-eagles-confess.md
+++ b/.changeset/sour-eagles-confess.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+---
+
+fix: pass correct query param when uploading a script
+
+In f9c1423f0c5b6008f05b9657c9b84eb6f173563a the query param was incorrectly changed from
+`available_on_subdomain` to `available_on_subdomains`.

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -1051,6 +1051,118 @@ export default{
     });
   });
 
+  describe("workers_dev setting", () => {
+    it("should deploy to a workers.dev domain if workers_dev is undefined", async () => {
+      writeWranglerToml();
+      writeWorkerSource();
+      mockUploadWorkerRequest();
+      mockSubDomainRequest();
+
+      await runWrangler("publish ./index");
+
+      expect(std.out).toMatchInlineSnapshot(`
+        "Uploaded
+        test-name
+        (TIMINGS)
+        Deployed
+        test-name
+        (TIMINGS)
+
+        test-name.test-sub-domain.workers.dev"
+      `);
+      expect(std.err).toMatchInlineSnapshot(`""`);
+    });
+
+    it("should deploy to the workers.dev domain if workers_dev is `true`", async () => {
+      writeWranglerToml({
+        workers_dev: true,
+      });
+      writeWorkerSource();
+      mockUploadWorkerRequest();
+      mockSubDomainRequest();
+
+      await runWrangler("publish ./index");
+
+      expect(std.out).toMatchInlineSnapshot(`
+        "Uploaded
+        test-name
+        (TIMINGS)
+        Deployed
+        test-name
+        (TIMINGS)
+
+        test-name.test-sub-domain.workers.dev"
+      `);
+      expect(std.err).toMatchInlineSnapshot(`""`);
+    });
+
+    it("should disable the workers.dev domain if workers_dev is `false`", async () => {
+      writeWranglerToml({
+        workers_dev: false,
+      });
+      writeWorkerSource();
+      mockUploadWorkerRequest();
+      mockSubDomainRequest();
+      mockUpdateWorkerRequest({ enabled: false });
+
+      await runWrangler("publish ./index");
+
+      expect(std.out).toMatchInlineSnapshot(`
+        "Uploaded
+        test-name
+        (TIMINGS)
+        No deployment targets for
+        test-name
+        (TIMINGS)"
+      `);
+      expect(std.err).toMatchInlineSnapshot(`""`);
+    });
+
+    it("should enable the workers.dev domain if workers_dev is undefined and subdomain is not already available", async () => {
+      writeWranglerToml();
+      writeWorkerSource();
+      mockUploadWorkerRequest({ available_on_subdomain: false });
+      mockSubDomainRequest();
+      mockUpdateWorkerRequest({ enabled: true });
+
+      await runWrangler("publish ./index");
+
+      expect(std.out).toMatchInlineSnapshot(`
+        "Uploaded
+        test-name
+        (TIMINGS)
+        Deployed
+        test-name
+        (TIMINGS)
+
+        test-name.test-sub-domain.workers.dev"
+      `);
+      expect(std.err).toMatchInlineSnapshot(`""`);
+    });
+
+    it("should enable the workers.dev domain if workers_dev is true and subdomain is not already available", async () => {
+      writeWranglerToml({ workers_dev: true });
+      writeWorkerSource();
+      mockUploadWorkerRequest({ available_on_subdomain: false });
+      mockSubDomainRequest();
+      mockUpdateWorkerRequest({ enabled: true });
+
+      await runWrangler("publish ./index");
+
+      expect(std.out).toMatchInlineSnapshot(`
+        "Uploaded
+        test-name
+        (TIMINGS)
+        Deployed
+        test-name
+        (TIMINGS)
+
+        test-name.test-sub-domain.workers.dev"
+      `);
+      expect(std.err).toMatchInlineSnapshot(`""`);
+    });
+  });
+
   describe("custom builds", () => {
     it("should run a custom build before publishing", async () => {
       writeWranglerToml({
@@ -1494,9 +1606,30 @@ function mockUploadWorkerRequest({
 
 /** Create a mock handler for the request to get the account's subdomain. */
 function mockSubDomainRequest(subdomain = "test-sub-domain") {
-  setMockResponse("/accounts/:accountId/workers/subdomain", () => {
+  setMockResponse("/accounts/:accountId/workers/subdomain", "GET", () => {
     return { subdomain };
   });
+}
+
+function mockUpdateWorkerRequest({
+  env,
+  enabled,
+}: {
+  env?: string | undefined;
+  enabled: boolean;
+}) {
+  const requests = { count: 0 };
+  const servicesOrScripts = env ? "services" : "scripts";
+  const environment = env ? "/environments/:envName" : "";
+  setMockResponse(
+    `/accounts/:accountId/workers/${servicesOrScripts}/:scriptName${environment}/subdomain`,
+    "POST",
+    (_, { body }) => {
+      expect(JSON.parse(body as string)).toEqual({ enabled });
+      return null;
+    }
+  );
+  return requests;
 }
 
 /** Create a mock handler for the request to get a list of all KV namespaces. */

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -1464,7 +1464,7 @@ function mockUploadWorkerRequest({
     async ([_url, accountId, scriptName], { body }, queryParams) => {
       expect(accountId).toEqual("some-account-id");
       expect(scriptName).toEqual("test-name");
-      expect(queryParams.get("available_on_subdomains")).toEqual("true");
+      expect(queryParams.get("available_on_subdomain")).toEqual("true");
       const formBody = body as FormData;
       if (expectedEntry !== undefined) {
         expect(await (formBody.get("index.js") as File).text()).toMatch(

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -242,7 +242,7 @@ export default async function publish(props: Props): Promise<void> {
         method: "PUT",
         body: toFormData(worker),
       },
-      new URLSearchParams({ available_on_subdomains: "true" })
+      new URLSearchParams({ available_on_subdomain: "true" })
     );
 
     const uploadMs = Date.now() - start;


### PR DESCRIPTION
Previously we always published to the workers.dev subdomain, ignoring the `workers_dev` setting in the `wrangler.toml` configuration.

Now we respect this configuration setting, and also disable an current workers.dev subdomain worker when we publish and `workers_dev` is `false`.

Fixes https://github.com/cloudflare/wrangler2/issues/410