### PR TITLE
Fix: Losing `error_tracking_opt`/`error_tracking_opt_date` on refresh

### DIFF
--- a/.changeset/long-buttons-sort.md
+++ b/.changeset/long-buttons-sort.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+bugfix: create `reporting.toml` file in "wrangler/config" and move error reporting user decisions to new `reporting.toml`

--- a/packages/wrangler/src/__tests__/sentry.test.ts
+++ b/packages/wrangler/src/__tests__/sentry.test.ts
@@ -14,6 +14,7 @@ const { reportError } = jest.requireActual("../reporting");
 describe("Error Reporting", () => {
   runInTempDir({ homedir: "./home" });
   mockConsoleMethods();
+  const reportingTOMLPath = ".wrangler/config/reporting.toml";
 
   const originalTTY = process.stdout.isTTY;
   beforeEach(() => {
@@ -34,10 +35,7 @@ describe("Error Reporting", () => {
     await reportError(new Error("test error"), "testFalse");
 
     const { error_tracking_opt, error_tracking_opt_date } = TOML.parse(
-      await fsp.readFile(
-        path.join(os.homedir(), ".wrangler/config/default.toml"),
-        "utf-8"
-      )
+      await fsp.readFile(path.join(os.homedir(), reportingTOMLPath), "utf-8")
     );
 
     expect(error_tracking_opt).toBe(true);
@@ -53,10 +51,7 @@ describe("Error Reporting", () => {
     await reportError(new Error("test error"), "testFalse");
 
     const { error_tracking_opt, error_tracking_opt_date } = TOML.parse(
-      await fsp.readFile(
-        path.join(os.homedir(), ".wrangler/config/default.toml"),
-        "utf-8"
-      )
+      await fsp.readFile(path.join(os.homedir(), reportingTOMLPath), "utf-8")
     );
 
     expect(error_tracking_opt).toBe(false);
@@ -73,9 +68,9 @@ describe("Error Reporting", () => {
     await runWrangler();
     await reportError(new Error("test error"), "testFalse");
 
-    expect(
-      fs.existsSync(path.join(os.homedir(), ".wrangler/config/default.toml"))
-    ).toBe(false);
+    expect(fs.existsSync(path.join(os.homedir(), reportingTOMLPath))).toBe(
+      false
+    );
 
     expect(Sentry.captureException).not.toHaveBeenCalledWith(
       new Error("test error"),
@@ -137,10 +132,7 @@ describe("Error Reporting", () => {
     await reportError(new Error("test error"), "testFalse");
 
     const { error_tracking_opt, error_tracking_opt_date } = TOML.parse(
-      await fsp.readFile(
-        path.join(os.homedir(), ".wrangler/config/default.toml"),
-        "utf-8"
-      )
+      await fsp.readFile(path.join(os.homedir(), reportingTOMLPath), "utf-8")
     );
 
     expect(error_tracking_opt).toBe(false);

--- a/packages/wrangler/src/reporting.ts
+++ b/packages/wrangler/src/reporting.ts
@@ -45,7 +45,7 @@ async function appendReportingDecision(userInput: "true" | "false") {
   const homePath = path.join(os.homedir(), ".wrangler/config/");
   fs.mkdirSync(homePath, { recursive: true });
   await appendFile(
-    path.join(homePath, "default.toml"),
+    path.join(homePath, "reporting.toml"),
     `error_tracking_opt = ${userInput} # Sentry \nerror_tracking_opt_date = ${new Date().toISOString()} # Sentry Date Decision \n`,
     { encoding: "utf-8" }
   );
@@ -97,15 +97,17 @@ export async function reportError(err: Error, origin = "") {
 }
 
 async function reportingPermission() {
-  if (!fs.existsSync(path.join(os.homedir(), ".wrangler/config/default.toml")))
+  if (
+    !fs.existsSync(path.join(os.homedir(), ".wrangler/config/reporting.toml"))
+  )
     return undefined;
 
-  const defaultTOML = TOML.parse(
-    await readFile(path.join(os.homedir(), ".wrangler/config/default.toml"), {
+  const reportingTOML = TOML.parse(
+    await readFile(path.join(os.homedir(), ".wrangler/config/reporting.toml"), {
       encoding: "utf-8",
     })
   );
-  const { error_tracking_opt } = defaultTOML as {
+  const { error_tracking_opt } = reportingTOML as {
     error_tracking_opt: string | undefined;
   };
 


### PR DESCRIPTION
Created `reporting.toml` file in "wrangler/config" and move error reporting user decisions to new `reporting.toml` and
updated tests to reflect new `reporting.toml`

resolves #460 