### PR TITLE
Add a nicer error when there's no workers.dev subdomain

### DIFF
--- a/.changeset/nice-jars-teach.md
+++ b/.changeset/nice-jars-teach.md
@@ -1,0 +1,10 @@
+---
+"wrangler": patch
+---
+
+Show an actionable error message when publishing to a workers.dev subdomain that hasn't been created yet.
+
+When publishing a worker to workers.dev, you need to first have registered your workers.dev subdomain
+(e.g. my-subdomain.workers.dev). We now check to ensure that the user has created their subdomain before
+uploading a worker to workers.dev, and if they haven't, we provide a link to where they can go through
+the workers onboarding flow and create one.

--- a/packages/wrangler/src/__tests__/helpers/mock-cfetch.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-cfetch.ts
@@ -1,6 +1,6 @@
 import { URL, URLSearchParams } from "node:url";
 import { pathToRegexp } from "path-to-regexp";
-import { getCloudflareApiBaseUrl } from "../../cfetch";
+import { FetchError, FetchError, getCloudflareApiBaseUrl } from "../../cfetch";
 import type { FetchResult } from "../../cfetch";
 import type { RequestInit } from "undici";
 
@@ -143,8 +143,8 @@ export function setMockResponse<ResponseType>(
 export async function createFetchResult<ResponseType>(
   result: ResponseType | Promise<ResponseType>,
   success = true,
-  errors = [],
-  messages = [],
+  errors: FetchError[] = [],
+  messages: string[] = [],
   result_info?: unknown
 ): Promise<FetchResult<ResponseType>> {
   return result_info

--- a/packages/wrangler/src/__tests__/helpers/mock-cfetch.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-cfetch.ts
@@ -1,7 +1,7 @@
 import { URL, URLSearchParams } from "node:url";
 import { pathToRegexp } from "path-to-regexp";
-import { FetchError, FetchError, getCloudflareApiBaseUrl } from "../../cfetch";
-import type { FetchResult } from "../../cfetch";
+import { getCloudflareApiBaseUrl } from "../../cfetch";
+import type { FetchResult, FetchError } from "../../cfetch";
 import type { RequestInit } from "undici";
 
 /**

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -1328,8 +1328,8 @@ export default{
 
       await expect(runWrangler("publish ./index")).rejects
         .toThrowErrorMatchingInlineSnapshot(`
-              "Error: Set up a workers.dev subdomain before using workers_dev in wrangler.toml
-              To create a workers.dev subdomain, click the link below
+              "Error: You need to register a workers.dev subdomain before publishing to workers.dev
+              You can either publish your worker to one or more routes by specifying them in wrangler.toml, or register a workers.dev subdomain here:
               https://dash.cloudflare.com/some-account-id/workers/onboarding"
             `);
     });

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -1039,46 +1039,6 @@ export async function main(argv: string[]): Promise<void> {
 
       const accountId = await requireAuth(config);
 
-      /**
-       * Check to see if the wrangler project has routes assigned to it
-       * @param c Config wrangler was invoked with
-       * @returns true if the user specified routes somehow
-       */
-      function hasRoutes(c: Config): boolean {
-        const multipleRoutes = !!c.routes && c.routes.length !== 0;
-        const singleRoute = !!c.route;
-        return singleRoute || multipleRoutes;
-      }
-
-      if (config.workers_dev) {
-        // check if workers.dev subdomain exists
-        try {
-          await fetchResult(`/accounts/${accountId}/workers/subdomain`);
-        } catch (e) {
-          const error = e as { code?: number };
-          if (typeof error === "object" && !!error && error.code === 10007) {
-            // 10007 error code: not found
-            // https://api.cloudflare.com/#worker-subdomain-get-subdomain
-            const errorMessage =
-              "Please set up a workers.dev subdomain before using workers_dev in wrangler.toml";
-            const onboardingMessage =
-              "To create a workers.dev subdomain, click the link below";
-            const onboardingLink = `https://dash.cloudflare.com/${accountId}/workers/onboarding`;
-
-            throw new Error(
-              `${errorMessage}\n${onboardingMessage}\n${onboardingLink}`
-            );
-          } else {
-            throw e;
-          }
-        }
-      } else if (!hasRoutes(config)) {
-        // check if routes are specified
-        throw new Error(
-          "Please specify either workers_dev or routes in wrangler.toml"
-        );
-      }
-
       const assetPaths = getAssetPaths(
         config,
         args["experimental-public"] || args.site,

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -795,6 +795,8 @@ export async function main(argv: string[]): Promise<void> {
 
       const accountId = !args.local ? await requireAuth(config) : undefined;
 
+      // TODO: if worker_dev = false and no routes, then error (only for dev)
+
       /**
        * Given something that resembles a URL,
        * try to extract a host from it

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -370,15 +370,14 @@ async function getSubdomain(accountId: string): Promise<string> {
     if (typeof error === "object" && !!error && error.code === 10007) {
       // 10007 error code: not found
       // https://api.cloudflare.com/#worker-subdomain-get-subdomain
+
       const errorMessage =
-        "Error: Set up a workers.dev subdomain before using workers_dev in wrangler.toml";
-      const onboardingMessage =
-        "To create a workers.dev subdomain, click the link below";
+        "Error: You need to register a workers.dev subdomain before publishing to workers.dev";
+      const solutionMessage =
+        "You can either publish your worker to one or more routes by specifying them in wrangler.toml, or register a workers.dev subdomain here:";
       const onboardingLink = `https://dash.cloudflare.com/${accountId}/workers/onboarding`;
 
-      throw new Error(
-        `${errorMessage}\n${onboardingMessage}\n${onboardingLink}`
-      );
+      throw new Error(`${errorMessage}\n${solutionMessage}\n${onboardingLink}`);
     } else {
       throw e;
     }

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -242,14 +242,6 @@ export default async function publish(props: Props): Promise<void> {
       ? `/accounts/${accountId}/workers/services/${scriptName}/environments/${envName}`
       : `/accounts/${accountId}/workers/scripts/${scriptName}`;
 
-    // it can be confusing to see "uploaded <worker>" but fail on the deployment step
-    // when the user is uploading to workers.dev but hasn't registered a subdomain,
-    // so we head off a "subdomain doesn't exist" error early
-    let userSubdomain = "";
-    if (deployToWorkersDev) {
-      userSubdomain = await getSubdomain(accountId);
-    }
-
     // Upload the script so it has time to propagate.
     const { available_on_subdomain } = await fetchResult(
       workerUrl,
@@ -261,11 +253,11 @@ export default async function publish(props: Props): Promise<void> {
     );
 
     const uploadMs = Date.now() - start;
-    console.log("Uploaded", workerName, formatTime(uploadMs));
     const deployments: Promise<string[]>[] = [];
 
     if (deployToWorkersDev) {
       // Deploy to a subdomain of `workers.dev`
+      const userSubdomain = await getSubdomain(accountId);
       const scriptURL =
         props.legacyEnv || !props.env
           ? `${scriptName}.${userSubdomain}.workers.dev`
@@ -303,6 +295,8 @@ export default async function publish(props: Props): Promise<void> {
         },
       });
     }
+
+    console.log("Uploaded", workerName, formatTime(uploadMs));
 
     // Update routing table for the script.
     if (routes.length > 0) {


### PR DESCRIPTION
Show an actionable error message when publishing to a workers.dev subdomain that hasn't been created yet.

When publishing a worker to workers.dev, you need to first have registered your workers.dev subdomain
(e.g. my-subdomain.workers.dev). We now check to ensure that the user has created their subdomain before
uploading a worker to workers.dev, and if they haven't, we provide a link to where they can go through
the workers onboarding flow and create one.

Closes #318