### PR TITLE
fix: wrangler dev on unnamed workers in remote mode

### DIFF
--- a/.changeset/great-cats-lie.md
+++ b/.changeset/great-cats-lie.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: wrangler dev on unnamed workers in remote mode
+
+With unnamed workers, we use the filename as the name of the worker, which isn't a valid name for workers because of the `.` (This break was introduced in https://github.com/cloudflare/wrangler2/pull/545). The preview service accepts unnamed workers and generates a hash anyway, so the fix is to simply not send it, and use the host that the service provides.

--- a/packages/wrangler/src/api/preview.ts
+++ b/packages/wrangler/src/api/preview.ts
@@ -129,7 +129,8 @@ export async function previewToken(
     value: preview_token,
     host: ctx.zone
       ? ctx.zone.host
-      : `${
+      : worker.name
+      ? `${
           worker.name
           // TODO: this should also probably have the env prefix
           // but it doesn't appear to work yet, instead giving us the
@@ -137,7 +138,8 @@ export async function previewToken(
           // ctx.env && !ctx.legacyEnv
           //   ? `${ctx.env}.${worker.name}`
           //   : worker.name
-        }.${host.split(".").slice(1).join(".")}`,
+        }.${host.split(".").slice(1).join(".")}`
+      : host,
 
     inspectorUrl,
     prewarmUrl,

--- a/packages/wrangler/src/api/worker.ts
+++ b/packages/wrangler/src/api/worker.ts
@@ -133,7 +133,7 @@ export interface CfWorkerInit {
   /**
    * The name of the worker.
    */
-  name: string;
+  name: string | undefined;
   /**
    * The entrypoint module.
    */

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -114,13 +114,12 @@ function Dev(props: DevProps): JSX.Element {
   );
 
   useTunnel(toggles.tunnel);
-  const scriptName = props.name || path.basename(props.entry.file);
 
   return (
     <>
       {toggles.local ? (
         <Local
-          name={scriptName}
+          name={props.name}
           bundle={bundle}
           format={format}
           bindings={props.bindings}
@@ -133,7 +132,7 @@ function Dev(props: DevProps): JSX.Element {
         />
       ) : (
         <Remote
-          name={scriptName}
+          name={props.name}
           bundle={bundle}
           format={format}
           accountId={props.accountId}
@@ -182,7 +181,7 @@ function useWorkerFormat(props: {
 }
 
 function Remote(props: {
-  name: string;
+  name: string | undefined;
   bundle: EsbuildBundle | undefined;
   format: CfScriptFormat | undefined;
   public: undefined | string;
@@ -678,7 +677,7 @@ function useEsbuild({
 }
 
 function useWorker(props: {
-  name: string;
+  name: string | undefined;
   bundle: EsbuildBundle | undefined;
   format: CfScriptFormat | undefined;
   modules: CfModule[];


### PR DESCRIPTION
With unnamed workers, we use the filename as the name of the worker, which isn't a valid name for workers because of the `.` (This break was introduced in https://github.com/cloudflare/wrangler2/pull/545). The preview service accepts unnamed workers and generates a hash anyway, so the fix is to simply not send it, and use the host that the service provides.

(Yes, I broke the build 😔)