### PR TITLE
Stop reporting breadcrumbs to sentry

### DIFF
--- a/.changeset/itchy-bobcats-hug.md
+++ b/.changeset/itchy-bobcats-hug.md
@@ -1,0 +1,22 @@
+---
+"wrangler": patch
+---
+
+Stop reporting breadcrumbs to sentry
+
+Sentry's SDK automatically tracks "breadcrumbs", which are pieces of information
+that get tracked leading up to an exception. This can be useful for debugging
+errors because it gives better insight into what happens before an error occurs,
+so you can more easily understand and recreate exactly what happened before an
+error occurred.
+
+Unfortunately, Sentry automatically includes all `console` statements. And since
+we use the console a lot (e.g. logging every request received in `wrangler dev`),
+this is mostly useless. Additionally, since developers frequently use the console
+to debug their workers we end up with a bunch of data that is not only irrelevant
+to the reported error, but also contains data that could be potentially sensitive.
+
+For now, we're turning off breadcrumbs entirely. Later, we might wish to add our
+own breadcrumbs manually (e.g. add a "wrangler dev" breadcrumb when a user runs
+`wrangler dev`), at which point we can selectively enable breadcrumbs to catch
+only the ones we've put in there ourselves.

--- a/packages/wrangler/src/reporting.ts
+++ b/packages/wrangler/src/reporting.ts
@@ -22,6 +22,14 @@ export function initReporting() {
     initialScope: {
       tags: { [pkj.name]: pkj.version },
     },
+    beforeBreadcrumb: (_breadcrumb, _hint) => {
+      // eventually, we might want to actually start dropping our own breadcrumbs.
+      // until then, we want to just ignore all of them, since sentry will
+      // automatically include breadcrumbs for things like console output,
+      // which can include unsanitized data that the user logs
+      // from their worker during development
+      return null;
+    },
     dsn: "https://5089b76bf8a64a9c949bf5c2b5e8003c@o51786.ingest.sentry.io/6190959",
     tracesSampleRate: 1.0,
     integrations: [


### PR DESCRIPTION
Sentry's SDK automatically tracks "breadcrumbs", which are pieces of information
that get tracked leading up to an exception. This can be useful for debugging
errors because it gives better insight into what happens before an error occurs,
so you can more easily understand and recreate exactly what happened before an
error occurred.

Unfortunately, Sentry automatically includes all `console` statements. And since
we use the console a lot (e.g. logging every request received in `wrangler dev`),
this is mostly useless. Additionally, since developers frequently use the console
to debug their workers we end up with a bunch of data that is not only irrelevant
to the reported error, but also contains data that could be potentially sensitive.

For now, we're turning off breadcrumbs entirely. Later, we might wish to add our
own breadcrumbs manually (e.g. add a "wrangler dev" breadcrumb when a user runs
`wrangler dev`), at which point we can selectively enable breadcrumbs to catch
only the ones we've put in there ourselves.

I think this closes #516 