### PR TITLE
Deprecate `preview` command

### DIFF
--- a/.changeset/proud-jars-protect.md
+++ b/.changeset/proud-jars-protect.md
@@ -1,0 +1,12 @@
+---
+"wrangler": patch
+---
+
+refactor: delegate deprecated `preview` command to `dev` if possible
+
+The `preview` command is deprecated and not supported in this version of Wrangler.
+Instead, one should use the `dev` command for most `preview` use-cases.
+
+This change attempts to delegate any use of `preview` to `dev` failing if the command line contains positional arguments that are not compatible with `dev`.
+
+Resolves #9

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -768,4 +768,23 @@ describe("wrangler", () => {
             `);
     });
   });
+
+  describe("preview", () => {
+    it("should throw an error if the deprecated command is used with positional arguments", async () => {
+      await expect(runWrangler("preview GET")).rejects
+        .toThrowErrorMatchingInlineSnapshot(`
+              "DEPRECATION WARNING:
+              The \`wrangler preview\` command has been deprecated.
+              Try using \`wrangler dev\` to to try out a worker during development.
+              "
+            `);
+      await expect(runWrangler("preview GET 'Some Body'")).rejects
+        .toThrowErrorMatchingInlineSnapshot(`
+              "DEPRECATION WARNING:
+              The \`wrangler preview\` command has been deprecated.
+              Try using \`wrangler dev\` to to try out a worker during development.
+              "
+            `);
+    });
+  });
 });


### PR DESCRIPTION
The `preview` command is deprecated and not supported in this version of Wrangler.
Instead, one should use the `dev` command for most `preview` use-cases.

This change attempts to delegate any use of `preview` to `dev` failing if the command line contains positional arguments that are not compatible with `dev`.

Resolves #9