### PR TITLE
Support backwards compatibility with environment names and related CLI flags

### DIFF
--- a/.changeset/swift-apes-battle.md
+++ b/.changeset/swift-apes-battle.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+---
+
+refactor: support backwards compatibility with environment names and related CLI flags
+
+1. When in Legacy environment mode we should not compute name field if specified in an environment.
+2. Throw an Error when `--env` and `--name` are used together in Legacy Environment, except for Secrets & Tail which are using a special case `getLegacyScriptName` for parity with Wrangler1
+3. Started the refactor for args being utilized at the Config level, currently checking for Legacy Environment only.
+
+Fixes https://github.com/cloudflare/wrangler2/issues/672

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -12,7 +12,8 @@ describe("normalizeAndValidateConfig()", () => {
     const { config, diagnostics } = normalizeAndValidateConfig(
       {},
       undefined,
-      undefined
+      undefined,
+      {}
     );
 
     expect(config).toEqual({
@@ -79,7 +80,8 @@ describe("normalizeAndValidateConfig()", () => {
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig,
         undefined,
-        undefined
+        undefined,
+        {}
       );
 
       expect(config).toEqual(expect.objectContaining(expectedConfig));
@@ -101,7 +103,8 @@ describe("normalizeAndValidateConfig()", () => {
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig as unknown as RawConfig,
         undefined,
-        undefined
+        undefined,
+        {}
       );
 
       expect(config).toEqual(
@@ -128,7 +131,8 @@ describe("normalizeAndValidateConfig()", () => {
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig as unknown as RawConfig,
         undefined,
-        undefined
+        undefined,
+        {}
       );
 
       expect("unexpected" in config).toBe(false);
@@ -149,7 +153,8 @@ describe("normalizeAndValidateConfig()", () => {
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig as unknown as RawConfig,
         undefined,
-        undefined
+        undefined,
+        {}
       );
 
       expect("miniflare" in config).toBe(false);
@@ -180,7 +185,8 @@ describe("normalizeAndValidateConfig()", () => {
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig,
         undefined,
-        undefined
+        undefined,
+        {}
       );
 
       expect(config).toEqual(expect.objectContaining(expectedConfig));
@@ -208,7 +214,8 @@ describe("normalizeAndValidateConfig()", () => {
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig as unknown as RawConfig,
         undefined,
-        undefined
+        undefined,
+        {}
       );
 
       expect(config).toEqual(expect.objectContaining(expectedConfig));
@@ -237,7 +244,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           expectedConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(expect.objectContaining(expectedConfig));
@@ -257,7 +265,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           expectedConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(expect.objectContaining(expectedConfig));
@@ -281,7 +290,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           expectedConfig as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(expect.objectContaining(expectedConfig));
@@ -304,7 +314,8 @@ describe("normalizeAndValidateConfig()", () => {
             },
           } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config.site).toMatchInlineSnapshot(`
@@ -340,7 +351,8 @@ describe("normalizeAndValidateConfig()", () => {
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig,
         "project/wrangler.toml",
-        undefined
+        undefined,
+        {}
       );
 
       expect(config).toEqual(
@@ -366,7 +378,8 @@ describe("normalizeAndValidateConfig()", () => {
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig as unknown as RawConfig,
         "project/wrangler.toml",
-        undefined
+        undefined,
+        {}
       );
 
       expect(config).toEqual(
@@ -393,7 +406,8 @@ describe("normalizeAndValidateConfig()", () => {
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig,
         "project/wrangler.toml",
-        undefined
+        undefined,
+        {}
       );
 
       expect(config).toEqual(
@@ -419,7 +433,8 @@ describe("normalizeAndValidateConfig()", () => {
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig as unknown as RawConfig,
         "project/wrangler.toml",
-        undefined
+        undefined,
+        {}
       );
 
       expect(config).toEqual(
@@ -445,7 +460,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           rawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         // Note the `.not.` here...
@@ -535,7 +551,8 @@ describe("normalizeAndValidateConfig()", () => {
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig,
         undefined,
-        undefined
+        undefined,
+        {}
       );
 
       expect(config).toEqual(
@@ -572,7 +589,8 @@ describe("normalizeAndValidateConfig()", () => {
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig,
         undefined,
-        undefined
+        undefined,
+        {}
       );
 
       expect(config).toEqual(expect.objectContaining(expectedConfig));
@@ -612,7 +630,8 @@ describe("normalizeAndValidateConfig()", () => {
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig,
         path.resolve("project/wrangler.toml"),
-        undefined
+        undefined,
+        {}
       );
 
       expect(config.main).toEqual(path.resolve("project/src/index.ts"));
@@ -652,7 +671,8 @@ describe("normalizeAndValidateConfig()", () => {
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig,
         undefined,
-        undefined
+        undefined,
+        {}
       );
 
       expect(config.build).toEqual(
@@ -677,7 +697,8 @@ describe("normalizeAndValidateConfig()", () => {
       const { config, diagnostics } = normalizeAndValidateConfig(
         expectedConfig,
         "project/wrangler.toml",
-        undefined
+        undefined,
+        {}
       );
 
       expect(config.build).toEqual(
@@ -696,7 +717,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { durable_objects: [] } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -713,7 +735,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { durable_objects: "BAD" } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -730,7 +753,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { durable_objects: 999 } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -747,7 +771,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { durable_objects: null } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -764,7 +789,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { durable_objects: {} } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -781,7 +807,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { durable_objects: { bindings: {} } } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -800,7 +827,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { durable_objects: { bindings: "BAD" } } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -819,7 +847,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { durable_objects: { bindings: 999 } } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -838,7 +867,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { durable_objects: { bindings: null } } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -870,7 +900,8 @@ describe("normalizeAndValidateConfig()", () => {
             },
           } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -906,7 +937,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { kv_namespaces: {} } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -923,7 +955,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { kv_namespaces: "BAD" } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -940,7 +973,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { kv_namespaces: 999 } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -957,7 +991,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { kv_namespaces: null } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -985,7 +1020,8 @@ describe("normalizeAndValidateConfig()", () => {
             ],
           } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -1011,7 +1047,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { r2_buckets: {} } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -1028,7 +1065,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { r2_buckets: "BAD" } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -1045,7 +1083,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { r2_buckets: 999 } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -1062,7 +1101,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { r2_buckets: null } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -1090,7 +1130,8 @@ describe("normalizeAndValidateConfig()", () => {
             ],
           } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -1116,7 +1157,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { unsafe: [] } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -1136,7 +1178,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { unsafe: "BAD" } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -1156,7 +1199,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { unsafe: 999 } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -1176,7 +1220,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { unsafe: null } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -1196,7 +1241,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { unsafe: {} } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -1216,7 +1262,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { unsafe: { bindings: {} } } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -1238,7 +1285,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { unsafe: { bindings: "BAD" } } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -1260,7 +1308,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { unsafe: { bindings: 999 } } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -1282,7 +1331,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { unsafe: { bindings: null } } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -1317,7 +1367,8 @@ describe("normalizeAndValidateConfig()", () => {
             },
           } as unknown as RawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(config).toEqual(
@@ -1362,7 +1413,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           rawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect("experimental_services" in config).toBe(false);
@@ -1397,7 +1449,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { diagnostics } = normalizeAndValidateConfig(
           rawConfig,
           undefined,
-          undefined
+          undefined,
+          {}
         );
 
         expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
@@ -1414,7 +1467,8 @@ describe("normalizeAndValidateConfig()", () => {
       const { diagnostics } = normalizeAndValidateConfig(
         rawConfig,
         undefined,
-        "DEV"
+        "DEV",
+        {}
       );
       expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
         "Processing wrangler configuration:
@@ -1438,7 +1492,8 @@ describe("normalizeAndValidateConfig()", () => {
       const { diagnostics } = normalizeAndValidateConfig(
         rawConfig,
         undefined,
-        "DEV"
+        "DEV",
+        {}
       );
       expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
         "Processing wrangler configuration:
@@ -1461,7 +1516,7 @@ describe("normalizeAndValidateConfig()", () => {
     it("should use top-level values for inheritable config fields", () => {
       const main = "src/index.ts";
       const resolvedMain = path.resolve(process.cwd(), main);
-      const expectedConfig: RawConfig = {
+      const rawConfig: RawConfig = {
         name: "NAME",
         account_id: "ACCOUNT_ID",
         compatibility_date: "2022-01-01",
@@ -1481,13 +1536,18 @@ describe("normalizeAndValidateConfig()", () => {
       };
 
       const { config, diagnostics } = normalizeAndValidateConfig(
-        { ...expectedConfig, env: { DEV: {} } },
+        { ...rawConfig, env: { DEV: {} } },
         undefined,
-        "DEV"
+        "DEV",
+        {}
       );
 
       expect(config).toEqual(
-        expect.objectContaining({ ...expectedConfig, main: resolvedMain })
+        expect.objectContaining({
+          ...rawConfig,
+          main: resolvedMain,
+          name: "NAME-DEV",
+        })
       );
       expect(diagnostics.hasErrors()).toBe(false);
       expect(diagnostics.hasWarnings()).toBe(false);
@@ -1539,7 +1599,8 @@ describe("normalizeAndValidateConfig()", () => {
       const { config, diagnostics } = normalizeAndValidateConfig(
         rawConfig,
         undefined,
-        "ENV1"
+        "ENV1",
+        {}
       );
 
       expect(config).toEqual(
@@ -1560,7 +1621,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           rawConfig,
           undefined,
-          "DEV"
+          "DEV",
+          {}
         );
 
         expect(config.name).toEqual("NAME");
@@ -1581,7 +1643,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           rawConfig,
           undefined,
-          "DEV"
+          "DEV",
+          {}
         );
 
         expect(config.name).toBeUndefined();
@@ -1609,7 +1672,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           rawConfig,
           undefined,
-          "DEV"
+          "DEV",
+          {}
         );
 
         expect(config.name).toEqual("NAME");
@@ -1648,7 +1712,8 @@ describe("normalizeAndValidateConfig()", () => {
       const { config, diagnostics } = normalizeAndValidateConfig(
         rawConfig,
         undefined,
-        "ENV1"
+        "ENV1",
+        {}
       );
 
       expect(config).toEqual(
@@ -1707,7 +1772,8 @@ describe("normalizeAndValidateConfig()", () => {
       const { config, diagnostics } = normalizeAndValidateConfig(
         { env: { ENV1: expectedConfig } },
         undefined,
-        "ENV1"
+        "ENV1",
+        {}
       );
 
       expect(config).toEqual(expect.objectContaining(expectedConfig));
@@ -1739,7 +1805,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { durable_objects: [] } } } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -1758,7 +1825,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { durable_objects: "BAD" } } } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -1777,7 +1845,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { durable_objects: 999 } } } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -1796,7 +1865,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { durable_objects: null } } } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -1815,7 +1885,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { durable_objects: {} } } } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -1836,7 +1907,8 @@ describe("normalizeAndValidateConfig()", () => {
             env: { ENV1: { durable_objects: { bindings: {} } } },
           } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -1859,7 +1931,8 @@ describe("normalizeAndValidateConfig()", () => {
             env: { ENV1: { durable_objects: { bindings: "BAD" } } },
           } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -1882,7 +1955,8 @@ describe("normalizeAndValidateConfig()", () => {
             env: { ENV1: { durable_objects: { bindings: 999 } } },
           } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -1905,7 +1979,8 @@ describe("normalizeAndValidateConfig()", () => {
             env: { ENV1: { durable_objects: { bindings: null } } },
           } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -1943,7 +2018,8 @@ describe("normalizeAndValidateConfig()", () => {
             },
           } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -1981,7 +2057,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { kv_namespaces: {} } } } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -2000,7 +2077,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { kv_namespaces: "BAD" } } } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -2019,7 +2097,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { kv_namespaces: 999 } } } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -2038,7 +2117,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { kv_namespaces: null } } } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -2072,7 +2152,8 @@ describe("normalizeAndValidateConfig()", () => {
             },
           } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -2100,7 +2181,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { r2_buckets: {} } } } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -2119,7 +2201,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { r2_buckets: "BAD" } } } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -2138,7 +2221,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { r2_buckets: 999 } } } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -2157,7 +2241,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { r2_buckets: null } } } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -2191,7 +2276,8 @@ describe("normalizeAndValidateConfig()", () => {
             },
           } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -2219,7 +2305,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { unsafe: [] } } } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -2243,7 +2330,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { unsafe: "BAD" } } } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -2267,7 +2355,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { unsafe: 999 } } } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -2291,7 +2380,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { unsafe: null } } } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -2315,7 +2405,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           { env: { ENV1: { unsafe: {} } } } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -2341,7 +2432,8 @@ describe("normalizeAndValidateConfig()", () => {
             env: { ENV1: { unsafe: { bindings: {} } } },
           } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -2369,7 +2461,8 @@ describe("normalizeAndValidateConfig()", () => {
             env: { ENV1: { unsafe: { bindings: "BAD" } } },
           } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -2397,7 +2490,8 @@ describe("normalizeAndValidateConfig()", () => {
             env: { ENV1: { unsafe: { bindings: 999 } } },
           } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -2425,7 +2519,8 @@ describe("normalizeAndValidateConfig()", () => {
             env: { ENV1: { unsafe: { bindings: null } } },
           } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -2468,7 +2563,8 @@ describe("normalizeAndValidateConfig()", () => {
             },
           } as unknown as RawConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(
@@ -2521,7 +2617,8 @@ describe("normalizeAndValidateConfig()", () => {
             },
           },
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect("experimental_services" in config).toBe(false);
@@ -2582,7 +2679,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           expectedConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(expect.objectContaining(environment));
@@ -2630,7 +2728,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           expectedConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(expect.objectContaining(environment));
@@ -2675,7 +2774,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           expectedConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(expect.objectContaining(environment));
@@ -2715,7 +2815,8 @@ describe("normalizeAndValidateConfig()", () => {
         const { config, diagnostics } = normalizeAndValidateConfig(
           expectedConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(config).toEqual(expect.objectContaining(environment));
@@ -2768,7 +2869,8 @@ describe("normalizeAndValidateConfig()", () => {
         const result1 = normalizeAndValidateConfig(
           expectedConfig,
           undefined,
-          "ENV1"
+          "ENV1",
+          {}
         );
 
         expect(result1.config).toEqual(expect.objectContaining(environment1));
@@ -2778,7 +2880,8 @@ describe("normalizeAndValidateConfig()", () => {
         const result2 = normalizeAndValidateConfig(
           expectedConfig,
           undefined,
-          "ENV2"
+          "ENV2",
+          {}
         );
 
         expect(result2.config).toEqual(expect.objectContaining(environment2));

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -89,6 +89,26 @@ describe("publish", () => {
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.warn).toMatchInlineSnapshot(`""`);
       });
+
+      it("should throw an error w/ helpful message when using --env --name", async () => {
+        writeWranglerToml({ env: { "some-env": {} } });
+        writeWorkerSource();
+        mockSubDomainRequest();
+        mockUploadWorkerRequest({
+          env: "some-env",
+          legacyEnv: true,
+        });
+        await runWrangler(
+          "publish index.js --name voyager --env some-env --legacy-env true"
+        ).catch((err) =>
+          expect(err).toMatchInlineSnapshot(`
+            [Error: In legacy environment mode you cannot use --name and --env together. If you want to specify a Worker name for a specific environment you can add the following to your wrangler.toml config:
+                [env.some-env]
+                name = "voyager"
+                ]
+          `)
+        );
+      });
     });
 
     describe("services", () => {

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -21,7 +21,8 @@ export type {
  */
 export function readConfig(
   configPath: string | undefined,
-  envName: string | undefined
+  envName: string | undefined,
+  args: unknown
 ): Config {
   let rawConfig: RawConfig = {};
   if (!configPath) {
@@ -37,7 +38,8 @@ export function readConfig(
   const { config, diagnostics } = normalizeAndValidateConfig(
     rawConfig,
     configPath,
-    envName
+    envName,
+    args
   );
 
   if (diagnostics.hasWarnings()) {

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -22,6 +22,7 @@ import {
   all,
   isMutuallyExclusiveWith,
   inheritableInLegacyEnvironments,
+  appendEnvName,
 } from "./validation-helpers";
 import type { Config, DevConfig, RawConfig, RawDevConfig } from "./config";
 import type {
@@ -43,7 +44,8 @@ import type { ValidatorFn } from "./validation-helpers";
 export function normalizeAndValidateConfig(
   rawConfig: RawConfig,
   configPath: string | undefined,
-  envName: string | undefined
+  envName: string | undefined,
+  args: unknown
 ): {
   config: Config;
   diagnostics: Diagnostics;
@@ -88,7 +90,10 @@ export function normalizeAndValidateConfig(
   );
 
   // TODO: set the default to false to turn on service environments as the default
-  const isLegacyEnv = rawConfig.legacy_env ?? true;
+  const isLegacyEnv =
+    (args as { "legacy-env": boolean | undefined })["legacy-env"] ??
+    rawConfig.legacy_env ??
+    true;
 
   const topLevelEnv = normalizeAndValidateEnvironment(
     diagnostics,
@@ -584,6 +589,7 @@ function normalizeAndValidateEnvironment(
       rawEnv,
       "name",
       isString,
+      appendEnvName(envName),
       undefined
     ),
     main: normalizeAndValidateMainField(

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -100,24 +100,36 @@ function printWranglerBanner() {
 }
 
 function isLegacyEnv(args: unknown, config: Config): boolean {
-  return (
-    (args as { "legacy-env": boolean | undefined })["legacy-env"] ??
-    config.legacy_env
-  );
+  return config.legacy_env;
 }
 
 function getScriptName(
   args: { name: string | undefined; env: string | undefined },
   config: Config
 ): string | undefined {
-  const shortScriptName = args.name ?? config.name;
-  if (!shortScriptName) {
-    return;
+  if (args.name && isLegacyEnv(args, config) && args.env) {
+    throw new CommandLineArgsError(
+      "In legacy environment mode you cannot use --name and --env together. If you want to specify a Worker name for a specific environment you can add the following to your wrangler.toml config:" +
+        `
+    [env.${args.env}]
+    name = "${args.name}"
+    `
+    );
   }
 
-  return isLegacyEnv(args, config)
-    ? `${shortScriptName}${args.env ? `-${args.env}` : ""}`
-    : shortScriptName;
+  return args.name ?? config.name;
+}
+
+/**
+ * Alternative to the getScriptName() because special Legacy cases allowed "name", and "env" together in Wrangler1
+ */
+function getLegacyScriptName(
+  args: { name: string | undefined; env: string | undefined },
+  config: Config
+) {
+  return args.name && args.env && isLegacyEnv(args, config)
+    ? `${args.name}-${args.env}`
+    : args.name ?? config.name;
 }
 
 /**
@@ -802,7 +814,7 @@ export async function main(argv: string[]): Promise<void> {
       const configPath =
         (args.config as ConfigPath) ||
         (args.script && findWranglerToml(path.dirname(args.script)));
-      const config = readConfig(configPath, args.env);
+      const config = readConfig(configPath, args.env, args);
       const entry = await getEntry(args, config, "dev");
 
       if (args["experimental-public"]) {
@@ -1071,7 +1083,7 @@ export async function main(argv: string[]): Promise<void> {
       const configPath =
         (args.config as ConfigPath) ||
         (args.script && findWranglerToml(path.dirname(args.script)));
-      const config = readConfig(configPath, args.env);
+      const config = readConfig(configPath, args.env, args);
       const entry = await getEntry(args, config, "publish");
 
       if (args.latest) {
@@ -1173,9 +1185,9 @@ export async function main(argv: string[]): Promise<void> {
       if (args.format === "pretty") {
         printWranglerBanner();
       }
-      const config = readConfig(args.config as ConfigPath, args.env);
+      const config = readConfig(args.config as ConfigPath, args.env, args);
 
-      const scriptName = getScriptName(args, config);
+      const scriptName = getLegacyScriptName(args, config);
 
       if (!scriptName) {
         throw new Error("Missing script name");
@@ -1286,7 +1298,7 @@ export async function main(argv: string[]): Promise<void> {
           "***************************************************\n"
       );
 
-      const config = readConfig(args.config as ConfigPath, args.env);
+      const config = readConfig(args.config as ConfigPath, args.env, args);
       const entry = await getEntry({}, config, "dev");
 
       const accountId = await requireAuth(config);
@@ -1475,9 +1487,13 @@ export async function main(argv: string[]): Promise<void> {
           },
           async (args) => {
             printWranglerBanner();
-            const config = readConfig(args.config as ConfigPath, args.env);
+            const config = readConfig(
+              args.config as ConfigPath,
+              args.env,
+              args
+            );
 
-            const scriptName = getScriptName(args, config);
+            const scriptName = getLegacyScriptName(args, config);
             if (!scriptName) {
               throw new Error("Missing script name");
             }
@@ -1592,9 +1608,13 @@ export async function main(argv: string[]): Promise<void> {
               });
           },
           async (args) => {
-            const config = readConfig(args.config as ConfigPath, args.env);
+            const config = readConfig(
+              args.config as ConfigPath,
+              args.env,
+              args
+            );
 
-            const scriptName = getScriptName(args, config);
+            const scriptName = getLegacyScriptName(args, config);
             if (!scriptName) {
               throw new Error("Missing script name");
             }
@@ -1643,9 +1663,13 @@ export async function main(argv: string[]): Promise<void> {
               });
           },
           async (args) => {
-            const config = readConfig(args.config as ConfigPath, args.env);
+            const config = readConfig(
+              args.config as ConfigPath,
+              args.env,
+              args
+            );
 
-            const scriptName = getScriptName(args, config);
+            const scriptName = getLegacyScriptName(args, config);
             if (!scriptName) {
               throw new Error("Missing script name");
             }
@@ -1706,7 +1730,11 @@ export async function main(argv: string[]): Promise<void> {
               );
             }
 
-            const config = readConfig(args.config as ConfigPath, args.env);
+            const config = readConfig(
+              args.config as ConfigPath,
+              args.env,
+              args
+            );
             if (!config.name) {
               console.warn(
                 "No configured name present, using `worker` as a prefix for the title"
@@ -1743,7 +1771,11 @@ export async function main(argv: string[]): Promise<void> {
           "Outputs a list of all KV namespaces associated with your account id.",
           {},
           async (args) => {
-            const config = readConfig(args.config as ConfigPath, undefined);
+            const config = readConfig(
+              args.config as ConfigPath,
+              undefined,
+              args
+            );
 
             const accountId = await requireAuth(config);
 
@@ -1780,7 +1812,11 @@ export async function main(argv: string[]): Promise<void> {
           },
           async (args) => {
             printWranglerBanner();
-            const config = readConfig(args.config as ConfigPath, args.env);
+            const config = readConfig(
+              args.config as ConfigPath,
+              args.env,
+              args
+            );
 
             let id;
             try {
@@ -1876,7 +1912,11 @@ export async function main(argv: string[]): Promise<void> {
           },
           async ({ key, ttl, expiration, ...args }) => {
             printWranglerBanner();
-            const config = readConfig(args.config as ConfigPath, args.env);
+            const config = readConfig(
+              args.config as ConfigPath,
+              args.env,
+              args
+            );
             const namespaceId = getNamespaceId(args, config);
             // One of `args.path` and `args.value` must be defined
             const value = args.path
@@ -1936,7 +1976,11 @@ export async function main(argv: string[]): Promise<void> {
           },
           async ({ prefix, ...args }) => {
             // TODO: support for limit+cursor (pagination)
-            const config = readConfig(args.config as ConfigPath, args.env);
+            const config = readConfig(
+              args.config as ConfigPath,
+              args.env,
+              args
+            );
             const namespaceId = getNamespaceId(args, config);
 
             const accountId = await requireAuth(config);
@@ -1985,7 +2029,11 @@ export async function main(argv: string[]): Promise<void> {
               });
           },
           async ({ key, ...args }) => {
-            const config = readConfig(args.config as ConfigPath, args.env);
+            const config = readConfig(
+              args.config as ConfigPath,
+              args.env,
+              args
+            );
             const namespaceId = getNamespaceId(args, config);
 
             const accountId = await requireAuth(config);
@@ -2024,7 +2072,11 @@ export async function main(argv: string[]): Promise<void> {
           },
           async ({ key, ...args }) => {
             printWranglerBanner();
-            const config = readConfig(args.config as ConfigPath, args.env);
+            const config = readConfig(
+              args.config as ConfigPath,
+              args.env,
+              args
+            );
             const namespaceId = getNamespaceId(args, config);
 
             console.log(
@@ -2084,7 +2136,11 @@ export async function main(argv: string[]): Promise<void> {
             // This could be made more efficient with a streaming parser/uploader
             // but we'll do that in the future if needed.
 
-            const config = readConfig(args.config as ConfigPath, args.env);
+            const config = readConfig(
+              args.config as ConfigPath,
+              args.env,
+              args
+            );
             const namespaceId = getNamespaceId(args, config);
             const content = parseJSON(readFileSync(filename), filename);
 
@@ -2191,7 +2247,11 @@ export async function main(argv: string[]): Promise<void> {
           },
           async ({ filename, ...args }) => {
             printWranglerBanner();
-            const config = readConfig(args.config as ConfigPath, args.env);
+            const config = readConfig(
+              args.config as ConfigPath,
+              args.env,
+              args
+            );
             const namespaceId = getNamespaceId(args, config);
 
             if (!args.force) {
@@ -2280,7 +2340,11 @@ export async function main(argv: string[]): Promise<void> {
               );
             }
 
-            const config = readConfig(args.config as ConfigPath, undefined);
+            const config = readConfig(
+              args.config as ConfigPath,
+              undefined,
+              args
+            );
 
             const accountId = await requireAuth(config);
 
@@ -2291,7 +2355,7 @@ export async function main(argv: string[]): Promise<void> {
         );
 
         r2BucketYargs.command("list", "List R2 buckets", {}, async (args) => {
-          const config = readConfig(args.config as ConfigPath, undefined);
+          const config = readConfig(args.config as ConfigPath, undefined, args);
 
           const accountId = await requireAuth(config);
 
@@ -2318,7 +2382,11 @@ export async function main(argv: string[]): Promise<void> {
               );
             }
 
-            const config = readConfig(args.config as ConfigPath, undefined);
+            const config = readConfig(
+              args.config as ConfigPath,
+              undefined,
+              args
+            );
 
             const accountId = await requireAuth(config);
 


### PR DESCRIPTION
1. When in Legacy environment mode we should not compute name field if specified in an environment.
2. Throw an Error when `--env` and `--name` are used together in Legacy Environment, except for Secrets & Tail which are using a special case `getLegacyScriptName` for parity with Wrangler1
3. Started the refactor for args being utilized at the Config level, currently checking for Legacy Environment only.

Fixes https://github.com/cloudflare/wrangler2/issues/672