### PR TITLE
fix(pages): ensure remaining args passed to `pages dev` command are captured

### DIFF
--- a/.changeset/selfish-dogs-do.md
+++ b/.changeset/selfish-dogs-do.md
@@ -1,0 +1,17 @@
+---
+"wrangler": patch
+---
+
+fix(pages): ensure remaining args passed to `pages dev` command are captured
+
+It is common to pass additional commands to `pages dev` to generate the input source.
+For example:
+
+```bash
+npx wrangler@beta pages dev -- npm run dev
+```
+
+Previously the args after `--` were being dropped.
+This change ensures that these are captured and used correctly.
+
+Fixes #482

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -771,7 +771,7 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
         kv: kvs = [],
         do: durableObjects = [],
         "live-reload": liveReload,
-        "--": remaining = [],
+        _: [_pages, _dev, ...remaining],
       }) => {
         if (!local) {
           console.error("Only local mode is supported at the moment.");


### PR DESCRIPTION
It is common to pass additional commands to `pages dev` to generate the input source.
For example:

```bash
npx wrangler@beta pages dev -- npm run dev
```

Previously the args after `--` were being dropped.
This change ensures that these are captured and used correctly.

Fixes #482