### PR TITLE
fix: publish environment specific routes

### DIFF
--- a/.changeset/brown-spies-deliver.md
+++ b/.changeset/brown-spies-deliver.md
@@ -1,0 +1,12 @@
+---
+"wrangler": patch
+---
+
+fix: publish environment specific routes
+
+This adds some tests for publishing routes, and fixes a couple of bugs with the flow.
+
+- fixes publishing environment specific routes, closes https://github.com/cloudflare/wrangler2/issues/513
+- default `workers_dev` to `false` if there are any routes specified
+- catches a hanging promise when we were toggling off a `workers.dev` subdomain (which should have been caught by the `no-floating-promises` lint rule, so that's concerning)
+- this also fixes publishing environment specific crons, but I'll write tests for that when I'm doing that feature in depth

--- a/packages/wrangler/src/__tests__/helpers/write-wrangler-toml.ts
+++ b/packages/wrangler/src/__tests__/helpers/write-wrangler-toml.ts
@@ -3,10 +3,7 @@ import TOML from "@iarna/toml";
 import type { Config } from "../../config";
 
 /** Write a mock wrangler.toml file to disk. */
-export default function writeWranglerToml(config: Omit<Config, "env"> = {}) {
-  // We Omit `env` from config because TOML.stringify() appears to
-  // have a weird type signature that appears to fail. We'll revisit this
-  // when we write tests for publishing environments
+export default function writeWranglerToml(config: Config = {}) {
   fs.writeFileSync(
     "./wrangler.toml",
     TOML.stringify({

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -831,7 +831,7 @@ export async function main(argv: string[]): Promise<void> {
             (args["compatibility-flags"] as string[]) ||
             config.compatibility_flags
           }
-          usageModel={config.usage_model}
+          usageModel={envRootObj.usage_model}
           bindings={{
             kv_namespaces: envRootObj.kv_namespaces?.map(
               ({ binding, preview_id, id: _id }) => {


### PR DESCRIPTION
This adds some tests for publishing routes, and fixes a couple of bugs with the flow.
- fixes publishing environment specific routes, closes https://github.com/cloudflare/wrangler2/issues/513
- default `workers_dev` to `false` if there are any routes specified
- catches a hanging promise when we were toggling off a `workers.dev` subdomain (which should have been caught by the `no-floating-promises` lint rule, so that's concerning)
- this also fixes publishing environment specific crons, but I'll write tests for that when I'm doing that feature in depth

I expect to send some followup PRs for routes, but this should make it a little more stable right now