### PR TITLE
chore: prevent `prettier --check` on CHANGELOG

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ packages/example-worker-app/dist/
 packages/example-remix-pages-app/build
 packages/example-remix-pages-app/public/
 packages/prerelease-registry/_worker.js
+packages/wrangler/CHANGELOG.md


### PR DESCRIPTION
changesets currently relies on on older version of prettier when generating changelogs, which then makes our `prettier --check` run fail during releases, which breaks our releases (.20. .21, .22). ref: https://github.com/changesets/changesets/issues/616. The fix for now is to simply ignore the changelog when generating the check.