### PR TITLE
feat: pass env value as `CLOUDFLARE_WRANGLER_ENV` to custom builds

### DIFF
--- a/.changeset/afraid-worms-perform.md
+++ b/.changeset/afraid-worms-perform.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+feat: pass env value as `CLOUDFLARE_WRANGLER_ENV` to custom builds
+
+When running custom builds, it's useful to know what the name of the environment actually is (for example, to apply minification, or choose a localisation, etc). This feature passes the name of the environment as a process level environment variable to custom builds.

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -1576,6 +1576,31 @@ export default{
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.warn).toMatchInlineSnapshot(`""`);
       });
+
+      it("should pass env as CLOUDFLARE_WRANGLER_ENV to the build process", async () => {
+        writeWranglerToml({
+          build: {
+            command: `echo "export default { fetch(){ return new Response('\${CLOUDFLARE_WRANGLER_ENV}') } }" > index.js`,
+          },
+        });
+
+        mockUploadWorkerRequest({
+          env: "environmentname",
+          legacyEnv: true,
+          expectedEntry: 'return new Response("environmentname")',
+        });
+        mockSubDomainRequest();
+
+        await runWrangler("publish index.js --env environmentname");
+        expect(std.out).toMatchInlineSnapshot(`
+          "running: echo \\"export default { fetch(){ return new Response('\${CLOUDFLARE_WRANGLER_ENV}') } }\\" > index.js
+          Uploaded test-name-environmentname (TIMINGS)
+          Published test-name-environmentname (TIMINGS)
+            test-name-environmentname.test-sub-domain.workers.dev"
+        `);
+        expect(std.err).toMatchInlineSnapshot(`""`);
+        expect(std.warn).toMatchInlineSnapshot(`""`);
+      });
     }
 
     it("should throw an error if the entry doesn't exist after the build finishes", async () => {

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -59,7 +59,7 @@ export function DevImplementation(props: DevProps): JSX.Element {
   const apiToken = props.initialMode === "remote" ? getAPIToken() : undefined;
   const directory = useTmpDir();
 
-  useCustomBuild(props.entry, props.buildCommand);
+  useCustomBuild(props.entry, props.buildCommand, props.env);
 
   if (props.public && props.entry.format === "service-worker") {
     throw new Error(
@@ -179,7 +179,8 @@ function useCustomBuild(
     command?: undefined | string;
     cwd?: undefined | string;
     watch_dir?: undefined | string;
-  }
+  },
+  env: string | undefined
 ): void {
   useEffect(() => {
     if (!build.command) return;
@@ -191,7 +192,7 @@ function useCustomBuild(
       }).on("all", (_event, filePath) => {
         //TODO: we should buffer requests to the proxy until this completes
         console.log(`The file ${filePath} changed, restarting build...`);
-        runCustomBuild(expectedEntry.file, build).catch((err) => {
+        runCustomBuild(expectedEntry.file, build, env).catch((err) => {
           console.error("Custom build failed:", err);
         });
       });
@@ -200,7 +201,7 @@ function useCustomBuild(
     return () => {
       watcher?.close();
     };
-  }, [build, expectedEntry.file]);
+  }, [build, expectedEntry.file, env]);
 }
 
 function sleep(period: number) {

--- a/packages/wrangler/src/entry.ts
+++ b/packages/wrangler/src/entry.ts
@@ -18,7 +18,11 @@ export type Entry = { file: string; directory: string; format: CfScriptFormat };
  * Compute the entry-point for the Worker.
  */
 export async function getEntry(
-  args: { script?: string; format?: CfScriptFormat | undefined },
+  args: {
+    script?: string;
+    format?: CfScriptFormat | undefined;
+    env: string | undefined;
+  },
   config: Config,
   command: string
 ): Promise<Entry> {
@@ -36,7 +40,7 @@ export async function getEntry(
     file = path.resolve(directory, config.main);
   }
 
-  await runCustomBuild(file, config.build);
+  await runCustomBuild(file, config.build, args.env);
 
   if (fileExists(file) === false) {
     throw new Error(
@@ -53,7 +57,8 @@ export async function getEntry(
 
 export async function runCustomBuild(
   expectedEntry: string,
-  build: Config["build"]
+  build: Config["build"],
+  env: string | undefined
 ) {
   if (build?.command) {
     // TODO: add a deprecation message here?
@@ -63,6 +68,9 @@ export async function runCustomBuild(
       stdout: "inherit",
       stderr: "inherit",
       timeout: 1000 * 30,
+      env: {
+        CLOUDFLARE_WRANGLER_ENV: env,
+      },
       ...(build.cwd && { cwd: build.cwd }),
     });
 

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -1261,7 +1261,7 @@ export async function main(argv: string[]): Promise<void> {
       );
 
       const config = readConfig(args.config as ConfigPath);
-      const entry = await getEntry({}, config, "dev");
+      const entry = await getEntry({ env: args.env }, config, "dev");
 
       const accountId = await requireAuth(config);
 


### PR DESCRIPTION
When running custom builds, it's useful to know what the name of the environment actually is (for example, to apply minification, or choose a localisation, etc). This feature passes the name of the environment as a process level environment variable `CLOUDFLARE_WRANGLER_ENV` to custom build commands.