### PR TITLE
feat: default to legacy environments

### DIFF
--- a/.changeset/kind-hairs-sneeze.md
+++ b/.changeset/kind-hairs-sneeze.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+feat: default to legacy environments
+
+While implementing support for service environments, we unearthed a small number of usage issues. While we work those out, we should default to using regular "legacy" environments.

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -107,7 +107,7 @@ describe("publish", () => {
           env: "some-env",
           legacyEnv: false,
         });
-        await runWrangler("publish index.js --env some-env");
+        await runWrangler("publish index.js --env some-env --legacy-env false");
         expect(std.out).toMatchInlineSnapshot(`
           "Uploaded
           test-name (some-env)
@@ -215,7 +215,7 @@ describe("publish", () => {
         routes: ["dev-example.com/some-route/*"],
         env: "dev",
       });
-      await runWrangler("publish ./index --env dev");
+      await runWrangler("publish ./index --env dev --legacy-env false");
     });
 
     it.todo("should error if it's a workers.dev route");
@@ -796,7 +796,7 @@ export default{
       mockListKVNamespacesRequest(kvNamespace);
       mockKeyListRequest(kvNamespace.id, []);
       mockUploadAssetsToKVRequest(kvNamespace.id, assets);
-      await runWrangler("publish --env some-env");
+      await runWrangler("publish --env some-env --legacy-env false");
 
       expect(std.out).toMatchInlineSnapshot(`
         "reading assets/file-1.txt...

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -96,7 +96,9 @@ describe("wrangler secret", () => {
         "some-env",
         false
       );
-      await runWrangler("secret put the-key --name script-name --env some-env");
+      await runWrangler(
+        "secret put the-key --name script-name --env some-env --legacy-env false"
+      );
 
       expect(std.out).toMatchInlineSnapshot(`
         "🌀 Creating the secret for script script-name (some-env)
@@ -216,7 +218,7 @@ describe("wrangler secret", () => {
         result: true,
       });
       await runWrangler(
-        "secret delete the-key --name script-name --env some-env"
+        "secret delete the-key --name script-name --env some-env --legacy-env false"
       );
       expect(std.out).toMatchInlineSnapshot(`
         "🌀 Deleting the secret the-key on script script-name (some-env)
@@ -321,7 +323,9 @@ describe("wrangler secret", () => {
 
     it("should list secrets: service envs", async () => {
       mockListRequest({ scriptName: "script-name" }, "some-env");
-      await runWrangler("secret list --name script-name --env some-env");
+      await runWrangler(
+        "secret list --name script-name --env some-env --legacy-env false"
+      );
       expect(std.out).toMatchInlineSnapshot(`
         "[
           {

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -58,7 +58,7 @@ describe("tail", () => {
       const api = mockWebsocketAPIs("some-env");
       expect(api.requests.creation.count).toStrictEqual(0);
 
-      await runWrangler("tail test-worker --env some-env");
+      await runWrangler("tail test-worker --env some-env --legacy-env false");
 
       await expect(api.ws.connected).resolves.toBeTruthy();
       expect(api.requests.creation.count).toStrictEqual(1);

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -243,11 +243,13 @@ ${TOML.stringify({ rules: config.build.upload.rules })}`
   return rules;
 }
 
+const LEGACY_ENV_DEFAULT = true; // TODO: set this as false to turn on service environments as the default
+
 function isLegacyEnv(args: unknown, config: Config): boolean {
   return (
     (args as { "legacy-env": boolean | undefined })["legacy-env"] ??
     config.legacy_env ??
-    false
+    LEGACY_ENV_DEFAULT
   );
 }
 
@@ -1311,7 +1313,7 @@ export async function main(argv: string[]): Promise<void> {
           legacyEnv={
             (args["legacy-env"] as boolean | undefined) ??
             config.legacy_env ??
-            false
+            LEGACY_ENV_DEFAULT
           }
           buildCommand={config.build || {}}
           format={config.build?.upload?.format}


### PR DESCRIPTION
While implementing support for service environments, we unearthed a small number of usage issues. While we work those out, we should default to using regular "legacy" environments.