### PR TITLE
feat: expire unused assets in `[site]` uploads

### DIFF
--- a/.changeset/thick-keys-worry.md
+++ b/.changeset/thick-keys-worry.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+feat: expire unused assets in `[site]` uploads
+
+This expires any previously uploaded assets when using a Sites / `[site]` configuration. Because we currently do a full iteration of a namespace's keys when publishing, for rapidly changing sites this means that uploads get slower and slower. We can't just delete unused assets because it leads to occasional 404s on older publishes while we're publishing. So we expire previous assets while uploading new ones. The implementation/constraints of the kv api means that uploads may become slower, but should hopefully be faster overall. These optimisations also only matter for rapidly changing sites, so common usecases still have the same perf characteristics.

--- a/packages/wrangler/src/__tests__/helpers/mock-kv.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-kv.ts
@@ -1,18 +1,15 @@
 import { createFetchResult, setMockRawResponse } from "./mock-cfetch";
+import type { NamespaceKeyInfo } from "../../kv";
 
 export function mockKeyListRequest(
   expectedNamespaceId: string,
-  expectedKeys: string[],
+  expectedKeys: NamespaceKeyInfo[],
   keysPerRequest = 1000,
   blankCursorValue: "" | undefined | null = undefined
 ) {
   const requests = { count: 0 };
   // See https://api.cloudflare.com/#workers-kv-namespace-list-a-namespace-s-keys
-  const expectedKeyObjects = expectedKeys.map((name) => ({
-    name,
-    expiration: 123456789,
-    metadata: {},
-  }));
+
   setMockRawResponse(
     "/accounts/:accountId/storage/kv/namespaces/:namespaceId/keys",
     "GET",
@@ -20,19 +17,15 @@ export function mockKeyListRequest(
       requests.count++;
       expect(accountId).toEqual("some-account-id");
       expect(namespaceId).toEqual(expectedNamespaceId);
-      if (expectedKeyObjects.length <= keysPerRequest) {
-        return createFetchResult(expectedKeyObjects);
+      if (expectedKeys.length <= keysPerRequest) {
+        return createFetchResult(expectedKeys);
       } else {
         const start = parseInt(query.get("cursor") ?? "0") || 0;
         const end = start + keysPerRequest;
-        const cursor = end < expectedKeyObjects.length ? end : blankCursorValue;
-        return createFetchResult(
-          expectedKeyObjects.slice(start, end),
-          true,
-          [],
-          [],
-          { cursor }
-        );
+        const cursor = end < expectedKeys.length ? end : blankCursorValue;
+        return createFetchResult(expectedKeys.slice(start, end), true, [], [], {
+          cursor,
+        });
       }
     }
   );

--- a/packages/wrangler/src/__tests__/kv.test.ts
+++ b/packages/wrangler/src/__tests__/kv.test.ts
@@ -673,26 +673,25 @@ describe("wrangler", () => {
 
     describe("list", () => {
       it("should list the keys of a namespace specified by namespace-id", async () => {
-        const keys = ["key-1", "key-2", "key-3"];
+        const keys = [
+          { name: "key-1" },
+          { name: "key-2", expiration: 123456789 },
+          { name: "key-3" },
+        ];
         mockKeyListRequest("some-namespace-id", keys);
         await runWrangler("kv:key list --namespace-id some-namespace-id");
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.out).toMatchInlineSnapshot(`
           "[
             {
-              \\"name\\": \\"key-1\\",
-              \\"expiration\\": 123456789,
-              \\"metadata\\": {}
+              \\"name\\": \\"key-1\\"
             },
             {
               \\"name\\": \\"key-2\\",
-              \\"expiration\\": 123456789,
-              \\"metadata\\": {}
+              \\"expiration\\": 123456789
             },
             {
-              \\"name\\": \\"key-3\\",
-              \\"expiration\\": 123456789,
-              \\"metadata\\": {}
+              \\"name\\": \\"key-3\\"
             }
           ]"
         `);
@@ -700,7 +699,7 @@ describe("wrangler", () => {
 
       it("should list the keys of a namespace specified by binding", async () => {
         writeWranglerConfig();
-        const keys = ["key-1", "key-2", "key-3"];
+        const keys = [{ name: "key-1" }, { name: "key-2" }, { name: "key-3" }];
         mockKeyListRequest("bound-id", keys);
 
         await runWrangler("kv:key list --binding someBinding");
@@ -708,19 +707,13 @@ describe("wrangler", () => {
         expect(std.out).toMatchInlineSnapshot(`
           "[
             {
-              \\"name\\": \\"key-1\\",
-              \\"expiration\\": 123456789,
-              \\"metadata\\": {}
+              \\"name\\": \\"key-1\\"
             },
             {
-              \\"name\\": \\"key-2\\",
-              \\"expiration\\": 123456789,
-              \\"metadata\\": {}
+              \\"name\\": \\"key-2\\"
             },
             {
-              \\"name\\": \\"key-3\\",
-              \\"expiration\\": 123456789,
-              \\"metadata\\": {}
+              \\"name\\": \\"key-3\\"
             }
           ]"
         `);
@@ -728,26 +721,20 @@ describe("wrangler", () => {
 
       it("should list the keys of a preview namespace specified by binding", async () => {
         writeWranglerConfig();
-        const keys = ["key-1", "key-2", "key-3"];
+        const keys = [{ name: "key-1" }, { name: "key-2" }, { name: "key-3" }];
         mockKeyListRequest("preview-bound-id", keys);
         await runWrangler("kv:key list --binding someBinding --preview");
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.out).toMatchInlineSnapshot(`
           "[
             {
-              \\"name\\": \\"key-1\\",
-              \\"expiration\\": 123456789,
-              \\"metadata\\": {}
+              \\"name\\": \\"key-1\\"
             },
             {
-              \\"name\\": \\"key-2\\",
-              \\"expiration\\": 123456789,
-              \\"metadata\\": {}
+              \\"name\\": \\"key-2\\"
             },
             {
-              \\"name\\": \\"key-3\\",
-              \\"expiration\\": 123456789,
-              \\"metadata\\": {}
+              \\"name\\": \\"key-3\\"
             }
           ]"
         `);
@@ -755,7 +742,7 @@ describe("wrangler", () => {
 
       it("should list the keys of a namespace specified by binding, in a given environment", async () => {
         writeWranglerConfig();
-        const keys = ["key-1", "key-2", "key-3"];
+        const keys = [{ name: "key-1" }, { name: "key-2" }, { name: "key-3" }];
         mockKeyListRequest("env-bound-id", keys);
         await runWrangler(
           "kv:key list --binding someBinding --env some-environment"
@@ -764,19 +751,13 @@ describe("wrangler", () => {
         expect(std.out).toMatchInlineSnapshot(`
           "[
             {
-              \\"name\\": \\"key-1\\",
-              \\"expiration\\": 123456789,
-              \\"metadata\\": {}
+              \\"name\\": \\"key-1\\"
             },
             {
-              \\"name\\": \\"key-2\\",
-              \\"expiration\\": 123456789,
-              \\"metadata\\": {}
+              \\"name\\": \\"key-2\\"
             },
             {
-              \\"name\\": \\"key-3\\",
-              \\"expiration\\": 123456789,
-              \\"metadata\\": {}
+              \\"name\\": \\"key-3\\"
             }
           ]"
         `);
@@ -784,7 +765,7 @@ describe("wrangler", () => {
 
       it("should list the keys of a preview namespace specified by binding, in a given environment", async () => {
         writeWranglerConfig();
-        const keys = ["key-1", "key-2", "key-3"];
+        const keys = [{ name: "key-1" }, { name: "key-2" }, { name: "key-3" }];
         mockKeyListRequest("preview-env-bound-id", keys);
         await runWrangler(
           "kv:key list --binding someBinding --preview --env some-environment"
@@ -793,19 +774,13 @@ describe("wrangler", () => {
         expect(std.out).toMatchInlineSnapshot(`
           "[
             {
-              \\"name\\": \\"key-1\\",
-              \\"expiration\\": 123456789,
-              \\"metadata\\": {}
+              \\"name\\": \\"key-1\\"
             },
             {
-              \\"name\\": \\"key-2\\",
-              \\"expiration\\": 123456789,
-              \\"metadata\\": {}
+              \\"name\\": \\"key-2\\"
             },
             {
-              \\"name\\": \\"key-3\\",
-              \\"expiration\\": 123456789,
-              \\"metadata\\": {}
+              \\"name\\": \\"key-3\\"
             }
           ]"
         `);
@@ -822,9 +797,9 @@ describe("wrangler", () => {
         describe(`cursor - ${blankCursorValue}`, () => {
           it("should make multiple requests for paginated results", async () => {
             // Create a lot of mock keys, so that the fetch requests will be paginated
-            const keys: string[] = [];
+            const keys: NamespaceKeyInfo[] = [];
             for (let i = 0; i < 550; i++) {
-              keys.push("key-" + i);
+              keys.push({ name: "key-" + i });
             }
             // Ask for the keys in pages of size 100.
             const requests = mockKeyListRequest(
@@ -837,9 +812,7 @@ describe("wrangler", () => {
               "kv:key list --namespace-id some-namespace-id --limit 100"
             );
             expect(std.err).toMatchInlineSnapshot(`""`);
-            expect(
-              JSON.parse(std.out).map((k: NamespaceKeyInfo) => k.name)
-            ).toEqual(keys);
+            expect(JSON.parse(std.out)).toEqual(keys);
             expect(requests.count).toEqual(6);
           });
         });

--- a/packages/wrangler/src/kv.ts
+++ b/packages/wrangler/src/kv.ts
@@ -1,6 +1,6 @@
 import { URLSearchParams } from "node:url";
-import { fetchListResult, fetchResult, fetchKVGetValue } from "../cfetch";
-import type { Config, Environment } from "../config";
+import { fetchListResult, fetchResult, fetchKVGetValue } from "./cfetch";
+import type { Config, Environment } from "./config";
 
 /** The largest number of kv items we can pass to the API in a single request. */
 const API_MAX = 10000;


### PR DESCRIPTION
This expires any previously uploaded assets when using a Sites / `[site]` configuration. Because we currently do a full iteration of a namespace's keys when publishing, for rapidly changing sites this means that uploads get slower and slower. We can't just delete unused assets because it leads to occasional 404s on older publishes while we're publishing. So we expire previous assets while uploading new ones. The implementation/constraints of the kv api means that uploads may become slower, but should hopefully be faster overall. These optimisations also only matter for rapidly changing sites, so common usecases still have the same perf characteristics.

--- 

I've started this PR as a discussion point, to discuss tradeoffs of the approach, and to make the constraints apparent before we move ahead with this. // @jgentes @koeninger 

Closes #459 