### PR TITLE
Request Pages API scopes when logging in

### DIFF
--- a/.changeset/giant-sloths-fail.md
+++ b/.changeset/giant-sloths-fail.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Request Pages OAuth scopes when logging in

--- a/packages/wrangler/src/user.tsx
+++ b/packages/wrangler/src/user.tsx
@@ -285,6 +285,8 @@ const Scopes = {
   "workers_scripts:write":
     "See and change Cloudflare Workers scripts, durable objects, subdomains, triggers, and tail data.",
   "workers_tail:read": "See Cloudflare Workers tail and script data.",
+  "pages:write":
+    "See and change Cloudflare Pages projects, settings and deployments.",
   "zone:read": "Grants read level access to account zone.",
 } as const;
 


### PR DESCRIPTION
Not ready quite yet (still waiting for some internal stuff first).

This adds the `pages:write` scope to the requests that wrangler makes when a user `npx wrangler login`. We should get this merged in as soon as we can, so that anyone who logs in gets these scopes, ready for when we can start doing Pages things inside of wrangler.

For those who are already logged in and don't have the `pages:write` scope, they'll currently see a generic:

```json
{"success":false,"errors":[{"code":10000,"message":"Authentication error"}]}
```

We could improve special-case handle this in the Pages commands we introduce and suggest re-consenting.