### PR TITLE
Fix: TypeError localWebsocket.destroy is not a function

### DIFF
--- a/.changeset/few-cherries-compare.md
+++ b/.changeset/few-cherries-compare.md
@@ -1,0 +1,6 @@
+---
+"wrangler": patch
+---
+
+bugfix: Replace `.destroy()` on `faye-websockets` with `.close()`
+added: Interface to give faye same types as compliant `ws` with additional `.pipe()` implementation; `.on("message" => fn)`


### PR DESCRIPTION
Replace `.destroy()` on `faye-websockets` with `.close()`
Added interface to give faye same types as compliant ws with additional `pipe()` implementation

resolves #463 