### PR TITLE
Cache prerelease artifacts for one week

### DIFF
--- a/packages/prerelease-registry/functions/utils/getArtifactForWorkflowRun.ts
+++ b/packages/prerelease-registry/functions/utils/getArtifactForWorkflowRun.ts
@@ -5,6 +5,8 @@ interface Artifact {
   archive_download_url: string;
 }
 
+const ONE_WEEK = 60 * 60 * 24 * 7;
+
 export const getArtifactForWorkflowRun = async ({
   runID,
   name,
@@ -67,7 +69,9 @@ export const getArtifactForWorkflowRun = async ({
     if (tgzFileName === undefined) return new Response(null, { status: 404 });
 
     const tgzBlob = await files[tgzFileName].async("blob");
-    const response = new Response(tgzBlob);
+    const response = new Response(tgzBlob, {
+      headers: { "Cache-Control": `public, s-maxage=${ONE_WEEK}` },
+    });
 
     waitUntil(cache.put(cacheKey, response.clone()));
 


### PR DESCRIPTION
Previously, they would only have been cached for [two hours](https://developers.cloudflare.com/cache/how-to/configure-cache-status-code#edge-ttl).

We're using [`s-maxage`](https://developers.cloudflare.com/cache/about/cache-control#cache-control-directives) because we want to cache the artifact in Cloudflare's cache relative to the workflow number for a decent amount of time, but don't want to cache client-side for any duration because we might be getting it by PR number. Not that `npm` will respect the cache headers anyway...