### PR TITLE
chore: silence logs in `route.test.ts`

### DIFF
--- a/packages/wrangler/src/__tests__/route.test.ts
+++ b/packages/wrangler/src/__tests__/route.test.ts
@@ -1,7 +1,9 @@
+import { mockConsoleMethods } from "./helpers/mock-console";
 import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 
 describe("wrangler route", () => {
+  mockConsoleMethods();
   runInTempDir();
 
   it("shows a deprecation notice when `wrangler route` is run", async () => {


### PR DESCRIPTION
This mocks the console methods in `route.test.ts` so the terminal isn't as noisy.