### PR TITLE
fix: use `expiration_ttl` to expire assets with `[site]`

### DIFF
--- a/.changeset/blue-nails-unite.md
+++ b/.changeset/blue-nails-unite.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: use `expiration_ttl` to expire assets with `[site]`
+
+This switches how we expire static assets with `[site]` uploads to use `expiration_ttl` instead of `expiration`. This is because we can't trust the time that a deploy target may provide (like in https://github.com/cloudflare/wrangler/issues/2224).

--- a/packages/wrangler/src/__tests__/kv.test.ts
+++ b/packages/wrangler/src/__tests__/kv.test.ts
@@ -676,7 +676,7 @@ describe("wrangler", () => {
         const keys = [
           { name: "key-1" },
           { name: "key-2", expiration: 123456789 },
-          { name: "key-3" },
+          { name: "key-3", expiration_ttl: 666 },
         ];
         mockKeyListRequest("some-namespace-id", keys);
         await runWrangler("kv:key list --namespace-id some-namespace-id");
@@ -691,7 +691,8 @@ describe("wrangler", () => {
               \\"expiration\\": 123456789
             },
             {
-              \\"name\\": \\"key-3\\"
+              \\"name\\": \\"key-3\\",
+              \\"expiration_ttl\\": 666
             }
           ]"
         `);

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -1239,18 +1239,6 @@ export default{
     });
 
     describe("expire unused assets", () => {
-      // it's a 100 seconds past epoch
-      // everyone's still talking about how great woodstock was
-      const DATE_NOW = 100000;
-      beforeEach(() => {
-        jest.spyOn(Date, "now").mockImplementation((): number => {
-          return DATE_NOW;
-        });
-      });
-      afterEach(() => {
-        (Date.now as jest.Mock).mockRestore();
-      });
-
       it("should expire uploaded assets that aren't included anymore", async () => {
         const assets = [
           { filePath: "assets/file-1.txt", content: "Content of file-1" },
@@ -1299,14 +1287,14 @@ export default{
           {
             filePath: "assets/file-3.txt",
             content: "Content of file-3",
-            // expire this asset 300 seconds from now
-            expiration: DATE_NOW / 1000 + 300,
+            // expect to expire this asset 300 seconds from now
+            expiration_ttl: 300,
           },
           {
             filePath: "assets/file-4.txt",
             content: "Content of file-4",
-            // expire this asset 300 seconds from now
-            expiration: DATE_NOW / 1000 + 300,
+            // expect to expire this asset 300 seconds from now
+            expiration_ttl: 300,
           },
         ]);
 
@@ -1375,8 +1363,8 @@ export default{
           {
             filePath: "assets/file-4.txt",
             content: "Content of file-4",
-            // expire this asset 300 seconds from now
-            expiration: DATE_NOW / 1000 + 300,
+            // expect to expire this asset 300 seconds from now
+            expiration_ttl: 300,
           },
         ]);
 
@@ -2580,7 +2568,12 @@ function mockListKVNamespacesRequest(...namespaces: KVNamespaceInfo[]) {
 /** Create a mock handler for the request that tries to do a bulk upload of assets to a KV namespace. */
 function mockUploadAssetsToKVRequest(
   expectedNamespaceId: string,
-  assets: { filePath: string; content: string; expiration?: number }[]
+  assets: {
+    filePath: string;
+    content: string;
+    expiration?: number;
+    expiration_ttl?: number;
+  }[]
 ) {
   setMockResponse(
     "/accounts/:accountId/storage/kv/namespaces/:namespaceId/bulk",
@@ -2610,6 +2603,7 @@ function mockUploadAssetsToKVRequest(
           asset.content
         );
         expect(upload.expiration).toEqual(asset.expiration);
+        expect(upload.expiration_ttl).toEqual(asset.expiration_ttl);
       }
       return null;
     }


### PR DESCRIPTION
This switches how we expire static assets with `[site]` uploads to use `expiration_ttl` instead of `expiration`. This is because we can't trust the time that a deploy target may provide (like in https://github.com/cloudflare/wrangler/issues/2224).