### PR TITLE
feat: top level `main` config field

### DIFF
--- a/.changeset/chatty-berries-divide.md
+++ b/.changeset/chatty-berries-divide.md
@@ -1,0 +1,17 @@
+---
+"wrangler": patch
+---
+
+feat: top level `main` config field
+
+This implements a top level `main` field for `wrangler.toml` to define an entry point for the worker , and adds a deprecation warning for `build.upload.main`. The deprecation warning is detailed enough to give the exact line to copy-paste into your config file. Example -
+
+```
+The `build.upload` field is deprecated. Delete the `build.upload` field, and add this to your configuration file:
+
+main = "src/chat.mjs"
+```
+
+This also makes `./dist` a default for `build.upload.dir`, to match wrangler 1's behaviour.
+
+Closes https://github.com/cloudflare/wrangler2/issues/488

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -35,12 +35,12 @@ describe("Dev component", () => {
       await expect(
         runWrangler("dev")
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Missing entry-point: The entry-point should be specified via the command line (e.g. \`wrangler dev path/to/script\`) or the \`build.upload.main\` config field."`
+        `"Missing entry-point: The entry-point should be specified via the command line (e.g. \`wrangler dev path/to/script\`) or the \`main\` config field."`
       );
 
       expect(std.out).toMatchInlineSnapshot(`""`);
       expect(std.err).toMatchInlineSnapshot(`
-        "Missing entry-point: The entry-point should be specified via the command line (e.g. \`wrangler dev path/to/script\`) or the \`build.upload.main\` config field.
+        "Missing entry-point: The entry-point should be specified via the command line (e.g. \`wrangler dev path/to/script\`) or the \`main\` config field.
 
         [32m%s[0m
         If you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new."

--- a/packages/wrangler/src/config.ts
+++ b/packages/wrangler/src/config.ts
@@ -37,7 +37,6 @@ export type Config = {
    *
    * @optional
    * @inherited
-   * @todo this needs to be implemented!
    */
   main?: string;
 
@@ -427,7 +426,7 @@ export type Config = {
   } & /**
    * Much of the rest of this configuration isn't necessary anymore
    * in wrangler2. We infer the format automatically, and we can pass
-   * the path to the script either in the CLI (or, @todo, as the top level
+   * the path to the script either in the CLI (or, as the top level
    * `main` property).
    */ {
     /**

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -73,7 +73,7 @@ export default async function publish(props: Props): Promise<void> {
   if (config.site?.["entry-point"]) {
     console.warn(
       "Deprecation notice: The `site.entry-point` config field is no longer used.\n" +
-        "The entry-point should be specified via the command line (e.g. `wrangler publish path/to/script`) or the `build.upload.main` config field.\n" +
+        "The entry-point should be specified via the command line (e.g. `wrangler publish path/to/script`) or the `main` config field.\n" +
         "Please remove the `site.entry-point` field from the `wrangler.toml` file."
     );
   }


### PR DESCRIPTION
This implements a top level `main` field for `wrangler.toml` to define an entry point for the worker , and adds a deprecation warning for `build.upload.main`. The deprecation warning is detailed enough to give the exact line to copy-paste into your config file. Example -
```
The `build.upload` field is deprecated. Delete the `build.upload` field, and add this to your configuration file:

main = "src/chat.mjs"
```

This also makes `./dist` a default for `build.upload.dir`, to match wrangler 1's behaviour.

Closes https://github.com/cloudflare/wrangler2/issues/488