### PR TITLE
Use inherited config in `publish`

### DIFF
--- a/.changeset/silver-poems-brush.md
+++ b/.changeset/silver-poems-brush.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: use environment specific and inherited config values in `publish`

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -1274,7 +1274,6 @@ export default{
       });
       writeWorkerSource();
       mockUploadWorkerRequest();
-      mockSubDomainRequest();
       mockUpdateWorkerRequest({ enabled: false });
 
       await runWrangler("publish ./index");
@@ -1282,6 +1281,104 @@ export default{
       expect(std.out).toMatchInlineSnapshot(`
         "Uploaded test-name (TIMINGS)
         No publish targets for test-name (TIMINGS)"
+      `);
+      expect(std.err).toMatchInlineSnapshot(`""`);
+    });
+
+    it("should disable the workers.dev domain if workers_dev is undefined but overwritten to `false` in environment", async () => {
+      writeWranglerToml({
+        env: {
+          dev: {
+            workers_dev: false,
+          },
+        },
+      });
+      writeWorkerSource();
+      mockUploadWorkerRequest({
+        env: "dev",
+      });
+      mockUpdateWorkerRequest({ enabled: false, env: "dev" });
+
+      await runWrangler("publish ./index --env dev --legacy-env false");
+
+      expect(std.out).toMatchInlineSnapshot(`
+        "Uploaded test-name (dev) (TIMINGS)
+        No publish targets for test-name (dev) (TIMINGS)"
+      `);
+      expect(std.err).toMatchInlineSnapshot(`""`);
+    });
+
+    it("should disable the workers.dev domain if workers_dev is `true` but overwritten to `false` in environment", async () => {
+      writeWranglerToml({
+        workers_dev: true,
+        env: {
+          dev: {
+            workers_dev: false,
+          },
+        },
+      });
+      writeWorkerSource();
+      mockUploadWorkerRequest({
+        env: "dev",
+      });
+      mockUpdateWorkerRequest({ enabled: false, env: "dev" });
+
+      await runWrangler("publish ./index --env dev --legacy-env false");
+
+      expect(std.out).toMatchInlineSnapshot(`
+        "Uploaded test-name (dev) (TIMINGS)
+        No publish targets for test-name (dev) (TIMINGS)"
+      `);
+      expect(std.err).toMatchInlineSnapshot(`""`);
+    });
+
+    it("should publish to a workers.dev domain if workers_dev is undefined but overwritten to `true` in environment", async () => {
+      writeWranglerToml({
+        env: {
+          dev: {
+            workers_dev: true,
+          },
+        },
+      });
+      writeWorkerSource();
+      mockUploadWorkerRequest({
+        env: "dev",
+      });
+      mockSubDomainRequest();
+      mockUpdateWorkerRequest({ enabled: true, env: "dev" });
+
+      await runWrangler("publish ./index --env dev --legacy-env false");
+
+      expect(std.out).toMatchInlineSnapshot(`
+        "Uploaded test-name (dev) (TIMINGS)
+        Published test-name (dev) (TIMINGS)
+          dev.test-name.test-sub-domain.workers.dev"
+      `);
+      expect(std.err).toMatchInlineSnapshot(`""`);
+    });
+
+    it("should publish to a workers.dev domain if workers_dev is `false` but overwritten to `true` in environment", async () => {
+      writeWranglerToml({
+        workers_dev: false,
+        env: {
+          dev: {
+            workers_dev: true,
+          },
+        },
+      });
+      writeWorkerSource();
+      mockUploadWorkerRequest({
+        env: "dev",
+      });
+      mockSubDomainRequest();
+      mockUpdateWorkerRequest({ enabled: true, env: "dev" });
+
+      await runWrangler("publish ./index --env dev --legacy-env false");
+
+      expect(std.out).toMatchInlineSnapshot(`
+        "Uploaded test-name (dev) (TIMINGS)
+        Published test-name (dev) (TIMINGS)
+          dev.test-name.test-sub-domain.workers.dev"
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
     });

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -42,7 +42,7 @@ export default async function publish(props: Props): Promise<void> {
   const envRootObj = (props.env && config.env[props.env]) || config;
 
   assert(
-    envRootObj.compatibility_date || props.compatibilityDate,
+    props.compatibilityDate || envRootObj.compatibility_date,
     "A compatibility_date is required when publishing. Add one to your wrangler.toml file, or pass it in your terminal as --compatibility_date. See https://developers.cloudflare.com/workers/platform/compatibility-dates for more information."
   );
 
@@ -53,7 +53,7 @@ export default async function publish(props: Props): Promise<void> {
     (envRootObj.route ? [envRootObj.route] : []) ??
     [];
 
-  const { workers_dev: deployToWorkersDev } = config;
+  const deployToWorkersDev = envRootObj.workers_dev;
 
   const jsxFactory = props.jsxFactory || envRootObj.jsx_factory;
   const jsxFragment = props.jsxFragment || envRootObj.jsx_fragment;
@@ -197,9 +197,11 @@ export default async function publish(props: Props): Promise<void> {
       bindings,
       migrations,
       modules,
-      compatibility_date: config.compatibility_date,
-      compatibility_flags: config.compatibility_flags,
-      usage_model: config.usage_model,
+      compatibility_date:
+        props.compatibilityDate ?? envRootObj.compatibility_date,
+      compatibility_flags:
+        props.compatibilityFlags ?? envRootObj.compatibility_flags,
+      usage_model: envRootObj.usage_model,
     };
 
     const start = Date.now();


### PR DESCRIPTION
I found that the env specific overwrite did not work for `workers_dev`.
Also fixed some others.