### PR TITLE
feat: dev+envs

### DIFF
--- a/.changeset/healthy-bugs-reply.md
+++ b/.changeset/healthy-bugs-reply.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+feat: dev+envs
+
+This implements service environments + `wrangler dev`. Fairly simple, it just needed the right url when creating the edge preview token.
+
+I tested this by publishing a service under one env, adding secrets under it in the dashboard, and then trying to dev under another env, and verifying that the secrets didn't leak.

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -82,7 +82,8 @@ function renderDev({
   usageModel,
   buildCommand = {},
   enableLocalPersistence = false,
-  env = undefined,
+  env,
+  zone,
 }: Partial<DevProps>) {
   return render(
     <Dev
@@ -106,6 +107,7 @@ function renderDev({
       usageModel={usageModel}
       bindings={bindings}
       enableLocalPersistence={enableLocalPersistence}
+      zone={zone}
     />
   );
 }

--- a/packages/wrangler/src/api/worker.ts
+++ b/packages/wrangler/src/api/worker.ts
@@ -16,10 +16,6 @@ export interface CfAccount {
    * An account ID.
    */
   accountId: string;
-  /**
-   * A zone ID, only required if not using `workers.dev`.
-   */
-  zoneId?: string;
 }
 
 /**
@@ -164,6 +160,12 @@ export interface CfWorkerInit {
   usage_model: undefined | "bundled" | "unbound";
 }
 
+export interface CfWorkerContext {
+  env: string | undefined;
+  legacyEnv: boolean | undefined;
+  zone: string | undefined;
+}
+
 /**
  * A stub to create a Cloudflare Worker preview.
  *
@@ -172,9 +174,10 @@ export interface CfWorkerInit {
  */
 export async function createWorker(
   init: CfWorkerInit,
-  account: CfAccount
+  account: CfAccount,
+  ctx: CfWorkerContext
 ): Promise<CfPreviewToken> {
-  const token = await previewToken(account, init);
+  const token = await previewToken(account, init, ctx);
   const response = await fetch(token.prewarmUrl.href, { method: "POST" });
   if (!response.ok) {
     // console.error("worker failed to prewarm: ", response.statusText);

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -56,6 +56,7 @@ export type DevProps = {
   };
   env: string | undefined;
   legacyEnv: boolean;
+  zone: string | undefined;
 };
 
 function Dev(props: DevProps): JSX.Element {
@@ -142,6 +143,7 @@ function Dev(props: DevProps): JSX.Element {
           usageModel={props.usageModel}
           env={props.env}
           legacyEnv={props.legacyEnv}
+          zone={props.zone}
         />
       )}
       <Box borderStyle="round" paddingLeft={1} paddingRight={1}>
@@ -192,6 +194,7 @@ function Remote(props: {
   usageModel: undefined | "bundled" | "unbound";
   env: string | undefined;
   legacyEnv: boolean | undefined;
+  zone: string | undefined;
 }) {
   assert(props.accountId, "accountId is required");
   assert(props.apiToken, "apiToken is required");
@@ -210,6 +213,7 @@ function Remote(props: {
     usageModel: props.usageModel,
     env: props.env,
     legacyEnv: props.legacyEnv,
+    zone: props.zone,
   });
 
   usePreviewServer({
@@ -685,6 +689,7 @@ function useWorker(props: {
   usageModel: undefined | "bundled" | "unbound";
   env: string | undefined;
   legacyEnv: boolean | undefined;
+  zone: string | undefined;
 }): CfPreviewToken | undefined {
   const {
     name,
@@ -769,10 +774,14 @@ function useWorker(props: {
         usage_model: usageModel,
       };
       setToken(
-        await createWorker(init, {
-          accountId,
-          apiToken,
-        })
+        await createWorker(
+          init,
+          {
+            accountId,
+            apiToken,
+          },
+          { env: props.env, legacyEnv: props.legacyEnv, zone: props.zone }
+        )
       );
     }
     start().catch((err) => {
@@ -795,6 +804,7 @@ function useWorker(props: {
     modules,
     props.env,
     props.legacyEnv,
+    props.zone,
   ]);
   return token;
 }

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -707,6 +707,7 @@ export async function main(argv: string[]): Promise<void> {
           name={getScriptName(args, config)}
           entry={entry}
           env={args.env}
+          zone={undefined}
           rules={getRules(config)}
           legacyEnv={isLegacyEnv(args, config)}
           buildCommand={config.build || {}}
@@ -1151,6 +1152,7 @@ export async function main(argv: string[]): Promise<void> {
           entry={entry}
           rules={getRules(config)}
           env={args.env}
+          zone={undefined}
           legacyEnv={isLegacyEnv(args, config)}
           buildCommand={config.build || {}}
           format={config.build?.upload?.format}


### PR DESCRIPTION
This implements service environments + `wrangler dev`. Fairly simple, it just needed the right url when creating the edge preview token.

I tested this by publishing a service under one env, adding secrets under it in the dashboard, and then trying to dev under another env, and verifying that the secrets didn't leak.

(This uncovered an issue where we can't set the right host incl. the env prefix, but it's not critical right now, following up internally.)