### PR TITLE
fix: ensure the correct worker name is published in legacy environments

### DIFF
--- a/.changeset/beige-olives-doubt.md
+++ b/.changeset/beige-olives-doubt.md
@@ -1,0 +1,18 @@
+---
+"wrangler": patch
+---
+
+fix: ensure the correct worker name is published in legacy environments
+
+When a developer uses `--env` to specify an environment name, the Worker name should
+be computed from the top-level Worker name and the environment name.
+
+When the given environment name does not match those in the wrangler.toml, we error.
+But if no environments have been specified in the wrangler.toml, at all, then we only
+log a warning and continue.
+
+In this second case, we were reusing the top-level environment, which did not have the
+correct legacy environment fields set, such as the name. Now we ensure that such an
+environment is created as needed.
+
+See https://github.com/cloudflare/wrangler2/pull/680#issuecomment-1080407556

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -108,11 +108,11 @@ export function normalizeAndValidateConfig(
 
   let activeEnv = topLevelEnv;
   if (envName !== undefined) {
+    const envDiagnostics = new Diagnostics(
+      `"env.${envName}" environment configuration`
+    );
     const rawEnv = rawConfig.env?.[envName];
     if (rawEnv !== undefined) {
-      const envDiagnostics = new Diagnostics(
-        `"env.${envName}" environment configuration`
-      );
       activeEnv = normalizeAndValidateEnvironment(
         envDiagnostics,
         configPath,
@@ -124,6 +124,18 @@ export function normalizeAndValidateConfig(
       );
       diagnostics.addChild(envDiagnostics);
     } else {
+      // An environment was specified, but no configuration for it was found.
+      // To cover any legacy environment cases, where the `envName` is used,
+      // Let's create a fake active environment with the specified `envName`.
+      activeEnv = normalizeAndValidateEnvironment(
+        envDiagnostics,
+        configPath,
+        {},
+        envName,
+        topLevelEnv,
+        isLegacyEnv,
+        rawConfig
+      );
       const envNames = rawConfig.env
         ? `The available configured environment names are: ${JSON.stringify(
             Object.keys(rawConfig.env)


### PR DESCRIPTION
When a developer uses `--env` to specify an environment name, the Worker name should
be computed from the top-level Worker name and the environment name.

When the given environment name does not match those in the wrangler.toml, we error.
But if no environments have been specified in the wrangler.toml, at all, then we only
log a warning and continue.

In this second case, we were reusing the top-level environment, which did not have the
correct legacy environment fields set, such as the name. Now we ensure that such an
environment is created as needed.

See https://github.com/cloudflare/wrangler2/pull/680#issuecomment-1080407556