### PR TITLE
fix: improve authentication logging and warnings

### DIFF
--- a/.changeset/large-pillows-clap.md
+++ b/.changeset/large-pillows-clap.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+---
+
+fix: improve authentication logging and warnings
+
+- If a user has previously logged in via Wrangler 1 with an API token, we now display a helpful warning.
+- When logging in and out, we no longer display the path to the internal user auh config file.
+- When logging in, we now display an initial message to indicate the authentication flow is starting.
+
+Fixes [#526](https://github.com/cloudflare/wrangler2/issues/526)

--- a/packages/wrangler/src/__tests__/logout.test.ts
+++ b/packages/wrangler/src/__tests__/logout.test.ts
@@ -38,10 +38,7 @@ describe("wrangler", () => {
       reinitialiseAuthTokens();
       await runWrangler("logout");
 
-      expect(std.out).toMatchInlineSnapshot(`
-        "💁  Wrangler is configured with an OAuth token. The token has been successfully revoked
-        Removing ./home/.wrangler/config/default.toml.. success!"
-      `);
+      expect(std.out).toMatchInlineSnapshot(`"Successfully logged out."`);
 
       // Make sure that we made the request to logout.
       expect(fetchMock).toHaveBeenCalledTimes(1);

--- a/packages/wrangler/src/cfetch/internal.ts
+++ b/packages/wrangler/src/cfetch/internal.ts
@@ -89,11 +89,11 @@ async function requireLoggedIn(): Promise<void> {
 }
 
 function requireApiToken(): string {
-  const apiToken = getAPIToken();
-  if (!apiToken) {
+  const authToken = getAPIToken();
+  if (!authToken) {
     throw new Error("No API token found.");
   }
-  return apiToken;
+  return authToken;
 }
 
 function addAuthorizationHeader(


### PR DESCRIPTION
- If a user has previously logged in via Wrangler 1 with an API token, we now display a helpful warning.
- When logging in and out, we no longer display the path to the internal user auh config file.
- When logging in, we now display an initial message to indicate the authentication flow is starting.

Fixes [#526](https://github.com/cloudflare/wrangler2/issues/526)