### PR TITLE
feat: secrets + environments

### DIFF
--- a/.changeset/angry-badgers-beam.md
+++ b/.changeset/angry-badgers-beam.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+feat: secrets + environments
+
+This implements environment support for `wrangler secret` (both legacy and services). We now consistently generate the right script name across commands with the `getScriptName()` helper.
+
+Based on the work by @mitchelvanbever in https://github.com/cloudflare/wrangler2/pull/95.

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -2008,11 +2008,14 @@ function mockUpdateWorkerRequest({
   setMockResponse(
     `/accounts/:accountId/workers/${servicesOrScripts}/:scriptName${environment}/subdomain`,
     "POST",
-    ([_url, accountId, scriptName], { body }) => {
+    ([_url, accountId, scriptName, envName], { body }) => {
       expect(accountId).toEqual("some-account-id");
       expect(scriptName).toEqual(
         legacyEnv && env ? `test-name-${env}` : "test-name"
       );
+      if (!legacyEnv) {
+        expect(envName).toEqual(env);
+      }
       expect(JSON.parse(body as string)).toEqual({ enabled });
       return null;
     }
@@ -2035,11 +2038,15 @@ function mockPublishRoutesRequest({
   setMockResponse(
     `/accounts/:accountId/workers/${servicesOrScripts}/:scriptName${environment}/routes`,
     "PUT",
-    ([_url, accountId, scriptName], { body }) => {
+    ([_url, accountId, scriptName, envName], { body }) => {
       expect(accountId).toEqual("some-account-id");
       expect(scriptName).toEqual(
         legacyEnv && env ? `test-name-${env}` : "test-name"
       );
+      if (!legacyEnv) {
+        expect(envName).toEqual(env);
+      }
+
       expect(JSON.parse(body as string)).toEqual(
         routes.map((pattern) => ({ pattern }))
       );

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -102,10 +102,7 @@ function Dev(props: DevProps): JSX.Element {
   );
 
   useTunnel(toggles.tunnel);
-  let scriptName = props.name || path.basename(props.entry.file);
-  if (props.legacyEnv) {
-    scriptName = `${scriptName}${props.env ? `-${props.env}` : ""}`;
-  }
+  const scriptName = props.name || path.basename(props.entry.file);
 
   return (
     <>

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -64,7 +64,7 @@ export default async function publish(props: Props): Promise<void> {
 
   assert(config.account_id, "missing account id");
 
-  let scriptName = props.name || config.name;
+  const scriptName = props.name;
   assert(
     scriptName,
     'You need to provide a name when publishing a worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`'
@@ -85,9 +85,6 @@ export default async function publish(props: Props): Promise<void> {
 
   const destination = await tmp.dir({ unsafeCleanup: true });
   try {
-    if (props.legacyEnv) {
-      scriptName += props.env ? `-${props.env}` : "";
-    }
     const envName = props.env ?? "production";
 
     if (props.config.build?.command) {


### PR DESCRIPTION
This implements environment support for `wrangler secret` (both legacy and services). We now consistently generate the right script name across commands with the `getScriptName()` helper.