### PR TITLE
Add links to documentation for deprecated commands

### DIFF
--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -914,60 +914,78 @@ describe("wrangler", () => {
       await runWrangler("kv:key");
       await endEventLoop();
       expect(std.out).toMatchInlineSnapshot(`
-       "wrangler kv:key
+               "wrangler kv:key
 
-       🔑 Individually manage Workers KV key-value pairs
+               🔑 Individually manage Workers KV key-value pairs
 
-       Commands:
-         wrangler kv:key put <key> [value]  Writes a single key/value pair to the given namespace.
-         wrangler kv:key list               Outputs a list of all keys in a given namespace.
-         wrangler kv:key get <key>          Reads a single value by key from the given namespace.
-         wrangler kv:key delete <key>       Removes a single key value pair from the given namespace.
+               Commands:
+                 wrangler kv:key put <key> [value]  Writes a single key/value pair to the given namespace.
+                 wrangler kv:key list               Outputs a list of all keys in a given namespace.
+                 wrangler kv:key get <key>          Reads a single value by key from the given namespace.
+                 wrangler kv:key delete <key>       Removes a single key value pair from the given namespace.
 
-       Flags:
-         -c, --config      Path to .toml configuration file  [string]
-         -h, --help        Show help  [boolean]
-         -v, --version     Show version number  [boolean]
-             --legacy-env  Use legacy environments  [boolean]"
-      `);
+               Flags:
+                 -c, --config      Path to .toml configuration file  [string]
+                 -h, --help        Show help  [boolean]
+                 -v, --version     Show version number  [boolean]
+                     --legacy-env  Use legacy environments  [boolean]"
+            `);
     });
 
     it("no subcommand 'kv:bulk' should display a list of available subcommands", async () => {
       await runWrangler("kv:bulk");
       await endEventLoop();
       expect(std.out).toMatchInlineSnapshot(`
-       "wrangler kv:bulk
+               "wrangler kv:bulk
 
-       💪 Interact with multiple Workers KV key-value pairs at once
+               💪 Interact with multiple Workers KV key-value pairs at once
 
-       Commands:
-         wrangler kv:bulk put <filename>     Upload multiple key-value pairs to a namespace
-         wrangler kv:bulk delete <filename>  Delete multiple key-value pairs from a namespace
+               Commands:
+                 wrangler kv:bulk put <filename>     Upload multiple key-value pairs to a namespace
+                 wrangler kv:bulk delete <filename>  Delete multiple key-value pairs from a namespace
 
-       Flags:
-         -c, --config      Path to .toml configuration file  [string]
-         -h, --help        Show help  [boolean]
-         -v, --version     Show version number  [boolean]
-             --legacy-env  Use legacy environments  [boolean]"
-      `);
+               Flags:
+                 -c, --config      Path to .toml configuration file  [string]
+                 -h, --help        Show help  [boolean]
+                 -v, --version     Show version number  [boolean]
+                     --legacy-env  Use legacy environments  [boolean]"
+            `);
     });
     it("no subcommand 'r2' should display a list of available subcommands", async () => {
       await runWrangler("r2");
       await endEventLoop();
       expect(std.out).toMatchInlineSnapshot(`
-       "wrangler r2
+               "wrangler r2
 
-       📦 Interact with an R2 store
+               📦 Interact with an R2 store
 
-       Commands:
-         wrangler r2 bucket  Manage R2 buckets
+               Commands:
+                 wrangler r2 bucket  Manage R2 buckets
 
-       Flags:
-         -c, --config      Path to .toml configuration file  [string]
-         -h, --help        Show help  [boolean]
-         -v, --version     Show version number  [boolean]
-             --legacy-env  Use legacy environments  [boolean]"
-      `);
+               Flags:
+                 -c, --config      Path to .toml configuration file  [string]
+                 -h, --help        Show help  [boolean]
+                 -v, --version     Show version number  [boolean]
+                     --legacy-env  Use legacy environments  [boolean]"
+            `);
+    });
+  });
+  describe("Deprecated commands", () => {
+    it("should print a deprecation message for 'generate'", async () => {
+      await runWrangler("generate").catch((err) => {
+        expect(err.message).toMatchInlineSnapshot(`
+          "DEPRECATION WARNING:
+          \`wrangler generate\` has been deprecated, please refer to https://github.com/cloudflare/wrangler2/blob/main/docs/deprecations.md#generate for alternatives"
+        `);
+      });
+    });
+    it("should print a deprecation message for 'build'", async () => {
+      await runWrangler("build").catch((err) => {
+        expect(err.message).toMatchInlineSnapshot(`
+          "DEPRECATION WARNING:
+          \`wrangler build\` has been deprecated, please refer to https://github.com/cloudflare/wrangler2/blob/main/docs/deprecations.md#build for alternatives"
+        `);
+      });
     });
   });
 });

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -253,7 +253,7 @@ export async function main(argv: string[]): Promise<void> {
     () => {
       // "👯 [DEPRECATED]. Scaffold a Cloudflare Workers project from a public GitHub repository.",
       throw new DeprecationError(
-        "`wrangler generate` has been deprecated, please refer to TODO://some/path for alternatives"
+        "`wrangler generate` has been deprecated, please refer to https://github.com/cloudflare/wrangler2/blob/main/docs/deprecations.md#generate for alternatives"
       );
     }
   );
@@ -581,7 +581,7 @@ export async function main(argv: string[]): Promise<void> {
     () => {
       // "[DEPRECATED] 🦀 Build your project (if applicable)",
       throw new DeprecationError(
-        "`wrangler build` has been deprecated, please refer to TODO://some/path for alternatives"
+        "`wrangler build` has been deprecated, please refer to https://github.com/cloudflare/wrangler2/blob/main/docs/deprecations.md#build for alternatives"
       );
     }
   );


### PR DESCRIPTION
Previously using deprecated `generate` and `build` caused a message with "TODO://some/path" in the warning message.
Now links to deprecation documentation. 
resolves #345 
 