### PR TITLE
feat: `--legacy-env` cli arg / `legacy_env` config

### DIFF
--- a/.changeset/short-dancers-mix.md
+++ b/.changeset/short-dancers-mix.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+feat: `--legacy-env` cli arg / `legacy_env` config
+
+This is the first of a few changes to codify how we do environments in wrangler2, both older legacy style environments, and newer service environments. Here, we add a cli arg and a config field for specifying whether to enable/disable legacy style environments, and pass it on to dev/publish commands. We also fix how we were generating kv namespaces for Workers Sites, among other smaller fixes.

--- a/packages/prerelease-registry/functions/routes/prs/[[path]].ts
+++ b/packages/prerelease-registry/functions/routes/prs/[[path]].ts
@@ -1,5 +1,5 @@
-import { generateGitHubFetch } from "../../utils/gitHubFetch";
 import { getArtifactForWorkflowRun } from "../../utils/getArtifactForWorkflowRun";
+import { generateGitHubFetch } from "../../utils/gitHubFetch";
 
 interface PullRequest {
   head: { ref: string; sha: string };

--- a/packages/prerelease-registry/functions/routes/runs/[[path]].ts
+++ b/packages/prerelease-registry/functions/routes/runs/[[path]].ts
@@ -1,5 +1,5 @@
-import { generateGitHubFetch } from "../../utils/gitHubFetch";
 import { getArtifactForWorkflowRun } from "../../utils/getArtifactForWorkflowRun";
+import { generateGitHubFetch } from "../../utils/gitHubFetch";
 
 export const onRequestGet: PagesFunction<
   { GITHUB_API_TOKEN: string; GITHUB_USER: string },

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -60,6 +60,7 @@ function renderDev({
   port,
   format,
   accountId,
+  legacyEnv = true,
   initialMode = "local",
   jsxFactory,
   jsxFragment,
@@ -86,6 +87,7 @@ function renderDev({
       entry={entry}
       env={env}
       port={port}
+      legacyEnv={legacyEnv}
       buildCommand={buildCommand}
       format={format}
       initialMode={initialMode}

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -44,9 +44,10 @@ describe("wrangler", () => {
           wrangler r2                📦 Interact with an R2 store
 
         Flags:
-          -c, --config   Path to .toml configuration file  [string]
-          -h, --help     Show help  [boolean]
-          -v, --version  Show version number  [boolean]
+          -c, --config      Path to .toml configuration file  [string]
+          -h, --help        Show help  [boolean]
+          -v, --version     Show version number  [boolean]
+              --legacy-env  Use legacy environments  [boolean]
 
         Options:
           -l, --local  Run on my machine  [boolean] [default: false]"
@@ -82,9 +83,10 @@ describe("wrangler", () => {
           wrangler r2                📦 Interact with an R2 store
 
         Flags:
-          -c, --config   Path to .toml configuration file  [string]
-          -h, --help     Show help  [boolean]
-          -v, --version  Show version number  [boolean]
+          -c, --config      Path to .toml configuration file  [string]
+          -h, --help        Show help  [boolean]
+          -v, --version     Show version number  [boolean]
+              --legacy-env  Use legacy environments  [boolean]
 
         Options:
           -l, --local  Run on my machine  [boolean] [default: false]

--- a/packages/wrangler/src/__tests__/kv.test.ts
+++ b/packages/wrangler/src/__tests__/kv.test.ts
@@ -53,9 +53,10 @@ describe("wrangler", () => {
             namespace  The name of the new namespace  [string] [required]
 
           Flags:
-            -c, --config   Path to .toml configuration file  [string]
-            -h, --help     Show help  [boolean]
-            -v, --version  Show version number  [boolean]
+            -c, --config      Path to .toml configuration file  [string]
+            -h, --help        Show help  [boolean]
+            -v, --version     Show version number  [boolean]
+                --legacy-env  Use legacy environments  [boolean]
 
           Options:
             -l, --local    Run on my machine  [boolean] [default: false]
@@ -82,9 +83,10 @@ describe("wrangler", () => {
             namespace  The name of the new namespace  [string] [required]
 
           Flags:
-            -c, --config   Path to .toml configuration file  [string]
-            -h, --help     Show help  [boolean]
-            -v, --version  Show version number  [boolean]
+            -c, --config      Path to .toml configuration file  [string]
+            -h, --help        Show help  [boolean]
+            -v, --version     Show version number  [boolean]
+                --legacy-env  Use legacy environments  [boolean]
 
           Options:
             -l, --local    Run on my machine  [boolean] [default: false]
@@ -112,9 +114,10 @@ describe("wrangler", () => {
             namespace  The name of the new namespace  [string] [required]
 
           Flags:
-            -c, --config   Path to .toml configuration file  [string]
-            -h, --help     Show help  [boolean]
-            -v, --version  Show version number  [boolean]
+            -c, --config      Path to .toml configuration file  [string]
+            -h, --help        Show help  [boolean]
+            -v, --version     Show version number  [boolean]
+                --legacy-env  Use legacy environments  [boolean]
 
           Options:
             -l, --local    Run on my machine  [boolean] [default: false]
@@ -276,9 +279,10 @@ describe("wrangler", () => {
           Deletes a given namespace.
 
           Flags:
-            -c, --config   Path to .toml configuration file  [string]
-            -h, --help     Show help  [boolean]
-            -v, --version  Show version number  [boolean]
+            -c, --config      Path to .toml configuration file  [string]
+            -h, --help        Show help  [boolean]
+            -v, --version     Show version number  [boolean]
+                --legacy-env  Use legacy environments  [boolean]
 
           Options:
             -l, --local         Run on my machine  [boolean] [default: false]
@@ -467,23 +471,24 @@ describe("wrangler", () => {
           Writes a single key/value pair to the given namespace.
 
           Positionals:
-            key    The key to write to.  [string] [required]
-            value  The value to write.  [string]
+            key    The key to write to  [string] [required]
+            value  The value to write  [string]
 
           Flags:
-            -c, --config   Path to .toml configuration file  [string]
-            -h, --help     Show help  [boolean]
-            -v, --version  Show version number  [boolean]
+            -c, --config      Path to .toml configuration file  [string]
+            -h, --help        Show help  [boolean]
+            -v, --version     Show version number  [boolean]
+                --legacy-env  Use legacy environments  [boolean]
 
           Options:
             -l, --local         Run on my machine  [boolean] [default: false]
-                --binding       The binding of the namespace to write to.  [string]
-                --namespace-id  The id of the namespace to write to.  [string]
+                --binding       The binding of the namespace to write to  [string]
+                --namespace-id  The id of the namespace to write to  [string]
                 --env           Perform on a specific environment  [string]
                 --preview       Interact with a preview namespace  [boolean]
-                --ttl           Time for which the entries should be visible.  [number]
+                --ttl           Time for which the entries should be visible  [number]
                 --expiration    Time since the UNIX epoch after which the entry expires  [number]
-                --path          Read value from the file at a given path.  [string]
+                --path          Read value from the file at a given path  [string]
 
           Not enough non-option arguments: got 0, need at least 1"
         `);
@@ -503,23 +508,24 @@ describe("wrangler", () => {
           Writes a single key/value pair to the given namespace.
 
           Positionals:
-            key    The key to write to.  [string] [required]
-            value  The value to write.  [string]
+            key    The key to write to  [string] [required]
+            value  The value to write  [string]
 
           Flags:
-            -c, --config   Path to .toml configuration file  [string]
-            -h, --help     Show help  [boolean]
-            -v, --version  Show version number  [boolean]
+            -c, --config      Path to .toml configuration file  [string]
+            -h, --help        Show help  [boolean]
+            -v, --version     Show version number  [boolean]
+                --legacy-env  Use legacy environments  [boolean]
 
           Options:
             -l, --local         Run on my machine  [boolean] [default: false]
-                --binding       The binding of the namespace to write to.  [string]
-                --namespace-id  The id of the namespace to write to.  [string]
+                --binding       The binding of the namespace to write to  [string]
+                --namespace-id  The id of the namespace to write to  [string]
                 --env           Perform on a specific environment  [string]
                 --preview       Interact with a preview namespace  [boolean]
-                --ttl           Time for which the entries should be visible.  [number]
+                --ttl           Time for which the entries should be visible  [number]
                 --expiration    Time since the UNIX epoch after which the entry expires  [number]
-                --path          Read value from the file at a given path.  [string]
+                --path          Read value from the file at a given path  [string]
 
           Exactly one of the arguments binding and namespace-id is required"
         `);
@@ -539,23 +545,24 @@ describe("wrangler", () => {
           Writes a single key/value pair to the given namespace.
 
           Positionals:
-            key    The key to write to.  [string] [required]
-            value  The value to write.  [string]
+            key    The key to write to  [string] [required]
+            value  The value to write  [string]
 
           Flags:
-            -c, --config   Path to .toml configuration file  [string]
-            -h, --help     Show help  [boolean]
-            -v, --version  Show version number  [boolean]
+            -c, --config      Path to .toml configuration file  [string]
+            -h, --help        Show help  [boolean]
+            -v, --version     Show version number  [boolean]
+                --legacy-env  Use legacy environments  [boolean]
 
           Options:
             -l, --local         Run on my machine  [boolean] [default: false]
-                --binding       The binding of the namespace to write to.  [string]
-                --namespace-id  The id of the namespace to write to.  [string]
+                --binding       The binding of the namespace to write to  [string]
+                --namespace-id  The id of the namespace to write to  [string]
                 --env           Perform on a specific environment  [string]
                 --preview       Interact with a preview namespace  [boolean]
-                --ttl           Time for which the entries should be visible.  [number]
+                --ttl           Time for which the entries should be visible  [number]
                 --expiration    Time since the UNIX epoch after which the entry expires  [number]
-                --path          Read value from the file at a given path.  [string]
+                --path          Read value from the file at a given path  [string]
 
           Arguments binding and namespace-id are mutually exclusive"
         `);
@@ -575,23 +582,24 @@ describe("wrangler", () => {
           Writes a single key/value pair to the given namespace.
 
           Positionals:
-            key    The key to write to.  [string] [required]
-            value  The value to write.  [string]
+            key    The key to write to  [string] [required]
+            value  The value to write  [string]
 
           Flags:
-            -c, --config   Path to .toml configuration file  [string]
-            -h, --help     Show help  [boolean]
-            -v, --version  Show version number  [boolean]
+            -c, --config      Path to .toml configuration file  [string]
+            -h, --help        Show help  [boolean]
+            -v, --version     Show version number  [boolean]
+                --legacy-env  Use legacy environments  [boolean]
 
           Options:
             -l, --local         Run on my machine  [boolean] [default: false]
-                --binding       The binding of the namespace to write to.  [string]
-                --namespace-id  The id of the namespace to write to.  [string]
+                --binding       The binding of the namespace to write to  [string]
+                --namespace-id  The id of the namespace to write to  [string]
                 --env           Perform on a specific environment  [string]
                 --preview       Interact with a preview namespace  [boolean]
-                --ttl           Time for which the entries should be visible.  [number]
+                --ttl           Time for which the entries should be visible  [number]
                 --expiration    Time since the UNIX epoch after which the entry expires  [number]
-                --path          Read value from the file at a given path.  [string]
+                --path          Read value from the file at a given path  [string]
 
           Exactly one of the arguments value and path is required"
         `);
@@ -611,23 +619,24 @@ describe("wrangler", () => {
           Writes a single key/value pair to the given namespace.
 
           Positionals:
-            key    The key to write to.  [string] [required]
-            value  The value to write.  [string]
+            key    The key to write to  [string] [required]
+            value  The value to write  [string]
 
           Flags:
-            -c, --config   Path to .toml configuration file  [string]
-            -h, --help     Show help  [boolean]
-            -v, --version  Show version number  [boolean]
+            -c, --config      Path to .toml configuration file  [string]
+            -h, --help        Show help  [boolean]
+            -v, --version     Show version number  [boolean]
+                --legacy-env  Use legacy environments  [boolean]
 
           Options:
             -l, --local         Run on my machine  [boolean] [default: false]
-                --binding       The binding of the namespace to write to.  [string]
-                --namespace-id  The id of the namespace to write to.  [string]
+                --binding       The binding of the namespace to write to  [string]
+                --namespace-id  The id of the namespace to write to  [string]
                 --env           Perform on a specific environment  [string]
                 --preview       Interact with a preview namespace  [boolean]
-                --ttl           Time for which the entries should be visible.  [number]
+                --ttl           Time for which the entries should be visible  [number]
                 --expiration    Time since the UNIX epoch after which the entry expires  [number]
-                --path          Read value from the file at a given path.  [string]
+                --path          Read value from the file at a given path  [string]
 
           Arguments value and path are mutually exclusive"
         `);
@@ -940,9 +949,10 @@ describe("wrangler", () => {
             key  The key value to get.  [string] [required]
 
           Flags:
-            -c, --config   Path to .toml configuration file  [string]
-            -h, --help     Show help  [boolean]
-            -v, --version  Show version number  [boolean]
+            -c, --config      Path to .toml configuration file  [string]
+            -h, --help        Show help  [boolean]
+            -v, --version     Show version number  [boolean]
+                --legacy-env  Use legacy environments  [boolean]
 
           Options:
             -l, --local         Run on my machine  [boolean] [default: false]
@@ -971,9 +981,10 @@ describe("wrangler", () => {
             key  The key value to get.  [string] [required]
 
           Flags:
-            -c, --config   Path to .toml configuration file  [string]
-            -h, --help     Show help  [boolean]
-            -v, --version  Show version number  [boolean]
+            -c, --config      Path to .toml configuration file  [string]
+            -h, --help        Show help  [boolean]
+            -v, --version     Show version number  [boolean]
+                --legacy-env  Use legacy environments  [boolean]
 
           Options:
             -l, --local         Run on my machine  [boolean] [default: false]
@@ -1003,9 +1014,10 @@ describe("wrangler", () => {
             key  The key value to get.  [string] [required]
 
           Flags:
-            -c, --config   Path to .toml configuration file  [string]
-            -h, --help     Show help  [boolean]
-            -v, --version  Show version number  [boolean]
+            -c, --config      Path to .toml configuration file  [string]
+            -h, --help        Show help  [boolean]
+            -v, --version     Show version number  [boolean]
+                --legacy-env  Use legacy environments  [boolean]
 
           Options:
             -l, --local         Run on my machine  [boolean] [default: false]

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -77,9 +77,10 @@ describe("wrangler", () => {
               name  The name of the new bucket  [string] [required]
 
             Flags:
-              -c, --config   Path to .toml configuration file  [string]
-              -h, --help     Show help  [boolean]
-              -v, --version  Show version number  [boolean]
+              -c, --config      Path to .toml configuration file  [string]
+              -h, --help        Show help  [boolean]
+              -v, --version     Show version number  [boolean]
+                  --legacy-env  Use legacy environments  [boolean]
 
             Options:
               -l, --local  Run on my machine  [boolean] [default: false]
@@ -104,9 +105,10 @@ describe("wrangler", () => {
               name  The name of the new bucket  [string] [required]
 
             Flags:
-              -c, --config   Path to .toml configuration file  [string]
-              -h, --help     Show help  [boolean]
-              -v, --version  Show version number  [boolean]
+              -c, --config      Path to .toml configuration file  [string]
+              -h, --help        Show help  [boolean]
+              -v, --version     Show version number  [boolean]
+                  --legacy-env  Use legacy environments  [boolean]
 
             Options:
               -l, --local  Run on my machine  [boolean] [default: false]
@@ -157,9 +159,10 @@ describe("wrangler", () => {
               name  The name of the bucket to delete  [string] [required]
 
             Flags:
-              -c, --config   Path to .toml configuration file  [string]
-              -h, --help     Show help  [boolean]
-              -v, --version  Show version number  [boolean]
+              -c, --config      Path to .toml configuration file  [string]
+              -h, --help        Show help  [boolean]
+              -v, --version     Show version number  [boolean]
+                  --legacy-env  Use legacy environments  [boolean]
 
             Options:
               -l, --local  Run on my machine  [boolean] [default: false]
@@ -184,9 +187,10 @@ describe("wrangler", () => {
               name  The name of the bucket to delete  [string] [required]
 
             Flags:
-              -c, --config   Path to .toml configuration file  [string]
-              -h, --help     Show help  [boolean]
-              -v, --version  Show version number  [boolean]
+              -c, --config      Path to .toml configuration file  [string]
+              -h, --help        Show help  [boolean]
+              -v, --version     Show version number  [boolean]
+                  --legacy-env  Use legacy environments  [boolean]
 
             Options:
               -l, --local  Run on my machine  [boolean] [default: false]

--- a/packages/wrangler/src/config.ts
+++ b/packages/wrangler/src/config.ts
@@ -471,6 +471,19 @@ export type Config = {
   };
 
   /**
+   * A boolean to enable "legacy" style wrangler environments (from wrangler 1).
+   * These have been superceded by Services, but there may be projects that won't
+   * (or can't) use them. If you're using a legacy environment, you can set this
+   * to `true` to enable it.
+   *
+   * NB: This is not inherited, and should not be duplicated across all environments.
+   *
+   * @optional
+
+   */
+  legacy_env?: boolean;
+
+  /**
    * The `env` section defines overrides for the configuration for
    * different environments. Most fields can be overridden, while
    * some have to be specifically duplicated in every environment.
@@ -479,7 +492,10 @@ export type Config = {
   env?: {
     [envName: string]:
       | undefined
-      | Omit<Config, "env" | "wasm_modules" | "migrations" | "site" | "dev">;
+      | Omit<
+          Config,
+          "env" | "wasm_modules" | "migrations" | "site" | "dev" | "legacy_env"
+        >;
   };
 };
 
@@ -538,7 +554,7 @@ export function normaliseAndValidateEnvironmentsConfig(config: Config) {
 
     type InheritedField = keyof Omit<
       Config,
-      "env" | "migrations" | "wasm_modules" | "site" | "dev"
+      "env" | "migrations" | "wasm_modules" | "site" | "dev" | "legacy_env"
     >;
 
     const inheritedFields: InheritedField[] = [

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -181,10 +181,13 @@ export default async function publish(props: Props): Promise<void> {
 
     const assets = await syncAssets(
       accountId,
-      scriptName,
+      // When we're using the newer service environments, we wouldn't
+      // have added the env name on to the script name. However, we must
+      // include it in the kv namespace name regardless (since there's no
+      // concept of service environments for kv namespaces yet).
+      scriptName + (!props.legacyEnv && props.env ? `-${props.env}` : ""),
       props.assetPaths,
-      false,
-      props.env
+      false
     );
 
     const bindings: CfWorkerInit["bindings"] = {

--- a/packages/wrangler/src/sites.tsx
+++ b/packages/wrangler/src/sites.tsx
@@ -99,7 +99,6 @@ async function createKVNamespaceIfNotAlreadyExisting(
  * @param scriptName the name of the worker whose assets we are uploading.
  * @param siteAssets an objects describing what assets to upload, or undefined if there are no assets to upload.
  * @param preview if true then upload to a "preview" KV namespace.
- * @param _env (not implemented).
  * @returns a promise for an object mapping the relative paths of the assets to the key of that
  * asset in the KV namespace.
  */
@@ -107,8 +106,7 @@ export async function syncAssets(
   accountId: string,
   scriptName: string,
   siteAssets: AssetPaths | undefined,
-  preview: boolean,
-  env: string | undefined
+  preview: boolean
 ): Promise<{
   manifest: { [filePath: string]: string } | undefined;
   namespace: string | undefined;
@@ -117,7 +115,7 @@ export async function syncAssets(
     return { manifest: undefined, namespace: undefined };
   }
 
-  const title = `__${scriptName}${env ? `-${env}` : ""}-workers_sites_assets${
+  const title = `__${scriptName}-workers_sites_assets${
     preview ? "_preview" : ""
   }`;
   const { id: namespace } = await createKVNamespaceIfNotAlreadyExisting(
@@ -226,7 +224,6 @@ export interface AssetPaths {
  * Uses the args (passed from the command line) if available,
  * falling back to those defined in the config.
  *
- * // TODO: Support for environments
  */
 export function getAssetPaths(
   config: Config,


### PR DESCRIPTION
This is the first of a few changes to codify how we do environments in wrangler2, both older legacy style environments, and newer service environments. Here, we add a cli arg and a config field for specifying whether to enable/disable legacy style environments, and pass it on to dev/publish commands. We also fix how we were generating kv namespaces for Workers Sites, among other smaller fixes.