### PR TITLE
fix: limit bulk API requests to batches of 5,000

### DIFF
--- a/.changeset/angry-countries-matter.md
+++ b/.changeset/angry-countries-matter.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+---
+
+fix: limit bulk put API requests to batches of 5,000
+
+The `kv:bulk put` command now batches up put requests in groups of 5,000,
+displaying progress for each request.

--- a/.changeset/smooth-tables-admire.md
+++ b/.changeset/smooth-tables-admire.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+---
+
+fix: limit bulk delete API requests to batches of 5,000
+
+The `kv:bulk delete` command now batches up delete requests in groups of 5,000,
+displaying progress for each request.

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -2031,7 +2031,16 @@ export async function main(argv: string[]): Promise<void> {
             }
 
             const accountId = await requireAuth(config);
-            await putBulkKeyValue(accountId, namespaceId, content);
+            await putBulkKeyValue(
+              accountId,
+              namespaceId,
+              content,
+              (index, total) => {
+                console.log(`Uploaded ${index} of ${total}.`);
+              }
+            );
+
+            console.log("Success!");
           }
         )
         .command(

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -2098,7 +2098,9 @@ export async function main(argv: string[]): Promise<void> {
               const key = content[i];
               if (typeof key !== "string") {
                 errors.push(
-                  `The item at index ${i} is a ${typeof key}: ${key}`
+                  `The item at index ${i} is type: "${typeof key}" - ${JSON.stringify(
+                    key
+                  )}`
                 );
               }
             }
@@ -2112,7 +2114,14 @@ export async function main(argv: string[]): Promise<void> {
 
             const accountId = await requireAuth(config);
 
-            await deleteBulkKeyValue(accountId, namespaceId, content);
+            await deleteBulkKeyValue(
+              accountId,
+              namespaceId,
+              content,
+              (index, total) => {
+                console.log(`Deleted ${index} of ${total}.`);
+              }
+            );
 
             console.log("Success!");
           }

--- a/packages/wrangler/src/sites.tsx
+++ b/packages/wrangler/src/sites.tsx
@@ -164,7 +164,7 @@ export async function syncAssets(
     }
     manifest[path.relative(siteAssets.baseDirectory, file)] = assetKey;
   }
-  await putBulkKeyValue(accountId, namespace, upload);
+  await putBulkKeyValue(accountId, namespace, upload, () => {});
   return { manifest, namespace };
 }
 


### PR DESCRIPTION
The `kv:bulk delete` and `kv:bulk put` commands now batch up requests in groups of 5,000,
displaying progress for each request.
