### PR TITLE
RFC feat: inject `process.env.NODE_ENV` into scripts

### DIFF
--- a/.changeset/strange-icons-search.md
+++ b/.changeset/strange-icons-search.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+feat: inject `process.env.NODE_ENV` into scripts
+
+An extremely common pattern in the js ecosystem is to add additional behaviour gated by the value of `process.env.NODE_ENV`. For example, React leverages it heavily to add dev-time checks and warnings/errors, and to load dev/production versions of code. By doing this substitution ourselves, we can get a significant runtime boost in libraries/code that leverage this.
+
+This does NOT tackle the additional features of either minification, or proper node compatibility, or injecting wrangler's own environment name, which we will tackle in future PRs.

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -57,6 +57,11 @@ export async function bundleWorker(
     sourcemap: true,
     metafile: true,
     conditions: ["worker", "browser"],
+    ...(process.env.NODE_ENV && {
+      define: {
+        "process.env.NODE_ENV": `"${process.env.NODE_ENV}"`,
+      },
+    }),
     loader: {
       ".js": "jsx",
       ".mjs": "jsx",


### PR DESCRIPTION
An extremely common pattern in the js ecosystem is to add additional behaviour gated by the value of `process.env.NODE_ENV`. For example, React leverages it heavily to add dev-time checks and warnings/errors, and to load dev/production versions of code. By doing this substitution ourselves, we can get a significant runtime boost in libraries/code that leverage this.

This does NOT tackle the additional features of either minification, or proper node compatibility, or injecting wrangler's own environment name, which we will tackle in future PRs.

--- 

I bumped into this need myself recently when hacking on some react code, and had to define a whole custom build script for this single feature, which is arguably super common already. Thoughts? 