### PR TITLE
fix: make `workers-chat-demo` work

### DIFF
--- a/packages/workers-chat-demo/README.md
+++ b/packages/workers-chat-demo/README.md
@@ -11,6 +11,8 @@ This is the demo for durable objects originally published at https://github.com/
 
 - The `module` field is removed from `package.json`.
 
+- Change calls from `https://...` to `http://...`, and `wss://...` to `ws://...`.
+
 Also a reminder: you need to publish this worker (or even a plain worker named `edge-chat-demo`) before you can develop on it. That's a problem that we need to solve on our end, but this is a workaround for now.
 
 The original README follows -

--- a/packages/workers-chat-demo/src/chat.html
+++ b/packages/workers-chat-demo/src/chat.html
@@ -301,7 +301,7 @@
         goPublicButton.disabled = true;
         event.currentTarget.disabled = true;
 
-        let response = await fetch("https://" + hostname + "/api/room", {
+        let response = await fetch("http://" + hostname + "/api/room", {
           method: "POST",
         });
         if (!response.ok) {
@@ -398,7 +398,7 @@
 
     function join() {
       let ws = new WebSocket(
-        "wss://" + hostname + "/api/room/" + roomname + "/websocket"
+        "ws://" + hostname + "/api/room/" + roomname + "/websocket"
       );
       let rejoined = false;
       let startTime = Date.now();


### PR DESCRIPTION
This required a couple more changes in `chat.html`.

Closes https://github.com/cloudflare/wrangler2/issues/477

(A proper fix would be to automatically choose the right protocol, and we should also probably default `wrangler dev` to https.)