### PR TITLE
chore: refactor some common code into `requireAuth()`

### DIFF
--- a/.changeset/rare-starfishes-deliver.md
+++ b/.changeset/rare-starfishes-deliver.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+chore: refactor some common code into `requireAuth()`
+
+There was a common chunk of code across most commands that ensures a user is logged in, and retrieves an account ID. I'd resisted making this into an abstraction for a while. Now that the codebase is stable, and https://github.com/cloudflare/wrangler2/pull/537 removes some surrounding code there, I made an abstraction for this common code as `requireAuth()`. This gets a mention in the changelog simply because it touches a bunch of code, although it's mostly mechanical deletion/replacement.

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -16,6 +16,7 @@ import type { AssetPaths } from "./sites";
 
 type Props = {
   config: Config;
+  accountId: string;
   format: CfScriptFormat | undefined;
   entry: { file: string; directory: string };
   rules: Config["rules"];
@@ -38,7 +39,7 @@ function sleep(ms: number) {
 
 export default async function publish(props: Props): Promise<void> {
   // TODO: warn if git/hg has uncommitted changes
-  const { config } = props;
+  const { config, accountId } = props;
 
   // TODO: should we automatically fallback to top level config if there is no matching environment??
   const envRootObj = (props.env && config.env[props.env]) || config;
@@ -55,16 +56,10 @@ export default async function publish(props: Props): Promise<void> {
     (envRootObj.route ? [envRootObj.route] : []) ??
     [];
 
-  const { account_id: accountId, workers_dev: deployToWorkersDev } = config;
-
-  if (accountId === undefined) {
-    throw new Error("No account_id provided.");
-  }
+  const { workers_dev: deployToWorkersDev } = config;
 
   const jsxFactory = props.jsxFactory || envRootObj.jsx_factory;
   const jsxFragment = props.jsxFragment || envRootObj.jsx_fragment;
-
-  assert(config.account_id, "missing account id");
 
   const scriptName = props.name;
   assert(

--- a/packages/wrangler/src/user.tsx
+++ b/packages/wrangler/src/user.tsx
@@ -976,7 +976,7 @@ export function listScopes(): void {
   // TODO: maybe a good idea to show usage here
 }
 
-export async function getAccountId() {
+export async function getAccountId(): Promise<string | undefined> {
   const apiToken = getAPIToken();
   if (!apiToken) return;
 


### PR DESCRIPTION
There was a common chunk of code across most commands that ensures a user is logged in, and retrieves an account ID. I'd resisted making this into an abstraction for a while. Now that the codebase is stable, and https://github.com/cloudflare/wrangler2/pull/537 removes some surrounding code there, I made an abstraction for this common code as `requireAuth()`. This gets a mention in the changelog simply because it touches a bunch of code, although it's mostly mechanical deletion/replacement.