### PR TITLE
fix: resolve non-js modules correctly in local mode

### DIFF
--- a/.changeset/gold-forks-retire.md
+++ b/.changeset/gold-forks-retire.md
@@ -1,0 +1,16 @@
+---
+"wrangler": patch
+---
+
+fix: resolve non-js modules correctly in local mode
+
+In https://github.com/cloudflare/wrangler2/pull/633, we missed passing a cwd to the process that runs the miniflare cli. This broke how miniflare resolves modules, and led back to the dreaded "path should be a `path.relative()`d string" error. The fix is to simply pass the cwd to the `spawn` call.
+
+Test plan:
+
+```
+cd packages/wrangler
+npm run build
+cd ../workers-chat-demo
+npx wrangler dev --local
+```

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 packages/wrangler/vendor/
 packages/wrangler/wrangler-dist/
+packages/wrangler/miniflare-dist/
 packages/example-worker-app/dist/
 packages/example-remix-pages-app/build
 packages/example-remix-pages-app/public/

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -144,14 +144,20 @@ function useLocalWorker({
       const optionsArg = JSON.stringify(options, null);
 
       console.log("⎔ Starting a local server...");
-      local.current = spawn("node", [
-        "--experimental-vm-modules", // ensures that Miniflare can run ESM Workers
-        "--no-warnings", // hide annoying Node warnings
-        "--inspect", // start Miniflare listening for a debugger to attach
-        miniflareCLIPath,
-        optionsArg,
-        // "--log=VERBOSE", // uncomment this to Miniflare to log "everything"!
-      ]);
+      local.current = spawn(
+        "node",
+        [
+          "--experimental-vm-modules", // ensures that Miniflare can run ESM Workers
+          "--no-warnings", // hide annoying Node warnings
+          "--inspect", // start Miniflare listening for a debugger to attach
+          miniflareCLIPath,
+          optionsArg,
+          // "--log=VERBOSE", // uncomment this to Miniflare to log "everything"!
+        ],
+        {
+          cwd: path.dirname(scriptPath),
+        }
+      );
 
       local.current.on("close", (code) => {
         if (code) {


### PR DESCRIPTION
In https://github.com/cloudflare/wrangler2/pull/633, we missed passing a cwd to the process that runs the miniflare cli. This broke how miniflare resolves modules, and led back to the dreaded "path should be a `path.relative()`d string" error. The fix is to simply pass the cwd to the `spawn` call.

Test plan
```
cd packages/wrangler 
npm run build
cd ../workers-chat-demo 
npx wrangler dev --local
```