### PR TITLE
fix: exit dev if build fails on first run

### DIFF
--- a/.changeset/itchy-cheetahs-sit.md
+++ b/.changeset/itchy-cheetahs-sit.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: exit dev if build fails on first run
+
+Because of https://github.com/evanw/esbuild/issues/1037, we can't recover dev if esbuild fails on first run. The workaround is to end the process if it does so, until we have a better fix.
+
+Reported in https://github.com/cloudflare/wrangler2/issues/731


### PR DESCRIPTION
Because of https://github.com/evanw/esbuild/issues/1037, we can't recover dev if esbuild fails on first run. The workaround is to end the process if it does so, until we have a better fix.

Reported in https://github.com/cloudflare/wrangler2/issues/731