### PR TITLE
Add messaging for CLI pages command being in Beta

### DIFF
--- a/.changeset/happy-trainers-teach.md
+++ b/.changeset/happy-trainers-teach.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+polish: add "Beta" messaging around the CLI command for Pages. Explicitly specifying the command is Beta, not to be confused with Pages itself which is production ready.

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -32,7 +32,7 @@ import {
   unexpectedKeyValueProps,
 } from "./kv";
 import { getPackageManager } from "./package-manager";
-import { pages } from "./pages";
+import { pages, pagesBetaWarning } from "./pages";
 import { formatMessage, ParseError, parseJSON, readFileSync } from "./parse";
 import publish from "./publish";
 import { createR2Bucket, deleteR2Bucket, listR2Buckets } from "./r2";
@@ -2312,8 +2312,12 @@ export async function main(argv: string[]): Promise<void> {
     }
   );
 
-  wrangler.command("pages", "⚡️ Configure Cloudflare Pages", (pagesYargs) =>
-    pages(pagesYargs.command(subHelp))
+  wrangler.command(
+    "pages",
+    "⚡️ Configure Cloudflare Pages",
+    async (pagesYargs) => {
+      await pages(pagesYargs.command(subHelp).epilogue(pagesBetaWarning));
+    }
   );
 
   wrangler.command("r2", "📦 Interact with an R2 store", (r2Yargs) => {

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -22,6 +22,9 @@ import type { BuilderCallback } from "yargs";
 // and also modifies some `stream/web` and `undici` prototypes, so we
 // don't want to do this if pages commands aren't being called.
 
+export const pagesBetaWarning =
+  "🚧 'wrangler pages <command>' is a beta command. Please report any issues to https://github.com/cloudflare/wrangler2/issues/new/choose";
+
 const EXIT_CALLBACKS: (() => void)[] = [];
 const EXIT = (message?: string, code?: number) => {
   if (message) console.log(message);
@@ -760,7 +763,8 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
               description: "Auto reload HTML pages when change is detected",
             },
             // TODO: Miniflare user options
-          });
+          })
+          .epilogue(pagesBetaWarning);
       },
       async ({
         local,
@@ -774,6 +778,9 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
         "live-reload": liveReload,
         _: [_pages, _dev, ...remaining],
       }) => {
+        // Beta message for `wrangler pages <commands>` usage
+        console.log(pagesBetaWarning);
+
         if (!local) {
           console.error("Only local mode is supported at the moment.");
           return;
@@ -1017,7 +1024,8 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
                 description:
                   "Watch for changes to the functions and automatically rebuild the Worker script",
               },
-            }),
+            })
+            .epilogue(pagesBetaWarning),
         async ({
           directory,
           "script-path": scriptPath,
@@ -1027,6 +1035,9 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
           fallbackService,
           watch,
         }) => {
+          // Beta message for `wrangler pages <commands>` usage
+          console.log(pagesBetaWarning);
+
           await buildFunctions({
             scriptPath,
             outputConfigPath,


### PR DESCRIPTION
Adding "Beta" messaging around the CLI command for Pages.
 
Explicitly specifying the command is Beta, not to be confused with Pages itself which is production ready, the messaging could need additional tweaking to prevent any confusion between `Pages` and `npx wrangler pages <command>`

@nevikashah

resolves #642 