### PR TITLE
Allow alternative ports for devtools connection in `wrangler dev`

### DIFF
--- a/.changeset/kind-masks-jump.md
+++ b/.changeset/kind-masks-jump.md
@@ -1,0 +1,12 @@
+---
+"wrangler": patch
+---
+
+fix: Improve port selection for `wrangler dev` for both worker ports and inspector ports.
+
+Previously when running `wrangler dev` on multiple workers at the same time, you couldn't attach DevTools to both workers, since they were both listening on port 9229.
+With this PR, that behavior is improved -- you can now pass an `--inspector-port` flag to specify a port for DevTools to connect to on a per-worker basis, or
+if the option is omitted, wrangler will assign a random unused port for you.
+
+This "if no option is given, assign a random unused port" behavior has also been added to `wrangler dev --port`, so running `wrangler dev` on two
+workers at once should now "just work". Hopefully.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7220,9 +7220,10 @@
       }
     },
     "node_modules/get-port": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-6.1.1.tgz",
-      "integrity": "sha512-RQOsDPSd2PcoLwakY1dwEtLiAbTR7IfmnxsKswfcHEfRKKbhWAG2R5Qo7C8ga6Ne4Mq4lFbogXfDGNfqFxwAaw==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-6.1.2.tgz",
+      "integrity": "sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw==",
+      "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -16880,6 +16881,7 @@
         "faye-websocket": "^0.11.4",
         "finalhandler": "^1.1.2",
         "find-up": "^6.2.0",
+        "get-port": "^6.1.2",
         "glob-to-regexp": "0.4.1",
         "ignore": "^5.2.0",
         "ink": "^3.2.0",
@@ -21637,9 +21639,10 @@
       "version": "0.1.0"
     },
     "get-port": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-6.1.1.tgz",
-      "integrity": "sha512-RQOsDPSd2PcoLwakY1dwEtLiAbTR7IfmnxsKswfcHEfRKKbhWAG2R5Qo7C8ga6Ne4Mq4lFbogXfDGNfqFxwAaw=="
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-6.1.2.tgz",
+      "integrity": "sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw==",
+      "dev": true
     },
     "get-stream": {
       "version": "6.0.1"
@@ -27516,6 +27519,7 @@
         "finalhandler": "^1.1.2",
         "find-up": "^6.2.0",
         "fsevents": "~2.3.2",
+        "get-port": "^6.1.2",
         "glob-to-regexp": "0.4.1",
         "ignore": "^5.2.0",
         "ink": "^3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7219,6 +7219,17 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/get-port": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-6.1.1.tgz",
+      "integrity": "sha512-RQOsDPSd2PcoLwakY1dwEtLiAbTR7IfmnxsKswfcHEfRKKbhWAG2R5Qo7C8ga6Ne4Mq4lFbogXfDGNfqFxwAaw==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "license": "MIT",
@@ -21624,6 +21635,11 @@
     },
     "get-package-type": {
       "version": "0.1.0"
+    },
+    "get-port": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-6.1.1.tgz",
+      "integrity": "sha512-RQOsDPSd2PcoLwakY1dwEtLiAbTR7IfmnxsKswfcHEfRKKbhWAG2R5Qo7C8ga6Ne4Mq4lFbogXfDGNfqFxwAaw=="
     },
     "get-stream": {
       "version": "6.0.1"

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -119,7 +119,7 @@
     "testTimeout": 30000,
     "testRegex": ".*.(test|spec)\\.[jt]sx?$",
     "transformIgnorePatterns": [
-      "node_modules/(?!find-up|locate-path|p-locate|p-limit|yocto-queue|path-exists|execa|strip-final-newline|npm-run-path|path-key|onetime|mimic-fn|human-signals|is-stream)"
+      "node_modules/(?!find-up|locate-path|p-locate|p-limit|yocto-queue|path-exists|execa|strip-final-newline|npm-run-path|path-key|onetime|mimic-fn|human-signals|is-stream|get-port)"
     ],
     "moduleNameMapper": {
       "clipboardy": "<rootDir>/src/__tests__/helpers/clipboardy-mock.js"

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -70,6 +70,7 @@
     "faye-websocket": "^0.11.4",
     "finalhandler": "^1.1.2",
     "find-up": "^6.2.0",
+    "get-port": "^6.1.2",
     "glob-to-regexp": "0.4.1",
     "ignore": "^5.2.0",
     "ink": "^3.2.0",

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -58,6 +58,7 @@ function renderDev({
   name,
   entry = { file: "some/entry.ts", directory: process.cwd() },
   port,
+  inspectorPort = 8008,
   format,
   accountId,
   legacyEnv = true,
@@ -90,6 +91,7 @@ function renderDev({
       env={env}
       rules={rules}
       port={port}
+      inspectorPort={inspectorPort}
       legacyEnv={legacyEnv}
       buildCommand={buildCommand}
       format={format}

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -58,7 +58,7 @@ function renderDev({
   name,
   entry = { file: "some/entry.ts", directory: process.cwd() },
   port,
-  inspectorPort = 8008,
+  inspectorPort = 9229,
   format,
   accountId,
   legacyEnv = true,

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -766,12 +766,11 @@ export async function main(argv: string[]): Promise<void> {
           default: "127.0.0.1",
         })
         .option("port", {
-          describe: "Port to listen on, defaults to 8787",
+          describe: "Port to listen on",
           type: "number",
-          default: 8787,
         })
-        .option("devtools-port", {
-          describe: "Port for devtools to connect to, defaults to 9229",
+        .option("inspector-port", {
+          describe: "Port for devtools to connect to",
           type: "number",
         })
         .option("host", {
@@ -893,8 +892,12 @@ export async function main(argv: string[]): Promise<void> {
             args.siteInclude,
             args.siteExclude
           )}
-          port={args.port || config.dev?.port}
-          inspectorPort={args.devtoolsPort ?? (await getPort({ port: 9229 }))}
+          port={
+            args.port || config.dev?.port || (await getPort({ port: 8787 }))
+          }
+          inspectorPort={
+            args["inspector-port"] ?? (await getPort({ port: 9229 }))
+          }
           public={args["experimental-public"]}
           compatibilityDate={
             args["compatibility-date"] ||
@@ -1369,7 +1372,7 @@ export async function main(argv: string[]): Promise<void> {
             r2_buckets: envRootObj.r2_buckets,
             unsafe: envRootObj.unsafe?.bindings,
           }}
-          inspectorPort={9229}
+          inspectorPort={await getPort({ port: 9229 })}
         />
       );
       await waitUntilExit();

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -5,6 +5,7 @@ import path from "node:path";
 import { setTimeout } from "node:timers/promises";
 import TOML from "@iarna/toml";
 import { findUp } from "find-up";
+import getPort from "get-port";
 import { render } from "ink";
 import React from "react";
 import onExit from "signal-exit";
@@ -769,6 +770,10 @@ export async function main(argv: string[]): Promise<void> {
           type: "number",
           default: 8787,
         })
+        .option("devtools-port", {
+          describe: "Port for devtools to connect to, defaults to 9229",
+          type: "number",
+        })
         .option("host", {
           type: "string",
           describe:
@@ -889,6 +894,7 @@ export async function main(argv: string[]): Promise<void> {
             args.siteExclude
           )}
           port={args.port || config.dev?.port}
+          inspectorPort={args.devtoolsPort ?? (await getPort({ port: 9229 }))}
           public={args["experimental-public"]}
           compatibilityDate={
             args["compatibility-date"] ||
@@ -1363,6 +1369,7 @@ export async function main(argv: string[]): Promise<void> {
             r2_buckets: envRootObj.r2_buckets,
             unsafe: envRootObj.unsafe?.bindings,
           }}
+          inspectorPort={9229}
         />
       );
       await waitUntilExit();


### PR DESCRIPTION
Currently, attempting to use `wrangler dev` multiple times won't allow you to use devtools on each worker, because they all want the same "9229" port.

This PR fixes that issue by

1. Allowing the user to pass in a custom port if they'd like to use it
2. Randomly choosing a port, starting by trying 9229, if you don't specify

I haven't tested it out myself yet, but it seems like the test suite is passing so I figured I'd go ahead and push so I can get some early feedback.

closes #21 