### PR TITLE
chore: add workers-chat-demo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5159,6 +5159,10 @@
         "node": ">=10"
       }
     },
+    "node_modules/edge-chat-demo": {
+      "resolved": "packages/workers-chat-demo",
+      "link": true
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "dev": true,
@@ -16844,6 +16848,9 @@
         "typescript": "^4.5.5"
       }
     },
+    "packages/workers-chat-demo": {
+      "version": "1.0.0"
+    },
     "packages/wrangler": {
       "version": "0.0.16",
       "license": "MIT OR Apache-2.0",
@@ -20600,6 +20607,9 @@
     },
     "dotenv": {
       "version": "8.6.0"
+    },
+    "edge-chat-demo": {
+      "version": "file:packages/workers-chat-demo"
     },
     "ee-first": {
       "version": "1.1.1",

--- a/packages/workers-chat-demo/LICENSE
+++ b/packages/workers-chat-demo/LICENSE
@@ -1,0 +1,26 @@
+Copyright (c) 2020, Cloudflare. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/workers-chat-demo/README.md
+++ b/packages/workers-chat-demo/README.md
@@ -1,0 +1,80 @@
+This is the demo for durable objects originally published at https://github.com/cloudflare/workers-chat-demo, but with some modifications -
+
+- The html file is imported as a relative import.
+
+```diff
+- import HTML from "chat.html";
++ import HTML from "./chat.html";
+```
+
+- The following fields are removed from `wrangler.toml` - `type`, `workers_dev`, `account_id`, `build.upload.format`, `build.upload.rules`.
+
+- The `module` field is removed from `package.json`.
+
+Also a reminder: you need to publish this worker (or even a plain worker named `edge-chat-demo`) before you can develop on it. That's a problem that we need to solve on our end, but this is a workaround for now.
+
+The original README follows -
+
+# Cloudflare Edge Chat Demo
+
+This is a demo app written on [Cloudflare Workers](https://workers.cloudflare.com/) utilizing [Durable Objects](https://blog.cloudflare.com/introducing-workers-durable-objects) to implement real-time chat with stored history. This app runs 100% on Cloudflare's edge.
+
+Try it here: https://edge-chat-demo.cloudflareworkers.com
+
+The reason this demo is remarkable is because it deals with state. Before Durable Objects, Workers were stateless, and state had to be stored elsewhere. State can mean storage, but it also means the ability to coordinate. In a chat room, when one user sends a message, the app must somehow route that message to other users, via connections that those other users already had open. These connections are state, and coordinating them in a stateless framework is hard if not impossible.
+
+## How does it work?
+
+This chat app uses a Durable Object to control each chat room. Users connect to the object using WebSockets. Messages from one user are broadcast to all the other users. The chat history is also stored in durable storage, but this is only for history. Real-time messages are relayed directly from one user to others without going through the storage layer.
+
+Additionally, this demo uses Durable Objects for a second purpose: Applying a rate limit to messages from any particular IP. Each IP is assigned a Durable Object that tracks recent request frequency, so that users who send too many messages can be temporarily blocked -- even across multiple chat rooms. Interestingly, these objects don't actually store any durable state at all, because they only care about very recent history, and it's not a big deal if a rate limiter randomly resets on occasion. So, these rate limiter objects are an example of a pure coordination object with no storage.
+
+This chat app is only a few hundred lines of code. The deployment configuration is only a few lines. Yet, it will scale seamlessly to any number of chat rooms, limited only by Cloudflare's available resources. Of course, any individual chat room's scalability has a limit, since each object is single-threaded. But, that limit is far beyond what a human participant could keep up with anyway.
+
+For more details, take a look at the code! It is well-commented.
+
+## Learn More
+
+- [Durable Objects introductory blog post](https://blog.cloudflare.com/introducing-workers-durable-objects)
+- [Durable Objects documentation](https://developers.cloudflare.com/workers/learning/using-durable-objects)
+
+## Deploy it yourself
+
+If you haven't already, join the Durable Objects beta by visiting the [Cloudflare dashboard](https://dash.cloudflare.com/) and navigating to "Workers" and then "Durable Objects".
+
+Then, make sure you have [Wrangler](https://developers.cloudflare.com/workers/cli-wrangler/install-update), the official Workers CLI, installed. Version 1.19.3 or newer is required to publish this example as written.
+
+After installing it, run `wrangler login` to [connect it to your Cloudflare account](https://developers.cloudflare.com/workers/cli-wrangler/authentication).
+
+Once you're in the Durable Objects beta and have Wrangler installed and authenticated, you can deploy the app for the first time by adding your Cloudflare account ID (which can be viewed by running `wrangler whoami`) to the wrangler.toml file and then running:
+
+    wrangler publish
+
+If you get an error saying "Cannot create binding for class [...] because it is not currently configured to implement durable objects", you need to update your version of Wrangler.
+
+This command will deploy the app to your account under the name `edge-chat-demo`.
+
+## What are the dependencies?
+
+This demo code does not have any dependencies, aside from Cloudflare Workers (for the server side, `chat.mjs`) and a modern web browser (for the client side, `chat.html`). Deploying the code requires Wrangler.
+
+## How to uninstall
+
+Modify wrangler.toml to remove the durable_objects bindings and add a deleted_classes migration. The bottom of your wrangler.toml should look like:
+
+```
+[durable_objects]
+bindings = [
+]
+
+# Indicate that you want the ChatRoom and RateLimiter classes to be callable as Durable Objects.
+[[migrations]]
+tag = "v1" # Should be unique for each entry
+new_classes = ["ChatRoom", "RateLimiter"]
+
+[[migrations]]
+tag = "v2"
+deleted_classes = ["ChatRoom", "RateLimiter"]
+```
+
+Then run `wrangler publish`, which will delete the Durable Objects and all data stored in them. To remove the Worker, go to [dash.cloudflare.com](dash.cloudflare.com) and navigate to Workers -> Overview -> edge-chat-demo -> Manage Service -> Delete (bottom of page)

--- a/packages/workers-chat-demo/package.json
+++ b/packages/workers-chat-demo/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "edge-chat-demo",
+  "description": "An edge chat service that runs on Cloudflare Workers using Durable Objects",
+  "version": "1.0.0",
+  "private": true
+}

--- a/packages/workers-chat-demo/src/chat.html
+++ b/packages/workers-chat-demo/src/chat.html
@@ -1,0 +1,524 @@
+<!DOCTYPE html>
+<!--
+  THIS IS NOT THE INTERESTING FILE
+
+  This is just some UI code. There's nothing interesting and unique in this file. The interesting
+  thing about this demo is the server side, which is in chat.mjs.
+
+  WARNING: This was written by a systems engineer, not a web developer. It's probably bad.
+-->
+
+<html>
+  <head>
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, user-scalable=no"
+    />
+    <!--===================================================================================-->
+    <!-- Inline style to avoid an extra round trip before the page can render. -->
+    <style type="text/css">
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        font-family: Arial, Helvetica, sans-serif;
+      }
+
+      #chatlog {
+        position: fixed;
+        top: 0;
+        bottom: 32px;
+        left: 0;
+        right: 200px;
+        overflow-y: auto;
+        padding: 8px;
+        overflow-wrap: break-word;
+      }
+      #chatlog span.username {
+        font-weight: bold;
+      }
+      #spacer {
+        height: calc(100vh - 32px - 5em);
+      }
+
+      #roster {
+        font-weight: bold;
+        padding: 8px;
+      }
+
+      p {
+        margin-top: 0;
+        margin-bottom: 8px;
+      }
+      p:last-of-type {
+        margin: 0;
+      }
+
+      #roster {
+        position: fixed;
+        right: 0;
+        top: 0;
+        bottom: 32px;
+        width: 200px;
+        border-left: none;
+      }
+
+      ::-webkit-scrollbar {
+        display: none;
+      }
+
+      @media (max-width: 600px) {
+        #roster {
+          display: none;
+        }
+        #chatlog {
+          right: 0;
+        }
+      }
+
+      #chat-input {
+        position: fixed;
+        width: 100%;
+        height: 32px;
+        bottom: 0;
+        left: 0;
+        border: none;
+        border-top: none;
+        padding-left: 32px;
+        outline: none;
+      }
+      #chatroom::before {
+        z-index: 1;
+        display: block;
+        content: ">";
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        width: 32px;
+        height: 32px;
+        line-height: 32px;
+        text-align: center;
+        font-weight: bold;
+        color: #888;
+        -webkit-text-stroke-width: 2px;
+      }
+
+      #name-form {
+        position: fixed;
+        z-index: 3;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        background-color: white;
+      }
+
+      #name-input {
+        position: fixed;
+        font-size: 200%;
+        top: calc(50% - 1em);
+        left: calc(50% - 8em);
+        width: 16em;
+        height: 2em;
+        margin: 0;
+        text-align: center;
+        border: 1px solid #bbb;
+      }
+
+      #name-form p {
+        position: fixed;
+        top: calc(50% + 3em);
+        width: 100%;
+        text-align: center;
+      }
+
+      #room-form {
+        position: fixed;
+        z-index: 2;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        background-color: white;
+        font-size: 200%;
+        margin-top: calc(50vh - 3em);
+        text-align: center;
+      }
+
+      #room-name {
+        font-size: inherit;
+        border: 1px solid #bbb;
+        height: 2em;
+        width: 16em;
+        padding-left: 1em;
+      }
+
+      #room-form button {
+        font-size: inherit;
+        border: 1px solid #bbb;
+        background-color: #eee;
+        height: 2em;
+      }
+
+      @media (max-width: 660px) {
+        #name-input,
+        #room-form {
+          font-size: 150%;
+        }
+        #name-form p {
+          font-size: 75%;
+        }
+      }
+      @media (max-width: 500px) {
+        #name-input,
+        #room-form {
+          font-size: 100%;
+        }
+        #name-form p {
+          font-size: 50%;
+        }
+      }
+
+      #go-public {
+        width: 4em;
+      }
+      #go-private {
+        width: 20em;
+      }
+    </style>
+
+    <!--===================================================================================-->
+    <!-- The actual HTML. There is not much of it. -->
+  </head>
+  <body>
+    <form id="name-form" action="/fake-form-action">
+      <input id="name-input" placeholder="your name" />
+      <p>
+        This chat runs entirely on the edge, powered by<br />
+        <a
+          href="https://blog.cloudflare.com/introducing-workers-durable-objects"
+          target="_blank"
+          >Cloudflare Workers Durable Objects</a
+        >
+      </p>
+    </form>
+    <form id="room-form" action="/fake-form-action">
+      <p>Enter a public room:</p>
+      <input id="room-name" placeholder="room name" /><button id="go-public">
+        Go &raquo;
+      </button>
+      <p>OR</p>
+      <button id="go-private">Create a Private Room &raquo;</button>
+    </form>
+    <form id="chatroom" action="/fake-form-action">
+      <div id="chatlog">
+        <div id="spacer"></div>
+      </div>
+      <div id="roster"></div>
+      <input id="chat-input" />
+    </form>
+  </body>
+
+  <!--===================================================================================-->
+  <!-- Client-side JavaScript code for the app. -->
+
+  <script type="text/javascript">
+    let currentWebSocket = null;
+
+    let nameForm = document.querySelector("#name-form");
+    let nameInput = document.querySelector("#name-input");
+    let roomForm = document.querySelector("#room-form");
+    let roomNameInput = document.querySelector("#room-name");
+    let goPublicButton = document.querySelector("#go-public");
+    let goPrivateButton = document.querySelector("#go-private");
+    let chatroom = document.querySelector("#chatroom");
+    let chatlog = document.querySelector("#chatlog");
+    let chatInput = document.querySelector("#chat-input");
+    let roster = document.querySelector("#roster");
+
+    // Is the chatlog scrolled to the bottom?
+    let isAtBottom = true;
+
+    let username;
+    let roomname;
+
+    let hostname = window.location.host;
+    if (hostname == "") {
+      // Probably testing the HTML locally.
+      hostname = "edge-chat-demo.cloudflareworkers.com";
+    }
+
+    function startNameChooser() {
+      nameForm.addEventListener("submit", (event) => {
+        event.preventDefault();
+        username = nameInput.value;
+        if (username.length > 0) {
+          startRoomChooser();
+        }
+      });
+
+      nameInput.addEventListener("input", (event) => {
+        if (event.currentTarget.value.length > 32) {
+          event.currentTarget.value = event.currentTarget.value.slice(0, 32);
+        }
+      });
+
+      nameInput.focus();
+    }
+
+    function startRoomChooser() {
+      nameForm.remove();
+
+      if (document.location.hash.length > 1) {
+        roomname = document.location.hash.slice(1);
+        startChat();
+        return;
+      }
+
+      roomForm.addEventListener("submit", (event) => {
+        event.preventDefault();
+        roomname = roomNameInput.value;
+        if (roomname.length > 0) {
+          startChat();
+        }
+      });
+
+      roomNameInput.addEventListener("input", (event) => {
+        if (event.currentTarget.value.length > 32) {
+          event.currentTarget.value = event.currentTarget.value.slice(0, 32);
+        }
+      });
+
+      goPublicButton.addEventListener("click", (event) => {
+        roomname = roomNameInput.value;
+        if (roomname.length > 0) {
+          startChat();
+        }
+      });
+
+      goPrivateButton.addEventListener("click", async (event) => {
+        roomNameInput.disabled = true;
+        goPublicButton.disabled = true;
+        event.currentTarget.disabled = true;
+
+        let response = await fetch("https://" + hostname + "/api/room", {
+          method: "POST",
+        });
+        if (!response.ok) {
+          alert("something went wrong");
+          document.location.reload();
+          return;
+        }
+
+        roomname = await response.text();
+        startChat();
+      });
+
+      roomNameInput.focus();
+    }
+
+    function startChat() {
+      roomForm.remove();
+
+      // Normalize the room name a bit.
+      roomname = roomname
+        .replace(/[^a-zA-Z0-9_-]/g, "")
+        .replace(/_/g, "-")
+        .toLowerCase();
+
+      if (roomname.length > 32 && !roomname.match(/^[0-9a-f]{64}$/)) {
+        addChatMessage("ERROR", "Invalid room name.");
+        return;
+      }
+
+      document.location.hash = "#" + roomname;
+
+      chatInput.addEventListener("keydown", (event) => {
+        if (event.keyCode == 38) {
+          // up arrow
+          chatlog.scrollBy(0, -50);
+        } else if (event.keyCode == 40) {
+          // down arrow
+          chatlog.scrollBy(0, 50);
+        } else if (event.keyCode == 33) {
+          // page up
+          chatlog.scrollBy(0, -chatlog.clientHeight + 50);
+        } else if (event.keyCode == 34) {
+          // page down
+          chatlog.scrollBy(0, chatlog.clientHeight - 50);
+        }
+      });
+
+      chatroom.addEventListener("submit", (event) => {
+        event.preventDefault();
+
+        if (currentWebSocket) {
+          currentWebSocket.send(JSON.stringify({ message: chatInput.value }));
+          chatInput.value = "";
+
+          // Scroll to bottom whenever sending a message.
+          chatlog.scrollBy(0, 1e8);
+        }
+      });
+
+      chatInput.addEventListener("input", (event) => {
+        if (event.currentTarget.value.length > 256) {
+          event.currentTarget.value = event.currentTarget.value.slice(0, 256);
+        }
+      });
+
+      chatlog.addEventListener("scroll", (event) => {
+        isAtBottom =
+          chatlog.scrollTop + chatlog.clientHeight >= chatlog.scrollHeight;
+      });
+
+      chatInput.focus();
+      document.body.addEventListener("click", (event) => {
+        // If the user clicked somewhere in the window without selecting any text, focus the chat
+        // input.
+        if (window.getSelection().toString() == "") {
+          chatInput.focus();
+        }
+      });
+
+      // Detect mobile keyboard appearing and disappearing, and adjust the scroll as appropriate.
+      if ("visualViewport" in window) {
+        window.visualViewport.addEventListener("resize", function (event) {
+          if (isAtBottom) {
+            chatlog.scrollBy(0, 1e8);
+          }
+        });
+      }
+
+      join();
+    }
+
+    let lastSeenTimestamp = 0;
+    let wroteWelcomeMessages = false;
+
+    function join() {
+      let ws = new WebSocket(
+        "wss://" + hostname + "/api/room/" + roomname + "/websocket"
+      );
+      let rejoined = false;
+      let startTime = Date.now();
+
+      let rejoin = async () => {
+        if (!rejoined) {
+          rejoined = true;
+          currentWebSocket = null;
+
+          // Clear the roster.
+          while (roster.firstChild) {
+            roster.removeChild(roster.firstChild);
+          }
+
+          // Don't try to reconnect too rapidly.
+          let timeSinceLastJoin = Date.now() - startTime;
+          if (timeSinceLastJoin < 10000) {
+            // Less than 10 seconds elapsed since last join. Pause a bit.
+            await new Promise((resolve) =>
+              setTimeout(resolve, 10000 - timeSinceLastJoin)
+            );
+          }
+
+          // OK, reconnect now!
+          join();
+        }
+      };
+
+      ws.addEventListener("open", (event) => {
+        currentWebSocket = ws;
+
+        // Send user info message.
+        ws.send(JSON.stringify({ name: username }));
+      });
+
+      ws.addEventListener("message", (event) => {
+        let data = JSON.parse(event.data);
+
+        if (data.error) {
+          addChatMessage(null, "* Error: " + data.error);
+        } else if (data.joined) {
+          let p = document.createElement("p");
+          p.innerText = data.joined;
+          roster.appendChild(p);
+        } else if (data.quit) {
+          for (let child of roster.childNodes) {
+            if (child.innerText == data.quit) {
+              roster.removeChild(child);
+              break;
+            }
+          }
+        } else if (data.ready) {
+          // All pre-join messages have been delivered.
+          if (!wroteWelcomeMessages) {
+            wroteWelcomeMessages = true;
+            addChatMessage(
+              null,
+              "* This is a demo app built with Cloudflare Workers Durable Objects. The source code " +
+                "can be found at: https://github.com/cloudflare/workers-chat-demo"
+            );
+            addChatMessage(
+              null,
+              "* WARNING: Participants in this chat are random people on the internet. " +
+                "Names are not authenticated; anyone can pretend to be anyone. The people " +
+                "you are chatting with are NOT Cloudflare employees. Chat history is saved."
+            );
+            if (roomname.length == 64) {
+              addChatMessage(
+                null,
+                "* This is a private room. You can invite someone to the room by sending them the URL."
+              );
+            } else {
+              addChatMessage(null, "* Welcome to #" + roomname + ". Say hi!");
+            }
+          }
+        } else {
+          // A regular chat message.
+          if (data.timestamp > lastSeenTimestamp) {
+            addChatMessage(data.name, data.message);
+            lastSeenTimestamp = data.timestamp;
+          }
+        }
+      });
+
+      ws.addEventListener("close", (event) => {
+        console.log(event);
+        console.log(
+          "WebSocket closed, reconnecting: ",
+          event.code,
+          event.reason
+        );
+        rejoin();
+      });
+      ws.addEventListener("error", (event) => {
+        console.error(event);
+        console.log("WebSocket error, reconnecting:", event);
+        rejoin();
+      });
+    }
+
+    function addChatMessage(name, text) {
+      let p = document.createElement("p");
+      if (name) {
+        let tag = document.createElement("span");
+        tag.className = "username";
+        tag.innerText = name + ": ";
+        p.appendChild(tag);
+      }
+      p.appendChild(document.createTextNode(text));
+
+      // Append the new chat line, making sure that if the chatlog was scrolled to the bottom
+      // before, it remains scrolled to the bottom, and otherwise the scroll position doesn't
+      // change.
+      chatlog.appendChild(p);
+      if (isAtBottom) {
+        chatlog.scrollBy(0, 1e8);
+      }
+    }
+
+    startNameChooser();
+  </script>
+  <!--===================================================================================-->
+</html>

--- a/packages/workers-chat-demo/src/chat.mjs
+++ b/packages/workers-chat-demo/src/chat.mjs
@@ -1,0 +1,555 @@
+// This is the Edge Chat Demo Worker, built using Durable Objects!
+
+// ===============================
+// Introduction to Modules
+// ===============================
+//
+// The first thing you might notice, if you are familiar with the Workers platform, is that this
+// Worker is written differently from others you may have seen. It even has a different file
+// extension. The `mjs` extension means this JavaScript is an ES Module, which, among other things,
+// means it has imports and exports. Unlike other Workers, this code doesn't use
+// `addEventListener("fetch", handler)` to register its main HTTP handler; instead, it _exports_
+// a handler, as we'll see below.
+//
+// This is a new way of writing Workers that we expect to introduce more broadly in the future. We
+// like this syntax because it is *composable*: You can take two workers written this way and
+// merge them into one worker, by importing the two Workers' exported handlers yourself, and then
+// exporting a new handler that call into the other Workers as appropriate.
+//
+// This new syntax is required when using Durable Objects, because your Durable Objects are
+// implemented by classes, and those classes need to be exported. The new syntax can be used for
+// writing regular Workers (without Durable Objects) too, but for now, you must be in the Durable
+// Objects beta to be able to use the new syntax, while we work out the quirks.
+//
+// To see an example configuration for uploading module-based Workers, check out the wrangler.toml
+// file or one of our Durable Object templates for Wrangler:
+//   * https://github.com/cloudflare/durable-objects-template
+//   * https://github.com/cloudflare/durable-objects-rollup-esm
+//   * https://github.com/cloudflare/durable-objects-webpack-commonjs
+
+// ===============================
+// Required Environment
+// ===============================
+//
+// This worker, when deployed, must be configured with two environment bindings:
+// * rooms: A Durable Object namespace binding mapped to the ChatRoom class.
+// * limiters: A Durable Object namespace binding mapped to the RateLimiter class.
+//
+// Incidentally, in pre-modules Workers syntax, "bindings" (like KV bindings, secrets, etc.)
+// appeared in your script as global variables, but in the new modules syntax, this is no longer
+// the case. Instead, bindings are now delivered in an "environment object" when an event handler
+// (or Durable Object class constructor) is called. Look for the variable `env` below.
+//
+// We made this change, again, for composability: The global scope is global, but if you want to
+// call into existing code that has different environment requirements, then you need to be able
+// to pass the environment as a parameter instead.
+//
+// Once again, see the wrangler.toml file to understand how the environment is configured.
+
+// =======================================================================================
+// The regular Worker part...
+//
+// This section of the code implements a normal Worker that receives HTTP requests from external
+// clients. This part is stateless.
+
+// With the introduction of modules, we're experimenting with allowing text/data blobs to be
+// uploaded and exposed as synthetic modules. In wrangler.toml we specify a rule that files ending
+// in .html should be uploaded as "Data", equivalent to content-type `application/octet-stream`.
+// So when we import it as `HTML` here, we get the HTML content as an `ArrayBuffer`. This lets us
+// serve our app's static asset without relying on any separate storage. (However, the space
+// available for assets served this way is very limited; larger sites should continue to use Workers
+// KV to serve assets.)
+import HTML from "./chat.html";
+
+// `handleErrors()` is a little utility function that can wrap an HTTP request handler in a
+// try/catch and return errors to the client. You probably wouldn't want to use this in production
+// code but it is convenient when debugging and iterating.
+async function handleErrors(request, func) {
+  try {
+    return await func();
+  } catch (err) {
+    if (request.headers.get("Upgrade") == "websocket") {
+      // Annoyingly, if we return an HTTP error in response to a WebSocket request, Chrome devtools
+      // won't show us the response body! So... let's send a WebSocket response with an error
+      // frame instead.
+      let pair = new WebSocketPair();
+      pair[1].accept();
+      pair[1].send(JSON.stringify({ error: err.stack }));
+      pair[1].close(1011, "Uncaught exception during session setup");
+      return new Response(null, { status: 101, webSocket: pair[0] });
+    } else {
+      return new Response(err.stack, { status: 500 });
+    }
+  }
+}
+
+// In modules-syntax workers, we use `export default` to export our script's main event handlers.
+// Here, we export one handler, `fetch`, for receiving HTTP requests. In pre-modules workers, the
+// fetch handler was registered using `addEventHandler("fetch", event => { ... })`; this is just
+// new syntax for essentially the same thing.
+//
+// `fetch` isn't the only handler. If your worker runs on a Cron schedule, it will receive calls
+// to a handler named `scheduled`, which should be exported here in a similar way. We will be
+// adding other handlers for other types of events over time.
+export default {
+  async fetch(request, env) {
+    return await handleErrors(request, async () => {
+      // We have received an HTTP request! Parse the URL and route the request.
+
+      let url = new URL(request.url);
+      let path = url.pathname.slice(1).split("/");
+
+      if (!path[0]) {
+        // Serve our HTML at the root path.
+        return new Response(HTML, {
+          headers: { "Content-Type": "text/html;charset=UTF-8" },
+        });
+      }
+
+      switch (path[0]) {
+        case "api":
+          // This is a request for `/api/...`, call the API handler.
+          return handleApiRequest(path.slice(1), request, env);
+
+        default:
+          return new Response("Not found", { status: 404 });
+      }
+    });
+  },
+};
+
+async function handleApiRequest(path, request, env) {
+  // We've received at API request. Route the request based on the path.
+
+  switch (path[0]) {
+    case "room": {
+      // Request for `/api/room/...`.
+
+      if (!path[1]) {
+        // The request is for just "/api/room", with no ID.
+        if (request.method == "POST") {
+          // POST to /api/room creates a private room.
+          //
+          // Incidentally, this code doesn't actually store anything. It just generates a valid
+          // unique ID for this namespace. Each durable object namespace has its own ID space, but
+          // IDs from one namespace are not valid for any other.
+          //
+          // The IDs returned by `newUniqueId()` are unguessable, so are a valid way to implement
+          // "anyone with the link can access" sharing. Additionally, IDs generated this way have
+          // a performance benefit over IDs generated from names: When a unique ID is generated,
+          // the system knows it is unique without having to communicate with the rest of the
+          // world -- i.e., there is no way that someone in the UK and someone in New Zealand
+          // could coincidentally create the same ID at the same time, because unique IDs are,
+          // well, unique!
+          let id = env.rooms.newUniqueId();
+          return new Response(id.toString(), {
+            headers: { "Access-Control-Allow-Origin": "*" },
+          });
+        } else {
+          // If we wanted to support returning a list of public rooms, this might be a place to do
+          // it. The list of room names might be a good thing to store in KV, though a singleton
+          // Durable Object is also a possibility as long as the Cache API is used to cache reads.
+          // (A caching layer would be needed because a single Durable Object is single-threaded,
+          // so the amount of traffic it can handle is limited. Also, caching would improve latency
+          // for users who don't happen to be located close to the singleton.)
+          //
+          // For this demo, though, we're not implementing a public room list, mainly because
+          // inevitably some trolls would probably register a bunch of offensive room names. Sigh.
+          return new Response("Method not allowed", { status: 405 });
+        }
+      }
+
+      // OK, the request is for `/api/room/<name>/...`. It's time to route to the Durable Object
+      // for the specific room.
+      let name = path[1];
+
+      // Each Durable Object has a 256-bit unique ID. IDs can be derived from string names, or
+      // chosen randomly by the system.
+      let id;
+      if (name.match(/^[0-9a-f]{64}$/)) {
+        // The name is 64 hex digits, so let's assume it actually just encodes an ID. We use this
+        // for private rooms. `idFromString()` simply parses the text as a hex encoding of the raw
+        // ID (and verifies that this is a valid ID for this namespace).
+        id = env.rooms.idFromString(name);
+      } else if (name.length <= 32) {
+        // Treat as a string room name (limited to 32 characters). `idFromName()` consistently
+        // derives an ID from a string.
+        id = env.rooms.idFromName(name);
+      } else {
+        return new Response("Name too long", { status: 404 });
+      }
+
+      // Get the Durable Object stub for this room! The stub is a client object that can be used
+      // to send messages to the remote Durable Object instance. The stub is returned immediately;
+      // there is no need to await it. This is important because you would not want to wait for
+      // a network round trip before you could start sending requests. Since Durable Objects are
+      // created on-demand when the ID is first used, there's nothing to wait for anyway; we know
+      // an object will be available somewhere to receive our requests.
+      let roomObject = env.rooms.get(id);
+
+      // Compute a new URL with `/api/room/<name>` removed. We'll forward the rest of the path
+      // to the Durable Object.
+      let newUrl = new URL(request.url);
+      newUrl.pathname = "/" + path.slice(2).join("/");
+
+      // Send the request to the object. The `fetch()` method of a Durable Object stub has the
+      // same signature as the global `fetch()` function, but the request is always sent to the
+      // object, regardless of the request's URL.
+      return roomObject.fetch(newUrl, request);
+    }
+
+    default:
+      return new Response("Not found", { status: 404 });
+  }
+}
+
+// =======================================================================================
+// The ChatRoom Durable Object Class
+
+// ChatRoom implements a Durable Object that coordinates an individual chat room. Participants
+// connect to the room using WebSockets, and the room broadcasts messages from each participant
+// to all others.
+export class ChatRoom {
+  constructor(controller, env) {
+    // `controller.storage` provides access to our durable storage. It provides a simple KV
+    // get()/put() interface.
+    this.storage = controller.storage;
+
+    // `env` is our environment bindings (discussed earlier).
+    this.env = env;
+
+    // We will put the WebSocket objects for each client, along with some metadata, into
+    // `sessions`.
+    this.sessions = [];
+
+    // We keep track of the last-seen message's timestamp just so that we can assign monotonically
+    // increasing timestamps even if multiple messages arrive simultaneously (see below). There's
+    // no need to store this to disk since we assume if the object is destroyed and recreated, much
+    // more than a millisecond will have gone by.
+    this.lastTimestamp = 0;
+  }
+
+  // The system will call fetch() whenever an HTTP request is sent to this Object. Such requests
+  // can only be sent from other Worker code, such as the code above; these requests don't come
+  // directly from the internet. In the future, we will support other formats than HTTP for these
+  // communications, but we started with HTTP for its familiarity.
+  async fetch(request) {
+    return await handleErrors(request, async () => {
+      let url = new URL(request.url);
+
+      switch (url.pathname) {
+        case "/websocket": {
+          // The request is to `/api/room/<name>/websocket`. A client is trying to establish a new
+          // WebSocket session.
+          if (request.headers.get("Upgrade") != "websocket") {
+            return new Response("expected websocket", { status: 400 });
+          }
+
+          // Get the client's IP address for use with the rate limiter.
+          let ip = request.headers.get("CF-Connecting-IP");
+
+          // To accept the WebSocket request, we create a WebSocketPair (which is like a socketpair,
+          // i.e. two WebSockets that talk to each other), we return one end of the pair in the
+          // response, and we operate on the other end. Note that this API is not part of the
+          // Fetch API standard; unfortunately, the Fetch API / Service Workers specs do not define
+          // any way to act as a WebSocket server today.
+          let pair = new WebSocketPair();
+
+          // We're going to take pair[1] as our end, and return pair[0] to the client.
+          await this.handleSession(pair[1], ip);
+
+          // Now we return the other end of the pair to the client.
+          return new Response(null, { status: 101, webSocket: pair[0] });
+        }
+
+        default:
+          return new Response("Not found", { status: 404 });
+      }
+    });
+  }
+
+  // handleSession() implements our WebSocket-based chat protocol.
+  async handleSession(webSocket, ip) {
+    // Accept our end of the WebSocket. This tells the runtime that we'll be terminating the
+    // WebSocket in JavaScript, not sending it elsewhere.
+    webSocket.accept();
+
+    // Set up our rate limiter client.
+    let limiterId = this.env.limiters.idFromName(ip);
+    let limiter = new RateLimiterClient(
+      () => this.env.limiters.get(limiterId),
+      (err) => webSocket.close(1011, err.stack)
+    );
+
+    // Create our session and add it to the sessions list.
+    // We don't send any messages to the client until it has sent us the initial user info
+    // message. Until then, we will queue messages in `session.blockedMessages`.
+    let session = { webSocket, blockedMessages: [] };
+    this.sessions.push(session);
+
+    // Queue "join" messages for all online users, to populate the client's roster.
+    this.sessions.forEach((otherSession) => {
+      if (otherSession.name) {
+        session.blockedMessages.push(
+          JSON.stringify({ joined: otherSession.name })
+        );
+      }
+    });
+
+    // Load the last 100 messages from the chat history stored on disk, and send them to the
+    // client.
+    let storage = await this.storage.list({ reverse: true, limit: 100 });
+    let backlog = [...storage.values()];
+    backlog.reverse();
+    backlog.forEach((value) => {
+      session.blockedMessages.push(value);
+    });
+
+    // Set event handlers to receive messages.
+    let receivedUserInfo = false;
+    webSocket.addEventListener("message", async (msg) => {
+      try {
+        if (session.quit) {
+          // Whoops, when trying to send to this WebSocket in the past, it threw an exception and
+          // we marked it broken. But somehow we got another message? I guess try sending a
+          // close(), which might throw, in which case we'll try to send an error, which will also
+          // throw, and whatever, at least we won't accept the message. (This probably can't
+          // actually happen. This is defensive coding.)
+          webSocket.close(1011, "WebSocket broken.");
+          return;
+        }
+
+        // Check if the user is over their rate limit and reject the message if so.
+        if (!limiter.checkLimit()) {
+          webSocket.send(
+            JSON.stringify({
+              error: "Your IP is being rate-limited, please try again later.",
+            })
+          );
+          return;
+        }
+
+        // I guess we'll use JSON.
+        let data = JSON.parse(msg.data);
+
+        if (!receivedUserInfo) {
+          // The first message the client sends is the user info message with their name. Save it
+          // into their session object.
+          session.name = "" + (data.name || "anonymous");
+
+          // Don't let people use ridiculously long names. (This is also enforced on the client,
+          // so if they get here they are not using the intended client.)
+          if (session.name.length > 32) {
+            webSocket.send(JSON.stringify({ error: "Name too long." }));
+            webSocket.close(1009, "Name too long.");
+            return;
+          }
+
+          // Deliver all the messages we queued up since the user connected.
+          session.blockedMessages.forEach((queued) => {
+            webSocket.send(queued);
+          });
+          delete session.blockedMessages;
+
+          // Broadcast to all other connections that this user has joined.
+          this.broadcast({ joined: session.name });
+
+          webSocket.send(JSON.stringify({ ready: true }));
+
+          // Note that we've now received the user info message.
+          receivedUserInfo = true;
+
+          return;
+        }
+
+        // Construct sanitized message for storage and broadcast.
+        data = { name: session.name, message: "" + data.message };
+
+        // Block people from sending overly long messages. This is also enforced on the client,
+        // so to trigger this the user must be bypassing the client code.
+        if (data.message.length > 256) {
+          webSocket.send(JSON.stringify({ error: "Message too long." }));
+          return;
+        }
+
+        // Add timestamp. Here's where this.lastTimestamp comes in -- if we receive a bunch of
+        // messages at the same time (or if the clock somehow goes backwards????), we'll assign
+        // them sequential timestamps, so at least the ordering is maintained.
+        data.timestamp = Math.max(Date.now(), this.lastTimestamp + 1);
+        this.lastTimestamp = data.timestamp;
+
+        // Broadcast the message to all other WebSockets.
+        let dataStr = JSON.stringify(data);
+        this.broadcast(dataStr);
+
+        // Save message.
+        let key = new Date(data.timestamp).toISOString();
+        await this.storage.put(key, dataStr);
+      } catch (err) {
+        // Report any exceptions directly back to the client. As with our handleErrors() this
+        // probably isn't what you'd want to do in production, but it's convenient when testing.
+        webSocket.send(JSON.stringify({ error: err.stack }));
+      }
+    });
+
+    // On "close" and "error" events, remove the WebSocket from the sessions list and broadcast
+    // a quit message.
+    let closeOrErrorHandler = (evt) => {
+      session.quit = true;
+      this.sessions = this.sessions.filter((member) => member !== session);
+      if (session.name) {
+        this.broadcast({ quit: session.name });
+      }
+    };
+    webSocket.addEventListener("close", closeOrErrorHandler);
+    webSocket.addEventListener("error", closeOrErrorHandler);
+  }
+
+  // broadcast() broadcasts a message to all clients.
+  broadcast(message) {
+    // Apply JSON if we weren't given a string to start with.
+    if (typeof message !== "string") {
+      message = JSON.stringify(message);
+    }
+
+    // Iterate over all the sessions sending them messages.
+    let quitters = [];
+    this.sessions = this.sessions.filter((session) => {
+      if (session.name) {
+        try {
+          session.webSocket.send(message);
+          return true;
+        } catch (err) {
+          // Whoops, this connection is dead. Remove it from the list and arrange to notify
+          // everyone below.
+          session.quit = true;
+          quitters.push(session);
+          return false;
+        }
+      } else {
+        // This session hasn't sent the initial user info message yet, so we're not sending them
+        // messages yet (no secret lurking!). Queue the message to be sent later.
+        session.blockedMessages.push(message);
+        return true;
+      }
+    });
+
+    quitters.forEach((quitter) => {
+      if (quitter.name) {
+        this.broadcast({ quit: quitter.name });
+      }
+    });
+  }
+}
+
+// =======================================================================================
+// The RateLimiter Durable Object class.
+
+// RateLimiter implements a Durable Object that tracks the frequency of messages from a particular
+// source and decides when messages should be dropped because the source is sending too many
+// messages.
+//
+// We utilize this in ChatRoom, above, to apply a per-IP-address rate limit. These limits are
+// global, i.e. they apply across all chat rooms, so if a user spams one chat room, they will find
+// themselves rate limited in all other chat rooms simultaneously.
+export class RateLimiter {
+  constructor(controller, env) {
+    // Timestamp at which this IP will next be allowed to send a message. Start in the distant
+    // past, i.e. the IP can send a message now.
+    this.nextAllowedTime = 0;
+  }
+
+  // Our protocol is: POST when the IP performs an action, or GET to simply read the current limit.
+  // Either way, the result is the number of seconds to wait before allowing the IP to perform its
+  // next action.
+  async fetch(request) {
+    return await handleErrors(request, async () => {
+      let now = Date.now() / 1000;
+
+      this.nextAllowedTime = Math.max(now, this.nextAllowedTime);
+
+      if (request.method == "POST") {
+        // POST request means the user performed an action.
+        // We allow one action per 5 seconds.
+        this.nextAllowedTime += 5;
+      }
+
+      // Return the number of seconds that the client needs to wait.
+      //
+      // We provide a "grace" period of 20 seconds, meaning that the client can make 4-5 requests
+      // in a quick burst before they start being limited.
+      let cooldown = Math.max(0, this.nextAllowedTime - now - 20);
+      return new Response(cooldown);
+    });
+  }
+}
+
+// RateLimiterClient implements rate limiting logic on the caller's side.
+class RateLimiterClient {
+  // The constructor takes two functions:
+  // * getLimiterStub() returns a new Durable Object stub for the RateLimiter object that manages
+  //   the limit. This may be called multiple times as needed to reconnect, if the connection is
+  //   lost.
+  // * reportError(err) is called when something goes wrong and the rate limiter is broken. It
+  //   should probably disconnect the client, so that they can reconnect and start over.
+  constructor(getLimiterStub, reportError) {
+    this.getLimiterStub = getLimiterStub;
+    this.reportError = reportError;
+
+    // Call the callback to get the initial stub.
+    this.limiter = getLimiterStub();
+
+    // When `inCooldown` is true, the rate limit is currently applied and checkLimit() will return
+    // false.
+    this.inCooldown = false;
+  }
+
+  // Call checkLimit() when a message is received to decide if it should be blocked due to the
+  // rate limit. Returns `true` if the message should be accepted, `false` to reject.
+  checkLimit() {
+    if (this.inCooldown) {
+      return false;
+    }
+    this.inCooldown = true;
+    this.callLimiter();
+    return true;
+  }
+
+  // callLimiter() is an internal method which talks to the rate limiter.
+  async callLimiter() {
+    try {
+      let response;
+      try {
+        // Currently, fetch() needs a valid URL even though it's not actually going to the
+        // internet. We may loosen this in the future to accept an arbitrary string. But for now,
+        // we have to provide a dummy URL that will be ignored at the other end anyway.
+        response = await this.limiter.fetch("https://dummy-url", {
+          method: "POST",
+        });
+      } catch (err) {
+        // `fetch()` threw an exception. This is probably because the limiter has been
+        // disconnected. Stubs implement E-order semantics, meaning that calls to the same stub
+        // are delivered to the remote object in order, until the stub becomes disconnected, after
+        // which point all further calls fail. This guarantee makes a lot of complex interaction
+        // patterns easier, but it means we must be prepared for the occasional disconnect, as
+        // networks are inherently unreliable.
+        //
+        // Anyway, get a new limiter and try again. If it fails again, something else is probably
+        // wrong.
+        this.limiter = this.getLimiterStub();
+        response = await this.limiter.fetch("https://dummy-url", {
+          method: "POST",
+        });
+      }
+
+      // The response indicates how long we want to pause before accepting more requests.
+      let cooldown = +(await response.text());
+      await new Promise((resolve) => setTimeout(resolve, cooldown * 1000));
+
+      // Done waiting.
+      this.inCooldown = false;
+    } catch (err) {
+      this.reportError(err);
+    }
+  }
+}

--- a/packages/workers-chat-demo/wrangler.toml
+++ b/packages/workers-chat-demo/wrangler.toml
@@ -1,0 +1,17 @@
+name = "edge-chat-demo"
+compatibility_date = "2021-11-08"
+
+[build.upload]
+dir = "src"
+main = "./chat.mjs"
+
+[durable_objects]
+bindings = [
+  { name = "rooms", class_name = "ChatRoom" },
+  { name = "limiters", class_name = "RateLimiter" }
+]
+
+# Indicate that you want the ChatRoom and RateLimiter classes to be callable as Durable Objects.
+[[migrations]]
+tag = "v1" # Should be unique for each entry
+new_classes = ["ChatRoom", "RateLimiter"]


### PR DESCRIPTION
This adds the `workers-chat-demo` from https://github.com/cloudflare/workers-chat-demo as an example app into our monorepo. It has some modifications, documted at the top of its `README.md`.

Of note, you'll note that this _doesn't_ work with wrangler. Landing this so we can debug and have a shared reference that we need to get to work.