### PR TITLE
Add Wrangler specific error captures

### DIFF
--- a/packages/wrangler/src/cfetch/internal.ts
+++ b/packages/wrangler/src/cfetch/internal.ts
@@ -1,6 +1,7 @@
 import { fetch } from "undici";
 import { getEnvironmentVariableFactory } from "../environment-variables";
 import { ParseError, parseJSON } from "../parse";
+import { reportError } from "../reporting";
 import { getAPIToken, loginOrRefreshIfRequired } from "../user";
 import type { URLSearchParams } from "node:url";
 import type { RequestInit, HeadersInit } from "undici";
@@ -47,6 +48,7 @@ export async function fetchInternal<ResponseType>(
   try {
     return parseJSON(jsonText) as ResponseType;
   } catch (err) {
+    await reportError(err as Error);
     throw new ParseError({
       text: "Received a malformed response from the API",
       notes: [

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -19,6 +19,7 @@ import useInspector from "./inspect";
 import { DEFAULT_MODULE_RULES } from "./module-collection";
 import openInBrowser from "./open-in-browser";
 import { usePreviewServer, waitForPortToBeAvailable } from "./proxy";
+import { reportError } from "./reporting";
 import { syncAssets } from "./sites";
 import { getAPIToken } from "./user";
 import type { Config } from "./config";
@@ -801,8 +802,9 @@ function useTunnel(toggle: boolean) {
       }
     }
 
-    startTunnel().catch((err) => {
+    startTunnel().catch(async (err) => {
       console.error("tunnel:", err);
+      await reportError(err);
     });
 
     return () => {

--- a/packages/wrangler/src/proxy.ts
+++ b/packages/wrangler/src/proxy.ts
@@ -5,6 +5,7 @@ import WebSocket from "faye-websocket";
 import { useEffect, useRef, useState } from "react";
 import serveStatic from "serve-static";
 import { getHttpsOptions } from "./https-options";
+import { reportError } from "./reporting";
 import type { CfPreviewToken } from "./create-worker-preview";
 import type {
   IncomingHttpHeaders,
@@ -88,8 +89,9 @@ export function usePreviewServer({
     if (proxyServer === undefined) {
       createProxyServer(localProtocol)
         .then((proxy) => setProxyServer(proxy))
-        .catch((err) => {
+        .catch(async (err) => {
           console.error("Failed to create proxy server.", err);
+          await reportError(err);
         });
     }
   }, [proxyServer, localProtocol]);


### PR DESCRIPTION
Junk errors were removed when the `await reportError(err);` was moved into the unhandled exception listener. This reduced insight into other Wrangler internals, though handled they are not reported. 
Observability added:
- Capturing errors for cf-fetch internal errors.
- Capturing errors for proxy creation.
- Capturing errors for tunnel creation.

resolves #444 