### PR TITLE
fix: only send durable object migrations when required

### DIFF
--- a/.changeset/forty-poets-invite.md
+++ b/.changeset/forty-poets-invite.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: only send durable object migrations when required
+
+We had a bug where even if you'd published a script with migrations, we would still send a blank set of migrations on the next round. The api doesn't accept this, so the fix is to not do so. I also expanded test coverage for migrations.
+
+Fixes https://github.com/cloudflare/wrangler2/issues/705

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -102,14 +102,36 @@ export default async function publish(props: Props): Promise<void> {
       }
     );
 
+    // Some validation of durable objects + migrations
+    if (config.durable_objects.bindings.length > 0) {
+      // TODO: implement durable objects for service environments
+      if (!props.legacyEnv) {
+        throw new Error(
+          "Publishing Durable Objects to a service environment is not currently supported. This is being tracked at https://github.com/cloudflare/wrangler2/issues/739"
+        );
+      }
+
+      // intrinsic [durable_objects] implies [migrations]
+      const exportedDurableObjects = config.durable_objects.bindings.filter(
+        (binding) => !binding.script_name
+      );
+      if (exportedDurableObjects.length > 0 && config.migrations.length === 0) {
+        console.warn(
+          `In wrangler.toml, you have configured [durable_objects] exported by this Worker (${exportedDurableObjects.map(
+            (durable) => durable.class_name
+          )}), but no [migrations] for them. This may not work as expected until you add a [migrations] section to your wrangler.toml. Refer to https://developers.cloudflare.com/workers/learning/using-durable-objects/#durable-object-migrations-in-wranglertoml for more details.`
+        );
+      }
+    }
+
     const content = readFileSync(resolvedEntryPointPath, {
       encoding: "utf-8",
     });
 
     // if config.migrations
-    // get current migration tag
     let migrations;
     if (config.migrations.length > 0) {
+      // get current migration tag
       const scripts = await fetchResult<
         { id: string; migration_tag: string }[]
       >(`/accounts/${accountId}/workers/scripts`);
@@ -129,15 +151,21 @@ export default async function publish(props: Props): Promise<void> {
             steps: config.migrations.map(({ tag: _tag, ...rest }) => rest),
           };
         } else {
-          migrations = {
-            old_tag: script.migration_tag,
-            new_tag: config.migrations[config.migrations.length - 1].tag,
-            steps: config.migrations
-              .slice(foundIndex + 1)
-              .map(({ tag: _tag, ...rest }) => rest),
-          };
+          if (foundIndex !== config.migrations.length - 1) {
+            // there are new migrations to send up
+            migrations = {
+              old_tag: script.migration_tag,
+              new_tag: config.migrations[config.migrations.length - 1].tag,
+              steps: config.migrations
+                .slice(foundIndex + 1)
+                .map(({ tag: _tag, ...rest }) => rest),
+            };
+          }
+          // else, we're up to date, no migrations to send
         }
       } else {
+        // first time publishing durable objects to this script,
+        // so we send all the migrations
         migrations = {
           new_tag: config.migrations[config.migrations.length - 1].tag,
           steps: config.migrations.map(({ tag: _tag, ...rest }) => rest),


### PR DESCRIPTION
We had a bug where even if you'd published a script with migrations, we would still send a blank set of migrations on the next round. The api doesn't accept this, so the fix is to not do so. I also expanded test coverage for migrations.

Fixes https://github.com/cloudflare/wrangler2/issues/705

--- 

This is the first in a set of a few PRs I'll send for durable objects. Next, more validations based on exports. 