### PR TITLE
fix: replace the word "deploy" with "publish" everywhere.

### DIFF
--- a/.changeset/funny-cycles-smile.md
+++ b/.changeset/funny-cycles-smile.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: replace the word "deploy" with "publish" everywhere.
+
+We should be consistent with the word that describes how we get a worker to the edge. The command is `publish`, so let's use that everywhere.

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -35,7 +35,7 @@ describe("wrangler", () => {
           wrangler whoami            🕵️  Retrieve your user info and test your auth config
           wrangler dev [script]      👂 Start a local server for developing your worker
           wrangler publish [script]  🆙 Publish your Worker to Cloudflare.
-          wrangler tail [name]       🦚 Starts a log tailing session for a deployed Worker.
+          wrangler tail [name]       🦚 Starts a log tailing session for a published Worker.
           wrangler secret            🤫 Generate a secret that can be referenced in the worker script
           wrangler kv:namespace      🗂️  Interact with your Workers KV Namespaces
           wrangler kv:key            🔑 Individually manage Workers KV key-value pairs
@@ -73,7 +73,7 @@ describe("wrangler", () => {
           wrangler whoami            🕵️  Retrieve your user info and test your auth config
           wrangler dev [script]      👂 Start a local server for developing your worker
           wrangler publish [script]  🆙 Publish your Worker to Cloudflare.
-          wrangler tail [name]       🦚 Starts a log tailing session for a deployed Worker.
+          wrangler tail [name]       🦚 Starts a log tailing session for a published Worker.
           wrangler secret            🤫 Generate a secret that can be referenced in the worker script
           wrangler kv:namespace      🗂️  Interact with your Workers KV Namespaces
           wrangler kv:key            🔑 Individually manage Workers KV key-value pairs
@@ -397,7 +397,7 @@ describe("wrangler", () => {
       expect(fs.existsSync("./src/index.ts")).toBe(true);
 
       expect(packageJson.scripts.start).toBe("wrangler dev src/index.ts");
-      expect(packageJson.scripts.deploy).toBe("wrangler publish src/index.ts");
+      expect(packageJson.scripts.publish).toBe("wrangler publish src/index.ts");
       expect(packageJson.name).toContain("wrangler-tests");
       expect(packageJson.version).toEqual("0.0.0");
       expect(std.out).toMatchInlineSnapshot(`
@@ -405,7 +405,7 @@ describe("wrangler", () => {
               ✨ Created package.json
               ✨ Created tsconfig.json, installed @cloudflare/workers-types into devDependencies
               To start developing on your worker, run npm start.
-              To publish your worker on to the internet, run npm run deploy.
+              To publish your worker on to the internet, run npm run publish.
               ✨ Created src/index.ts"
             `);
     });
@@ -430,7 +430,7 @@ describe("wrangler", () => {
         JSON.stringify({
           scripts: {
             start: "test-start",
-            deploy: "test-deploy",
+            publish: "test-publish",
           },
         })
       );
@@ -443,7 +443,7 @@ describe("wrangler", () => {
       expect(fs.existsSync("./src/index.ts")).toBe(true);
 
       expect(packageJson.scripts.start).toBe("test-start");
-      expect(packageJson.scripts.deploy).toBe("test-deploy");
+      expect(packageJson.scripts.publish).toBe("test-publish");
       expect(std.out).toMatchInlineSnapshot(`
               "✨ Successfully created wrangler.toml
               ✨ Created tsconfig.json, installed @cloudflare/workers-types into devDependencies
@@ -483,14 +483,14 @@ describe("wrangler", () => {
       expect(fs.existsSync("./src/index.ts")).toBe(false);
 
       expect(packageJson.scripts.start).toBe("wrangler dev src/index.js");
-      expect(packageJson.scripts.deploy).toBe("wrangler publish src/index.js");
+      expect(packageJson.scripts.publish).toBe("wrangler publish src/index.js");
       expect(packageJson.name).toContain("wrangler-tests");
       expect(packageJson.version).toEqual("0.0.0");
       expect(std.out).toMatchInlineSnapshot(`
               "✨ Successfully created wrangler.toml
               ✨ Created package.json
               To start developing on your worker, run npm start.
-              To publish your worker on to the internet, run npm run deploy.
+              To publish your worker on to the internet, run npm run publish.
               ✨ Created src/index.js"
             `);
     });
@@ -515,7 +515,7 @@ describe("wrangler", () => {
         JSON.stringify({
           scripts: {
             start: "test-start",
-            deploy: "test-deploy",
+            publish: "test-publish",
           },
         })
       );
@@ -528,7 +528,7 @@ describe("wrangler", () => {
       expect(fs.existsSync("./src/index.ts")).toBe(false);
 
       expect(packageJson.scripts.start).toBe("test-start");
-      expect(packageJson.scripts.deploy).toBe("test-deploy");
+      expect(packageJson.scripts.publish).toBe("test-publish");
       expect(std.out).toMatchInlineSnapshot(`
               "✨ Successfully created wrangler.toml
               To start developing on your worker, npx wrangler dev src/index.js

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -55,7 +55,7 @@ describe("publish", () => {
       "Uploaded
       test-name
       (TIMINGS)
-      Deployed
+      Published
       test-name
       (TIMINGS)
 
@@ -77,7 +77,7 @@ describe("publish", () => {
         "Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -98,7 +98,7 @@ describe("publish", () => {
         "Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -119,7 +119,7 @@ describe("publish", () => {
         "Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -146,7 +146,7 @@ describe("publish", () => {
         "Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -175,7 +175,7 @@ describe("publish", () => {
         "Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -195,7 +195,7 @@ describe("publish", () => {
         "Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -218,7 +218,7 @@ describe("publish", () => {
         "Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -248,7 +248,7 @@ export default{
         "Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -269,7 +269,7 @@ export default{
         "Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -293,7 +293,7 @@ export default{
         "Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -367,7 +367,7 @@ export default{
         Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -435,7 +435,7 @@ export default{
         Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -487,7 +487,7 @@ export default{
         Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -541,7 +541,7 @@ export default{
         Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -592,7 +592,7 @@ export default{
         Uploaded
         test-name (some-env)
         (TIMINGS)
-        Deployed
+        Published
         test-name (some-env)
         (TIMINGS)
 
@@ -638,7 +638,7 @@ export default{
         Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -681,7 +681,7 @@ export default{
         Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -724,7 +724,7 @@ export default{
         Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -768,7 +768,7 @@ export default{
         Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -812,7 +812,7 @@ export default{
         Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -856,7 +856,7 @@ export default{
         Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -900,7 +900,7 @@ export default{
         Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -946,7 +946,7 @@ export default{
         Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -996,7 +996,7 @@ export default{
         Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -1094,7 +1094,7 @@ export default{
   });
 
   describe("workers_dev setting", () => {
-    it("should deploy to a workers.dev domain if workers_dev is undefined", async () => {
+    it("should publish to a workers.dev domain if workers_dev is undefined", async () => {
       writeWranglerToml();
       writeWorkerSource();
       mockUploadWorkerRequest();
@@ -1106,7 +1106,7 @@ export default{
         "Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -1115,7 +1115,7 @@ export default{
       expect(std.err).toMatchInlineSnapshot(`""`);
     });
 
-    it("should deploy to the workers.dev domain if workers_dev is `true`", async () => {
+    it("should publish to the workers.dev domain if workers_dev is `true`", async () => {
       writeWranglerToml({
         workers_dev: true,
       });
@@ -1129,7 +1129,7 @@ export default{
         "Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -1153,7 +1153,7 @@ export default{
         "Uploaded
         test-name
         (TIMINGS)
-        No deployment targets for
+        No publish targets for
         test-name
         (TIMINGS)"
       `);
@@ -1173,7 +1173,7 @@ export default{
         "Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -1195,7 +1195,7 @@ export default{
         "Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -1230,7 +1230,7 @@ export default{
         Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -1260,7 +1260,7 @@ export default{
           Uploaded
           test-name
           (TIMINGS)
-          Deployed
+          Published
           test-name
           (TIMINGS)
 
@@ -1295,7 +1295,7 @@ export default{
         "Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -1363,7 +1363,7 @@ export default{
         "Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -1397,7 +1397,7 @@ export default{
         "Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -1436,7 +1436,7 @@ export default{
         "Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -1465,7 +1465,7 @@ export default{
         "Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -1506,7 +1506,7 @@ export default{
         "Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 
@@ -1546,7 +1546,7 @@ export default{
         "Uploaded
         test-name
         (TIMINGS)
-        Deployed
+        Published
         test-name
         (TIMINGS)
 

--- a/packages/wrangler/src/config.ts
+++ b/packages/wrangler/src/config.ts
@@ -106,7 +106,7 @@ export type Config = {
   zone_id?: string;
 
   /**
-   * A list of routes that your worker should be deployed to.
+   * A list of routes that your worker should be published to.
    * Only one of `routes` or `route` is required.
    *
    * @optional false only when workers_dev is false, and there's no scheduled worker
@@ -115,7 +115,7 @@ export type Config = {
   routes?: string[];
 
   /**
-   * A route that your worker should be deployed to. Literally
+   * A route that your worker should be published to. Literally
    * the same as routes, but only one.
    * Only one of `routes` or `route` is required.
    *

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -466,7 +466,7 @@ export async function main(argv: string[]): Promise<void> {
       );
       const shouldWritePackageJsonScripts =
         !packageJsonContent.scripts?.start &&
-        !packageJsonContent.scripts?.deploy &&
+        !packageJsonContent.scripts?.publish &&
         shouldCreatePackageJson;
       async function writePackageJsonScripts(
         isWritingScripts: boolean,
@@ -482,7 +482,7 @@ export async function main(argv: string[]): Promise<void> {
                 scripts: {
                   ...packageJsonContent.scripts,
                   start: `wrangler dev ${scriptPath}`,
-                  deploy: `wrangler publish ${scriptPath}`,
+                  publish: `wrangler publish ${scriptPath}`,
                 },
               },
               null,
@@ -491,7 +491,7 @@ export async function main(argv: string[]): Promise<void> {
           );
           console.log(`To start developing on your worker, run npm start.`);
           console.log(
-            `To publish your worker on to the internet, run npm run deploy.`
+            `To publish your worker on to the internet, run npm run publish.`
           );
         } else {
           console.log(
@@ -1033,7 +1033,7 @@ export async function main(argv: string[]): Promise<void> {
   // tail
   wrangler.command(
     "tail [name]",
-    "🦚 Starts a log tailing session for a deployed Worker.",
+    "🦚 Starts a log tailing session for a published Worker.",
     (yargs) => {
       return (
         yargs

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -341,16 +341,12 @@ export default async function publish(props: Props): Promise<void> {
     const deployMs = Date.now() - start - uploadMs;
 
     if (deployments.length > 0) {
-      console.log("Deployed", workerName, formatTime(deployMs));
+      console.log("Published", workerName, formatTime(deployMs));
       for (const target of targets.flat()) {
         console.log(" ", target);
       }
     } else {
-      console.log(
-        "No deployment targets for",
-        workerName,
-        formatTime(deployMs)
-      );
+      console.log("No publish targets for", workerName, formatTime(deployMs));
     }
   } finally {
     await destination.cleanup();

--- a/packages/wrangler/templates/new-worker.js
+++ b/packages/wrangler/templates/new-worker.js
@@ -3,7 +3,7 @@
  *
  * - Run `npx wrangler dev src/index.js` in your terminal to start a development server
  * - Open a browser tab at http://localhost:8787/ to see your worker in action
- * - Run `npx wrangler publish src/index.js --name my-worker` to deploy your worker
+ * - Run `npx wrangler publish src/index.js --name my-worker` to publish your worker
  *
  * Learn more at https://developers.cloudflare.com/workers/
  */

--- a/packages/wrangler/templates/new-worker.ts
+++ b/packages/wrangler/templates/new-worker.ts
@@ -3,7 +3,7 @@
  *
  * - Run `wrangler dev src/index.ts` in your terminal to start a development server
  * - Open a browser tab at http://localhost:8787/ to see your worker in action
- * - Run `wrangler publish src/index.ts --name my-worker` to deploy your worker
+ * - Run `wrangler publish src/index.ts --name my-worker` to publish your worker
  *
  * Learn more at https://developers.cloudflare.com/workers/
  */


### PR DESCRIPTION
We should be consistent with the word that describes how we get a worker to the edge. The command is `publish`, so let's use that everywhere.