### PR TITLE
bug: `wrangler pages functions` does not log a beta warning

### DIFF
--- a/packages/wrangler/src/__tests__/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages.test.ts
@@ -51,32 +51,36 @@ describe("subcommand implicit help ran on imcomplete command execution", () => {
 describe("beta message for subcommands", () => {
   const isWindows = process.platform === "win32";
   it("should display for pages:dev", async () => {
+    let err: Error | undefined;
     try {
       execaSync("npx", ["wrangler", "pages", "dev"], {
         shell: isWindows,
         env: { BROWSER: "none", ...process.env },
       }).stderr;
     } catch (e: unknown) {
-      expect(e).toMatchInlineSnapshot(`
+      err = e as Error;
+    }
+    expect(err).toMatchInlineSnapshot(`
         [Error: Command failed with exit code 1: npx wrangler pages dev
         🚧 'wrangler pages <command>' is a beta command. Please report any issues to https://github.com/cloudflare/wrangler2/issues/new/choose
         Must specify a directory of static assets to serve or a command to run.]
       `);
-    }
   });
 
   it("should display for pages:functions", async () => {
+    let err: Error | undefined;
     try {
       execaSync("npx", ["wrangler", "pages", "functions"], {
         shell: isWindows,
         env: { BROWSER: "none", ...process.env },
       }).stderr;
     } catch (e: unknown) {
-      expect(e).toMatchInlineSnapshot(`
+      err = e as Error;
+    }
+    expect(err).toMatchInlineSnapshot(`
           [Error: Command failed with exit code 1: npx wrangler pages functions
           🚧 'wrangler pages <command>' is a beta command. Please report any issues to https://github.com/cloudflare/wrangler2/issues/new/choose
           Must specify a directory of static assets to serve or a command to run.]
         `);
-    }
   });
 });

--- a/packages/wrangler/src/__tests__/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages.test.ts
@@ -49,6 +49,8 @@ describe("subcommand implicit help ran on imcomplete command execution", () => {
 });
 
 describe("beta message for subcommands", () => {
+  const betaMsg =
+    "🚧 'wrangler pages <command>' is a beta command. Please report any issues to https://github.com/cloudflare/wrangler2/issues/new/choose";
   const isWindows = process.platform === "win32";
   it("should display for pages:dev", async () => {
     let err: Error | undefined;
@@ -60,27 +62,20 @@ describe("beta message for subcommands", () => {
     } catch (e: unknown) {
       err = e as Error;
     }
-    expect(err).toMatchInlineSnapshot(`
-        [Error: Command failed with exit code 1: npx wrangler pages dev
-        🚧 'wrangler pages <command>' is a beta command. Please report any issues to https://github.com/cloudflare/wrangler2/issues/new/choose
-        Must specify a directory of static assets to serve or a command to run.]
-      `);
+    expect(err?.message.includes(betaMsg)).toBe(true);
   });
 
   it("should display for pages:functions", async () => {
     let err: Error | undefined;
     try {
-      execaSync("npx", ["wrangler", "pages", "functions"], {
+      execaSync("npx", ["wrangler", "pages", "functions", "build"], {
         shell: isWindows,
         env: { BROWSER: "none", ...process.env },
-      }).stderr;
+      });
     } catch (e: unknown) {
       err = e as Error;
     }
-    expect(err).toMatchInlineSnapshot(`
-          [Error: Command failed with exit code 1: npx wrangler pages functions
-          🚧 'wrangler pages <command>' is a beta command. Please report any issues to https://github.com/cloudflare/wrangler2/issues/new/choose
-          Must specify a directory of static assets to serve or a command to run.]
-        `);
+
+    expect(err?.message.includes(betaMsg)).toBe(true);
   });
 });


### PR DESCRIPTION
In https://github.com/cloudflare/wrangler2/pull/661, we wrote a test, but didn't actually test if the error gets thrown. Being explicit about the thrown error shows that the  error doesn't get thrown, and the warning doesn't get logged.

--- 

@JacobMGEvans Feel free to add commits to this branch and make the test pass. 