### PR TITLE
fix: assume a worker is a module worker only if it has a `default` export

### DIFF
--- a/.changeset/sharp-owls-dance.md
+++ b/.changeset/sharp-owls-dance.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: assume a worker is a module worker only if it has a `default` export
+
+This tweaks the logic that guesses worker formats to check whether a `default` export is defined on an entry point before assuming it's a module worker.

--- a/packages/wrangler/src/__tests__/guess-worker-format.test.ts
+++ b/packages/wrangler/src/__tests__/guess-worker-format.test.ts
@@ -1,10 +1,12 @@
 import { writeFile } from "fs/promises";
 import path from "path";
 import guessWorkerFormat from "../entry";
+import { mockConsoleMethods } from "./helpers/mock-console";
 import { runInTempDir } from "./helpers/run-in-tmp";
 
 describe("guess worker format", () => {
   runInTempDir();
+  const std = mockConsoleMethods();
   it('should detect a "modules" worker', async () => {
     await writeFile("./index.ts", "export default {};");
     // Note that this isn't actually a valid worker, because it's missing
@@ -39,7 +41,7 @@ describe("guess worker format", () => {
         "service-worker"
       )
     ).rejects.toThrow(
-      "You configured this worker to be a 'service-worker', but the file you are trying to build appears to have ES module exports. Please pass `--format modules`, or simply remove the configuration."
+      "You configured this worker to be a 'service-worker', but the file you are trying to build appears to have a `default` export like a module worker. Please pass `--format modules`, or simply remove the configuration."
     );
   });
 
@@ -64,5 +66,18 @@ describe("guess worker format", () => {
       undefined
     );
     expect(guess).toBe("service-worker");
+  });
+
+  it("logs a warning when a worker has exports, but not a default one", async () => {
+    await writeFile("./index.ts", "export const foo = 1;");
+    const guess = await guessWorkerFormat(
+      path.join(process.cwd(), "./index.ts"),
+      process.cwd(),
+      undefined
+    );
+    expect(guess).toBe("service-worker");
+    expect(std.warn).toMatchInlineSnapshot(
+      `"The entrypoint index.ts has exports like an ES Module, but hasn't defined a default export like a module worker normally would. Building the worker using \\"service-worker\\" format..."`
+    );
   });
 });


### PR DESCRIPTION
This tweaks the logic that guesses worker formats to check whether a `default` export is defined on an entry point before assuming it's a module worker.