### PR TITLE
feat: add confirmation and success messages to `kv:bulk delete` command

### DIFF
--- a/.changeset/heavy-hounds-talk.md
+++ b/.changeset/heavy-hounds-talk.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+---
+
+feat: add confirmation and success messages to `kv:bulk delete` command
+
+Added the following:
+
+- When the deletion completes, we get `Success!` logged to the console.
+- Before deleting, the user is now asked to confirm is that is desired.
+- A new flag `--force`/`-f` to avoid the confirmation check.

--- a/packages/wrangler/src/__tests__/jest.setup.ts
+++ b/packages/wrangler/src/__tests__/jest.setup.ts
@@ -43,16 +43,16 @@ jest.mock("../cfetch/internal");
 jest.mock("../dialogs");
 
 // By default (if not configured by mockConfirm()) calls to `confirm()` should throw.
-(confirm as jest.Mock).mockImplementation(() => {
+(confirm as jest.Mock).mockImplementation((text: string) => {
   throw new Error(
-    "Unexpected call to `confirm()`. You should use `mockConfirm()` to mock calls to `confirm()` with expectations. Search the codebase for `mockConfirm` to learn more."
+    `Unexpected call to \`confirm("${text}")\`.\nYou should use \`mockConfirm()\` to mock calls to \`confirm()\` with expectations. Search the codebase for \`mockConfirm\` to learn more.`
   );
 });
 
 // By default (if not configured by mockPrompt()) calls to `prompt()` should throw.
-(prompt as jest.Mock).mockImplementation(() => {
+(prompt as jest.Mock).mockImplementation((text: string) => {
   throw new Error(
-    "Unexpected call to `prompt()`. You should use `mockPrompt()` to mock calls to `prompt()` with expectations. Search the codebase for `mockPrompt` to learn more."
+    `Unexpected call to \`prompt(${text}, ...)\`.\nYou should use \`mockPrompt()\` to mock calls to \`prompt()\` with expectations. Search the codebase for \`mockPrompt\` to learn more.`
   );
 });
 

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -2263,11 +2263,27 @@ export async function main(argv: string[]): Promise<void> {
               .option("preview", {
                 type: "boolean",
                 describe: "Interact with a preview namespace",
+              })
+              .option("force", {
+                type: "boolean",
+                alias: "f",
+                describe: "Do not ask for confirmation before deleting",
               });
           },
           async ({ filename, ...args }) => {
             const config = readConfig(args.config as ConfigPath);
             const namespaceId = getNamespaceId(args, config);
+
+            if (!args.force) {
+              const result = await confirm(
+                `Are you sure you want to delete all the keys read from "${filename}" from kv-namespace with id "${namespaceId}"?`
+              );
+              if (!result) {
+                console.log(`Not deleting keys read from "${filename}".`);
+                return;
+              }
+            }
+
             const content = parseJSON(
               readFileSync(filename),
               filename
@@ -2314,6 +2330,8 @@ export async function main(argv: string[]): Promise<void> {
             // -- snip, end --
 
             await deleteBulkKeyValue(config.account_id, namespaceId, content);
+
+            console.log("Success!");
           }
         );
     }


### PR DESCRIPTION
Added the following:

- When the deletion completes, we get `Success!` logged to the console.
- Before deleting, the user is now asked to confirm is that is desired.
- A new flag `--force` to avoid the confirmation check.