### PR TITLE
Custom Miniflare CLI

### DIFF
--- a/.changeset/hungry-chairs-return.md
+++ b/.changeset/hungry-chairs-return.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+---
+
+refactor: create a custom CLI wrapper around Miniflare API
+
+This allows us to tightly control the options that are passed to Miniflare.
+The current CLI is setup to be more compatible with how Wrangler 1 works, which is not optimal for Wrangler 2.

--- a/.changeset/long-cameras-nail.md
+++ b/.changeset/long-cameras-nail.md
@@ -1,0 +1,13 @@
+---
+"wrangler": patch
+---
+
+fix: ensure asset keys are relative to the project root
+
+Previously, asset file paths were computed relative to the current working
+directory, even if we had used `-c` to run Wrangler on a project in a different
+directory to the current one.
+
+Now, assets file paths are computed relative to the "project root", which is
+either the directory containing the wrangler.toml or the current working directory
+if there is no config specified.

--- a/.gitignore
+++ b/.gitignore
@@ -174,5 +174,6 @@ dist
 # End of https://www.toptal.com/developers/gitignore/api/node,macos
 
 wrangler-dist/
+miniflare-dist
 packages/wrangler/wrangler.toml
 packages/prerelease-registry/_worker.js

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -106,7 +106,7 @@
     "import_meta_url.js"
   ],
   "scripts": {
-    "clean": "rm -rf wrangler-dist",
+    "clean": "rm -rf wrangler-dist miniflare-dist",
     "check:type": "tsc",
     "bundle": "node -r esbuild-register scripts/bundle.ts",
     "build": "npm run clean && npm run bundle",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -100,6 +100,7 @@
     "bin",
     "pages",
     "miniflare-config-stubs",
+    "miniflare-dist",
     "wrangler-dist",
     "templates",
     "vendor",

--- a/packages/wrangler/scripts/bundle.ts
+++ b/packages/wrangler/scripts/bundle.ts
@@ -25,6 +25,18 @@ async function run() {
       "import.meta.url": "import_meta_url",
     },
   });
+
+  // custom miniflare cli
+  await build({
+    entryPoints: ["./src/miniflare-cli/index.ts"],
+    bundle: true,
+    outfile: "./miniflare-dist/index.mjs",
+    platform: "node",
+    format: "esm",
+    minify: true,
+    external: ["miniflare", "@miniflare/core"],
+    sourcemap: true,
+  });
 }
 
 run().catch((e) => {

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -120,6 +120,7 @@ export function DevImplementation(props: DevProps): JSX.Element {
           rules={props.rules}
           inspectorPort={props.inspectorPort}
           enableLocalPersistence={props.enableLocalPersistence}
+          workingDir={props.entry.directory}
         />
       ) : (
         <Remote

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -120,7 +120,6 @@ export function DevImplementation(props: DevProps): JSX.Element {
           rules={props.rules}
           inspectorPort={props.inspectorPort}
           enableLocalPersistence={props.enableLocalPersistence}
-          workingDir={props.entry.directory}
         />
       ) : (
         <Remote

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -110,6 +110,8 @@ export function DevImplementation(props: DevProps): JSX.Element {
           name={props.name}
           bundle={bundle}
           format={props.entry.format}
+          compatibilityDate={props.compatibilityDate}
+          compatibilityFlags={props.compatibilityFlags}
           bindings={props.bindings}
           assetPaths={props.assetPaths}
           public={props.public}

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -119,7 +119,9 @@ function useLocalWorker({
         ),
         durableObjectsPersist: enableLocalPersistence,
         cachePersist: enableLocalPersistence,
-        sitePath: assetPaths?.assetDirectory,
+        sitePath: assetPaths?.assetDirectory
+          ? path.join(assetPaths.baseDirectory, assetPaths.assetDirectory)
+          : undefined,
         siteInclude: assetPaths?.includePatterns.length
           ? assetPaths?.includePatterns
           : undefined,

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -27,6 +27,7 @@ interface LocalProps {
   rules: Config["rules"];
   inspectorPort: number;
   enableLocalPersistence: boolean;
+  workingDir: string; // Currently from "Entry directory"
 }
 
 export function Local(props: LocalProps) {
@@ -52,6 +53,7 @@ function useLocalWorker({
   rules,
   enableLocalPersistence,
   ip,
+  workingDir,
 }: LocalProps) {
   // TODO: pass vars via command line
   const local = useRef<ReturnType<typeof spawn>>();
@@ -144,10 +146,10 @@ function useLocalWorker({
           "--inspect", // start Miniflare listening for a debugger to attach
           miniflareCLIPath,
           optionsArg,
-          // "--log=VERBOSE", // uncomment this to Miniflare to log "everything"!
+          "--log=VERBOSE", // uncomment this to Miniflare to log "everything"!
         ],
         {
-          cwd: path.dirname(scriptPath),
+          cwd: workingDir,
         }
       );
 
@@ -219,6 +221,7 @@ function useLocalWorker({
     publicDirectory,
     rules,
     bindings.wasm_modules,
+    workingDir,
   ]);
   return { inspectorUrl };
 }

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -118,7 +118,7 @@ function useLocalWorker({
           )
         ),
         durableObjectsPersist: enableLocalPersistence,
-        cache: !enableLocalPersistence,
+        cachePersist: !enableLocalPersistence,
         sitePath: assetPaths?.baseDirectory,
         siteInclude: assetPaths?.includePatterns.length
           ? assetPaths?.includePatterns

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -119,7 +119,7 @@ function useLocalWorker({
         ),
         durableObjectsPersist: enableLocalPersistence,
         cachePersist: !enableLocalPersistence,
-        sitePath: assetPaths?.baseDirectory,
+        sitePath: assetPaths?.assetDirectory,
         siteInclude: assetPaths?.includePatterns.length
           ? assetPaths?.includePatterns
           : undefined,

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -118,7 +118,7 @@ function useLocalWorker({
           )
         ),
         durableObjectsPersist: enableLocalPersistence,
-        cachePersist: !enableLocalPersistence,
+        cachePersist: enableLocalPersistence,
         sitePath: assetPaths?.assetDirectory,
         siteInclude: assetPaths?.includePatterns.length
           ? assetPaths?.includePatterns
@@ -148,7 +148,7 @@ function useLocalWorker({
         "--inspect", // start Miniflare listening for a debugger to attach
         miniflareCLIPath,
         optionsArg,
-        "--log=VERBOSE", // uncomment this to Miniflare to log "everything"!
+        // "--log=VERBOSE", // uncomment this to Miniflare to log "everything"!
       ]);
 
       local.current.on("close", (code) => {

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -128,6 +128,8 @@ function useLocalWorker({
           : undefined,
         bindings: bindings.vars,
         wasmBindings,
+        sourceMap: true,
+        logUnhandledRejections: true,
       };
 
       // The path to the Miniflare CLI assumes that this file is being run from

--- a/packages/wrangler/src/miniflare-cli/README.md
+++ b/packages/wrangler/src/miniflare-cli/README.md
@@ -1,0 +1,30 @@
+# Custom Miniflare CLI
+
+This directory contains a simple wrapper around the programmatic Miniflare API,
+which Wrangler spawns when running `wrangler dev` in local mode.
+
+## Building
+
+This CLI is built at the same time as Wrangler by running
+
+```
+npm run -w wrangler build
+```
+
+The output of the build is `miniflare-dist/index.mjs`.
+
+## Running
+
+The CLI expects a single command line argument which is the Miniflare options formatted as a string of JSON.
+
+```bash
+node --no-warnings ./packages/wrangler/miniflare-dist/index.mjs '{"watch": true, "script": ""}' --log VERBOSE
+```
+
+The `--log` argument is optional and takes one of Miniflare's LogLevels: "NONE", "ERROR", "WARN", "INFO", "DEBUG", "VERBOSE".
+It defaults to `INFO`.
+
+## Debugging
+
+Simply place a breakpoint in the code and run the above command in the VS Code "JavaScript Debug Terminal".
+The code will stop at the breakpoint as expected.

--- a/packages/wrangler/src/miniflare-cli/enum-keys.ts
+++ b/packages/wrangler/src/miniflare-cli/enum-keys.ts
@@ -1,0 +1,17 @@
+export type EnumKeys<Enum> = Exclude<keyof Enum, number>;
+
+export const enumObject = <Enum extends Record<string, number | string>>(
+  e: Enum
+) => {
+  const copy = { ...e } as { [K in EnumKeys<Enum>]: Enum[K] };
+  Object.values(e).forEach(
+    (value) => typeof value === "number" && delete copy[value]
+  );
+  return copy;
+};
+
+export const enumKeys = <Enum extends Record<string, number | string>>(
+  e: Enum
+) => {
+  return Object.keys(enumObject(e)) as EnumKeys<Enum>[];
+};

--- a/packages/wrangler/src/miniflare-cli/index.ts
+++ b/packages/wrangler/src/miniflare-cli/index.ts
@@ -1,0 +1,32 @@
+import { Log, LogLevel, Miniflare } from "miniflare";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+import { enumKeys } from "./enum-keys";
+
+async function main() {
+  const args = await yargs(hideBin(process.argv))
+    .help(false)
+    .version(false)
+    .option("log", {
+      choices: enumKeys(LogLevel),
+    }).argv;
+
+  const config = {
+    ...JSON.parse((args._[0] as string) ?? "{}"),
+    log: new Log(LogLevel[args.log ?? "INFO"]),
+  };
+
+  const mf = new Miniflare(config);
+
+  try {
+    // Start Miniflare development server
+    await mf.startServer();
+  } catch (e) {
+    mf.log.error(e as Error);
+    process.exitCode = 1;
+    // Unmount any mounted workers
+    await mf.dispose();
+  }
+}
+
+await main();

--- a/packages/wrangler/src/miniflare-cli/index.ts
+++ b/packages/wrangler/src/miniflare-cli/index.ts
@@ -11,10 +11,15 @@ async function main() {
       choices: enumKeys(LogLevel),
     }).argv;
 
+  const logLevel = LogLevel[args.log ?? "INFO"];
   const config = {
     ...JSON.parse((args._[0] as string) ?? "{}"),
-    log: new Log(LogLevel[args.log ?? "INFO"]),
+    log: new Log(logLevel),
   };
+
+  if (logLevel > LogLevel.INFO) {
+    console.log("OPTIONS:\n", JSON.stringify(config, null, 2));
+  }
 
   const mf = new Miniflare(config);
 

--- a/packages/wrangler/src/sites.tsx
+++ b/packages/wrangler/src/sites.tsx
@@ -265,7 +265,10 @@ export function getAssetPaths(
 ): undefined | AssetPaths {
   return baseDirectory
     ? {
-        baseDirectory,
+        baseDirectory: path.resolve(
+          path.dirname(config.configPath ?? "wrangler.toml"),
+          baseDirectory
+        ),
         includePatterns,
         excludePatterns,
       }

--- a/packages/wrangler/src/sites.tsx
+++ b/packages/wrangler/src/sites.tsx
@@ -289,6 +289,7 @@ export function getAssetPaths(
   const baseDirectory = path.resolve(
     path.dirname(config.configPath ?? "wrangler.toml")
   );
+
   return assetDirectory
     ? {
         baseDirectory,


### PR DESCRIPTION
Previously, Miniflare CLI was being ran for local through a child process which made passing options into it complicated for more complex inputs. 

Solution: **Create a custom CLI wrapper around Miniflare API**
This allows us to tightly control the options that are passed to Miniflare.
- Miniflare API config is more ergonomic and allows for far more complex inputs to be easily passed in.
- Instantiation, server startup, and cleanup with the API is far more explicit and manageable.

Bugfix: Likely pathing to the current working directory only worked if ran in the directory with a Worker, the base directory is now an absolute path to the directory with a `wrangler.toml`

The current CLI is setup to be more compatible with how Wrangler 1 works, which is not optimal for Wrangler 2. 