### PR TITLE
fix: error if a non-legacy service environment tries to define a work…

### DIFF
--- a/.changeset/olive-seahorses-sleep.md
+++ b/.changeset/olive-seahorses-sleep.md
@@ -1,0 +1,13 @@
+---
+"wrangler": patch
+---
+
+fix: error if a non-legacy service environment tries to define a worker name
+
+Given that service environments all live off the same worker, it doesn't make sense
+for them to have different names.
+
+This change adds validation to tell the developer to remove such `name` fields in
+service environment config.
+
+Fixes #623

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -21,6 +21,7 @@ import {
   validateTypedArray,
   all,
   isMutuallyExclusiveWith,
+  inheritableInLegacyEnvironments,
 } from "./validation-helpers";
 import type {
   Config,
@@ -537,7 +538,14 @@ function normalizeAndValidateEnvironment(
       deprecatedRules,
       envName
     ),
-    name: inheritable(diagnostics, config, rawEnv, "name", isString, undefined),
+    name: inheritableInLegacyEnvironments(
+      diagnostics,
+      config,
+      rawEnv,
+      "name",
+      isString,
+      undefined
+    ),
     route,
     routes,
     triggers: inheritable(


### PR DESCRIPTION
…er name

Given that service environments all live off the same worker, it doesn't make sense
for them to have different names.

This change adds validation to tell the developer to remove such `name` fields in
service environment config.

Fixes #623