### PR TITLE
chore: rename files under wrangler/src/api

### DIFF
--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -13,8 +13,8 @@ import { mockKeyListRequest } from "./helpers/mock-kv";
 import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import writeWranglerToml from "./helpers/write-wrangler-toml";
-import type { WorkerMetadata } from "../api/form_data";
 import type { Config } from "../config";
+import type { WorkerMetadata } from "../create-worker-upload-form";
 import type { KVNamespaceInfo } from "../kv";
 import type { FormData, File } from "undici";
 

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -3,9 +3,9 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as esbuild from "esbuild";
 import makeModuleCollector from "./module-collection";
-import type { CfModule, CfScriptFormat } from "./api/worker";
 import type { Config } from "./config";
 import type { Entry } from "./entry";
+import type { CfModule, CfScriptFormat } from "./worker";
 
 type BundleResult = {
   modules: CfModule[];

--- a/packages/wrangler/src/create-worker-upload-form.ts
+++ b/packages/wrangler/src/create-worker-upload-form.ts
@@ -51,7 +51,7 @@ export interface WorkerMetadata {
 /**
  * Creates a `FormData` upload from a `CfWorkerInit`.
  */
-export function toFormData(worker: CfWorkerInit): FormData {
+export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
   const formData = new FormData();
   const {
     main,

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -13,8 +13,8 @@ import { withErrorBoundary, useErrorHandler } from "react-error-boundary";
 import onExit from "signal-exit";
 import tmp from "tmp-promise";
 import { fetch } from "undici";
-import { createWorker } from "./api/worker";
 import { bundleWorker } from "./bundle";
+import { createWorkerPreview } from "./create-worker-preview";
 import guessWorkerFormat from "./guess-worker-format";
 import useInspector from "./inspect";
 import { DEFAULT_MODULE_RULES } from "./module-collection";
@@ -22,11 +22,11 @@ import openInBrowser from "./open-in-browser";
 import { usePreviewServer, waitForPortToBeAvailable } from "./proxy";
 import { syncAssets } from "./sites";
 import { getAPIToken } from "./user";
-import type { CfPreviewToken } from "./api/preview";
-import type { CfModule, CfWorkerInit, CfScriptFormat } from "./api/worker";
 import type { Config } from "./config";
+import type { CfPreviewToken } from "./create-worker-preview";
 import type { Entry } from "./entry";
 import type { AssetPaths } from "./sites";
+import type { CfModule, CfWorkerInit, CfScriptFormat } from "./worker";
 import type { WatchMode } from "esbuild";
 import type { ExecaChildProcess } from "execa";
 import type { DirectoryResult } from "tmp-promise";
@@ -776,7 +776,7 @@ function useWorker(props: {
         usage_model: usageModel,
       };
       setToken(
-        await createWorker(
+        await createWorkerPreview(
           init,
           {
             accountId,

--- a/packages/wrangler/src/guess-worker-format.ts
+++ b/packages/wrangler/src/guess-worker-format.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert";
 import { build } from "esbuild";
-import type { CfScriptFormat } from "./api/worker";
 import type { Entry } from "./entry";
+import type { CfScriptFormat } from "./worker";
 import type { Metafile } from "esbuild";
 
 /**

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -10,9 +10,9 @@ import React from "react";
 import onExit from "signal-exit";
 import makeCLI from "yargs";
 import { version as wranglerVersion } from "../package.json";
-import { toFormData } from "./api/form_data";
 import { fetchResult } from "./cfetch";
 import { findWranglerToml, readConfig } from "./config";
+import { createWorkerUploadForm } from "./create-worker-upload-form";
 import Dev from "./dev";
 import { confirm, prompt } from "./dialogs";
 import { getEntry } from "./entry";
@@ -1474,7 +1474,7 @@ export async function main(argv: string[]): Promise<void> {
                   : `/accounts/${accountId}/workers/scripts/${scriptName}`,
                 {
                   method: "PUT",
-                  body: toFormData({
+                  body: createWorkerUploadForm({
                     name: scriptName,
                     main: {
                       name: scriptName,

--- a/packages/wrangler/src/module-collection.ts
+++ b/packages/wrangler/src/module-collection.ts
@@ -2,8 +2,8 @@ import crypto from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import globToRegExp from "glob-to-regexp";
-import type { CfModule, CfModuleType, CfScriptFormat } from "./api/worker";
 import type { Config, ConfigModuleRuleType } from "./config";
+import type { CfModule, CfModuleType, CfScriptFormat } from "./worker";
 import type esbuild from "esbuild";
 
 const RuleTypeToModuleType: Record<ConfigModuleRuleType, CfModuleType> = {

--- a/packages/wrangler/src/proxy.ts
+++ b/packages/wrangler/src/proxy.ts
@@ -3,7 +3,7 @@ import { connect } from "node:http2";
 import WebSocket from "faye-websocket";
 import { useEffect, useRef, useState } from "react";
 import serveStatic from "serve-static";
-import type { CfPreviewToken } from "./api/preview";
+import type { CfPreviewToken } from "./create-worker-preview";
 import type {
   IncomingHttpHeaders,
   RequestListener,

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -4,15 +4,15 @@ import path from "node:path";
 import { URLSearchParams } from "node:url";
 import { execaCommand } from "execa";
 import tmp from "tmp-promise";
-import { toFormData } from "./api/form_data";
 import { bundleWorker } from "./bundle";
 import { fetchResult } from "./cfetch";
+import { createWorkerUploadForm } from "./create-worker-upload-form";
 import { fileExists } from "./entry";
 import guessWorkerFormat from "./guess-worker-format";
 import { syncAssets } from "./sites";
-import type { CfScriptFormat, CfWorkerInit } from "./api/worker";
 import type { Config } from "./config";
 import type { AssetPaths } from "./sites";
+import type { CfScriptFormat, CfWorkerInit } from "./worker";
 
 type Props = {
   config: Config;
@@ -247,7 +247,7 @@ export default async function publish(props: Props): Promise<void> {
       workerUrl,
       {
         method: "PUT",
-        body: toFormData(worker),
+        body: createWorkerUploadForm(worker),
       },
       new URLSearchParams({ available_on_subdomain: "true" })
     );

--- a/packages/wrangler/src/worker.ts
+++ b/packages/wrangler/src/worker.ts
@@ -1,7 +1,3 @@
-import { fetch } from "undici";
-import { previewToken } from "./preview";
-import type { CfPreviewToken } from "./preview";
-
 /**
  * A Cloudflare account.
  */
@@ -164,23 +160,4 @@ export interface CfWorkerContext {
   env: string | undefined;
   legacyEnv: boolean | undefined;
   zone: { id: string; host: string } | undefined;
-}
-
-/**
- * A stub to create a Cloudflare Worker preview.
- *
- * @example
- * const {value, host} = await createWorker(init, acct);
- */
-export async function createWorker(
-  init: CfWorkerInit,
-  account: CfAccount,
-  ctx: CfWorkerContext
-): Promise<CfPreviewToken> {
-  const token = await previewToken(account, init, ctx);
-  const response = await fetch(token.prewarmUrl.href, { method: "POST" });
-  if (!response.ok) {
-    // console.error("worker failed to prewarm: ", response.statusText);
-  }
-  return token;
 }


### PR DESCRIPTION
This is a small reorganisation, it renames and moves some files under `src/preview` to `src`. There are no functional changes.

--- 

I didn't add a changeset because it seemed like overkill, but happy to do so if y'all think differently. 