### PR TITLE
Fix incorrect parse for env binding

### DIFF
--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -895,7 +895,7 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
           // User bindings
           bindings: {
             ...Object.fromEntries(
-              bindings.map((binding) => binding.toString().split("="))
+              bindings.map((binding) => binding.toString().split("=", 1))
             ),
           },
 


### PR DESCRIPTION
For example
```shell
npx wrangler pages dev public/ -b "AAA=foo=bar; foo2=bar2" # actually i want to pass a cookie
```
It will be parsed to
```javascript
{
  AAA: 'foo' // all remaining arguments are lost!
}
```
But it should be parsed to
```javascript
{
  AAA: 'foo=bar; foo2=bar2' 
}
```
