### PR TITLE
fix: allow the `build` field to be inherited/overridden in a named environment

### DIFF
--- a/.changeset/mean-goats-hang.md
+++ b/.changeset/mean-goats-hang.md
@@ -1,0 +1,10 @@
+---
+"wrangler": patch
+---
+
+fix: allow the `build` field to be inherited/overridden in a named environment"
+
+Now the `build` field can be specified within a named environment, overriding whatever
+may appear at the top level.
+
+Resolves https://github.com/cloudflare/wrangler2/issues/588

--- a/packages/wrangler/src/config/config.ts
+++ b/packages/wrangler/src/config/config.ts
@@ -135,28 +135,6 @@ export interface ConfigFields<Dev extends RawDevConfig> {
         [key: string]: string;
       }
     | undefined;
-
-  /**
-   * Configures a custom build step to be run by Wrangler when building your Worker.
-   *
-   * Refer to the [custom builds documentation](https://developers.cloudflare.com/workers/cli-wrangler/configuration#build)
-   * for more details.
-   *
-   * @default {}
-   */
-  build: {
-    /** The command used to build your Worker. On Linux and macOS, the command is executed in the `sh` shell and the `cmd` shell for Windows. The `&&` and `||` shell operators may be used. */
-    command?: string;
-    /** The directory in which the command is executed. */
-    cwd?: string;
-    /** The directory to watch for changes while using wrangler dev, defaults to the current working directory */
-    watch_dir?: string;
-    /**
-     * Deprecated field previously used to configure the build and upload of the script.
-     * @deprecated
-     */
-    upload?: DeprecatedUpload;
-  };
 }
 
 export interface DevConfig {
@@ -219,40 +197,6 @@ export interface DeprecatedConfigFields {
    * @breaking
    */
   webpack_config?: string;
-}
-
-/**
- * Deprecated upload configuration.
- */
-export interface DeprecatedUpload {
-  /**
-   * The format of the Worker script.
-   *
-   * @deprecated We infer the format automatically now.
-   */
-  format?: "modules" | "service-worker";
-
-  /**
-   * The directory you wish to upload your worker from,
-   * relative to the wrangler.toml file.
-   *
-   * Defaults to the directory containing the wrangler.toml file.
-   *
-   * @deprecated
-   */
-  dir?: string;
-
-  /**
-   * The path to the Worker script, relative to `upload.dir`.
-   *
-   * @deprecated This will be replaced by a command line argument.
-   */
-  main?: string;
-
-  /**
-   * @deprecated This is now defined at the top level `rules` field.
-   */
-  rules?: Environment["rules"];
 }
 
 interface EnvironmentMap {

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -139,6 +139,28 @@ interface EnvironmentInheritable {
   rules: Rule[];
 
   /**
+   * Configures a custom build step to be run by Wrangler when building your Worker.
+   *
+   * Refer to the [custom builds documentation](https://developers.cloudflare.com/workers/cli-wrangler/configuration#build)
+   * for more details.
+   *
+   * @default {}
+   */
+  build: {
+    /** The command used to build your Worker. On Linux and macOS, the command is executed in the `sh` shell and the `cmd` shell for Windows. The `&&` and `||` shell operators may be used. */
+    command?: string;
+    /** The directory in which the command is executed. */
+    cwd?: string;
+    /** The directory to watch for changes while using wrangler dev, defaults to the current working directory */
+    watch_dir?: string;
+    /**
+     * Deprecated field previously used to configure the build and upload of the script.
+     * @deprecated
+     */
+    upload?: DeprecatedUpload;
+  };
+
+  /**
    * TODO: remove this as it has been deprecated.
    *
    * This is just here for now because the `route` commands use it.
@@ -280,6 +302,40 @@ interface EnvironmentDeprecated {
     /** The Service's environment */
     environment: string;
   }[];
+}
+
+/**
+ * Deprecated upload configuration.
+ */
+export interface DeprecatedUpload {
+  /**
+   * The format of the Worker script.
+   *
+   * @deprecated We infer the format automatically now.
+   */
+  format?: "modules" | "service-worker";
+
+  /**
+   * The directory you wish to upload your worker from,
+   * relative to the wrangler.toml file.
+   *
+   * Defaults to the directory containing the wrangler.toml file.
+   *
+   * @deprecated
+   */
+  dir?: string;
+
+  /**
+   * The path to the Worker script, relative to `upload.dir`.
+   *
+   * @deprecated This will be replaced by a command line argument.
+   */
+  main?: string;
+
+  /**
+   * @deprecated This is now defined at the top level `rules` field.
+   */
+  rules?: Environment["rules"];
 }
 
 /**

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -3,7 +3,13 @@ import { parseTOML, readFileSync } from "../parse";
 import { normalizeAndValidateConfig } from "./validation";
 import type { Config, RawConfig } from "./config";
 
-export type { Config, RawConfig } from "./config";
+export type {
+  Config,
+  RawConfig,
+  ConfigFields,
+  DevConfig,
+  RawDevConfig,
+} from "./config";
 export type {
   Environment,
   RawEnvironment,


### PR DESCRIPTION
Now the `build` field can be specified within a named environment, overriding whatever
may appear at the top level.

Resolves https://github.com/cloudflare/wrangler2/issues/588