### PR TITLE
WIP: Fix Error using `ctrl-c` in dev mode

### DIFF
--- a/.changeset/flat-ladybugs-care.md
+++ b/.changeset/flat-ladybugs-care.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+bugfix: The proxyServer was conducting async behavior in useEffect without cleaning up the SIGINT didn't allow for graceful shutdown for subsequent startups of proxyServer.
+
+fixes #375

--- a/packages/wrangler/src/proxy.ts
+++ b/packages/wrangler/src/proxy.ts
@@ -96,6 +96,12 @@ export function usePreviewServer({
           await reportError(err);
         });
     }
+    return () => {
+      if (proxyServer !== undefined) {
+        proxyServer.close();
+        setProxyServer(undefined);
+      }
+    };
   }, [proxyServer, localProtocol]);
 
   /**


### PR DESCRIPTION
The `proxyServer` was conducting async behavior in `useEffect` without cleaning up, the SIGINT didn't allow for graceful shutdown for subsequent startups of `proxyServer`.

resolve #375 