### PR TITLE
chore: update `package-lock.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13827,6 +13827,10 @@
         "node": ">=6"
       }
     },
+    "node_modules/pages-functions-example": {
+      "resolved": "packages/example-pages-functions-app",
+      "link": true
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "license": "(MIT AND Zlib)"
@@ -17224,6 +17228,16 @@
     "packages/create-workers-app": {
       "version": "1.0.0",
       "license": "ISC"
+    },
+    "packages/example-pages-functions-app": {
+      "name": "pages-functions-example",
+      "devDependencies": {
+        "@cloudflare/workers-types": "^3.2.0",
+        "undici": "^4.13.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
     },
     "packages/example-remix-cloudflare-pages-app": {
       "extraneous": true
@@ -26727,6 +26741,13 @@
     },
     "p-try": {
       "version": "2.2.0"
+    },
+    "pages-functions-example": {
+      "version": "file:packages/example-pages-functions-app",
+      "requires": {
+        "@cloudflare/workers-types": "^3.2.0",
+        "undici": "^4.13.0"
+      }
     },
     "pako": {
       "version": "1.0.11"

--- a/packages/example-pages-functions-app/package.json
+++ b/packages/example-pages-functions-app/package.json
@@ -7,7 +7,6 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^3.2.0",
-    "typescript": "^4.1.2",
     "undici": "^4.13.0"
   },
   "engines": {


### PR DESCRIPTION
Looks like we forgot to run `npm install` at the root in https://github.com/cloudflare/wrangler2/pull/617. Also removed an unnecessary `typescript` dependency.