### PR TITLE
fix: setup jsx loaders when guessing worker format

### DIFF
--- a/.changeset/neat-points-punch.md
+++ b/.changeset/neat-points-punch.md
@@ -1,0 +1,13 @@
+---
+"wrangler": patch
+---
+
+fix: setup jsx loaders when guessing worker format
+
+- We consider jsx to be regular js, and have setup our esbuild process to process js/mjs/cjs files as jsx.
+- We use a separate esbuild run on an entry point file when trying to guess the worker format, but hadn't setup the loaders there.
+- So if just the entrypoint file has any jsx in it, then we error because it can't parse the code.
+
+The fix is to add the same loaders to the esbuild run that guesses the worker format.
+
+Reported in https://github.com/cloudflare/wrangler2/issues/701

--- a/packages/wrangler/src/__tests__/guess-worker-format.test.ts
+++ b/packages/wrangler/src/__tests__/guess-worker-format.test.ts
@@ -55,4 +55,14 @@ describe("guess worker format", () => {
       "You configured this worker to be 'modules', but the file you are trying to build doesn't export a handler. Please pass `--format service-worker`, or simply remove the configuration."
     );
   });
+
+  it("should not error if a .js entry point has jsx", async () => {
+    await writeFile("./index.js", "console.log(<div/>)");
+    const guess = await guessWorkerFormat(
+      path.join(process.cwd(), "./index.js"),
+      process.cwd(),
+      undefined
+    );
+    expect(guess).toBe("service-worker");
+  });
 });

--- a/packages/wrangler/src/entry.ts
+++ b/packages/wrangler/src/entry.ts
@@ -125,6 +125,11 @@ export default async function guessWorkerFormat(
     bundle: false,
     format: "esm",
     write: false,
+    loader: {
+      ".js": "jsx",
+      ".mjs": "jsx",
+      ".cjs": "jsx",
+    },
   });
   // result.metafile is defined because of the `metafile: true` option above.
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion


### PR DESCRIPTION
- We consider jsx to be regular js, and have setup our esbuild process to process js/mjs/cjs files as jsx.
- We use a separate esbuild run on an entry point file when trying to guess the worker format, but hadn't setup the loaders there.
- So if just the entrypoint file has any jsx in it, then we error because it can't parse the code.

The fix is to add the same loaders to the esbuild run that guesses the worker format.

Reported in https://github.com/cloudflare/wrangler2/issues/701