### PR TITLE
rfc: with `wrangler init`, create a new directory for named workers

### DIFF
--- a/.changeset/soft-eagles-taste.md
+++ b/.changeset/soft-eagles-taste.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+feat: with `wrangler init`, create a new directory for named workers
+
+Currently, when creating a new project, we usually first have to create a directory before running `wrangler init`, since it defaults to creating the `wrangler.toml`, `package.json`, etc in the current working directory. This fix introduces an enhancement, where using the `wrangler init [name]` form creates a directory named `[name]` and initialises the project files inside it. This matches the usage pattern a little better, and still preserves the older behaviour when we're creating a worker inside existing projects.

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -13,7 +13,7 @@ export type {
 /**
  * Get the Wrangler configuration; read it from the give `configPath` if available.
  */
-export function readConfig(configPath?: string): Config {
+export async function readConfig(configPath?: string): Promise<Config> {
   let rawConfig: RawConfig = {};
   if (!configPath) {
     configPath = findWranglerToml();
@@ -21,7 +21,7 @@ export function readConfig(configPath?: string): Config {
 
   // Load the configuration from disk if available
   if (configPath) {
-    rawConfig = parseTOML(readFile(configPath), configPath);
+    rawConfig = parseTOML(await readFile(configPath), configPath);
   }
 
   // Process the top-level configuration.

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -842,7 +842,7 @@ function useTunnel(toggle: boolean) {
           await commandExists("cloudflared");
         } catch (e) {
           console.error(
-            "To share your worker on the internet, please install `cloudflared` from https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation"
+            "To share your worker on the Internet, please install `cloudflared` from https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation"
           );
           return;
         }

--- a/packages/wrangler/src/parse.ts
+++ b/packages/wrangler/src/parse.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import * as fsp from "fs/promises";
 import { resolve } from "node:path";
 import TOML from "@iarna/toml";
 import { formatMessagesSync } from "esbuild";
@@ -122,9 +122,9 @@ export function parseJSON(input: string, file?: string): any {
 /**
  * Reads a file and parses it based on its type.
  */
-export function readFile(file: string): string {
+export async function readFile(file: string): Promise<string> {
   try {
-    return readFileSync(file, { encoding: "utf-8" });
+    return await fsp.readFile(file, { encoding: "utf-8" });
   } catch (err) {
     const { message } = err as Error;
     throw new ParseError({


### PR DESCRIPTION
(I got bored on my flight so... I made a PR as a place for discussion of this, and also to generate the prerelease builds so we could actually try it out.)

Currently, when creating a new project, we usually first have to create a directory before running `wrangler init`, since it defaults to creating the `wrangler.toml`, `package.json`, etc in the current working directory. This fix introduces an enhancement, where using the `wrangler init [name]` form creates a directory named `[name]` and initialises the project files inside it. This matches the usage pattern a little better, and still preserves the older behaviour when we're creating a worker inside existing projects.
