### PR TITLE
fix: websockets in `wrangler dev`

### DIFF
--- a/.changeset/empty-trains-mix.md
+++ b/.changeset/empty-trains-mix.md
@@ -1,0 +1,17 @@
+---
+"wrangler": patch
+---
+
+fix: websockets
+
+This fixes websockets in `wrangler dev`. It looks like we broke it in https://github.com/cloudflare/wrangler2/pull/503. I've reverted the specific changes made to `proxy.ts`.
+
+Test plan -
+
+```
+cd packages/wrangler
+npm run build
+cd ../workers-chat-demo
+npx wrangler dev
+
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -6900,6 +6900,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "dev": true,
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.1",
       "license": "Apache-2.0",
@@ -7521,6 +7533,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/http-parser-js": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.5.tgz",
+      "integrity": "sha512-x+JVEkO2PoM8qqpbPbOL3cqHPwerep7OwzK7Ay+sMQjKzaKCqWvjoXm5tqMP9tXWWTnTzAjIhXg+J99XYuPhPA==",
+      "dev": true
     },
     "node_modules/http-proxy-agent": {
       "version": "4.0.1",
@@ -16356,6 +16374,29 @@
         "node": ">=10.4"
       }
     },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "dev": true,
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/whatwg-encoding": {
       "version": "1.0.5",
       "license": "MIT",
@@ -16804,6 +16845,7 @@
         "command-exists": "^1.2.9",
         "devtools-protocol": "^0.0.955664",
         "execa": "^6.0.0",
+        "faye-websocket": "^0.11.4",
         "finalhandler": "^1.1.2",
         "find-up": "^6.2.0",
         "ignore": "^5.2.0",
@@ -21340,6 +21382,15 @@
         "format": "^0.2.0"
       }
     },
+    "faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "dev": true,
+      "requires": {
+        "websocket-driver": ">=0.5.1"
+      }
+    },
     "fb-watchman": {
       "version": "2.0.1",
       "requires": {
@@ -21746,6 +21797,12 @@
         "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.1"
       }
+    },
+    "http-parser-js": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.5.tgz",
+      "integrity": "sha512-x+JVEkO2PoM8qqpbPbOL3cqHPwerep7OwzK7Ay+sMQjKzaKCqWvjoXm5tqMP9tXWWTnTzAjIhXg+J99XYuPhPA==",
+      "dev": true
     },
     "http-proxy-agent": {
       "version": "4.0.1",
@@ -27298,6 +27355,23 @@
     "webidl-conversions": {
       "version": "6.1.0"
     },
+    "websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "dev": true,
+      "requires": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      }
+    },
+    "websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "dev": true
+    },
     "whatwg-encoding": {
       "version": "1.0.5",
       "requires": {
@@ -27384,6 +27458,7 @@
         "devtools-protocol": "^0.0.955664",
         "esbuild": "0.14.23",
         "execa": "^6.0.0",
+        "faye-websocket": "^0.11.4",
         "finalhandler": "^1.1.2",
         "find-up": "^6.2.0",
         "fsevents": "~2.3.2",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -66,6 +66,7 @@
     "command-exists": "^1.2.9",
     "devtools-protocol": "^0.0.955664",
     "execa": "^6.0.0",
+    "faye-websocket": "^0.11.4",
     "finalhandler": "^1.1.2",
     "find-up": "^6.2.0",
     "ignore": "^5.2.0",

--- a/packages/wrangler/src/__tests__/helpers/faye-websocket.d.ts
+++ b/packages/wrangler/src/__tests__/helpers/faye-websocket.d.ts
@@ -1,0 +1,6 @@
+module "faye-websocket" {
+  /**
+   * Standards-compliant WebSocket client and server.
+   */
+  export default WebSocket;
+}


### PR DESCRIPTION
This fixes websockets in `wrangler dev`. It looks like we broke it in https://github.com/cloudflare/wrangler2/pull/503. I've reverted the specific changes made to `proxy.ts`.

Test plan -

```
cd packages/wrangler
npm run build
cd ../workers-chat-demo
npx wrangler dev

```