### PR TITLE
feat: tail+envs

### DIFF
--- a/.changeset/dull-llamas-drive.md
+++ b/.changeset/dull-llamas-drive.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+feat: tail+envs
+
+This implements service environment support for `wrangler tail`. Fairly simple, we just generate the right URLs. wrangler tail already works for legacy envs, so there's nothing to do there.

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -1151,8 +1151,13 @@ export async function main(argv: string[]): Promise<void> {
       const { tail, expiration, deleteTail } = await createTail(
         accountId,
         scriptName,
-        filters
+        filters,
+        !isLegacyEnv(args, config) ? args.env : undefined
       );
+
+      const scriptDisplayName = `${scriptName}${
+        args.env && !isLegacyEnv(args, config) ? ` (${args.env})` : ""
+      }`;
 
       console.log(
         `successfully created tail, expires at ${expiration.toLocaleString()}`
@@ -1177,11 +1182,13 @@ export async function main(argv: string[]): Promise<void> {
             await setTimeout(100);
             break;
           case tail.CLOSED:
-            throw new Error(`Connection to ${scriptName} closed unexpectedly.`);
+            throw new Error(
+              `Connection to ${scriptDisplayName} closed unexpectedly.`
+            );
         }
       }
 
-      console.log(`Connected to ${scriptName}, waiting for logs...`);
+      console.log(`Connected to ${scriptDisplayName}, waiting for logs...`);
 
       tail.on("close", async () => {
         tail.terminate();

--- a/packages/wrangler/src/tail/index.ts
+++ b/packages/wrangler/src/tail/index.ts
@@ -28,8 +28,14 @@ type TailCreationApiResponse = {
  * @param workerName the name of the worker to tail
  * @returns a `cfetch`-ready URL for creating a new tail
  */
-function makeCreateTailUrl(accountId: string, workerName: string): string {
-  return `/accounts/${accountId}/workers/scripts/${workerName}/tails`;
+function makeCreateTailUrl(
+  accountId: string,
+  workerName: string,
+  env: string | undefined
+): string {
+  return env
+    ? `/accounts/${accountId}/workers/services/${workerName}/environments/${env}/tails`
+    : `/accounts/${accountId}/workers/scripts/${workerName}/tails`;
 }
 
 /**
@@ -45,9 +51,12 @@ function makeCreateTailUrl(accountId: string, workerName: string): string {
 function makeDeleteTailUrl(
   accountId: string,
   workerName: string,
-  tailId: string
+  tailId: string,
+  env: string | undefined
 ): string {
-  return `/accounts/${accountId}/workers/scripts/${workerName}/tails/${tailId}`;
+  return env
+    ? `/accounts/${accountId}/workers/services/${workerName}/environments/${env}/tails/${tailId}`
+    : `/accounts/${accountId}/workers/scripts/${workerName}/tails/${tailId}`;
 }
 
 /**
@@ -66,14 +75,15 @@ function makeDeleteTailUrl(
 export async function createTail(
   accountId: string,
   workerName: string,
-  message: TailFilterMessage
+  message: TailFilterMessage,
+  env: string | undefined
 ): Promise<{
   tail: WebSocket;
   expiration: Date;
   deleteTail: () => Promise<void>;
 }> {
   // create the tail
-  const createTailUrl = makeCreateTailUrl(accountId, workerName);
+  const createTailUrl = makeCreateTailUrl(accountId, workerName, env);
   const {
     id: tailId,
     url: websocketUrl,
@@ -83,7 +93,7 @@ export async function createTail(
   });
 
   // delete the tail (not yet!)
-  const deleteUrl = makeDeleteTailUrl(accountId, workerName, tailId);
+  const deleteUrl = makeDeleteTailUrl(accountId, workerName, tailId, env);
   async function deleteTail() {
     await fetchResult(deleteUrl, { method: "DELETE" });
   }


### PR DESCRIPTION
This implements service environment support for `wrangler tail`. Fairly simple, we just generate the right URLs. wrangler tail already works for legacy envs, so there's nothing to do there.