### PR TITLE
deprecate wrangler route

### DIFF
--- a/.changeset/fluffy-cameras-greet.md
+++ b/.changeset/fluffy-cameras-greet.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+---
+
+Deprecate `wrangler route`, `wrangler route list`, and `wrangler route delete`
+
+Users should instead modify their wrangler.toml or use the `--routes` flag when publishing
+to manage routes.

--- a/packages/wrangler/src/__tests__/route.test.ts
+++ b/packages/wrangler/src/__tests__/route.test.ts
@@ -18,8 +18,7 @@ describe("wrangler route", () => {
       .toThrowErrorMatchingInlineSnapshot(`
             "DEPRECATION WARNING:
             \`wrangler route delete\` has been deprecated.
-            Modify wrangler.toml to update the routes your worker will be deployed to upon publishing.
-            Use the Cloudflare Dashboard to unassign a worker from existing routes"
+            Remove the unwanted route(s) from wrangler.toml and run \`wrangler publish\` to remove your worker from those routes."
           `);
   });
 
@@ -28,8 +27,7 @@ describe("wrangler route", () => {
       .toThrowErrorMatchingInlineSnapshot(`
             "DEPRECATION WARNING:
             \`wrangler route delete\` has been deprecated.
-            Modify wrangler.toml to update the routes your worker will be deployed to upon publishing.
-            Use the Cloudflare Dashboard to unassign a worker from existing routes"
+            Remove the unwanted route(s) from wrangler.toml and run \`wrangler publish\` to remove your worker from those routes."
           `);
   });
 

--- a/packages/wrangler/src/__tests__/route.test.ts
+++ b/packages/wrangler/src/__tests__/route.test.ts
@@ -1,0 +1,45 @@
+import { runInTempDir } from "./helpers/run-in-tmp";
+import { runWrangler } from "./helpers/run-wrangler";
+
+describe("wrangler route", () => {
+  runInTempDir();
+
+  it("shows a deprecation notice when `wrangler route` is run", async () => {
+    await expect(runWrangler("route")).rejects
+      .toThrowErrorMatchingInlineSnapshot(`
+            "DEPRECATION WARNING:
+            \`wrangler route\` has been deprecated.
+            Please use wrangler.toml and/or \`wrangler publish --routes\` to modify routes"
+          `);
+  });
+
+  it("shows a deprecation notice when `wrangler route delete` is run", async () => {
+    await expect(runWrangler("route delete")).rejects
+      .toThrowErrorMatchingInlineSnapshot(`
+            "DEPRECATION WARNING:
+            \`wrangler route delete\` has been deprecated.
+            Modify wrangler.toml to update the routes your worker will be deployed to upon publishing.
+            Use the Cloudflare Dashboard to unassign a worker from existing routes"
+          `);
+  });
+
+  it("shows a deprecation notice when `wrangler route delete <id>` is run", async () => {
+    await expect(runWrangler("route delete some-zone-id")).rejects
+      .toThrowErrorMatchingInlineSnapshot(`
+            "DEPRECATION WARNING:
+            \`wrangler route delete\` has been deprecated.
+            Modify wrangler.toml to update the routes your worker will be deployed to upon publishing.
+            Use the Cloudflare Dashboard to unassign a worker from existing routes"
+          `);
+  });
+
+  it("shows a deprecation notice when `wrangler route list` is run", async () => {
+    await expect(runWrangler("route list")).rejects
+      .toThrowErrorMatchingInlineSnapshot(`
+            "DEPRECATION WARNING:
+            \`wrangler route list\` has been deprecated.
+            Refer to wrangler.toml for a list of routes the worker will be deployed to upon publishing.
+            Refer to the Cloudflare Dashboard to see the routes this worker is currently running on."
+          `);
+  });
+});

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -1319,7 +1319,7 @@ export async function main(argv: string[]): Promise<void> {
     }
   );
 
-  // route
+  // [DEPRECATED] route
   wrangler.command(
     "route",
     false, // I think we want to hide this command
@@ -1344,21 +1344,21 @@ export async function main(argv: string[]): Promise<void> {
                 type: "string",
               });
           },
-          async (args) => {
-            console.log(":route list", args);
-            // TODO: use environment (current wrangler doesn't do so?)
-            // TODO: don't get `zone_id` from config at all and require the command line arg `--zone`.
-            const config = readConfig(args.config as ConfigPath);
-            const zone = args.zone || config.zone_id;
-            if (!zone) {
-              throw new Error("missing zone id");
-            }
-
-            console.log(await fetchResult(`/zones/${zone}/workers/routes`));
+          () => {
+            // "👯 [DEPRECATED]. Use wrangler.toml to manage routes.
+            const deprecationNotice =
+              "`wrangler route list` has been deprecated.";
+            const futureRoutes =
+              "Refer to wrangler.toml for a list of routes the worker will be deployed to upon publishing.";
+            const presentRoutes =
+              "Refer to the Cloudflare Dashboard to see the routes this worker is currently running on.";
+            throw new DeprecationError(
+              `${deprecationNotice}\n${futureRoutes}\n${presentRoutes}`
+            );
           }
         )
         .command(
-          "delete <id>",
+          "delete",
           "Delete a route associated with a zone",
           (yargs) => {
             return yargs
@@ -1375,22 +1375,26 @@ export async function main(argv: string[]): Promise<void> {
                 describe: "Perform on a specific environment",
               });
           },
-          async (args) => {
-            console.log(":route delete", args);
-            // TODO: use environment (current wrangler doesn't do so?)
-            const config = readConfig(args.config as ConfigPath);
-            const zone = args.zone || config.zone_id;
-            if (!zone) {
-              throw new Error("missing zone id");
-            }
-
-            console.log(
-              await fetchResult(`/zones/${zone}/workers/routes/${args.id}`, {
-                method: "DELETE",
-              })
+          () => {
+            // "👯 [DEPRECATED]. Use wrangler.toml to manage routes.
+            const deprecationNotice =
+              "`wrangler route delete` has been deprecated.";
+            const futureRoutes =
+              "Modify wrangler.toml to update the routes your worker will be deployed to upon publishing.";
+            const presentRoutes =
+              "Use the Cloudflare Dashboard to unassign a worker from existing routes";
+            throw new DeprecationError(
+              `${deprecationNotice}\n${futureRoutes}\n${presentRoutes}`
             );
           }
         );
+    },
+    () => {
+      // "👯 [DEPRECATED]. Use wrangler.toml to manage routes.
+      const deprecationNotice = "`wrangler route` has been deprecated.";
+      const shouldDo =
+        "Please use wrangler.toml and/or `wrangler publish --routes` to modify routes";
+      throw new DeprecationError(`${deprecationNotice}\n${shouldDo}`);
     }
   );
 

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -1379,13 +1379,9 @@ export async function main(argv: string[]): Promise<void> {
             // "👯 [DEPRECATED]. Use wrangler.toml to manage routes.
             const deprecationNotice =
               "`wrangler route delete` has been deprecated.";
-            const futureRoutes =
-              "Modify wrangler.toml to update the routes your worker will be deployed to upon publishing.";
-            const presentRoutes =
-              "Use the Cloudflare Dashboard to unassign a worker from existing routes";
-            throw new DeprecationError(
-              `${deprecationNotice}\n${futureRoutes}\n${presentRoutes}`
-            );
+            const shouldDo =
+              "Remove the unwanted route(s) from wrangler.toml and run `wrangler publish` to remove your worker from those routes.";
+            throw new DeprecationError(`${deprecationNotice}\n${shouldDo}`);
           }
         );
     },


### PR DESCRIPTION
Users should instead modify their wrangler.toml or use the `--routes` flag when publishing
to manage routes.

closes #542