### PR TITLE
fix: don't fetch zone id for `wrangler dev --local`

### DIFF
--- a/.changeset/calm-laws-explain.md
+++ b/.changeset/calm-laws-explain.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: don't fetch zone id for `wrangler dev --local`
+
+We shouldn't try to resolve a domain/route to a zone id when starting in local mode (since there may not even be network).

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -277,6 +277,15 @@ describe("wrangler dev", () => {
         `"Could not find zone for some-host.com"`
       );
     });
+
+    it("should not try to resolve a zone when starting in local mode", async () => {
+      writeWranglerToml({
+        main: "index.js",
+      });
+      fs.writeFileSync("index.js", `export default {};`);
+      await runWrangler("dev --host some-host.com --local");
+      expect((Dev as jest.Mock).mock.calls[0][0].zone).toEqual(undefined);
+    });
   });
 
   describe("custom builds", () => {


### PR DESCRIPTION
We shouldn't try to resolve a domain/route to a zone id when starting in local mode (since there may not even be network connectivity).