### PR TITLE
fix: trigger login flow if refreshtoken isn't valid

### DIFF
--- a/.changeset/late-mayflies-joke.md
+++ b/.changeset/late-mayflies-joke.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: trigger login flow if refreshtoken isn't valid
+
+If the auth refresh token isn't valid, then we should trigger the login flow. Reported in https://github.com/cloudflare/wrangler2/issues/316


### PR DESCRIPTION
If the auth refresh token isn't valid, then we should trigger the login flow. Reported in https://github.com/cloudflare/wrangler2/issues/316

--- 

We don't have any test coverage on this complicated login machinery 😓 We should fix that soon. I wish there was a good npm package for this, but there just isn't (that I could find). 