### PR TITLE
fix: add warning about setting upstream-protocol to `http`

### DIFF
--- a/.changeset/cyan-parrots-eat.md
+++ b/.changeset/cyan-parrots-eat.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: add warning about setting upstream-protocol to `http`
+
+We have not implemented setting upstream-protocol to `http` and currently do not intend to.
+
+This change just adds a warning if a developer tries to do so and provides a link to an issue where they can add their use-case.

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -308,6 +308,40 @@ describe("Dev component", () => {
     });
   });
 
+  describe("upstream-protocol", () => {
+    it("should default upstream-protocol to `https`", async () => {
+      writeWranglerToml({
+        main: "index.js",
+      });
+      fs.writeFileSync("index.js", `export default {};`);
+      await runWrangler("dev");
+      expect((Dev as jest.Mock).mock.calls[0][0].upstreamProtocol).toEqual(
+        "https"
+      );
+      expect(std.out).toMatchInlineSnapshot(`""`);
+      expect(std.warn).toMatchInlineSnapshot(`""`);
+      expect(std.err).toMatchInlineSnapshot(`""`);
+    });
+
+    it("should warn if `--upstream-protocol=http` is used", async () => {
+      writeWranglerToml({
+        main: "index.js",
+      });
+      fs.writeFileSync("index.js", `export default {};`);
+      await runWrangler("dev --upstream-protocol=http");
+      expect((Dev as jest.Mock).mock.calls[0][0].upstreamProtocol).toEqual(
+        "http"
+      );
+      expect(std.out).toMatchInlineSnapshot(`""`);
+      expect(std.warn).toMatchInlineSnapshot(`
+        "Setting upstream-protocol to http is not currently implemented.
+        If this is required in your project, please add your use case to the following issue:
+        https://github.com/cloudflare/wrangler2/issues/583."
+      `);
+      expect(std.err).toMatchInlineSnapshot(`""`);
+    });
+  });
+
   describe("local-protocol", () => {
     it("should default local-protocol to `http`", async () => {
       writeWranglerToml({

--- a/packages/wrangler/src/config/config.ts
+++ b/packages/wrangler/src/config/config.ts
@@ -209,8 +209,10 @@ export interface DevConfig {
   /**
    * Protocol that wrangler dev forwards requests on
    *
+   * Setting this to `http` is not currently implemented.
+   * See https://github.com/cloudflare/wrangler2/issues/583
+   *
    * @default `https`
-   * @todo this needs to be implemented
    */
   upstream_protocol: "https" | "http";
 

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -39,6 +39,7 @@ export type DevProps = {
   initialMode: "local" | "remote";
   jsxFactory: undefined | string;
   jsxFragment: undefined | string;
+  upstreamProtocol: "https" | "http";
   localProtocol: "https" | "http";
   enableLocalPersistence: boolean;
   bindings: CfWorkerInit["bindings"];

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -786,6 +786,17 @@ export async function main(argv: string[]): Promise<void> {
         );
       }
 
+      const upstreamProtocol =
+        (args["upstream-protocol"] as "http" | "https") ||
+        config.dev.upstream_protocol;
+      if (upstreamProtocol === "http") {
+        console.warn(
+          "Setting upstream-protocol to http is not currently implemented.\n" +
+            "If this is required in your project, please add your use case to the following issue:\n" +
+            "https://github.com/cloudflare/wrangler2/issues/583."
+        );
+      }
+
       const accountId = !args.local ? await requireAuth(config) : undefined;
 
       // TODO: if worker_dev = false and no routes, then error (only for dev)
@@ -870,6 +881,7 @@ export async function main(argv: string[]): Promise<void> {
           initialMode={args.local ? "local" : "remote"}
           jsxFactory={args["jsx-factory"] || envRootObj?.jsx_factory}
           jsxFragment={args["jsx-fragment"] || envRootObj?.jsx_fragment}
+          upstreamProtocol={upstreamProtocol}
           localProtocol={
             // The typings are not quite clever enough to handle element accesses, only property accesses,
             // so we need to cast here.
@@ -1259,6 +1271,7 @@ export async function main(argv: string[]): Promise<void> {
           initialMode={args.local ? "local" : "remote"}
           jsxFactory={envRootObj?.jsx_factory}
           jsxFragment={envRootObj?.jsx_fragment}
+          upstreamProtocol={config.dev.upstream_protocol}
           localProtocol={config.dev.local_protocol}
           enableLocalPersistence={false}
           accountId={accountId}


### PR DESCRIPTION
We have not implemented setting upstream-protocol to `http` and currently do not intend to.

This change just adds a warning if a developer tries to do so and provides a link to an issue where they can add their use-case.