### PR TITLE
fix: do not deploy to workers.dev when routes are defined in an environment

### DIFF
--- a/.changeset/fluffy-ghosts-jam.md
+++ b/.changeset/fluffy-ghosts-jam.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: do not deploy to workers.dev when routes are defined in an environment
+
+When `workers_dev` is not configured, we had a bug where it would default to true inside an environment even when there were routes defined, thus publishing both to a `workers.dev` subdomain as well as the defined routes. The fix is to default `workers_dev` to `undefined`, and check when publishing whether or not to publish to `workers.dev`/defined routes.
+
+Fixes https://github.com/cloudflare/wrangler2/issues/690

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -58,7 +58,7 @@ describe("normalizeAndValidateConfig()", () => {
       usage_model: undefined,
       vars: {},
       wasm_modules: undefined,
-      workers_dev: true,
+      workers_dev: undefined,
       zone_id: undefined,
     });
     expect(diagnostics.hasErrors()).toBe(false);

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -64,7 +64,7 @@ interface EnvironmentInheritable {
    * @breaking
    * @inheritable
    */
-  workers_dev: boolean;
+  workers_dev: boolean | undefined;
 
   /**
    * A list of routes that your worker should be published to.

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -528,7 +528,7 @@ function normalizeAndValidateEnvironment(
     rawEnv,
     "workers_dev",
     isBoolean,
-    !(routes || route)
+    undefined
   );
 
   const { deprecatedUpload, ...build } = normalizeAndValidateBuild(

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -47,7 +47,8 @@ export default async function publish(props: Props): Promise<void> {
   const routes =
     props.routes ?? config.routes ?? (config.route ? [config.route] : []) ?? [];
 
-  const deployToWorkersDev = config.workers_dev;
+  // deployToWorkersDev defaults to true only if there aren't any routes defined
+  const deployToWorkersDev = config.workers_dev ?? routes.length === 0;
 
   const jsxFactory = props.jsxFactory || config.jsx_factory;
   const jsxFragment = props.jsxFragment || config.jsx_fragment;


### PR DESCRIPTION
When `workers_dev` is not configured, we had a bug where it would default to true inside an environment even when there were routes defined, thus publishing both to a `workers.dev` subdomain as well as the defined routes. The fix is to default `workers_dev` to `undefined`, and check when publishing whether or not to publish to `workers.dev`/defined routes.

Fixes https://github.com/cloudflare/wrangler2/issues/690