### PR TITLE
chore: tweak build scripts

### DIFF
--- a/.github/workflows/create-pullrequest-prerelease.yml
+++ b/.github/workflows/create-pullrequest-prerelease.yml
@@ -58,7 +58,7 @@ jobs:
             npm install --save-dev https://prerelease-registry.developers.workers.dev/runs/${{ github.run_id }}/wrangler
             ```
 
-            Or you can try it out directly with:
+            Or you can try developing a worker directly with:
             ```sh
             npx https://prerelease-registry.developers.workers.dev/runs/${{ github.run_id }}/wrangler dev path/to/script.js
             ```

--- a/.github/workflows/create-pullrequest-prerelease.yml
+++ b/.github/workflows/create-pullrequest-prerelease.yml
@@ -52,8 +52,13 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           message: |
-            wrangler prerelease is available for testing:
+            A wrangler prerelease is available for testing. You can install it in your project with:
 
             ```sh
             npm install --save-dev https://prerelease-registry.developers.workers.dev/runs/${{ github.run_id }}/wrangler
+            ```
+
+            Or you can try it out directly with:
+            ```sh
+            npx https://prerelease-registry.developers.workers.dev/runs/${{ github.run_id }}/wrangler dev path/to/script.js
             ```

--- a/.github/workflows/experimental-wasm-release.yml
+++ b/.github/workflows/experimental-wasm-release.yml
@@ -27,10 +27,6 @@ jobs:
       - name: Modify package.json version
         run: node .github/version-script.js
 
-      - name: Build
-        run: npm run build
-        working-directory: packages/wrangler
-
       - name: Check for errors
         run: npm run check
 

--- a/.github/workflows/prereleases.yml
+++ b/.github/workflows/prereleases.yml
@@ -36,10 +36,6 @@ jobs:
       - name: Modify package.json version
         run: node .github/version-script.js
 
-      - name: Build
-        run: npm run build
-        working-directory: packages/wrangler
-
       - name: Check for errors
         run: npm run check
 

--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -56,5 +56,8 @@ jobs:
       - name: Install NPM Dependencies
         run: npm ci
 
-      - name: Run build and test
-        run: npm run build-and-test
+      - name: Run builds
+        run: npm run build
+
+      - name: Run tests
+        run: npm run test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,6 @@ jobs:
       - name: Install NPM Dependencies
         run: npm install
 
-      - name: Build
-        run: npm run build
-        working-directory: packages/wrangler
-
       - name: Check for errors
         run: npm run check
 

--- a/package.json
+++ b/package.json
@@ -35,8 +35,6 @@
     "check:type": "npm run check:type --workspaces --if-present",
     "check:lint": "eslint \"packages/**/*.[tj]s?(x)\" --cache --cache-strategy content",
     "check:format": "prettier packages/** --check --ignore-unknown",
-    "prebuild-and-test": "npm run build",
-    "build-and-test": "npm test",
     "build": "npm run build --workspace=wrangler",
     "test": "npm run test --workspaces --if-present",
     "prettify": "prettier packages/** --write --ignore-unknown"

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -104,6 +104,7 @@
     "check:type": "tsc",
     "bundle": "node -r esbuild-register scripts/bundle.ts",
     "build": "npm run clean && npm run bundle",
+    "prepublish": "npm run build",
     "start": "npm run bundle && NODE_OPTIONS=--enable-source-maps ./bin/wrangler.js",
     "test": "jest --silent=false --verbose=true",
     "test-watch": "npm run test -- --runInBand --testTimeout=50000 --watch"


### PR DESCRIPTION
Some modifications to our builds/workflows -

- The scripts `prebuild-and-test` and `build-and-test` weren't named well, so I removed them and inlined their usage.
- Added a `prepublish` script to `packages/wrangler`, so that a build is always run before we publish
- Removed `npm run build` from some workflows before publishes, since we have `prepublish` to  run that build
- Modified the prerelease message to include an `npx` invocation