### PR TITLE
chore: fix lint warnings

### DIFF
--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -36,7 +36,6 @@ import {
   prettyPrintLogs,
   translateCliFiltersToApiFilters,
 } from "./tail";
-import type { TailCLIFilters } from "./tail";
 import {
   login,
   logout,
@@ -50,8 +49,9 @@ import { whoami } from "./whoami";
 
 import type { Entry } from "./bundle";
 import type { Config } from "./config";
-import type Yargs from "yargs";
+import type { TailCLIFilters } from "./tail";
 import type { RawData } from "ws";
+import type Yargs from "yargs";
 
 const resetColor = "\x1b[0m";
 const fgGreenColor = "\x1b[32m";

--- a/packages/wrangler/src/tail.tsx
+++ b/packages/wrangler/src/tail.tsx
@@ -60,9 +60,6 @@ type ApiFilterMessage = {
   debug: boolean;
 };
 
-// TODO: make this a real type if we wanna pretty-print
-type TailMessage = string;
-
 function makeCreateTailUrl(accountId: string, workerName: string): string {
   return `/accounts/${accountId}/workers/scripts/${workerName}/tails`;
 }


### PR DESCRIPTION
Fixed some lint warnings introduced in https://github.com/cloudflare/wrangler2/pull/462

Some followups we should do -
- CI should fail on lint warnings
- we should swap the import-order plugin for a prettier based one, so it happens on save instead of having to manually do so