### PR TITLE
fix: spread tail messages when logging

### DIFF
--- a/.changeset/chilly-bears-invent.md
+++ b/.changeset/chilly-bears-invent.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: spread tail messages when logging
+
+Logged messages (via console, etc) would previously be logged as an array of values. This spreads it when logging to match what is expected.

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -293,6 +293,55 @@ describe("tail", () => {
       `);
     });
 
+    it("logs console messages and exceptions", async () => {
+      const api = mockWebsocketAPIs();
+      await runWrangler("tail test-worker");
+
+      const event = generateMockRequestEvent();
+      const message = generateMockEventMessage({
+        event,
+        logs: [
+          { message: ["some string"], level: "log", timestamp: 1234561 },
+          {
+            message: [{ complex: "object" }],
+            level: "log",
+            timestamp: 1234562,
+          },
+          { message: [1234], level: "error", timestamp: 1234563 },
+        ],
+        exceptions: [
+          { name: "Error", message: "some error", timestamp: 1234564 },
+          { name: "Error", message: { complex: "error" }, timestamp: 1234564 },
+        ],
+      });
+      const serializedMessage = serialize(message);
+
+      api.ws.send(serializedMessage);
+      expect(
+        std.out
+          .replace(
+            new Date(mockEventTimestamp).toLocaleString(),
+            "[mock event timestamp]"
+          )
+          .replace(
+            mockTailExpiration.toLocaleString(),
+            "[mock expiration date]"
+          )
+      ).toMatchInlineSnapshot(`
+        "successfully created tail, expires at [mock expiration date]
+        Connected to test-worker, waiting for logs...
+        GET https://example.org/ - Ok @ [mock event timestamp]
+          (log) some string
+          (log) { complex: 'object' }
+          (error) 1234"
+      `);
+      expect(std.err).toMatchInlineSnapshot(`
+        "  Error: some error
+          Error: { complex: 'error' }"
+      `);
+      expect(std.warn).toMatchInlineSnapshot(`""`);
+    });
+
     it("logs scheduled messages in pretty format", async () => {
       const api = mockWebsocketAPIs();
       await runWrangler("tail test-worker --format pretty");

--- a/packages/wrangler/src/tail/index.ts
+++ b/packages/wrangler/src/tail/index.ts
@@ -161,7 +161,7 @@ export type TailEventMessage = {
    * Any logs sent out by the worker
    */
   logs: {
-    message: unknown;
+    message: unknown[];
     level: string; // TODO: make this a union of possible values
     timestamp: number;
   }[];

--- a/packages/wrangler/src/tail/printing.ts
+++ b/packages/wrangler/src/tail/printing.ts
@@ -24,7 +24,7 @@ export function prettyPrintLogs(data: WebSocket.RawData): void {
 
   if (eventMessage.logs.length > 0) {
     eventMessage.logs.forEach(({ level, message }) => {
-      console.log(`  (${level})`, message);
+      console.log(`  (${level})`, ...message);
     });
   }
 


### PR DESCRIPTION
Logged messages (via console, etc) would previously be logged as an array of values. This spreads it when logging to match what is expected.