### PR TITLE
fix: tighten up the named environment configuration

### DIFF
--- a/.changeset/hot-kiwis-lie.md
+++ b/.changeset/hot-kiwis-lie.md
@@ -1,0 +1,18 @@
+---
+"wrangler": patch
+---
+
+fix: tighten up the named environment configuration
+
+Now, when we normalize and validate the raw config, we pass in the currently
+active environment name, and the config that is returned contains all the
+environment fields correctly normalized (including inheritance) at the top
+level of the config object. This avoids other commands from having to check
+both the current named environment and the top-level config for such fields.
+
+Also, now, handle the case where the active environment name passed in via the
+`--env` command line argument does not match any of the named environments
+in the configuration:
+
+- This is an error if there are named environments configured;
+- or only a warning if there are no named environments configured.

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -4,7 +4,11 @@ import type { RawConfig, RawEnvironment } from "../config";
 
 describe("normalizeAndValidateConfig()", () => {
   it("should use defaults for empty configuration", () => {
-    const { config, diagnostics } = normalizeAndValidateConfig({}, undefined);
+    const { config, diagnostics } = normalizeAndValidateConfig(
+      {},
+      undefined,
+      undefined
+    );
 
     expect(config).toEqual({
       account_id: undefined,
@@ -26,7 +30,6 @@ describe("normalizeAndValidateConfig()", () => {
       durable_objects: {
         bindings: [],
       },
-      env: {},
       jsx_factory: "React.createElement",
       jsx_fragment: "React.Fragment",
       kv_namespaces: [],
@@ -77,6 +80,7 @@ describe("normalizeAndValidateConfig()", () => {
 
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig,
+        undefined,
         undefined
       );
 
@@ -107,6 +111,7 @@ describe("normalizeAndValidateConfig()", () => {
 
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig as unknown as RawConfig,
+        undefined,
         undefined
       );
 
@@ -137,6 +142,7 @@ describe("normalizeAndValidateConfig()", () => {
 
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig as unknown as RawConfig,
+        undefined,
         undefined
       );
 
@@ -157,6 +163,7 @@ describe("normalizeAndValidateConfig()", () => {
 
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig as unknown as RawConfig,
+        undefined,
         undefined
       );
 
@@ -182,7 +189,8 @@ describe("normalizeAndValidateConfig()", () => {
 
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig,
-        path.resolve("project/wrangler.toml")
+        path.resolve("project/wrangler.toml"),
+        undefined
       );
 
       expect(config.main).toEqual(path.resolve("project/src/index.ts"));
@@ -221,6 +229,7 @@ describe("normalizeAndValidateConfig()", () => {
 
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig,
+        undefined,
         undefined
       );
 
@@ -245,7 +254,8 @@ describe("normalizeAndValidateConfig()", () => {
 
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig,
-        "project/wrangler.toml"
+        "project/wrangler.toml",
+        undefined
       );
 
       expect(config.build).toEqual(
@@ -278,6 +288,7 @@ describe("normalizeAndValidateConfig()", () => {
 
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig,
+        undefined,
         undefined
       );
 
@@ -305,6 +316,7 @@ describe("normalizeAndValidateConfig()", () => {
 
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig as unknown as RawConfig,
+        undefined,
         undefined
       );
 
@@ -333,6 +345,7 @@ describe("normalizeAndValidateConfig()", () => {
 
         const { config, diagnostics } = normalizeAndValidateConfig(
           expectedConfig,
+          undefined,
           undefined
         );
 
@@ -352,6 +365,7 @@ describe("normalizeAndValidateConfig()", () => {
 
         const { config, diagnostics } = normalizeAndValidateConfig(
           expectedConfig,
+          undefined,
           undefined
         );
 
@@ -375,6 +389,7 @@ describe("normalizeAndValidateConfig()", () => {
 
         const { config, diagnostics } = normalizeAndValidateConfig(
           expectedConfig as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -397,6 +412,7 @@ describe("normalizeAndValidateConfig()", () => {
               "entry-point": "some/other/script.js",
             },
           } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -432,7 +448,8 @@ describe("normalizeAndValidateConfig()", () => {
 
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig,
-        "project/wrangler.toml"
+        "project/wrangler.toml",
+        undefined
       );
 
       expect(config).toEqual(
@@ -457,7 +474,8 @@ describe("normalizeAndValidateConfig()", () => {
 
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig as unknown as RawConfig,
-        "project/wrangler.toml"
+        "project/wrangler.toml",
+        undefined
       );
 
       expect(config).toEqual(
@@ -483,7 +501,8 @@ describe("normalizeAndValidateConfig()", () => {
 
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig,
-        "project/wrangler.toml"
+        "project/wrangler.toml",
+        undefined
       );
 
       expect(config).toEqual(
@@ -508,7 +527,8 @@ describe("normalizeAndValidateConfig()", () => {
 
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig as unknown as RawConfig,
-        "project/wrangler.toml"
+        "project/wrangler.toml",
+        undefined
       );
 
       expect(config).toEqual(
@@ -533,6 +553,7 @@ describe("normalizeAndValidateConfig()", () => {
 
         const { config, diagnostics } = normalizeAndValidateConfig(
           rawConfig,
+          undefined,
           undefined
         );
 
@@ -613,6 +634,7 @@ describe("normalizeAndValidateConfig()", () => {
 
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig,
+        undefined,
         undefined
       );
 
@@ -641,6 +663,7 @@ describe("normalizeAndValidateConfig()", () => {
 
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig,
+        undefined,
         undefined
       );
 
@@ -666,6 +689,7 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if durable_objects is an array", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { durable_objects: [] } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -682,6 +706,7 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if durable_objects is a string", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { durable_objects: "BAD" } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -698,6 +723,7 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if durable_objects is a number", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { durable_objects: 999 } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -714,6 +740,7 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if durable_objects is null", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { durable_objects: null } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -730,6 +757,7 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if durable_objects.bindings is not defined", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { durable_objects: {} } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -746,6 +774,7 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if durable_objects.bindings is an object", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { durable_objects: { bindings: {} } } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -764,6 +793,7 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if durable_objects.bindings is a string", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { durable_objects: { bindings: "BAD" } } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -782,6 +812,7 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if durable_objects.bindings is a number", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { durable_objects: { bindings: 999 } } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -800,6 +831,7 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if durable_objects.bindings is null", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { durable_objects: { bindings: null } } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -831,6 +863,7 @@ describe("normalizeAndValidateConfig()", () => {
               ],
             },
           } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -866,6 +899,7 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if kv_namespaces is an object", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { kv_namespaces: {} } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -882,6 +916,7 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if kv_namespaces is a string", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { kv_namespaces: "BAD" } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -898,6 +933,7 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if kv_namespaces is a number", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { kv_namespaces: 999 } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -914,6 +950,7 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if kv_namespaces is null", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { kv_namespaces: null } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -941,6 +978,7 @@ describe("normalizeAndValidateConfig()", () => {
               },
             ],
           } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -966,6 +1004,7 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if r2_buckets is an object", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { r2_buckets: {} } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -982,6 +1021,7 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if r2_buckets is a string", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { r2_buckets: "BAD" } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -998,6 +1038,7 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if r2_buckets is a number", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { r2_buckets: 999 } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -1014,6 +1055,7 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if r2_buckets is null", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { r2_buckets: null } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -1041,6 +1083,7 @@ describe("normalizeAndValidateConfig()", () => {
               },
             ],
           } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -1066,6 +1109,7 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if unsafe is an array", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { unsafe: [] } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -1085,6 +1129,7 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if unsafe is a string", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { unsafe: "BAD" } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -1104,6 +1149,7 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if unsafe is a number", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { unsafe: 999 } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -1123,6 +1169,7 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if unsafe is null", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { unsafe: null } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -1142,6 +1189,7 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if unsafe.bindings is not defined", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { unsafe: {} } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -1161,6 +1209,7 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if unsafe.bindings is an object", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { unsafe: { bindings: {} } } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -1182,6 +1231,7 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if unsafe.bindings is a string", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { unsafe: { bindings: "BAD" } } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -1203,6 +1253,7 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if unsafe.bindings is a number", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { unsafe: { bindings: 999 } } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -1224,6 +1275,7 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if unsafe.bindings is null", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { unsafe: { bindings: null } } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -1258,6 +1310,7 @@ describe("normalizeAndValidateConfig()", () => {
               ],
             },
           } as unknown as RawConfig,
+          undefined,
           undefined
         );
 
@@ -1302,6 +1355,7 @@ describe("normalizeAndValidateConfig()", () => {
 
         const { config, diagnostics } = normalizeAndValidateConfig(
           rawConfig,
+          undefined,
           undefined
         );
 
@@ -1336,6 +1390,7 @@ describe("normalizeAndValidateConfig()", () => {
 
         const { diagnostics } = normalizeAndValidateConfig(
           rawConfig,
+          undefined,
           undefined
         );
 
@@ -1348,6 +1403,55 @@ describe("normalizeAndValidateConfig()", () => {
   });
 
   describe("named environments", () => {
+    it("should warn if we specify an environment but there are no named environments", () => {
+      const rawConfig: RawConfig = {};
+      const { diagnostics } = normalizeAndValidateConfig(
+        rawConfig,
+        undefined,
+        "DEV"
+      );
+      expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+        "Processing wrangler configuration:
+        "
+      `);
+      expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+        "Processing wrangler configuration:
+          - No environment found in configuration with name \\"DEV\\".
+            Before using \`--env=DEV\` there should be an equivalent environment section in the configuration.
+
+            Consider adding an environment configuration section to the wrangler.toml file:
+            \`\`\`
+            [env.DEV]
+            \`\`\`
+        "
+      `);
+    });
+
+    it("should warn if we specify an environment that does not match the named environments", () => {
+      const rawConfig: RawConfig = { env: { ENV1: {} } };
+      const { diagnostics } = normalizeAndValidateConfig(
+        rawConfig,
+        undefined,
+        "DEV"
+      );
+      expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+        "Processing wrangler configuration:
+          - No environment found in configuration with name \\"DEV\\".
+            Before using \`--env=DEV\` there should be an equivalent environment section in the configuration.
+            The available configured environment names are: [\\"ENV1\\"]
+
+            Consider adding an environment configuration section to the wrangler.toml file:
+            \`\`\`
+            [env.DEV]
+            \`\`\`
+        "
+      `);
+      expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+        "Processing wrangler configuration:
+        "
+      `);
+    });
+
     it("should use top-level values for inheritable config fields", () => {
       const expectedConfig: RawConfig = {
         name: "NAME",
@@ -1364,10 +1468,11 @@ describe("normalizeAndValidateConfig()", () => {
 
       const { config, diagnostics } = normalizeAndValidateConfig(
         { ...expectedConfig, env: { DEV: {} } },
-        undefined
+        undefined,
+        "DEV"
       );
 
-      expect(config.env.DEV).toEqual(expect.objectContaining(expectedConfig));
+      expect(config).toEqual(expect.objectContaining(expectedConfig));
       expect(diagnostics.hasErrors()).toBe(false);
       expect(diagnostics.hasWarnings()).toBe(false);
     });
@@ -1403,10 +1508,11 @@ describe("normalizeAndValidateConfig()", () => {
 
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig,
-        undefined
+        undefined,
+        "ENV1"
       );
 
-      expect(config.env.ENV1).toEqual(expect.objectContaining(environment));
+      expect(config).toEqual(expect.objectContaining(environment));
       expect(diagnostics.hasErrors()).toBe(false);
       expect(diagnostics.hasWarnings()).toBe(false);
     });
@@ -1421,10 +1527,11 @@ describe("normalizeAndValidateConfig()", () => {
 
         const { config, diagnostics } = normalizeAndValidateConfig(
           rawConfig,
-          undefined
+          undefined,
+          "DEV"
         );
 
-        expect(config.env.DEV.name).toEqual("NAME");
+        expect(config.name).toEqual("NAME");
         expect(diagnostics.hasErrors()).toBe(false);
         expect(diagnostics.hasWarnings()).toBe(false);
       });
@@ -1441,10 +1548,11 @@ describe("normalizeAndValidateConfig()", () => {
 
         const { config, diagnostics } = normalizeAndValidateConfig(
           rawConfig,
-          undefined
+          undefined,
+          "DEV"
         );
 
-        expect(config.env.DEV.name).toBeUndefined();
+        expect(config.name).toBeUndefined();
         expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
           "Processing wrangler configuration:
 
@@ -1468,10 +1576,11 @@ describe("normalizeAndValidateConfig()", () => {
 
         const { config, diagnostics } = normalizeAndValidateConfig(
           rawConfig,
-          undefined
+          undefined,
+          "DEV"
         );
 
-        expect(config.env.DEV.name).toEqual("NAME");
+        expect(config.name).toEqual("NAME");
         expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
           "Processing wrangler configuration:
 
@@ -1506,10 +1615,11 @@ describe("normalizeAndValidateConfig()", () => {
 
       const { config, diagnostics } = normalizeAndValidateConfig(
         rawConfig,
-        undefined
+        undefined,
+        "ENV1"
       );
 
-      expect(config.env.ENV1).toEqual(
+      expect(config).toEqual(
         expect.not.objectContaining({
           vars,
           durable_objects,
@@ -1558,10 +1668,11 @@ describe("normalizeAndValidateConfig()", () => {
 
       const { config, diagnostics } = normalizeAndValidateConfig(
         { env: { ENV1: expectedConfig } },
-        undefined
+        undefined,
+        "ENV1"
       );
 
-      expect(config.env.ENV1).toEqual(expect.objectContaining(expectedConfig));
+      expect(config).toEqual(expect.objectContaining(expectedConfig));
       expect(diagnostics.hasWarnings()).toBe(false);
       expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
         "Processing wrangler configuration:
@@ -1585,10 +1696,11 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if durable_objects is an array", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { durable_objects: [] } } } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({ durable_objects: expect.anything })
         );
         expect(diagnostics.hasWarnings()).toBe(false);
@@ -1603,10 +1715,11 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if durable_objects is a string", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { durable_objects: "BAD" } } } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({ durable_objects: expect.anything })
         );
         expect(diagnostics.hasWarnings()).toBe(false);
@@ -1621,10 +1734,11 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if durable_objects is a number", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { durable_objects: 999 } } } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({ durable_objects: expect.anything })
         );
         expect(diagnostics.hasWarnings()).toBe(false);
@@ -1639,10 +1753,11 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if durable_objects is null", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { durable_objects: null } } } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({ durable_objects: expect.anything })
         );
         expect(diagnostics.hasWarnings()).toBe(false);
@@ -1657,10 +1772,11 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if durable_objects.bindings is not defined", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { durable_objects: {} } } } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({ durable_objects: expect.anything })
         );
         expect(diagnostics.hasWarnings()).toBe(false);
@@ -1677,10 +1793,11 @@ describe("normalizeAndValidateConfig()", () => {
           {
             env: { ENV1: { durable_objects: { bindings: {} } } },
           } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({
             durable_objects: { bindings: expect.anything },
           })
@@ -1699,10 +1816,11 @@ describe("normalizeAndValidateConfig()", () => {
           {
             env: { ENV1: { durable_objects: { bindings: "BAD" } } },
           } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({
             durable_objects: { bindings: expect.anything },
           })
@@ -1721,10 +1839,11 @@ describe("normalizeAndValidateConfig()", () => {
           {
             env: { ENV1: { durable_objects: { bindings: 999 } } },
           } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({
             durable_objects: { bindings: expect.anything },
           })
@@ -1743,10 +1862,11 @@ describe("normalizeAndValidateConfig()", () => {
           {
             env: { ENV1: { durable_objects: { bindings: null } } },
           } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({
             durable_objects: { bindings: expect.anything },
           })
@@ -1780,10 +1900,11 @@ describe("normalizeAndValidateConfig()", () => {
               },
             },
           } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({
             durable_objects: { bindings: expect.anything },
           })
@@ -1817,10 +1938,11 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if kv_namespaces is an object", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { kv_namespaces: {} } } } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({ kv_namespaces: expect.anything })
         );
         expect(diagnostics.hasWarnings()).toBe(false);
@@ -1835,10 +1957,11 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if kv_namespaces is a string", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { kv_namespaces: "BAD" } } } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({ kv_namespaces: expect.anything })
         );
         expect(diagnostics.hasWarnings()).toBe(false);
@@ -1853,10 +1976,11 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if kv_namespaces is a number", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { kv_namespaces: 999 } } } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({ kv_namespaces: expect.anything })
         );
         expect(diagnostics.hasWarnings()).toBe(false);
@@ -1871,10 +1995,11 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if kv_namespaces is null", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { kv_namespaces: null } } } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({ kv_namespaces: expect.anything })
         );
         expect(diagnostics.hasWarnings()).toBe(false);
@@ -1904,10 +2029,11 @@ describe("normalizeAndValidateConfig()", () => {
               },
             },
           } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({
             kv_namespaces: { bindings: expect.anything },
           })
@@ -1931,10 +2057,11 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if r2_buckets is an object", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { r2_buckets: {} } } } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({ r2_buckets: expect.anything })
         );
         expect(diagnostics.hasWarnings()).toBe(false);
@@ -1949,10 +2076,11 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if r2_buckets is a string", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { r2_buckets: "BAD" } } } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({ r2_buckets: expect.anything })
         );
         expect(diagnostics.hasWarnings()).toBe(false);
@@ -1967,10 +2095,11 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if r2_buckets is a number", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { r2_buckets: 999 } } } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({ r2_buckets: expect.anything })
         );
         expect(diagnostics.hasWarnings()).toBe(false);
@@ -1985,10 +2114,11 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if r2_buckets is null", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { r2_buckets: null } } } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({ r2_buckets: expect.anything })
         );
         expect(diagnostics.hasWarnings()).toBe(false);
@@ -2018,10 +2148,11 @@ describe("normalizeAndValidateConfig()", () => {
               },
             },
           } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({
             r2_buckets: { bindings: expect.anything },
           })
@@ -2045,10 +2176,11 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if unsafe is an array", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { unsafe: [] } } } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({ unsafe: expect.anything })
         );
         expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
@@ -2068,10 +2200,11 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if unsafe is a string", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { unsafe: "BAD" } } } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({ unsafe: expect.anything })
         );
         expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
@@ -2091,10 +2224,11 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if unsafe is a number", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { unsafe: 999 } } } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({ unsafe: expect.anything })
         );
         expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
@@ -2114,10 +2248,11 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if unsafe is null", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { unsafe: null } } } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({ unsafe: expect.anything })
         );
         expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
@@ -2137,10 +2272,11 @@ describe("normalizeAndValidateConfig()", () => {
       it("should error if unsafe.bindings is not defined", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { unsafe: {} } } } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({ unsafe: expect.anything })
         );
         expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
@@ -2162,10 +2298,11 @@ describe("normalizeAndValidateConfig()", () => {
           {
             env: { ENV1: { unsafe: { bindings: {} } } },
           } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({
             unsafe: { bindings: expect.anything },
           })
@@ -2189,10 +2326,11 @@ describe("normalizeAndValidateConfig()", () => {
           {
             env: { ENV1: { unsafe: { bindings: "BAD" } } },
           } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({
             unsafe: { bindings: expect.anything },
           })
@@ -2216,10 +2354,11 @@ describe("normalizeAndValidateConfig()", () => {
           {
             env: { ENV1: { unsafe: { bindings: 999 } } },
           } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({
             unsafe: { bindings: expect.anything },
           })
@@ -2243,10 +2382,11 @@ describe("normalizeAndValidateConfig()", () => {
           {
             env: { ENV1: { unsafe: { bindings: null } } },
           } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({
             unsafe: { bindings: expect.anything },
           })
@@ -2285,10 +2425,11 @@ describe("normalizeAndValidateConfig()", () => {
               },
             },
           } as unknown as RawConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(
+        expect(config).toEqual(
           expect.not.objectContaining({
             durable_objects: { bindings: expect.anything },
           })
@@ -2337,12 +2478,13 @@ describe("normalizeAndValidateConfig()", () => {
               ENV1: environment,
             },
           },
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect("experimental_services" in config.env.ENV1).toBe(false);
+        expect("experimental_services" in config).toBe(false);
         // Zone is not removed yet, since `route` commands might use it
-        expect(config.env.ENV1.zone_id).toEqual("ZONE_ID");
+        expect(config.zone_id).toEqual("ZONE_ID");
         expect(diagnostics.hasErrors()).toBe(false);
         expect(diagnostics.hasWarnings()).toBe(true);
         expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
@@ -2397,10 +2539,11 @@ describe("normalizeAndValidateConfig()", () => {
 
         const { config, diagnostics } = normalizeAndValidateConfig(
           expectedConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(expect.objectContaining(environment));
+        expect(config).toEqual(expect.objectContaining(environment));
         expect(diagnostics.hasErrors()).toBe(true);
         expect(diagnostics.hasWarnings()).toBe(false);
 
@@ -2444,10 +2587,11 @@ describe("normalizeAndValidateConfig()", () => {
 
         const { config, diagnostics } = normalizeAndValidateConfig(
           expectedConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(expect.objectContaining(environment));
+        expect(config).toEqual(expect.objectContaining(environment));
         expect(diagnostics.hasErrors()).toBe(true);
         expect(diagnostics.hasWarnings()).toBe(false);
 
@@ -2488,10 +2632,11 @@ describe("normalizeAndValidateConfig()", () => {
 
         const { config, diagnostics } = normalizeAndValidateConfig(
           expectedConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(expect.objectContaining(environment));
+        expect(config).toEqual(expect.objectContaining(environment));
         expect(diagnostics.hasErrors()).toBe(false);
         expect(diagnostics.hasWarnings()).toBe(false);
       });
@@ -2527,10 +2672,11 @@ describe("normalizeAndValidateConfig()", () => {
 
         const { config, diagnostics } = normalizeAndValidateConfig(
           expectedConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(expect.objectContaining(environment));
+        expect(config).toEqual(expect.objectContaining(environment));
         expect(diagnostics.hasErrors()).toBe(false);
         expect(diagnostics.hasWarnings()).toBe(false);
       });
@@ -2577,15 +2723,25 @@ describe("normalizeAndValidateConfig()", () => {
           },
         };
 
-        const { config, diagnostics } = normalizeAndValidateConfig(
+        const result1 = normalizeAndValidateConfig(
           expectedConfig,
-          undefined
+          undefined,
+          "ENV1"
         );
 
-        expect(config.env.ENV1).toEqual(expect.objectContaining(environment1));
-        expect(config.env.ENV2).toEqual(expect.objectContaining(environment2));
-        expect(diagnostics.hasErrors()).toBe(false);
-        expect(diagnostics.hasWarnings()).toBe(false);
+        expect(result1.config).toEqual(expect.objectContaining(environment1));
+        expect(result1.diagnostics.hasErrors()).toBe(false);
+        expect(result1.diagnostics.hasWarnings()).toBe(false);
+
+        const result2 = normalizeAndValidateConfig(
+          expectedConfig,
+          undefined,
+          "ENV2"
+        );
+
+        expect(result2.config).toEqual(expect.objectContaining(environment2));
+        expect(result2.diagnostics.hasErrors()).toBe(false);
+        expect(result2.diagnostics.hasWarnings()).toBe(false);
       });
     });
   });

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -38,7 +38,7 @@ describe("publish", () => {
 
   describe("environments", () => {
     it("should use legacy environments by default", async () => {
-      writeWranglerToml();
+      writeWranglerToml({ env: { "some-env": {} } });
       writeWorkerSource();
       mockSubDomainRequest();
       mockUploadWorkerRequest({
@@ -74,7 +74,7 @@ describe("publish", () => {
       });
 
       it("appends the environment name when provided", async () => {
-        writeWranglerToml();
+        writeWranglerToml({ env: { "some-env": {} } });
         writeWorkerSource();
         mockSubDomainRequest();
         mockUploadWorkerRequest({
@@ -111,7 +111,7 @@ describe("publish", () => {
       });
 
       it("publishes as an environment when provided", async () => {
-        writeWranglerToml();
+        writeWranglerToml({ env: { "some-env": {} } });
         writeWorkerSource();
         mockSubDomainRequest();
         mockUploadWorkerRequest({
@@ -714,6 +714,7 @@ export default{
         site: {
           bucket: "assets",
         },
+        env: { "some-env": {} },
       });
       writeWorkerSource();
       writeAssets(assets);
@@ -760,6 +761,7 @@ export default{
         site: {
           bucket: "assets",
         },
+        env: { "some-env": {} },
       });
       writeWorkerSource();
       writeAssets(assets);

--- a/packages/wrangler/src/config/README.md
+++ b/packages/wrangler/src/config/README.md
@@ -25,24 +25,23 @@ This includes the `EnvironmentInheritable` and `EnvironmentNonInheritable` field
 ### Config
 
 The "non-overridable" types are defined in the [`ConfigFields`](./config.ts) type.
-Notably this also contains a property called `env` which is the container for the named environment configuration.
-
 The `Config` type is the overall configuration, which consists of the `ConfigFields` and also an `Environment`.
-In this case the `Environment`, here, corresponds to the top level environment.
+In this case the `Environment`, here, corresponds to the "currently active" environment. This is specified by the `--env` command line argument.
+If there is no argument passed then the currently active environment is the "top-level" environment.
 The fields in `Config` and `Environment` are not generally optional and so you can expect they have been filled with suitable inherited or default values.
 These types should be used when you are working with fields that should be passed to commands.
 
 ### RawConfig
 
 The `RawConfig` type is a version of `Config`, where all the fields are optional.
-The `RawConfig` type also includes `DeprecatedConfigFields` and extends and contains the `RawEnvironment` type,
-which is a version of `Environment` where all the fields are optional.
+The `RawConfig` type includes `DeprecatedConfigFields` and `EnvironmentMap`.
+It also extends the `RawEnvironment` type, which is a version of `Environment` where all the fields are optional.
 These optional fields map to the actual fields found in the `wrangler.toml`.
 These types should be used when you are working with raw configuration that is read or will be written to a `wrangler.toml`.
 
 ## Validation
 
-Validation is triggered by passing a `RawConfig` object to the `normalizeAndValidateConfig()` function.
+Validation is triggered by passing a `RawConfig` object, and the active environment name, to the `normalizeAndValidateConfig()` function.
 This function will return:
 
 - a `Config` object, where all the fields have suitable valid values
@@ -62,6 +61,7 @@ The [high level API](./index.ts) for configuration processing consists of the `f
 ### readConfig()
 
 The `readConfig()` function will find the nearest `wrangler.toml` file, load and parse it, then validate and normalize the values into a `Config` object.
+Note that you should pass the current active environment name in as a parameter. The resulting `Config` object will contain only the fields appropriate to that environment.
 If there are validation errors then it will throw a suitable error.
 
 ## Changing configuration

--- a/packages/wrangler/src/config/config.ts
+++ b/packages/wrangler/src/config/config.ts
@@ -3,7 +3,7 @@ import type { Environment, RawEnvironment } from "./environment";
 /**
  * This is the static type definition for the configuration object.
  *
- * It reflects the configuration that you can write in wrangler.toml,
+ * It reflects a normalized and validated version of the configuration that you can write in wrangler.toml,
  * and optionally augment with arguments passed directly to wrangler.
  *
  * For more information about the configuration object, see the
@@ -20,16 +20,14 @@ import type { Environment, RawEnvironment } from "./environment";
  * - `@breaking`: the deprecation/optionality is a breaking change from wrangler 1.
  * - `@todo`: there's more work to be done (with details attached).
  */
-export type Config = ConfigFields<Environment, DevConfig> & Environment;
+export type Config = ConfigFields<DevConfig> & Environment;
 
-export type RawConfig = Partial<ConfigFields<RawEnvironment, RawDevConfig>> &
+export type RawConfig = Partial<ConfigFields<RawDevConfig>> &
   RawEnvironment &
-  DeprecatedConfigFields;
+  DeprecatedConfigFields &
+  EnvironmentMap;
 
-export interface ConfigFields<
-  Env extends RawEnvironment,
-  Dev extends RawDevConfig
-> {
+export interface ConfigFields<Dev extends RawDevConfig> {
   configPath: string | undefined;
 
   /**
@@ -39,22 +37,6 @@ export interface ConfigFields<
    * to `true` to enable it.
    */
   legacy_env: boolean;
-
-  /**
-   * The `env` section defines overrides for the configuration for different environments.
-   *
-   * All environment fields can be specified at the top level of the config indicating the default environment settings.
-   *
-   * - Some fields are inherited and overridable in each environment.
-   * - But some are not inherited and must be explicitly specified in every environment, if they are specified at the top level.
-   *
-   * For more information, see the documentation at https://developers.cloudflare.com/workers/cli-wrangler/configuration#environments
-   *
-   * @default `{}`
-   */
-  env: {
-    [envName: string]: Env;
-  };
 
   /**
    * Options to configure the development server that your worker will use.
@@ -271,4 +253,22 @@ export interface DeprecatedUpload {
    * @deprecated This is now defined at the top level `rules` field.
    */
   rules?: Environment["rules"];
+}
+
+interface EnvironmentMap {
+  /**
+   * The `env` section defines overrides for the configuration for different environments.
+   *
+   * All environment fields can be specified at the top level of the config indicating the default environment settings.
+   *
+   * - Some fields are inherited and overridable in each environment.
+   * - But some are not inherited and must be explicitly specified in every environment, if they are specified at the top level.
+   *
+   * For more information, see the documentation at https://developers.cloudflare.com/workers/cli-wrangler/configuration#environments
+   *
+   * @default `{}`
+   */
+  env?: {
+    [envName: string]: RawEnvironment;
+  };
 }

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -13,7 +13,10 @@ export type {
 /**
  * Get the Wrangler configuration; read it from the give `configPath` if available.
  */
-export function readConfig(configPath?: string): Config {
+export function readConfig(
+  configPath: string | undefined,
+  envName: string | undefined
+): Config {
   let rawConfig: RawConfig = {};
   if (!configPath) {
     configPath = findWranglerToml();
@@ -27,7 +30,8 @@ export function readConfig(configPath?: string): Config {
   // Process the top-level configuration.
   const { config, diagnostics } = normalizeAndValidateConfig(
     rawConfig,
-    configPath
+    configPath,
+    envName
   );
 
   if (diagnostics.hasWarnings()) {

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -38,25 +38,19 @@ export default async function publish(props: Props): Promise<void> {
   // TODO: warn if git/hg has uncommitted changes
   const { config, accountId } = props;
 
-  // TODO: should we automatically fallback to top level config if there is no matching environment??
-  const envRootObj = (props.env && config.env[props.env]) || config;
-
   assert(
-    props.compatibilityDate || envRootObj.compatibility_date,
+    props.compatibilityDate || config.compatibility_date,
     "A compatibility_date is required when publishing. Add one to your wrangler.toml file, or pass it in your terminal as --compatibility_date. See https://developers.cloudflare.com/workers/platform/compatibility-dates for more information."
   );
 
-  const triggers = props.triggers || envRootObj.triggers?.crons;
+  const triggers = props.triggers || config.triggers?.crons;
   const routes =
-    props.routes ??
-    envRootObj.routes ??
-    (envRootObj.route ? [envRootObj.route] : []) ??
-    [];
+    props.routes ?? config.routes ?? (config.route ? [config.route] : []) ?? [];
 
-  const deployToWorkersDev = envRootObj.workers_dev;
+  const deployToWorkersDev = config.workers_dev;
 
-  const jsxFactory = props.jsxFactory || envRootObj.jsx_factory;
-  const jsxFragment = props.jsxFragment || envRootObj.jsx_fragment;
+  const jsxFactory = props.jsxFactory || config.jsx_factory;
+  const jsxFragment = props.jsxFragment || config.jsx_fragment;
 
   const scriptName = props.name;
   assert(
@@ -160,12 +154,12 @@ export default async function publish(props: Props): Promise<void> {
     );
 
     const bindings: CfWorkerInit["bindings"] = {
-      kv_namespaces: (envRootObj.kv_namespaces || []).concat(
+      kv_namespaces: (config.kv_namespaces || []).concat(
         assets.namespace
           ? { binding: "__STATIC_CONTENT", id: assets.namespace }
           : []
       ),
-      vars: envRootObj.vars,
+      vars: config.vars,
       wasm_modules: config.wasm_modules,
       text_blobs: {
         ...config.text_blobs,
@@ -174,9 +168,9 @@ export default async function publish(props: Props): Promise<void> {
             __STATIC_CONTENT_MANIFEST: "__STATIC_CONTENT_MANIFEST",
           }),
       },
-      durable_objects: envRootObj.durable_objects,
-      r2_buckets: envRootObj.r2_buckets,
-      unsafe: envRootObj.unsafe?.bindings,
+      durable_objects: config.durable_objects,
+      r2_buckets: config.r2_buckets,
+      unsafe: config.unsafe?.bindings,
     };
 
     if (assets.manifest) {
@@ -197,11 +191,10 @@ export default async function publish(props: Props): Promise<void> {
       bindings,
       migrations,
       modules,
-      compatibility_date:
-        props.compatibilityDate ?? envRootObj.compatibility_date,
+      compatibility_date: props.compatibilityDate ?? config.compatibility_date,
       compatibility_flags:
-        props.compatibilityFlags ?? envRootObj.compatibility_flags,
-      usage_model: envRootObj.usage_model,
+        props.compatibilityFlags ?? config.compatibility_flags,
+      usage_model: config.usage_model,
     };
 
     const start = Date.now();


### PR DESCRIPTION
Now, when we normalize and validate the raw config, we pass in the currently
active environment name, and the config that is returned contains all the
environment fields correctly normalized (including inheritance) at the top
level of the config object. This avoids other commands from having to check
both the current named environment and the top-level config for such fields.

Also, now, handle the case where the active environment name passed in via the
`--env` command line argument does not match any of the named environments
in the configuration:

- This is an error if there are named environments configured;
- or only a warning if there are no named environments configured.