### PR TITLE
feat: path to a custom `tsconfig`

### DIFF
--- a/.changeset/spotty-needles-brake.md
+++ b/.changeset/spotty-needles-brake.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+feat: path to a custom `tsconfig`
+
+This adds a config field and a command line arg `tsconfig` for passing a path to a custom typescript configuration file. We don't do any typechecking, but we do pass it along to our build process so things like `compilerOptions.paths` get resolved correctly.

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -35,6 +35,7 @@ describe("normalizeAndValidateConfig()", () => {
       },
       jsx_factory: "React.createElement",
       jsx_fragment: "React.Fragment",
+      tsconfig: undefined,
       kv_namespaces: [],
       legacy_env: true,
       main: undefined,
@@ -433,6 +434,27 @@ describe("normalizeAndValidateConfig()", () => {
       `);
     });
 
+    it("should resolve tsconfig relative to wrangler.toml", async () => {
+      const expectedConfig: RawEnvironment = {
+        tsconfig: "path/to/some-tsconfig.json",
+      };
+
+      const { config, diagnostics } = normalizeAndValidateConfig(
+        expectedConfig,
+        "project/wrangler.toml",
+        { env: undefined }
+      );
+
+      expect(config).toEqual(
+        expect.objectContaining({
+          tsconfig: path.normalize("project/path/to/some-tsconfig.json"),
+        })
+      );
+
+      expect(diagnostics.hasErrors()).toBe(false);
+      expect(diagnostics.hasWarnings()).toBe(false);
+    });
+
     describe("(deprecated)", () => {
       it("should remove and warn about deprecated properties", () => {
         const rawConfig: RawConfig = {
@@ -480,6 +502,7 @@ describe("normalizeAndValidateConfig()", () => {
         routes: ["ROUTE_1", "ROUTE_2"],
         jsx_factory: "JSX_FACTORY",
         jsx_fragment: "JSX_FRAGMENT",
+        tsconfig: "path/to/tsconfig",
         triggers: { crons: ["CRON_1", "CRON_2"] },
         usage_model: "bundled",
         main,
@@ -557,6 +580,7 @@ describe("normalizeAndValidateConfig()", () => {
         route: 888,
         jsx_factory: 999,
         jsx_fragment: 1000,
+        tsconfig: true,
         triggers: { crons: [1111, 1222] },
         usage_model: "INVALID",
         main: 1333,
@@ -589,6 +613,7 @@ describe("normalizeAndValidateConfig()", () => {
           - Expected \\"compatibility_flags\\" to be of type string array but got [444,555].
           - Expected \\"jsx_factory\\" to be of type string but got 999.
           - Expected \\"jsx_fragment\\" to be of type string but got 1000.
+          - Expected \\"tsconfig\\" to be of type string but got true.
           - Expected \\"name\\" to be of type string but got 111.
           - Expected \\"main\\" to be of type string but got 1333.
           - Expected \\"usage_model\\" field to be one of [\\"bundled\\",\\"unbound\\"] but got \\"INVALID\\"."
@@ -1464,6 +1489,7 @@ describe("normalizeAndValidateConfig()", () => {
         routes: ["ROUTE_1", "ROUTE_2"],
         jsx_factory: "JSX_FACTORY",
         jsx_fragment: "JSX_FRAGMENT",
+        tsconfig: "path/to/tsconfig.json",
         triggers: { crons: ["CRON_1", "CRON_2"] },
         usage_model: "bundled",
         main,
@@ -1503,6 +1529,7 @@ describe("normalizeAndValidateConfig()", () => {
         routes: ["ENV_ROUTE_1", "ENV_ROUTE_2"],
         jsx_factory: "ENV_JSX_FACTORY",
         jsx_fragment: "ENV_JSX_FRAGMENT",
+        tsconfig: "ENV_path/to/tsconfig.json",
         triggers: { crons: ["ENV_CRON_1", "ENV_CRON_2"] },
         usage_model: "unbound",
         main,
@@ -1521,6 +1548,7 @@ describe("normalizeAndValidateConfig()", () => {
         routes: ["ROUTE_1", "ROUTE_2"],
         jsx_factory: "JSX_FACTORY",
         jsx_fragment: "JSX_FRAGMENT",
+        tsconfig: "path/to/tsconfig.json",
         triggers: { crons: ["CRON_1", "CRON_2"] },
         usage_model: "bundled",
         main: "top-level.js",
@@ -1692,6 +1720,7 @@ describe("normalizeAndValidateConfig()", () => {
         route: 888,
         jsx_factory: 999,
         jsx_fragment: 1000,
+        tsconfig: 123,
         triggers: { crons: [1111, 1222] },
         usage_model: "INVALID",
         main: 1333,
@@ -1726,6 +1755,7 @@ describe("normalizeAndValidateConfig()", () => {
             - Expected \\"compatibility_flags\\" to be of type string array but got [444,555].
             - Expected \\"jsx_factory\\" to be of type string but got 999.
             - Expected \\"jsx_fragment\\" to be of type string but got 1000.
+            - Expected \\"tsconfig\\" to be of type string but got 123.
             - Expected \\"name\\" to be of type string but got 111.
             - Expected \\"main\\" to be of type string but got 1333.
             - Expected \\"usage_model\\" field to be one of [\\"bundled\\",\\"unbound\\"] but got \\"INVALID\\"."

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -26,10 +26,17 @@ export async function bundleWorker(
     jsxFragment: string | undefined;
     rules: Config["rules"];
     watch?: esbuild.WatchMode;
+    tsconfig: string | undefined;
   }
 ): Promise<BundleResult> {
-  const { serveAssetsFromWorker, jsxFactory, jsxFragment, rules, watch } =
-    options;
+  const {
+    serveAssetsFromWorker,
+    jsxFactory,
+    jsxFragment,
+    rules,
+    watch,
+    tsconfig,
+  } = options;
   const entryDirectory = path.dirname(entry.file);
   const moduleCollector = createModuleCollector({
     wrangler1xlegacyModuleReferences: {
@@ -65,6 +72,7 @@ export async function bundleWorker(
     plugins: [moduleCollector.plugin],
     ...(jsxFactory && { jsxFactory }),
     ...(jsxFragment && { jsxFragment }),
+    ...(tsconfig && { tsconfig }),
     watch,
   });
 

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -88,6 +88,11 @@ interface EnvironmentInheritable {
   route: string | undefined;
 
   /**
+   * Path to a custom tsconfig
+   */
+  tsconfig: string | undefined;
+
+  /**
    * The function to use to replace jsx syntax.
    *
    * @default `"React.createElement"`

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -594,6 +594,12 @@ function normalizeAndValidateEnvironment(
       isString,
       "React.Fragment"
     ),
+    tsconfig: validateAndNormalizeTsconfig(
+      diagnostics,
+      topLevelEnv,
+      rawEnv,
+      configPath
+    ),
     rules: validateAndNormalizeRules(
       diagnostics,
       topLevelEnv,
@@ -702,6 +708,29 @@ function normalizeAndValidateEnvironment(
   };
 
   return environment;
+}
+
+function validateAndNormalizeTsconfig(
+  diagnostics: Diagnostics,
+  topLevelEnv: Environment | undefined,
+  rawEnv: RawEnvironment,
+  configPath: string | undefined
+) {
+  const tsconfig = inheritable(
+    diagnostics,
+    topLevelEnv,
+    rawEnv,
+    "tsconfig",
+    isString,
+    undefined
+  );
+
+  return configPath && tsconfig
+    ? path.relative(
+        process.cwd(),
+        path.join(path.dirname(configPath), tsconfig)
+      )
+    : tsconfig;
 }
 
 const validateAndNormalizeRules = (

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -32,6 +32,7 @@ export type DevProps = {
   initialMode: "local" | "remote";
   jsxFactory: undefined | string;
   jsxFragment: undefined | string;
+  tsconfig: string | undefined;
   upstreamProtocol: "https" | "http";
   localProtocol: "https" | "http";
   enableLocalPersistence: boolean;
@@ -88,6 +89,7 @@ export function DevImplementation(props: DevProps): JSX.Element {
     rules: props.rules,
     jsxFragment: props.jsxFragment,
     serveAssetsFromWorker: !!props.public,
+    tsconfig: props.tsconfig,
   });
 
   // only load the UI if we're running in a supported environment

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -23,6 +23,7 @@ export function useEsbuild({
   jsxFragment,
   rules,
   serveAssetsFromWorker,
+  tsconfig,
 }: {
   entry: Entry;
   destination: string | undefined;
@@ -31,6 +32,7 @@ export function useEsbuild({
   jsxFragment: string | undefined;
   rules: Config["rules"];
   serveAssetsFromWorker: boolean;
+  tsconfig: string | undefined;
 }): EsbuildBundle | undefined {
   const [bundle, setBundle] = useState<EsbuildBundle>();
   useEffect(() => {
@@ -64,6 +66,7 @@ export function useEsbuild({
           jsxFragment,
           rules,
           watch: watchMode,
+          tsconfig,
         });
 
       // Capture the `stop()` method to use as the `useEffect()` destructor.
@@ -95,6 +98,7 @@ export function useEsbuild({
     jsxFragment,
     serveAssetsFromWorker,
     rules,
+    tsconfig,
   ]);
   return bundle;
 }

--- a/packages/wrangler/src/entry.ts
+++ b/packages/wrangler/src/entry.ts
@@ -46,7 +46,8 @@ export async function getEntry(
   const format = await guessWorkerFormat(
     file,
     directory,
-    args.format ?? config.build?.upload?.format
+    args.format ?? config.build?.upload?.format,
+    config.tsconfig
   );
 
   const { localBindings, remoteBindings } =
@@ -116,7 +117,8 @@ export async function runCustomBuild(
 export default async function guessWorkerFormat(
   entryFile: string,
   entryWorkingDirectory: string,
-  hint: CfScriptFormat | undefined
+  hint: CfScriptFormat | undefined,
+  tsconfig?: string | undefined
 ): Promise<CfScriptFormat> {
   const result = await esbuild.build({
     entryPoints: [entryFile],
@@ -130,6 +132,7 @@ export default async function guessWorkerFormat(
       ".mjs": "jsx",
       ".cjs": "jsx",
     },
+    ...(tsconfig && { tsconfig }),
   });
   // result.metafile is defined because of the `metafile: true` option above.
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -805,6 +805,10 @@ export async function main(argv: string[]): Promise<void> {
           describe: "The function that is called for each JSX fragment",
           type: "string",
         })
+        .option("tsconfig", {
+          describe: "Path to a custom tsconfig.json file",
+          type: "string",
+        })
         .option("local", {
           alias: "l",
           describe: "Run on my machine",
@@ -930,6 +934,7 @@ export async function main(argv: string[]): Promise<void> {
           initialMode={args.local ? "local" : "remote"}
           jsxFactory={args["jsx-factory"] || config.jsx_factory}
           jsxFragment={args["jsx-fragment"] || config.jsx_fragment}
+          tsconfig={args.tsconfig ?? config.tsconfig}
           upstreamProtocol={upstreamProtocol}
           localProtocol={
             // The typings are not quite clever enough to handle element accesses, only property accesses,
@@ -1074,6 +1079,10 @@ export async function main(argv: string[]): Promise<void> {
         .option("jsx-fragment", {
           describe: "The function that is called for each JSX fragment",
           type: "string",
+        })
+        .option("tsconfig", {
+          describe: "Path to a custom tsconfig.json file",
+          type: "string",
         });
     },
     async (args) => {
@@ -1123,6 +1132,7 @@ export async function main(argv: string[]): Promise<void> {
         triggers: args.triggers,
         jsxFactory: args["jsx-factory"],
         jsxFragment: args["jsx-fragment"],
+        tsconfig: args.tsconfig,
         routes: args.routes,
         assetPaths,
         legacyEnv: isLegacyEnv(args, config),
@@ -1324,6 +1334,7 @@ export async function main(argv: string[]): Promise<void> {
           initialMode={args.local ? "local" : "remote"}
           jsxFactory={config.jsx_factory}
           jsxFragment={config.jsx_fragment}
+          tsconfig={config.tsconfig}
           upstreamProtocol={config.dev.upstream_protocol}
           localProtocol={config.dev.local_protocol}
           enableLocalPersistence={false}

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -27,6 +27,7 @@ type Props = {
   legacyEnv: boolean | undefined;
   jsxFactory: undefined | string;
   jsxFragment: undefined | string;
+  tsconfig: undefined | string;
   experimentalPublic: boolean;
 };
 
@@ -97,6 +98,7 @@ export default async function publish(props: Props): Promise<void> {
         jsxFactory,
         jsxFragment,
         rules: props.rules,
+        tsconfig: props.tsconfig ?? config.tsconfig,
       }
     );
 


### PR DESCRIPTION
This adds a config field and a command line arg `tsconfig` for passing a path to a custom typescript configuration file. We don't do any typechecking, but we do pass it along to our build process so things like `compilerOptions.paths` get resolved correctly.