### PR TITLE
fix: remove warning if worker with a durable object doesn't have a name

### DIFF
--- a/.changeset/twenty-humans-hammer.md
+++ b/.changeset/twenty-humans-hammer.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: remove warning if worker with a durable object doesn't have a name
+
+We were warning if you were trying to develop a durable object with an unnamed worker. Further, the internal api would actually throw if you tried to develop with a named worker if it wasn't already published. The latter is being fixed internally and should live soon, and this fix removes the warning completely.

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -803,17 +803,6 @@ export async function main(argv: string[]): Promise<void> {
       const environments = config.env ?? {};
       const envRootObj = args.env ? environments[args.env] || {} : config;
 
-      // TODO: this error shouldn't actually happen,
-      // but we haven't fixed it internally yet
-      if ("durable_objects" in envRootObj) {
-        if (!(args.name || config.name)) {
-          console.warn(
-            'A worker with durable objects needs to be named, or it may not work as expected. Add a "name" into wrangler.toml, or pass it in the command line with --name.'
-          );
-        }
-        // TODO: if not already published, publish a draft worker
-      }
-
       const { waitUntilExit } = render(
         <Dev
           name={args.name || config.name}


### PR DESCRIPTION
We were warning if you were trying to develop a durable object with an unnamed worker. Further, the internal api would actually throw if you tried to develop with a named worker if it wasn't already published. The latter is being fixed internally and should live soon, and this fix removes the warning completely.