### PR TITLE
fix: add support for cron triggers in `dev --local` mode

### DIFF
--- a/.changeset/tricky-crabs-search.md
+++ b/.changeset/tricky-crabs-search.md
@@ -1,0 +1,10 @@
+---
+"example-worker-app": patch
+"wrangler": patch
+---
+
+fix: add support for cron triggers in `dev --local` mode
+
+Currently, I don't know if there is support for doing this in "remote" dev mode.
+
+Resolves #737

--- a/packages/example-worker-app/src/index.js
+++ b/packages/example-worker-app/src/index.js
@@ -10,6 +10,18 @@ export default {
 
     return new Response(`${request.url} ${now()}`);
   },
+
+  /**
+   * Handle a scheduled event.
+   *
+   * If developing using `--local` mode, you can trigger this scheduled event via a CURL.
+   * E.g. `curl "http://localhost:8787/cdn-cgi/mf/scheduled"`.
+   * See the Miniflare docs: https://miniflare.dev/core/scheduled.
+   */
+  scheduled(event, env, ctx) {
+    ctx.waitUntil(Promise.resolve(event.scheduledTime));
+    ctx.waitUntil(Promise.resolve(event.cron));
+  },
 };
 
 // addEventListener("fetch", (event) => {

--- a/packages/example-worker-app/wrangler.toml
+++ b/packages/example-worker-app/wrangler.toml
@@ -1,0 +1,7 @@
+name = "example-worker-app"
+compatibility_date = "2022-03-31"
+
+main = "src/index.js"
+
+[triggers]
+crons = ["1 * * * *"]

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -37,6 +37,7 @@ export type DevProps = {
   localProtocol: "https" | "http";
   enableLocalPersistence: boolean;
   bindings: CfWorkerInit["bindings"];
+  crons: Config["triggers"]["crons"];
   public: undefined | string;
   assetPaths: undefined | AssetPaths;
   compatibilityDate: undefined | string;
@@ -163,6 +164,7 @@ function DevSession(props: DevSessionProps) {
       rules={props.rules}
       inspectorPort={props.inspectorPort}
       enableLocalPersistence={props.enableLocalPersistence}
+      crons={props.crons}
     />
   ) : (
     <Remote

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -27,6 +27,7 @@ interface LocalProps {
   rules: Config["rules"];
   inspectorPort: number;
   enableLocalPersistence: boolean;
+  crons: Config["triggers"]["crons"];
 }
 
 export function Local(props: LocalProps) {
@@ -52,6 +53,7 @@ function useLocalWorker({
   rules,
   enableLocalPersistence,
   ip,
+  crons,
 }: LocalProps) {
   // TODO: pass vars via command line
   const local = useRef<ReturnType<typeof spawn>>();
@@ -150,6 +152,7 @@ function useLocalWorker({
         dataBlobBindings,
         sourceMap: true,
         logUnhandledRejections: true,
+        crons,
       };
 
       // The path to the Miniflare CLI assumes that this file is being run from
@@ -247,6 +250,7 @@ function useLocalWorker({
     bindings.wasm_modules,
     bindings.text_blobs,
     bindings.data_blobs,
+    crons,
   ]);
   return { inspectorUrl };
 }

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -927,6 +927,7 @@ export async function main(argv: string[]): Promise<void> {
             r2_buckets: config.r2_buckets,
             unsafe: config.unsafe?.bindings,
           }}
+          crons={config.triggers.crons}
         />
       );
       await waitUntilExit();
@@ -1310,6 +1311,7 @@ export async function main(argv: string[]): Promise<void> {
             r2_buckets: config.r2_buckets,
             unsafe: config.unsafe?.bindings,
           }}
+          crons={config.triggers.crons}
           inspectorPort={await getPort({ port: 9229 })}
         />
       );

--- a/packages/wrangler/src/miniflare-cli/index.ts
+++ b/packages/wrangler/src/miniflare-cli/index.ts
@@ -26,6 +26,7 @@ async function main() {
   try {
     // Start Miniflare development server
     await mf.startServer();
+    await mf.startScheduler();
   } catch (e) {
     mf.log.error(e as Error);
     process.exitCode = 1;


### PR DESCRIPTION
Currently, I don't know if there is support for doing this in "remote" dev mode.

Resolves #737