### PR TITLE
Two fixes to `wrangler dev`

### DIFF
--- a/.changeset/short-worms-argue.md
+++ b/.changeset/short-worms-argue.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: stop checking for open port once it has timed out in `waitForPortToBeAvailable()`
+
+Previously, if `waitForPortToBeAvailable()` timed out, the `checkPort()`
+function would continue to be called.
+Now we clean up fully once the promise is resolved or rejected.

--- a/.changeset/swift-suits-smoke.md
+++ b/.changeset/swift-suits-smoke.md
@@ -1,0 +1,12 @@
+---
+"wrangler": patch
+---
+
+fix: check for the correct inspector port in local dev
+
+Previously, the `useLocalWorker()` hook was being passed the wrong port for the `inspectorPort` prop.
+
+Once this was fixed, it became apparent that we were waiting for the port to become free in the wrong place, since this port is already being listened to in `useInspector()` by the time we were starting the check.
+
+Now, the check to see if the inspector port is free is done in `useInspector()`,
+which also means that `Remote` benefits from this check too.

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -33,7 +33,6 @@ export function Local(props: {
     public: props.public,
     port: props.port,
     rules: props.rules,
-    inspectorPort: props.port,
     enableLocalPersistence: props.enableLocalPersistence,
   });
   useInspector({
@@ -53,11 +52,10 @@ function useLocalWorker(props: {
   assetPaths: undefined | AssetPaths;
   public: undefined | string;
   port: number;
-  inspectorPort: number;
   enableLocalPersistence: boolean;
 }) {
   // TODO: pass vars via command line
-  const { bundle, format, bindings, port, assetPaths, inspectorPort } = props;
+  const { bundle, format, bindings, port, assetPaths } = props;
   const local = useRef<ReturnType<typeof spawn>>();
   const removeSignalExitListener = useRef<() => void>();
   const [inspectorUrl, setInspectorUrl] = useState<string | undefined>();
@@ -67,11 +65,6 @@ function useLocalWorker(props: {
 
       // port for the worker
       await waitForPortToBeAvailable(port, { retryPeriod: 200, timeout: 2000 });
-      // port for inspector
-      await waitForPortToBeAvailable(inspectorPort, {
-        retryPeriod: 200,
-        timeout: 2000,
-      });
 
       if (props.public) {
         throw new Error(
@@ -235,7 +228,6 @@ function useLocalWorker(props: {
     bundle,
     format,
     port,
-    inspectorPort,
     bindings.durable_objects?.bindings,
     bindings.kv_namespaces,
     bindings.vars,


### PR DESCRIPTION
- fix: stop checking for open port once it has timed out in `waitForPor…
- fix: check for the correct inspector port in local dev