### PR TITLE
chore: fix the syntax in the most recent changeset

### DIFF
--- a/.changeset/orange-vans-lay.md
+++ b/.changeset/orange-vans-lay.md
@@ -1,6 +1,7 @@
 ---
-"wrangler": chore
+"wrangler": patch
 ---
+
 chore: Remove acorn/acorn-walk dependency used in Pages Functions filepath-routing.
 
 This shouldn't cause any functional changes, Pages Functions filepath-routing now uses esbuild to find exports.


### PR DESCRIPTION
cc @jahands - FYI the front-matter of a changeset specifies the packages that were changed and the type of version bump required. In this case `patch`. 