### PR TITLE
fix: default `watch_dir` to `src` of project directory

### DIFF
--- a/.changeset/perfect-cars-leave.md
+++ b/.changeset/perfect-cars-leave.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: default `watch_dir` to `src` of project directory
+
+Via wrangler 1, when using custom builds in `wrangler dev`, `watch_dir` should default to `src` of the "project directory" (i.e - wherever the `wrangler.toml` is defined if it exists, else in the cwd.
+
+Fixes https://github.com/cloudflare/wrangler2/issues/631

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -212,6 +212,53 @@ describe("normalizeAndValidateConfig()", () => {
       `);
     });
 
+    it("should default custom build watch directories to src", () => {
+      const expectedConfig: RawConfig = {
+        build: {
+          command: "execute some --build",
+        },
+      };
+
+      const { config, diagnostics } = normalizeAndValidateConfig(
+        expectedConfig,
+        undefined
+      );
+
+      expect(config.build).toEqual(
+        expect.objectContaining({
+          command: "execute some --build",
+          watch_dir: "./src",
+        })
+      );
+
+      expect(diagnostics.hasErrors()).toBe(false);
+      expect(diagnostics.hasWarnings()).toBe(false);
+    });
+
+    it("should resolve custom build watch directories relative to wrangler.toml", async () => {
+      const expectedConfig: RawConfig = {
+        build: {
+          command: "execute some --build",
+          watch_dir: "some/path",
+        },
+      };
+
+      const { config, diagnostics } = normalizeAndValidateConfig(
+        expectedConfig,
+        "project/wrangler.toml"
+      );
+
+      expect(config.build).toEqual(
+        expect.objectContaining({
+          command: "execute some --build",
+          watch_dir: path.normalize("project/some/path"),
+        })
+      );
+
+      expect(diagnostics.hasErrors()).toBe(false);
+      expect(diagnostics.hasWarnings()).toBe(false);
+    });
+
     it("should override `migrations` config defaults with provided values", () => {
       const expectedConfig: RawConfig = {
         migrations: [

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -247,7 +247,7 @@ describe("Dev component", () => {
         command:
           "node -e \"console.log('custom build'); require('fs').writeFileSync('index.js', 'export default { fetch(){ return new Response(123) } }')\"",
         cwd: undefined,
-        watch_dir: undefined,
+        watch_dir: "src",
       });
       expect(std.out).toMatchInlineSnapshot(
         `"running: node -e \\"console.log('custom build'); require('fs').writeFileSync('index.js', 'export default { fetch(){ return new Response(123) } }')\\""`


### PR DESCRIPTION
Via wrangler 1, when using custom builds in `wrangler dev`, `watch_dir` should default to `src` of the "project directory" (i.e - wherever the `wrangler.toml` is defined if it exists, else in the cwd.

Fixes https://github.com/cloudflare/wrangler2/issues/631