### PR TITLE
feat: add service bindings support

### DIFF
--- a/.changeset/hot-insects-cry.md
+++ b/.changeset/hot-insects-cry.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+feat: add service bindings support

--- a/packages/wrangler/src/__tests__/dev2.test.tsx
+++ b/packages/wrangler/src/__tests__/dev2.test.tsx
@@ -106,6 +106,7 @@ async function renderDev({
     vars: {},
     durable_objects: { bindings: [] },
     r2_buckets: [],
+    services: [],
     wasm_modules: undefined,
     text_blobs: undefined,
     unsafe: [],

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -2104,6 +2104,37 @@ export default{
     });
   });
 
+  describe("service bindings", () => {
+    it("should support service bindings", async () => {
+      writeWranglerToml({
+        services: [
+          { binding: "FOO", service: "foo-service", environment: "production" },
+        ],
+      });
+      writeWorkerSource();
+      mockSubDomainRequest();
+      mockUploadWorkerRequest({
+        expectedBindings: [
+          {
+            type: "service",
+            name: "FOO",
+            service: "foo-service",
+            environment: "production",
+          },
+        ],
+      });
+
+      await runWrangler("publish index.js");
+      expect(std.out).toMatchInlineSnapshot(`
+        "Uploaded test-name (TIMINGS)
+        Published test-name (TIMINGS)
+          test-name.test-sub-domain.workers.dev"
+      `);
+      expect(std.err).toMatchInlineSnapshot(`""`);
+      expect(std.warn).toMatchInlineSnapshot(`""`);
+    });
+  });
+
   describe("unsafe bindings", () => {
     it("should warn if using unsafe bindings", async () => {
       writeWranglerToml({

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -252,6 +252,18 @@ interface EnvironmentNonInheritable {
   }[];
 
   /**
+   * Specifies service bindings (worker-to-worker) that are bound to this Worker environment.
+   */
+  services: {
+    /** The binding name used to refer to the bound service. */
+    binding: string;
+    /** The name of the service. */
+    service: string;
+    /** The environment of the service (e.g. production, staging, etc). */
+    environment: string;
+  }[];
+
+  /**
    * "Unsafe" tables for features that aren't directly supported by wrangler.
    *
    * NOTE: This field is not automatically inherited from the top level environment,

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -667,6 +667,16 @@ function normalizeAndValidateEnvironment(
       validateBindingArray(envName, validateR2Binding),
       []
     ),
+    services: notInheritable(
+      diagnostics,
+      topLevelEnv,
+      rawConfig,
+      rawEnv,
+      envName,
+      "services",
+      validateBindingArray(envName, validateServiceBinding),
+      []
+    ),
     unsafe: notInheritable(
       diagnostics,
       topLevelEnv,
@@ -950,6 +960,7 @@ const validateUnsafeBinding: ValidatorFn = (diagnostics, field, value) => {
       "json",
       "kv_namespace",
       "durable_object_namespace",
+      "service",
     ];
 
     if (safeBindings.includes(value.type)) {
@@ -1087,6 +1098,42 @@ const validateR2Binding: ValidatorFn = (diagnostics, field, value) => {
   if (!isOptionalProperty(value, "preview_bucket_name", "string")) {
     diagnostics.errors.push(
       `"${field}" bindings should, optionally, have a string "preview_bucket_name" field but got ${JSON.stringify(
+        value
+      )}.`
+    );
+    isValid = false;
+  }
+  return isValid;
+};
+
+const validateServiceBinding: ValidatorFn = (diagnostics, field, value) => {
+  if (typeof value !== "object" || value === null) {
+    diagnostics.errors.push(
+      `"services" bindings should be objects, but got ${JSON.stringify(value)}`
+    );
+    return false;
+  }
+  let isValid = true;
+  // Service bindings must have a binding, service, and environment.
+  if (!isRequiredProperty(value, "binding", "string")) {
+    diagnostics.errors.push(
+      `"${field}" bindings should have a string "binding" field but got ${JSON.stringify(
+        value
+      )}.`
+    );
+    isValid = false;
+  }
+  if (!isRequiredProperty(value, "service", "string")) {
+    diagnostics.errors.push(
+      `"${field}" bindings should have a string "service" field but got ${JSON.stringify(
+        value
+      )}.`
+    );
+    isValid = false;
+  }
+  if (!isOptionalProperty(value, "environment", "string")) {
+    diagnostics.errors.push(
+      `"${field}" bindings should have a string "environment" field but got ${JSON.stringify(
         value
       )}.`
     );

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -983,6 +983,7 @@ export async function main(argv: string[]): Promise<void> {
             text_blobs: config.text_blobs,
             durable_objects: config.durable_objects,
             r2_buckets: config.r2_buckets,
+            services: config.services,
             unsafe: config.unsafe?.bindings,
           }}
         />
@@ -1359,6 +1360,7 @@ export async function main(argv: string[]): Promise<void> {
             text_blobs: config.text_blobs,
             durable_objects: config.durable_objects,
             r2_buckets: config.r2_buckets,
+            services: config.services,
             unsafe: config.unsafe?.bindings,
           }}
           inspectorPort={await getPort({ port: 9229 })}
@@ -1548,6 +1550,7 @@ export async function main(argv: string[]): Promise<void> {
                       vars: {},
                       durable_objects: { bindings: [] },
                       r2_buckets: [],
+                      services: [],
                       wasm_modules: {},
                       text_blobs: {},
                       unsafe: [],

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -170,6 +170,7 @@ export default async function publish(props: Props): Promise<void> {
       },
       durable_objects: config.durable_objects,
       r2_buckets: config.r2_buckets,
+      services: config.services,
       unsafe: config.unsafe?.bindings,
     };
 

--- a/packages/wrangler/src/worker.ts
+++ b/packages/wrangler/src/worker.ts
@@ -104,6 +104,12 @@ interface CfR2Bucket {
   bucket_name: string;
 }
 
+interface CfService {
+  binding: string;
+  service: string;
+  environment: string;
+}
+
 interface CfUnsafeBinding {
   name: string;
   type: string;
@@ -148,6 +154,7 @@ export interface CfWorkerInit {
     text_blobs: CfTextBlobBindings | undefined;
     durable_objects: { bindings: CfDurableObject[] } | undefined;
     r2_buckets: CfR2Bucket[] | undefined;
+    services: CfService[] | undefined;
     unsafe: CfUnsafeBinding[] | undefined;
   };
   migrations: undefined | CfDurableObjectMigrations;


### PR DESCRIPTION
Soon service bindings won't be experimental, this PR adds service bindings support to Wrangler 2.

Adds warning to unsafe bindings that were used as "raw" service bindings

### Background

#### Experimental service bindings
Link: https://github.com/cloudflare/wrangler2/pull/166
Initial take on service bindings, replaced by the more generic unsafe bindings below.

#### Unsafe bindings
Link: https://github.com/cloudflare/wrangler2/pull/411
Used for any binding type not officially supported by Wrangler, including service bindings until today.