### PR TITLE
Abort signalling

### DIFF
--- a/.changeset/wet-tables-pretend.md
+++ b/.changeset/wet-tables-pretend.md
@@ -1,0 +1,10 @@
+---
+"wrangler": patch
+---
+
+fix: abort async operations in the `Remote` component to avoid unwanted side-effects
+When the `Remote` component is unmounted, we now signal outstanding `fetch()` requests, and
+`waitForPortToBeAvailable()` tasks to cancel them. This prevents unexpected requests from appearing
+after the component has been unmounted, and also allows the process to exit cleanly without a delay.
+
+fixes #375

--- a/packages/wrangler/src/create-worker-preview.ts
+++ b/packages/wrangler/src/create-worker-preview.ts
@@ -58,7 +58,7 @@ export interface CfPreviewToken {
 async function sessionToken(
   account: CfAccount,
   ctx: CfWorkerContext,
-  abort: AbortSignal
+  abortSignal: AbortSignal
 ): Promise<CfPreviewToken> {
   const { accountId } = account;
   const initUrl = ctx.zone
@@ -67,7 +67,7 @@ async function sessionToken(
 
   const { exchange_url } = await fetchResult<{ exchange_url: string }>(initUrl);
   const { inspector_websocket, token } = (await (
-    await fetch(exchange_url, { signal: abort })
+    await fetch(exchange_url, { signal: abortSignal })
   ).json()) as { inspector_websocket: string; token: string };
   const { host } = new URL(inspector_websocket);
   const query = `cf_workers_preview_token=${token}`;
@@ -98,12 +98,12 @@ async function createPreviewToken(
   account: CfAccount,
   worker: CfWorkerInit,
   ctx: CfWorkerContext,
-  abort: AbortSignal
+  abortSignal: AbortSignal
 ): Promise<CfPreviewToken> {
   const { value, host, inspectorUrl, prewarmUrl } = await sessionToken(
     account,
     ctx,
-    abort
+    abortSignal
   );
 
   const { accountId } = account;
@@ -159,12 +159,12 @@ export async function createWorkerPreview(
   init: CfWorkerInit,
   account: CfAccount,
   ctx: CfWorkerContext,
-  abort: AbortSignal
+  abortSignal: AbortSignal
 ): Promise<CfPreviewToken> {
-  const token = await createPreviewToken(account, init, ctx, abort);
+  const token = await createPreviewToken(account, init, ctx, abortSignal);
   const response = await fetch(token.prewarmUrl.href, {
     method: "POST",
-    signal: abort,
+    signal: abortSignal,
   });
   if (!response.ok) {
     // console.error("worker failed to prewarm: ", response.statusText);

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -348,6 +348,7 @@ function useHotkeys(
 ) {
   // UGH, we should put port in context instead
   const [toggles, setToggles] = useState(initial);
+  const { exit } = useApp();
   useInput(
     async (
       input,
@@ -385,7 +386,7 @@ function useHotkeys(
         // shut down
         case "q":
         case "x":
-          process.exit(0);
+          exit();
           break;
         default:
           // nothing?

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -60,11 +60,16 @@ function useLocalWorker({
   const removeSignalExitListener = useRef<() => void>();
   const [inspectorUrl, setInspectorUrl] = useState<string | undefined>();
   useEffect(() => {
+    const abortController = new AbortController();
     async function startLocalWorker() {
       if (!bundle || !format) return;
 
       // port for the worker
-      await waitForPortToBeAvailable(port, { retryPeriod: 200, timeout: 2000 });
+      await waitForPortToBeAvailable(port, {
+        retryPeriod: 200,
+        timeout: 2000,
+        abortSignal: abortController.signal,
+      });
 
       if (publicDirectory) {
         throw new Error(
@@ -249,6 +254,7 @@ function useLocalWorker({
     });
 
     return () => {
+      abortController.abort();
       if (local.current) {
         console.log("⎔ Shutting down local server.");
         local.current?.kill();

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -106,7 +106,7 @@ export function useWorker(props: {
   const startedRef = useRef(false);
 
   useEffect(() => {
-    const abortCtrl = new AbortController();
+    const abortController = new AbortController();
     async function start() {
       setToken(undefined); // reset token in case we're re-running
 
@@ -175,20 +175,18 @@ export function useWorker(props: {
             apiToken,
           },
           { env: props.env, legacyEnv: props.legacyEnv, zone: props.zone },
-          abortCtrl.signal
+          abortController.signal
         )
       );
     }
     start().catch((err) => {
-      if ((err as { code: string }).code !== "ABORT_ERR") {
-        // we want to log the error, but not end the process
-        // since it could recover after the developer fixes whatever's wrong
-        console.error("remote worker:", err);
-      }
+      // we want to log the error, but not end the process
+      // since it could recover after the developer fixes whatever's wrong
+      console.error("remote worker:", err);
     });
 
     return () => {
-      abortCtrl.abort();
+      abortController.abort();
     };
   }, [
     name,


### PR DESCRIPTION
fix: abort async operations in the `Remote` component to avoid unwanted side-effects
When the `Remote` component is unmounted, we now signal outstanding `fetch()` requests, and
`waitForPortToBeAvailable()` tasks to cancel them. This prevents unexpected requests from appearing
after the component has been unmounted, and also allows the process to exit cleanly without a delay.

fixes #375