### PR TITLE
ci: enable artifact comments in PR from forks

### DIFF
--- a/.github/workflows/create-pullrequest-prerelease.yml
+++ b/.github/workflows/create-pullrequest-prerelease.yml
@@ -48,17 +48,13 @@ jobs:
           name: wrangler
           path: packages/wrangler/wrangler-*.tgz
 
-      - name: Comment on PR with Link
-        uses: marocchino/sticky-pull-request-comment@v2
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          mkdir -p ./pr
+          echo $PR_NUMBER > ./pr/pr_number
+      - uses: actions/upload-artifact@v2
         with:
-          message: |
-            A wrangler prerelease is available for testing. You can install it in your project with:
-
-            ```sh
-            npm install --save-dev https://prerelease-registry.developers.workers.dev/runs/${{ github.run_id }}/wrangler
-            ```
-
-            Or you can try developing a worker directly with:
-            ```sh
-            npx https://prerelease-registry.developers.workers.dev/runs/${{ github.run_id }}/wrangler dev path/to/script.js
-            ```
+          name: pr_number
+          path: pr/

--- a/.github/workflows/write-prerelease-comment.yml
+++ b/.github/workflows/write-prerelease-comment.yml
@@ -1,0 +1,59 @@
+name: Write prerelease comment
+
+on:
+  workflow_run:
+    workflows: ["Create Pull Request Prerelease"]
+    types:
+      - completed
+
+jobs:
+  comment:
+    if: ${{ github.repository_owner == 'cloudflare' }}
+    runs-on: ubuntu-latest
+    name: Write comment to the PR
+    steps:
+      - name: "Download pr_number artifact"
+        uses: actions/github-script@v5
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr_number"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr_number.zip`, Buffer.from(download.data));
+      - name: "Unzip pr_number artifact"
+        run: unzip pr_number.zip
+      - name: "Write PR number to environment"
+        uses: actions/github-script@v5
+        with:
+          script: |
+            let fs = require('fs');
+            let pr_number = Number(fs.readFileSync('./pr_number'));
+            fs.appendFileSync(process.env.GITHUB_ENV, `WORKFLOW_RUN_PR=${pr_number}`);
+
+    - name: Comment on PR with Link
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ env.WORKFLOW_RUN_PR }}
+          message: |
+            A wrangler prerelease is available for testing. You can install it in your project with:
+
+            ```sh
+            npm install --save-dev https://prerelease-registry.developers.workers.dev/runs/${{ github.run_id }}/wrangler
+            ```
+
+            Or you can try developing a worker directly with:
+            ```sh
+            npx https://prerelease-registry.developers.workers.dev/runs/${{ github.run_id }}/wrangler dev path/to/script.js
+            ```


### PR DESCRIPTION
We store the wrangler build artifacts and then comment on the PR to tell users how to access them.
But the way that GH actions work, it is not possible to write a comment if the PR is from another fork.

This change uses a `workflow_run` GH action, which does have permission, to do the commenting.
We must pass the PR number to it via another artifact.