### PR TITLE
fix: publish prerelease worker correctly

### DIFF
--- a/packages/prerelease-registry/package.json
+++ b/packages/prerelease-registry/package.json
@@ -8,7 +8,7 @@
     "check:type": "tsc",
     "prestart": "npm run build",
     "start": "npx wrangler dev _worker.js",
-    "prepublishOnly": "npm run build",
+    "prepublish": "npm run build",
     "publish": "npx wrangler publish _worker.js"
   },
   "devDependencies": {


### PR DESCRIPTION
I broke this in https://github.com/cloudflare/wrangler2/pull/715, reverting this single change.