### PR TITLE
chore: run prettier on `.changeset`/`docs` folder

### DIFF
--- a/docs/compare-v1-v2.md
+++ b/docs/compare-v1-v2.md
@@ -1,36 +1,39 @@
 # Wrangler 1.0 and 2.0 comparison table
 
 ## Commands
-| Command | 1.x | 2.0 | Notes |
-|-|-|-|-|
-| `publish` | ✅  | ✅  |
-| `dev` | ✅  | ✅  |
-| `preview` | ✅  | ❌  | Removed, use `dev` instead. |
-| `init` | ✅ | ✅ |
-| `generate` | ✅ | ❌ | Removed, use `git clone` instead. |
-| `build` | ✅  | ❌ | Removed, invoke your own build script instead. |
-| `secret` | ✅  | ✅  |
-| `route` | ✅  | ❌  | Removed, use `publish` instead. |
-| `tail` | ✅  | ✅  |
-| `kv` | ✅  | ✅  |
-| `r2` | 🚧  | ✅  | Introduced in wrangler 1.19.8.
-| `pages` | ❌ | ✅ | 
-| `config` | ✅  | ❔ |
-| `login` | ✅  | ✅  |
-| `logout` | ✅  | ✅  |
-| `whoami` | ✅  | ✅  |
-| `subdomain` | ✅  | ❔ |
-| `report` | ✅  | ❌  | Removed, error reports are made interactively. |
+
+| Command     | 1.x | 2.0 | Notes                                          |
+| ----------- | --- | --- | ---------------------------------------------- |
+| `publish`   | ✅  | ✅  |
+| `dev`       | ✅  | ✅  |
+| `preview`   | ✅  | ❌  | Removed, use `dev` instead.                    |
+| `init`      | ✅  | ✅  |
+| `generate`  | ✅  | ❌  | Removed, use `git clone` instead.              |
+| `build`     | ✅  | ❌  | Removed, invoke your own build script instead. |
+| `secret`    | ✅  | ✅  |
+| `route`     | ✅  | ❌  | Removed, use `publish` instead.                |
+| `tail`      | ✅  | ✅  |
+| `kv`        | ✅  | ✅  |
+| `r2`        | 🚧  | ✅  | Introduced in wrangler 1.19.8.                 |
+| `pages`     | ❌  | ✅  |
+| `config`    | ✅  | ❔  |
+| `login`     | ✅  | ✅  |
+| `logout`    | ✅  | ✅  |
+| `whoami`    | ✅  | ✅  |
+| `subdomain` | ✅  | ❔  |
+| `report`    | ✅  | ❌  | Removed, error reports are made interactively. |
 
 ## Configuration
-| Property | 1.x | 2.0 | Notes |
-|-|-|-|-|
-| `type = "webpack"` | ✅ | ❌ | Removed, look at this guide to migrate.  |
-| `type = "rust"` | ✅ | ❌ | Removed, use [`workers-rs`](https://github.com/cloudflare/workers-rs) instead. |
-| `type = "javascript"` | ✅ | 🚧  | No longer required, can be omitted. |
+
+| Property              | 1.x | 2.0 | Notes                                                                          |
+| --------------------- | --- | --- | ------------------------------------------------------------------------------ |
+| `type = "webpack"`    | ✅  | ❌  | Removed, look at this guide to migrate.                                        |
+| `type = "rust"`       | ✅  | ❌  | Removed, use [`workers-rs`](https://github.com/cloudflare/workers-rs) instead. |
+| `type = "javascript"` | ✅  | 🚧  | No longer required, can be omitted.                                            |
 
 ## Features
-| Feature | 1.x | 2.0 | Notes |
-|-|-|-|-|
-| TypeScript | ❌ | ✅ | You can give wrangler a TypeScript file, and it will automatically transpile it to JavaScript using [`esbuild`](https://github.com/evanw/esbuild) under-the-hood. |
-| Local mode | ❌ | ✅ | `wrangler dev --local` will run your Worker on your local machine instead of on our network. This is powered by [Miniflare](https://github.com/cloudflare/miniflare).
+
+| Feature    | 1.x | 2.0 | Notes                                                                                                                                                                 |
+| ---------- | --- | --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| TypeScript | ❌  | ✅  | You can give wrangler a TypeScript file, and it will automatically transpile it to JavaScript using [`esbuild`](https://github.com/evanw/esbuild) under-the-hood.     |
+| Local mode | ❌  | ✅  | `wrangler dev --local` will run your Worker on your local machine instead of on our network. This is powered by [Miniflare](https://github.com/cloudflare/miniflare). |

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "check": "run-p check:* --aggregate-output --continue-on-error",
     "check:type": "npm run check:type --workspaces --if-present",
     "check:lint": "eslint \"packages/**/*.[tj]s?(x)\" --cache --cache-strategy content --max-warnings=0",
-    "check:format": "prettier packages/** --check --ignore-unknown",
+    "check:format": "prettier packages/** .changeset docs --check --ignore-unknown",
     "build": "npm run build --workspace=wrangler",
     "test": "npm run test --workspaces --if-present",
     "prettify": "prettier packages/** --write --ignore-unknown"


### PR DESCRIPTION
This should prevent failed builds when we do releases (like what happened with .20 and .21)