### PR TITLE
Fix roadmap/milestone links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 [(Read the full stack week launch blog post.)](https://blog.cloudflare.com/wrangler-v2-beta/)
 
-**DISCLAIMER**: This is a work in progress, and is NOT recommended for use in production. We are opening this preview for feedback from the community, and to openly share our [roadmap](https://github.com/cloudflare/wrangler2/issues/12) for the future. As such, expect APIs and documentation to change before the end of the preview.
+**DISCLAIMER**: This is a work in progress, and is NOT recommended for use in production. We are opening this preview for feedback from the community, and to openly share our [roadmap](https://github.com/cloudflare/wrangler2/milestones) for the future. As such, expect APIs and documentation to change before the end of the preview.
 
-Further, we will NOT do a general release until we are both feature complete, and have a full backward compatibility and incremental migration plan in place. For more details, follow the [parent roadmap issue](https://github.com/cloudflare/wrangler2/issues/12).
+Further, we will NOT do a general release until we are both feature complete, and have a full backward compatibility and incremental migration plan in place. For more details, follow the [2.0 milestone](https://github.com/cloudflare/wrangler2/milestone/1).
 
 ## Quick Start
 


### PR DESCRIPTION
The links to the roadmap point to a closed issue which has been superseded by the milestone(s)

https://github.com/cloudflare/wrangler2/issues/12#issuecomment-1027253829
![image](https://user-images.githubusercontent.com/10026538/160434677-935080db-1875-4250-b57b-9a02848b806f.png)

Could also choose to point the link to the project view instead?
https://github.com/orgs/cloudflare/projects/1/views/1

Feel free to push changes to this branch 🙃 