### PR TITLE
bugfix: add `-e` alias to all `--env` flag options

### DIFF
--- a/.changeset/strange-tools-heal.md
+++ b/.changeset/strange-tools-heal.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+bugfix: use alias `-e` for `--env` to prevent scripts using Wrangler 1 from breaking when switching to Wrangler 2.

--- a/packages/wrangler/src/__tests__/kv.test.ts
+++ b/packages/wrangler/src/__tests__/kv.test.ts
@@ -61,7 +61,7 @@ describe("wrangler", () => {
                 --legacy-env  Use legacy environments  [boolean]
 
           Options:
-                --env      Perform on a specific environment  [string]
+            -e, --env      Perform on a specific environment  [string]
                 --preview  Interact with a preview namespace  [boolean]
 
           Not enough non-option arguments: got 0, need at least 1"
@@ -90,7 +90,7 @@ describe("wrangler", () => {
                 --legacy-env  Use legacy environments  [boolean]
 
           Options:
-                --env      Perform on a specific environment  [string]
+            -e, --env      Perform on a specific environment  [string]
                 --preview  Interact with a preview namespace  [boolean]
 
           Unexpected additional positional arguments \\"def ghi\\"."
@@ -120,7 +120,7 @@ describe("wrangler", () => {
                 --legacy-env  Use legacy environments  [boolean]
 
           Options:
-                --env      Perform on a specific environment  [string]
+            -e, --env      Perform on a specific environment  [string]
                 --preview  Interact with a preview namespace  [boolean]
 
           The namespace binding name \\"abc-def\\" is invalid. It can only have alphanumeric and _ characters, and cannot begin with a number."
@@ -286,7 +286,7 @@ describe("wrangler", () => {
           Options:
                 --binding       The name of the namespace to delete  [string]
                 --namespace-id  The id of the namespace to delete  [string]
-                --env           Perform on a specific environment  [string]
+            -e, --env           Perform on a specific environment  [string]
                 --preview       Interact with a preview namespace  [boolean]
 
           Not able to delete namespace.
@@ -480,7 +480,7 @@ describe("wrangler", () => {
           Options:
                 --binding       The binding of the namespace to write to  [string]
                 --namespace-id  The id of the namespace to write to  [string]
-                --env           Perform on a specific environment  [string]
+            -e, --env           Perform on a specific environment  [string]
                 --preview       Interact with a preview namespace  [boolean]
                 --ttl           Time for which the entries should be visible  [number]
                 --expiration    Time since the UNIX epoch after which the entry expires  [number]
@@ -516,7 +516,7 @@ describe("wrangler", () => {
           Options:
                 --binding       The binding of the namespace to write to  [string]
                 --namespace-id  The id of the namespace to write to  [string]
-                --env           Perform on a specific environment  [string]
+            -e, --env           Perform on a specific environment  [string]
                 --preview       Interact with a preview namespace  [boolean]
                 --ttl           Time for which the entries should be visible  [number]
                 --expiration    Time since the UNIX epoch after which the entry expires  [number]
@@ -552,7 +552,7 @@ describe("wrangler", () => {
           Options:
                 --binding       The binding of the namespace to write to  [string]
                 --namespace-id  The id of the namespace to write to  [string]
-                --env           Perform on a specific environment  [string]
+            -e, --env           Perform on a specific environment  [string]
                 --preview       Interact with a preview namespace  [boolean]
                 --ttl           Time for which the entries should be visible  [number]
                 --expiration    Time since the UNIX epoch after which the entry expires  [number]
@@ -588,7 +588,7 @@ describe("wrangler", () => {
           Options:
                 --binding       The binding of the namespace to write to  [string]
                 --namespace-id  The id of the namespace to write to  [string]
-                --env           Perform on a specific environment  [string]
+            -e, --env           Perform on a specific environment  [string]
                 --preview       Interact with a preview namespace  [boolean]
                 --ttl           Time for which the entries should be visible  [number]
                 --expiration    Time since the UNIX epoch after which the entry expires  [number]
@@ -624,7 +624,7 @@ describe("wrangler", () => {
           Options:
                 --binding       The binding of the namespace to write to  [string]
                 --namespace-id  The id of the namespace to write to  [string]
-                --env           Perform on a specific environment  [string]
+            -e, --env           Perform on a specific environment  [string]
                 --preview       Interact with a preview namespace  [boolean]
                 --ttl           Time for which the entries should be visible  [number]
                 --expiration    Time since the UNIX epoch after which the entry expires  [number]
@@ -919,7 +919,7 @@ describe("wrangler", () => {
           Options:
                 --binding       The name of the namespace to get from  [string]
                 --namespace-id  The id of the namespace to get from  [string]
-                --env           Perform on a specific environment  [string]
+            -e, --env           Perform on a specific environment  [string]
                 --preview       Interact with a preview namespace  [boolean] [default: false]
 
           Not enough non-option arguments: got 0, need at least 1"
@@ -950,7 +950,7 @@ describe("wrangler", () => {
           Options:
                 --binding       The name of the namespace to get from  [string]
                 --namespace-id  The id of the namespace to get from  [string]
-                --env           Perform on a specific environment  [string]
+            -e, --env           Perform on a specific environment  [string]
                 --preview       Interact with a preview namespace  [boolean] [default: false]
 
           Exactly one of the arguments binding and namespace-id is required"
@@ -982,7 +982,7 @@ describe("wrangler", () => {
           Options:
                 --binding       The name of the namespace to get from  [string]
                 --namespace-id  The id of the namespace to get from  [string]
-                --env           Perform on a specific environment  [string]
+            -e, --env           Perform on a specific environment  [string]
                 --preview       Interact with a preview namespace  [boolean] [default: false]
 
           Arguments binding and namespace-id are mutually exclusive"

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -711,6 +711,7 @@ export async function main(argv: string[]): Promise<void> {
         .option("env", {
           describe: "Perform on a specific environment",
           type: "string",
+          alias: "e",
         })
         .option("compatibility-date", {
           describe: "Date to use for compatibility checks",
@@ -990,6 +991,7 @@ export async function main(argv: string[]): Promise<void> {
         .option("env", {
           type: "string",
           describe: "Perform on a specific environment",
+          alias: "e",
         })
         .positional("script", {
           describe: "The path to an entry point for your worker",
@@ -1159,6 +1161,7 @@ export async function main(argv: string[]): Promise<void> {
           .option("env", {
             type: "string",
             describe: "Perform on a specific environment",
+            alias: "e",
           })
           .option("debug", {
             type: "boolean",
@@ -1473,6 +1476,7 @@ export async function main(argv: string[]): Promise<void> {
                 type: "string",
                 describe:
                   "Binds the secret to the Worker of the specific environment",
+                alias: "e",
               });
           },
           async (args) => {
@@ -1590,6 +1594,7 @@ export async function main(argv: string[]): Promise<void> {
                 type: "string",
                 describe:
                   "Binds the secret to the Worker of the specific environment",
+                alias: "e",
               });
           },
           async (args) => {
@@ -1640,6 +1645,7 @@ export async function main(argv: string[]): Promise<void> {
                 type: "string",
                 describe:
                   "Binds the secret to the Worker of the specific environment.",
+                alias: "e",
               });
           },
           async (args) => {
@@ -1684,6 +1690,7 @@ export async function main(argv: string[]): Promise<void> {
               .option("env", {
                 type: "string",
                 describe: "Perform on a specific environment",
+                alias: "e",
               })
               .option("preview", {
                 type: "boolean",
@@ -1770,6 +1777,7 @@ export async function main(argv: string[]): Promise<void> {
               .option("env", {
                 type: "string",
                 describe: "Perform on a specific environment",
+                alias: "e",
               })
               .option("preview", {
                 type: "boolean",
@@ -1851,6 +1859,7 @@ export async function main(argv: string[]): Promise<void> {
               .option("env", {
                 type: "string",
                 describe: "Perform on a specific environment",
+                alias: "e",
               })
               .option("preview", {
                 type: "boolean",
@@ -1918,6 +1927,7 @@ export async function main(argv: string[]): Promise<void> {
               .option("env", {
                 type: "string",
                 describe: "Perform on a specific environment",
+                alias: "e",
               })
               .option("preview", {
                 type: "boolean",
@@ -1967,6 +1977,7 @@ export async function main(argv: string[]): Promise<void> {
               .option("env", {
                 type: "string",
                 describe: "Perform on a specific environment",
+                alias: "e",
               })
               .option("preview", {
                 type: "boolean",
@@ -2010,6 +2021,7 @@ export async function main(argv: string[]): Promise<void> {
               .option("env", {
                 type: "string",
                 describe: "Perform on a specific environment",
+                alias: "e",
               })
               .option("preview", {
                 type: "boolean",
@@ -2065,6 +2077,7 @@ export async function main(argv: string[]): Promise<void> {
               .option("env", {
                 type: "string",
                 describe: "Perform on a specific environment",
+                alias: "e",
               })
               .option("preview", {
                 type: "boolean",
@@ -2170,6 +2183,7 @@ export async function main(argv: string[]): Promise<void> {
               .option("env", {
                 type: "string",
                 describe: "Perform on a specific environment",
+                alias: "e",
               })
               .option("preview", {
                 type: "boolean",


### PR DESCRIPTION
When migrating a legacy Worker that was using many scripts for managing various environments, Wrangler 2 was missing aliases which were utilized in the Wrangler 1 scripts; this will allow for parity for environment flags.  

resolves #660 