### PR TITLE
feat: zoned worker support for `wrangler dev`

### DIFF
--- a/.changeset/large-vans-mix.md
+++ b/.changeset/large-vans-mix.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+feat: zoned worker support for `wrangler dev`
+
+This implements support for zoned workers in `wrangler dev`. Of note, since we're deprecating `zone_id`, we instead use the domain provided via `--host`/`config.dev.host`/`--routes`/`--route`/`config.routes`/`config.route` and infer the zone id from it.
+
+Fixes https://github.com/cloudflare/wrangler2/issues/544

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -21,6 +21,7 @@ describe("normalizeAndValidateConfig()", () => {
         local_protocol: "http",
         port: 8787,
         upstream_protocol: "https",
+        host: undefined,
       },
       durable_objects: {
         bindings: [],

--- a/packages/wrangler/src/__tests__/jest.setup.ts
+++ b/packages/wrangler/src/__tests__/jest.setup.ts
@@ -55,3 +55,15 @@ jest.mock("../dialogs");
     "Unexpected call to `prompt()`. You should use `mockPrompt()` to mock calls to `prompt()` with expectations. Search the codebase for `mockPrompt` to learn more."
   );
 });
+
+jest.mock("../dev", () => {
+  const { useApp } = jest.requireActual("ink");
+  const { useEffect } = jest.requireActual("react");
+  return jest.fn().mockImplementation(() => {
+    const { exit } = useApp();
+    useEffect(() => {
+      exit();
+    });
+    return null;
+  });
+});

--- a/packages/wrangler/src/api/preview.ts
+++ b/packages/wrangler/src/api/preview.ts
@@ -61,7 +61,7 @@ async function sessionToken(
 ): Promise<CfPreviewToken> {
   const { accountId } = account;
   const initUrl = ctx.zone
-    ? `/zones/${ctx.zone}/workers/edge-preview`
+    ? `/zones/${ctx.zone.id}/workers/edge-preview`
     : `/accounts/${accountId}/workers/subdomain/edge-preview`;
 
   const { exchange_url } = await fetchResult<{ exchange_url: string }>(initUrl);
@@ -111,7 +111,7 @@ export async function previewToken(
       : `/accounts/${accountId}/workers/scripts/${scriptId}/edge-preview`;
 
   const mode: CfPreviewMode = ctx.zone
-    ? { routes: ["*/*"] }
+    ? { routes: ["*/*"] } // TODO: should we support routes here? how?
     : { workers_dev: true };
 
   const formData = toFormData(worker);
@@ -127,20 +127,18 @@ export async function previewToken(
 
   return {
     value: preview_token,
-    // TODO: verify this works with zoned workers
-    host:
-      worker.name && !ctx.zone
-        ? // hrmm this might need change as well
-          `${
-            worker.name
-            // TODO: this should also probably have the env prefix
-            // but it doesn't appear to work yet, instead giving us the
-            // "There is nothing here yet" screen
-            // ctx.env && !ctx.legacyEnv
-            //   ? `${ctx.env}.${worker.name}`
-            //   : worker.name
-          }.${host.split(".").slice(1).join(".")}`
-        : host,
+    host: ctx.zone
+      ? ctx.zone.host
+      : `${
+          worker.name
+          // TODO: this should also probably have the env prefix
+          // but it doesn't appear to work yet, instead giving us the
+          // "There is nothing here yet" screen
+          // ctx.env && !ctx.legacyEnv
+          //   ? `${ctx.env}.${worker.name}`
+          //   : worker.name
+        }.${host.split(".").slice(1).join(".")}`,
+
     inspectorUrl,
     prewarmUrl,
   };

--- a/packages/wrangler/src/api/worker.ts
+++ b/packages/wrangler/src/api/worker.ts
@@ -133,7 +133,7 @@ export interface CfWorkerInit {
   /**
    * The name of the worker.
    */
-  name: string | undefined;
+  name: string;
   /**
    * The entrypoint module.
    */
@@ -163,7 +163,7 @@ export interface CfWorkerInit {
 export interface CfWorkerContext {
   env: string | undefined;
   legacyEnv: boolean | undefined;
-  zone: string | undefined;
+  zone: { id: string; host: string } | undefined;
 }
 
 /**

--- a/packages/wrangler/src/config/config.ts
+++ b/packages/wrangler/src/config/config.ts
@@ -94,6 +94,11 @@ export interface ConfigFields<Env extends RawEnvironment> {
      * @todo this needs to be implemented
      */
     upstream_protocol?: string;
+
+    /**
+     * Host to forward requests to, defaults to the zone of project
+     */
+    host?: string;
   };
 
   /**

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -246,6 +246,7 @@ function normalizeAndValidateDev(
     port = 8787,
     local_protocol = "http",
     upstream_protocol = "https",
+    host,
     ...rest
   } = rawDev;
   validateAdditionalProperties(diagnostics, "dev", Object.keys(rest), []);
@@ -266,7 +267,8 @@ function normalizeAndValidateDev(
     upstream_protocol,
     "string"
   );
-  return { ip, port, local_protocol, upstream_protocol };
+  validateOptionalProperty(diagnostics, "dev", "host", host, "string");
+  return { ip, port, local_protocol, upstream_protocol, host };
 }
 
 /**

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -56,7 +56,12 @@ export type DevProps = {
   };
   env: string | undefined;
   legacyEnv: boolean;
-  zone: string | undefined;
+  zone:
+    | {
+        id: string;
+        host: string;
+      }
+    | undefined;
 };
 
 function Dev(props: DevProps): JSX.Element {
@@ -128,7 +133,7 @@ function Dev(props: DevProps): JSX.Element {
         />
       ) : (
         <Remote
-          name={props.name}
+          name={scriptName}
           bundle={bundle}
           format={format}
           accountId={props.accountId}
@@ -179,7 +184,7 @@ function useWorkerFormat(props: {
 }
 
 function Remote(props: {
-  name: undefined | string;
+  name: string;
   bundle: EsbuildBundle | undefined;
   format: CfScriptFormat | undefined;
   public: undefined | string;
@@ -194,7 +199,7 @@ function Remote(props: {
   usageModel: undefined | "bundled" | "unbound";
   env: string | undefined;
   legacyEnv: boolean | undefined;
-  zone: string | undefined;
+  zone: { id: string; host: string } | undefined;
 }) {
   assert(props.accountId, "accountId is required");
   assert(props.apiToken, "apiToken is required");
@@ -675,7 +680,7 @@ function useEsbuild({
 }
 
 function useWorker(props: {
-  name: undefined | string;
+  name: string;
   bundle: EsbuildBundle | undefined;
   format: CfScriptFormat | undefined;
   modules: CfModule[];
@@ -689,7 +694,7 @@ function useWorker(props: {
   usageModel: undefined | "bundled" | "unbound";
   env: string | undefined;
   legacyEnv: boolean | undefined;
-  zone: string | undefined;
+  zone: { id: string; host: string } | undefined;
 }): CfPreviewToken | undefined {
   const {
     name,


### PR DESCRIPTION
This implements support for zoned workers in `wrangler dev`. Of note, since we're deprecating `zone_id`, we instead use the domain provided via `--host`/`config.dev.host`/`--routes`/`--route`/`config.routes`/`config.route` and infer the zone id from it.

Fixes https://github.com/cloudflare/wrangler2/issues/544