### PR TITLE
fix: `config.site.entry-point` as a breaking deprecation

### DIFF
--- a/.changeset/small-jokes-lay.md
+++ b/.changeset/small-jokes-lay.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: `config.site.entry-point` as a breaking deprecation
+
+This makes configuring `site.entry-point` in config as a breaking deprecation, and throws an error. We do this because existing apps with `site.entry-point` _won't_ work in v2.

--- a/packages/wrangler/src/config/config.ts
+++ b/packages/wrangler/src/config/config.ts
@@ -255,7 +255,6 @@ export interface DeprecatedUpload {
    * Defaults to the directory containing the wrangler.toml file.
    *
    * @deprecated
-   * @breaking In wrangler 1, this defaults to ./dist, whereas in wrangler 2 it defaults to ./
    */
   dir?: string;
 

--- a/packages/wrangler/src/config/validation-helpers.ts
+++ b/packages/wrangler/src/config/validation-helpers.ts
@@ -5,7 +5,7 @@ import type { Environment, RawEnvironment } from "./environment";
 /**
  *  Mark a field as deprecated.
  *
- * This function will add a diagnostics warning if the deprecated field is found in the `rawEnv`.
+ * This function will add a diagnostics warning if the deprecated field is found in the `rawEnv` (or an error if it's also a breaking deprecation)
  * The `fieldPath` is a dot separated property path, e.g. `"build.upload.format"`.
  */
 export function deprecated<T extends object>(
@@ -13,11 +13,14 @@ export function deprecated<T extends object>(
   config: T,
   fieldPath: DeepKeyOf<T>,
   message: string,
-  remove: boolean
+  remove: boolean,
+  breaking = false
 ): void {
   const result = unwindPropertyPath(config, fieldPath);
   if (result !== undefined && result.field in result.container) {
-    diagnostics.warnings.push(`DEPRECATION: "${fieldPath}":\n${message}`);
+    (breaking ? diagnostics.errors : diagnostics.warnings).push(
+      `DEPRECATION: "${fieldPath}":\n${message}`
+    );
     if (remove) {
       delete (result.container as Record<string, unknown>)[result.field];
     }

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -61,6 +61,15 @@ export function normalizeAndValidateConfig(
     true
   );
 
+  deprecated(
+    diagnostics,
+    rawConfig,
+    `site.entry-point`,
+    `The \`site.entry-point\` config field is no longer used.\nThe entry-point should be specified via the command line or the \`main\` config field.`,
+    false,
+    true
+  );
+
   const { deprecatedUpload, ...build } = normalizeAndValidateBuild(
     diagnostics,
     rawConfig,
@@ -342,25 +351,12 @@ function normalizeAndValidateSite(
   rawSite: Config["site"]
 ): Config["site"] {
   if (rawSite !== undefined) {
-    const {
-      bucket,
-      "entry-point": entryPoint,
-      include = [],
-      exclude = [],
-      ...rest
-    } = rawSite;
+    const { bucket, include = [], exclude = [], ...rest } = rawSite;
     validateAdditionalProperties(diagnostics, "site", Object.keys(rest), []);
     validateRequiredProperty(diagnostics, "site", "bucket", bucket, "string");
-    validateOptionalProperty(
-      diagnostics,
-      "site",
-      "entry_point",
-      entryPoint,
-      "string"
-    );
     validateTypedArray(diagnostics, "sites.include", include, "string");
     validateTypedArray(diagnostics, "sites.exclude", exclude, "string");
-    return { bucket, "entry-point": entryPoint, include, exclude };
+    return { bucket, include, exclude };
   }
   return undefined;
 }

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -788,14 +788,6 @@ export async function main(argv: string[]): Promise<void> {
         );
       }
 
-      if (config.site?.["entry-point"]) {
-        console.warn(
-          "Deprecation notice: The `site.entry-point` config field is no longer used.\n" +
-            "The entry-point is specified via the command line (e.g. `wrangler dev path/to/script`).\n" +
-            "Please remove the `site.entry-point` field from the `wrangler.toml` file."
-        );
-      }
-
       const accountId = !args.local ? await requireAuth(config) : undefined;
 
       // TODO: if worker_dev = false and no routes, then error (only for dev)

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -64,14 +64,6 @@ export default async function publish(props: Props): Promise<void> {
     'You need to provide a name when publishing a worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`'
   );
 
-  if (config.site?.["entry-point"]) {
-    console.warn(
-      "Deprecation notice: The `site.entry-point` config field is no longer used.\n" +
-        "The entry-point should be specified via the command line (e.g. `wrangler publish path/to/script`) or the `main` config field.\n" +
-        "Please remove the `site.entry-point` field from the `wrangler.toml` file."
-    );
-  }
-
   assert(
     !config.site || config.site.bucket,
     "A [site] definition requires a `bucket` field with a path to the site's public directory."


### PR DESCRIPTION
This makes configuring `site.entry-point` in config as a breaking deprecation, and throws an error. We do this because existing apps with `site.entry-point` _won't_ work in v2.

--- 

I would recommend turning off whitespace when reviewing this PR. 