### PR TITLE
Add: `zoneId` to `Dev`

### DIFF
--- a/.changeset/pretty-seas-double.md
+++ b/.changeset/pretty-seas-double.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+feat: add zoneid from config to dev, for preview usage.

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -79,6 +79,7 @@ function renderDev({
   buildCommand = {},
   enableLocalPersistence = false,
   env = undefined,
+  zoneId = undefined,
 }: Partial<DevProps>) {
   return render(
     <Dev
@@ -99,6 +100,7 @@ function renderDev({
       usageModel={usageModel}
       bindings={bindings}
       enableLocalPersistence={enableLocalPersistence}
+      zoneId={zoneId}
     />
   );
 }

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -51,6 +51,7 @@ export type DevProps = {
     watch_dir?: undefined | string;
   };
   env: string | undefined;
+  zoneId: string | undefined;
 };
 
 function Dev(props: DevProps): JSX.Element {
@@ -124,6 +125,7 @@ function Dev(props: DevProps): JSX.Element {
           compatibilityFlags={props.compatibilityFlags}
           usageModel={props.usageModel}
           env={props.env}
+          zoneId={props.zoneId}
         />
       )}
       <Box borderStyle="round" paddingLeft={1} paddingRight={1}>
@@ -172,6 +174,7 @@ function Remote(props: {
   compatibilityFlags: undefined | string[];
   usageModel: undefined | "bundled" | "unbound";
   env: string | undefined;
+  zoneId: string | undefined;
 }) {
   assert(props.accountId, "accountId is required");
   assert(props.apiToken, "apiToken is required");
@@ -189,6 +192,7 @@ function Remote(props: {
     compatibilityFlags: props.compatibilityFlags,
     usageModel: props.usageModel,
     env: props.env,
+    zoneId: props.zoneId,
   });
 
   usePreviewServer({
@@ -630,6 +634,7 @@ function useWorker(props: {
   compatibilityFlags: string[] | undefined;
   usageModel: undefined | "bundled" | "unbound";
   env: string | undefined;
+  zoneId: string | undefined;
 }): CfPreviewToken | undefined {
   const {
     name,
@@ -644,6 +649,7 @@ function useWorker(props: {
     compatibilityFlags,
     usageModel,
     port,
+    zoneId,
   } = props;
   const [token, setToken] = useState<CfPreviewToken | undefined>();
 
@@ -712,6 +718,7 @@ function useWorker(props: {
         await createWorker(init, {
           accountId,
           apiToken,
+          zoneId,
         })
       );
     }
@@ -734,6 +741,7 @@ function useWorker(props: {
     bindings,
     modules,
     props.env,
+    zoneId,
   ]);
   return token;
 }

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -874,6 +874,7 @@ export async function main(argv: string[]): Promise<void> {
             r2_buckets: envRootObj.r2_buckets,
             unsafe: envRootObj.unsafe?.bindings,
           }}
+          zoneId={config?.zone_id}
         />
       );
       await waitUntilExit();


### PR DESCRIPTION
add zoneid from config to dev, for preview usage.
Is also necessary for `--host` to be implemented 