### PR TITLE
polish: add a small banner for commands

### DIFF
--- a/.changeset/gold-readers-grin.md
+++ b/.changeset/gold-readers-grin.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+polish: add a small banner for commands
+
+This adds a small banner for most commands. Specifically, we avoid any commands that maybe used as a parse input (like json into jq). The banner itself simply says "⛅️ wrangler" with an orange underline.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3255,6 +3255,12 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
     },
+    "node_modules/@types/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@types/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-dPWnWsf+kzIG140B8z2w3fr5D03TLWbOAFQl45xUpI3vcizeXriNR5VYkWZ+WTMsUHqZ9Xlt3hrxGNANFyNQfw==",
+      "dev": true
+    },
     "node_modules/@types/unist": {
       "version": "2.0.6",
       "dev": true,
@@ -17383,6 +17389,7 @@
         "@types/react-test-renderer": "^17.0.1",
         "@types/serve-static": "^1.13.10",
         "@types/signal-exit": "^3.0.1",
+        "@types/supports-color": "^8.1.1",
         "@types/ws": "^8.2.1",
         "@types/yargs": "^17.0.7",
         "chokidar": "^3.5.2",
@@ -17412,6 +17419,7 @@
         "react-test-renderer": "^17.0.2",
         "serve-static": "^1.14.1",
         "signal-exit": "^3.0.6",
+        "supports-color": "^9.2.1",
         "tmp-promise": "^3.0.3",
         "undici": "^4.15.1",
         "ws": "^8.3.0",
@@ -17487,6 +17495,18 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "packages/wrangler/node_modules/supports-color": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.2.1.tgz",
+      "integrity": "sha512-Obv7ycoCTG51N7y175StI9BlAXrmgZrFhZOb0/PyjHBher/NmsdBgbbQ1Inhq+gIhz6+7Gb+jWF2Vqi7Mf1xnQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "packages/wrangler/node_modules/undici": {
@@ -19911,6 +19931,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
+    },
+    "@types/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@types/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-dPWnWsf+kzIG140B8z2w3fr5D03TLWbOAFQl45xUpI3vcizeXriNR5VYkWZ+WTMsUHqZ9Xlt3hrxGNANFyNQfw==",
+      "dev": true
     },
     "@types/unist": {
       "version": "2.0.6",
@@ -28930,6 +28956,7 @@
         "@types/react-test-renderer": "^17.0.1",
         "@types/serve-static": "^1.13.10",
         "@types/signal-exit": "^3.0.1",
+        "@types/supports-color": "^8.1.1",
         "@types/ws": "^8.2.1",
         "@types/yargs": "^17.0.7",
         "chokidar": "^3.5.2",
@@ -28965,6 +28992,7 @@
         "semiver": "^1.1.0",
         "serve-static": "^1.14.1",
         "signal-exit": "^3.0.6",
+        "supports-color": "^9.2.1",
         "tmp-promise": "^3.0.3",
         "undici": "^4.15.1",
         "ws": "^8.3.0",
@@ -29003,6 +29031,12 @@
         },
         "path-exists": {
           "version": "5.0.0",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "9.2.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.2.1.tgz",
+          "integrity": "sha512-Obv7ycoCTG51N7y175StI9BlAXrmgZrFhZOb0/PyjHBher/NmsdBgbbQ1Inhq+gIhz6+7Gb+jWF2Vqi7Mf1xnQ==",
           "dev": true
         },
         "undici": {

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -59,6 +59,7 @@
     "@types/react-test-renderer": "^17.0.1",
     "@types/serve-static": "^1.13.10",
     "@types/signal-exit": "^3.0.1",
+    "@types/supports-color": "^8.1.1",
     "@types/ws": "^8.2.1",
     "@types/yargs": "^17.0.7",
     "chokidar": "^3.5.2",
@@ -88,6 +89,7 @@
     "react-test-renderer": "^17.0.2",
     "serve-static": "^1.14.1",
     "signal-exit": "^3.0.6",
+    "supports-color": "^9.2.1",
     "tmp-promise": "^3.0.3",
     "undici": "^4.15.1",
     "ws": "^8.3.0",
@@ -121,7 +123,7 @@
     "testTimeout": 30000,
     "testRegex": ".*.(test|spec)\\.[jt]sx?$",
     "transformIgnorePatterns": [
-      "node_modules/(?!find-up|locate-path|p-locate|p-limit|yocto-queue|path-exists|execa|strip-final-newline|npm-run-path|path-key|onetime|mimic-fn|human-signals|is-stream|get-port)"
+      "node_modules/(?!find-up|locate-path|p-locate|p-limit|yocto-queue|path-exists|execa|strip-final-newline|npm-run-path|path-key|onetime|mimic-fn|human-signals|is-stream|get-port|supports-color)"
     ],
     "moduleNameMapper": {
       "clipboardy": "<rootDir>/src/__tests__/helpers/clipboardy-mock.js",

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -3,11 +3,13 @@ import { writeFile, mkdir } from "node:fs/promises";
 import path from "node:path";
 import { setTimeout } from "node:timers/promises";
 import TOML from "@iarna/toml";
+import chalk from "chalk";
 import { findUp } from "find-up";
 import getPort from "get-port";
 import { render } from "ink";
 import React from "react";
 import onExit from "signal-exit";
+import supportsColor from "supports-color";
 import makeCLI from "yargs";
 import { version as wranglerVersion } from "../package.json";
 import { fetchResult } from "./cfetch";
@@ -80,6 +82,22 @@ ${TOML.stringify({ rules: config.build.upload.rules })}`
     );
   }
   return rules;
+}
+
+function printWranglerBanner() {
+  // Let's not print this in tests
+  if (typeof jest !== "undefined") {
+    return;
+  }
+  const text = ` ⛅️ wrangler ${wranglerVersion} `;
+
+  console.log(
+    text +
+      "\n" +
+      (supportsColor.stdout
+        ? chalk.hex("#FF8800")("-".repeat(text.length))
+        : "-".repeat(text.length))
+  );
 }
 
 function isLegacyEnv(args: unknown, config: Config): boolean {
@@ -275,6 +293,7 @@ export async function main(argv: string[]): Promise<void> {
         });
     },
     async (args) => {
+      printWranglerBanner();
       if ("type" in args) {
         let message = "The --type option is no longer supported.";
         if (args.type === "webpack") {
@@ -608,6 +627,7 @@ export async function main(argv: string[]): Promise<void> {
       // TODO: scopes
     },
     async (args) => {
+      printWranglerBanner();
       if (args["scopes-list"]) {
         listScopes();
         return;
@@ -642,6 +662,7 @@ export async function main(argv: string[]): Promise<void> {
     // "🚪 Logout from Cloudflare",
     () => {},
     async () => {
+      printWranglerBanner();
       await logout();
     }
   );
@@ -652,6 +673,7 @@ export async function main(argv: string[]): Promise<void> {
     "🕵️  Retrieve your user info and test your auth config",
     () => {},
     async () => {
+      printWranglerBanner();
       await whoami();
     }
   );
@@ -777,6 +799,7 @@ export async function main(argv: string[]): Promise<void> {
         });
     },
     async (args) => {
+      printWranglerBanner();
       const config = readConfig(
         (args.config as ConfigPath) ||
           (args.script && findWranglerToml(path.dirname(args.script)))
@@ -1035,6 +1058,7 @@ export async function main(argv: string[]): Promise<void> {
         });
     },
     async (args) => {
+      printWranglerBanner();
       if (args["experimental-public"]) {
         console.warn(
           "🚨  The --experimental-public field is experimental and will change in the future."
@@ -1147,6 +1171,9 @@ export async function main(argv: string[]): Promise<void> {
       );
     },
     async (args) => {
+      if (args.format === "pretty") {
+        printWranglerBanner();
+      }
       const config = readConfig(args.config as ConfigPath);
 
       const scriptName = getScriptName(args, config);
@@ -1449,6 +1476,7 @@ export async function main(argv: string[]): Promise<void> {
               });
           },
           async (args) => {
+            printWranglerBanner();
             const config = readConfig(args.config as ConfigPath);
 
             const scriptName = getScriptName(args, config);
@@ -1548,6 +1576,7 @@ export async function main(argv: string[]): Promise<void> {
           "delete <key>",
           "Delete a secret variable from a script",
           (yargs) => {
+            printWranglerBanner();
             return yargs
               .positional("key", {
                 describe: "The variable name to be accessible in the script",
@@ -1662,6 +1691,7 @@ export async function main(argv: string[]): Promise<void> {
               });
           },
           async (args) => {
+            printWranglerBanner();
             if (args._.length > 2) {
               const extraArgs = args._.slice(2).join(" ");
               throw new CommandLineArgsError(
@@ -1747,6 +1777,7 @@ export async function main(argv: string[]): Promise<void> {
               });
           },
           async (args) => {
+            printWranglerBanner();
             const config = readConfig(args.config as ConfigPath);
 
             let id;
@@ -1841,6 +1872,7 @@ export async function main(argv: string[]): Promise<void> {
               .check(demandOneOfOption("value", "path"));
           },
           async ({ key, ttl, expiration, ...args }) => {
+            printWranglerBanner();
             const config = readConfig(args.config as ConfigPath);
             const namespaceId = getNamespaceId(args, config);
             // One of `args.path` and `args.value` must be defined
@@ -1985,6 +2017,7 @@ export async function main(argv: string[]): Promise<void> {
               });
           },
           async ({ key, ...args }) => {
+            printWranglerBanner();
             const config = readConfig(args.config as ConfigPath);
             const namespaceId = getNamespaceId(args, config);
 
@@ -2039,6 +2072,7 @@ export async function main(argv: string[]): Promise<void> {
               });
           },
           async ({ filename, ...args }) => {
+            printWranglerBanner();
             // The simplest implementation I could think of.
             // This could be made more efficient with a streaming parser/uploader
             // but we'll do that in the future if needed.
@@ -2148,6 +2182,7 @@ export async function main(argv: string[]): Promise<void> {
               });
           },
           async ({ filename, ...args }) => {
+            printWranglerBanner();
             const config = readConfig(args.config as ConfigPath);
             const namespaceId = getNamespaceId(args, config);
 
@@ -2228,6 +2263,7 @@ export async function main(argv: string[]): Promise<void> {
             });
           },
           async (args) => {
+            printWranglerBanner();
             // We expect three values in `_`: `r2`, `bucket`, `create`.
             if (args._.length > 3) {
               const extraArgs = args._.slice(3).join(" ");
@@ -2265,6 +2301,7 @@ export async function main(argv: string[]): Promise<void> {
             });
           },
           async (args) => {
+            printWranglerBanner();
             // We expect three values in `_`: `r2`, `bucket`, `delete`.
             if (args._.length > 3) {
               const extraArgs = args._.slice(3).join(" ");


### PR DESCRIPTION
This adds a small banner for most commands. Specifically, we avoid any commands that maybe used as a parse input (like json into jq). The banner itself simply says "⛅️ wrangler" with an orange underline.

--- 

Some screenshots of what it looks like: 
![image](https://user-images.githubusercontent.com/18808/158979854-0c5e4ba7-8a87-474a-be2d-2a82d82dab3e.png)

![image](https://user-images.githubusercontent.com/18808/158979870-708aa72d-753e-45f8-a72d-4f4aa01ce6bb.png)

![image](https://user-images.githubusercontent.com/18808/158979888-3767b7db-5769-470d-8d41-d6bcea5a458c.png)
