### PR TITLE
chore: better RequestEvent type for tail

### DIFF
--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -1,10 +1,11 @@
+import { Headers, Request } from "undici";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { setMockResponse } from "./helpers/mock-cfetch";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { WS } from "./helpers/mock-web-socket";
 import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
-import type { TailEventMessage, RequestEvent, ScheduledEvent } from "../tail";
+import type { TailEventMessage, RequestEvent } from "../tail";
 import type Websocket from "ws";
 
 describe("tail", () => {
@@ -330,33 +331,22 @@ function generateMockRequestEvent(
   opts?: Partial<RequestEvent["request"]>
 ): RequestEvent {
   return {
-    request: {
-      url: opts?.url || "https://example.org/",
-      method: opts?.url || "GET",
-      headers: opts?.headers || { "X-EXAMPLE-HEADER": "some_value" },
-      cf: opts?.cf || {
-        tlsCipher: "AEAD-ENCRYPT-O-MATIC-SHA",
-        tlsVersion: "TLSv2.0", // when will they invent tls 2
-        asn: 42069,
-        colo: "ATL",
-        httpProtocol: "HTTP/4",
-        asOrganization: "Cloudflare",
-      },
-    },
-  };
-}
-
-/**
- * Generate a mock `ScheduledEvent`
- *
- * @param opts Any part of the `ScheduledEvent` to use instead of defaults
- * @returns a `ScheduledEvent` for use in a `TailEventMessage`
- */
-function generateMockScheduledEvent(
-  opts?: Partial<ScheduledEvent>
-): ScheduledEvent {
-  return {
-    cron: opts?.cron || "* * * * *",
-    scheduledTime: opts?.scheduledTime || new Date().getTime(),
+    request: Object.assign(
+      new Request(opts?.url || "https://example.org/", {
+        method: opts?.method || "GET",
+        headers:
+          opts?.headers || new Headers({ "X-EXAMPLE-HEADER": "some_value" }),
+      }),
+      {
+        cf: opts?.cf || {
+          tlsCipher: "AEAD-ENCRYPT-O-MATIC-SHA",
+          tlsVersion: "TLSv2.0", // when will they invent tls 2
+          asn: 42069,
+          colo: "ATL",
+          httpProtocol: "HTTP/4",
+          asOrganization: "Cloudflare",
+        },
+      }
+    ),
   };
 }

--- a/packages/wrangler/src/tail/index.ts
+++ b/packages/wrangler/src/tail/index.ts
@@ -5,6 +5,7 @@ import type { TailFilterMessage, Outcome } from "./filters";
 export type { TailCLIFilters } from "./filters";
 export { translateCLICommandToFilterMessage } from "./filters";
 export { jsonPrintLogs, prettyPrintLogs } from "./printing";
+import type { Request } from "undici";
 
 /**
  * When creating a Tail, the response from the API contains
@@ -175,27 +176,9 @@ export type TailEventMessage = {
 /**
  * A request that triggered worker execution
  */
+
 export type RequestEvent = {
-  /**
-   * Copied mostly from https://developers.cloudflare.com/workers/runtime-apis/request#properties
-   * but with some properties omitted based on my own testing
-   */
-  request: {
-    /**
-     * The URL the request was sent to
-     */
-    url: string;
-
-    /**
-     * The request method
-     */
-    method: string;
-
-    /**
-     * Headers sent with the request
-     */
-    headers: Record<string, string>;
-
+  request: Pick<Request, "url" | "method" | "headers"> & {
     /**
      * Cloudflare-specific properties
      * https://developers.cloudflare.com/workers/runtime-apis/request#incomingrequestcfproperties


### PR DESCRIPTION
This adds a slightly better type for the `RequestEvent` used in `wrangler tail`. It's a "standard" type that `undici` uses, that's closer to the standard type we have in the Workers runtime.

I also deleted an unused function, I assume we'll bring that back when we write a test for tailing scheduled events.

Skipping a changeset here since there's no functional change.