### PR TITLE
Terminate dev test processes with prejudice on exit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "jest": "^27.5.1",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.5.1",
+        "terminate": "2.5.0",
         "typescript": "^4.6.2"
       },
       "engines": {
@@ -5215,6 +5216,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
+    },
     "node_modules/edge-chat-demo": {
       "resolved": "packages/workers-chat-demo",
       "link": true
@@ -6586,6 +6592,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "dependencies": {
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
+      }
+    },
     "node_modules/example-rules-app": {
       "resolved": "packages/example-rules-app",
       "link": true
@@ -7154,6 +7174,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
     },
     "node_modules/fs-extra": {
       "version": "7.0.1",
@@ -12131,6 +12156,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
+    },
     "node_modules/map-visit": {
       "version": "1.0.0",
       "license": "MIT",
@@ -13827,6 +13857,10 @@
         "node": ">=6"
       }
     },
+    "node_modules/pages-functions-example": {
+      "resolved": "packages/example-pages-functions-app",
+      "link": true
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "license": "(MIT AND Zlib)"
@@ -13942,6 +13976,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "dependencies": {
+        "through": "~2.3"
       }
     },
     "node_modules/periscopic": {
@@ -14200,6 +14242,20 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true
+    },
+    "node_modules/ps-tree": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
+      "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
+      "dependencies": {
+        "event-stream": "=3.3.4"
+      },
+      "bin": {
+        "ps-tree": "bin/ps-tree.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/pseudomap": {
       "version": "1.0.2",
@@ -15724,6 +15780,17 @@
       "version": "3.0.11",
       "license": "CC0-1.0"
     },
+    "node_modules/split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/split-string": {
       "version": "3.1.0",
       "license": "MIT",
@@ -15868,6 +15935,14 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "dependencies": {
+        "duplexer": "~0.1.1"
       }
     },
     "node_modules/stream-transform": {
@@ -16145,6 +16220,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/terminate": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/terminate/-/terminate-2.5.0.tgz",
+      "integrity": "sha512-WnhIjfoTiIvmrfey4GSkqJevEHbIFnSdKeutHwA+cm81/1+GlAHLw1pBKxsKqkrqMaQKK65V6WrvUa851phbgA==",
+      "dependencies": {
+        "ps-tree": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "license": "ISC",
@@ -16165,6 +16251,11 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
       "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w=="
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -17225,6 +17316,17 @@
       "version": "1.0.0",
       "license": "ISC"
     },
+    "packages/example-pages-functions-app": {
+      "name": "pages-functions-example",
+      "devDependencies": {
+        "@cloudflare/workers-types": "^3.2.0",
+        "terminate": "2.5.0",
+        "undici": "^4.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "packages/example-remix-cloudflare-pages-app": {
       "extraneous": true
     },
@@ -17246,6 +17348,7 @@
         "cross-env": "^7.0.3",
         "esbuild": "0.13.14",
         "npm-run-all": "^4.1.5",
+        "terminate": "2.5.0",
         "typescript": "^4.1.2",
         "undici": "^4.13.0"
       },
@@ -21081,6 +21184,11 @@
     "dotenv": {
       "version": "8.6.0"
     },
+    "duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
+    },
     "edge-chat-demo": {
       "version": "file:packages/workers-chat-demo"
     },
@@ -21884,6 +21992,20 @@
       "version": "1.8.1",
       "dev": true
     },
+    "event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "requires": {
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
+      }
+    },
     "example-rules-app": {
       "version": "file:packages/example-rules-app"
     },
@@ -22283,6 +22405,11 @@
     "fresh": {
       "version": "0.5.2",
       "dev": true
+    },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
     },
     "fs-extra": {
       "version": "7.0.1",
@@ -25746,6 +25873,11 @@
     "map-obj": {
       "version": "4.3.0"
     },
+    "map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
+    },
     "map-visit": {
       "version": "1.0.0",
       "requires": {
@@ -26728,6 +26860,14 @@
     "p-try": {
       "version": "2.2.0"
     },
+    "pages-functions-example": {
+      "version": "file:packages/example-pages-functions-app",
+      "requires": {
+        "@cloudflare/workers-types": "^3.2.0",
+        "terminate": "2.5.0",
+        "undici": "^4.13.0"
+      }
+    },
     "pako": {
       "version": "1.0.11"
     },
@@ -26797,6 +26937,14 @@
     },
     "path-type": {
       "version": "4.0.0"
+    },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "requires": {
+        "through": "~2.3"
+      }
     },
     "periscopic": {
       "version": "3.0.4",
@@ -26953,6 +27101,14 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true
+    },
+    "ps-tree": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
+      "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
+      "requires": {
+        "event-stream": "=3.3.4"
+      }
     },
     "pseudomap": {
       "version": "1.0.2"
@@ -27269,6 +27425,7 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "remix": "^1.1.3",
+        "terminate": "2.5.0",
         "typescript": "^4.1.2",
         "undici": "^4.13.0"
       },
@@ -28015,6 +28172,14 @@
     "spdx-license-ids": {
       "version": "3.0.11"
     },
+    "split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "requires": {
+        "through": "2"
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "requires": {
@@ -28110,6 +28275,14 @@
     "statuses": {
       "version": "1.5.0",
       "dev": true
+    },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "requires": {
+        "duplexer": "~0.1.1"
+      }
     },
     "stream-transform": {
       "version": "2.1.3",
@@ -28286,6 +28459,14 @@
         "supports-hyperlinks": "^2.0.0"
       }
     },
+    "terminate": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/terminate/-/terminate-2.5.0.tgz",
+      "integrity": "sha512-WnhIjfoTiIvmrfey4GSkqJevEHbIFnSdKeutHwA+cm81/1+GlAHLw1pBKxsKqkrqMaQKK65V6WrvUa851phbgA==",
+      "requires": {
+        "ps-tree": "^1.2.0"
+      }
+    },
     "test-exclude": {
       "version": "6.0.0",
       "requires": {
@@ -28301,6 +28482,11 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
       "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w=="
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "jest": "^27.5.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.5.1",
+    "terminate": "2.5.0",
     "typescript": "^4.6.2"
   },
   "scripts": {

--- a/packages/example-pages-functions-app/package.json
+++ b/packages/example-pages-functions-app/package.json
@@ -3,11 +3,11 @@
   "name": "pages-functions-example",
   "scripts": {
     "dev": "npx wrangler pages dev public --port 8789",
-    "test": "npx jest --forceExit"
+    "test": "npx jest"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^3.2.0",
-    "typescript": "^4.1.2",
+    "terminate": "2.5.0",
     "undici": "^4.13.0"
   },
   "engines": {

--- a/packages/example-remix-pages-app/package.json
+++ b/packages/example-remix-pages-app/package.json
@@ -10,7 +10,7 @@
     "dev:remix": "remix watch",
     "dev:wrangler": "wrangler pages dev ./public",
     "start": "npm run dev:wrangler",
-    "test": "npx jest --forceExit"
+    "test": "npx jest"
   },
   "dependencies": {
     "@remix-run/cloudflare-pages": "^1.1.3",
@@ -27,6 +27,7 @@
     "cross-env": "^7.0.3",
     "esbuild": "0.13.14",
     "npm-run-all": "^4.1.5",
+    "terminate": "2.5.0",
     "typescript": "^4.1.2",
     "undici": "^4.13.0"
   },


### PR DESCRIPTION
Fixes #397 (and #618)

Kills the dev processes aggressively when jest is finished its tests of the example repos.

Seems a handy utility. Maybe we use it elsewhere as well?