### PR TITLE
fix: s/prepublish/prepublishOnly

### DIFF
--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -104,7 +104,7 @@
     "check:type": "tsc",
     "bundle": "node -r esbuild-register scripts/bundle.ts",
     "build": "npm run clean && npm run bundle",
-    "prepublish": "npm run build",
+    "prepublishOnly": "npm run build",
     "start": "npm run bundle && NODE_OPTIONS=--enable-source-maps ./bin/wrangler.js",
     "test": "jest --silent=false --verbose=true",
     "test-watch": "npm run test -- --runInBand --testTimeout=50000 --watch"


### PR DESCRIPTION
Apparently prepublish does _not_ run on publish, and we should use prepublishOnly. This is documented, so fooey on me for assuming something does what it says 😡