### PR TITLE
Get out in front of trademark issues with `wrangler jeans` and `wrangler jeep`

### DIFF
--- a/.changeset/few-radios-drum.md
+++ b/.changeset/few-radios-drum.md
@@ -1,0 +1,13 @@
+---
+"wrangler": patch
+---
+
+Get out in front of trademark issues with `wrangler jeans` and `wrangler jeep`
+
+It's no secret that the wrangler 2 release is going to be big. Bigger than big. In fact, I don't think it's too much of a stretch to say it will change the way that software is developed and deployed on a huge scale. Like, on the same level as [git](https://blog.codacy.com/the-impact-of-git-on-software-development), or [CI/CD](https://jhall.io/archive/2021/09/26/a-brief-history-of-ci/cd/), or [debugging](https://revdebug.com/blog/debugging-history-origins/).
+
+As a result, there are bound to be lawsuits incoming. Lawyers clamoring at Cloudflare's door with spurious claims like "You can't monopolize the entire serverless market with your ridiculously sleek, top-of-the-line, dev-friendly CLI!" and "We're suing for damages because our team was unable to work for a month straight after your project became so popular that it single-handedly took down GitHub."
+
+These should be easily dealt with by Cloudflare's legal team. However, there is a potential issue regarding the naming of our CLI tool. Once wrangler becomes popular enough (which it will), and our SEO gets juiced enough (which it will), searches for "wrangler" will lead to our CLI first, and [jeans](https://www.wrangler.com/) and [Jeeps](https://www.jeep.com/wrangler.html) second.
+
+This PR aims to address these complaints before they happen, by incorporating both of those products into our own. Embrace, Extend, Extinguish. Eventually, of course, it will be buying "Cloudflare Jeans" and "Jeep Cloudflares", but until the inevitable merger between the three companies it's probably best to throw a bone their way.

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -3,6 +3,7 @@ import * as fsp from "node:fs/promises";
 import * as TOML from "@iarna/toml";
 import { parseConfigFileTextToJson } from "typescript";
 import { version as wranglerVersion } from "../../package.json";
+import openInBrowser from "../open-in-browser";
 import { getPackageManager } from "../package-manager";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { mockConfirm } from "./helpers/mock-dialogs";
@@ -48,6 +49,8 @@ describe("wrangler", () => {
           wrangler login             🔓 Login to Cloudflare
           wrangler logout            🚪 Logout from Cloudflare
           wrangler whoami            🕵️  Retrieve your user info and test your auth config
+          wrangler jeans             👖 Real. Comfortable. Jeans.®
+          wrangler jeep              🚙 Go Anywhere, Do Anything®
 
         Flags:
           -c, --config      Path to .toml configuration file  [string]
@@ -86,6 +89,8 @@ describe("wrangler", () => {
           wrangler login             🔓 Login to Cloudflare
           wrangler logout            🚪 Logout from Cloudflare
           wrangler whoami            🕵️  Retrieve your user info and test your auth config
+          wrangler jeans             👖 Real. Comfortable. Jeans.®
+          wrangler jeep              🚙 Go Anywhere, Do Anything®
 
         Flags:
           -c, --config      Path to .toml configuration file  [string]
@@ -982,6 +987,50 @@ describe("wrangler", () => {
           \`wrangler build\` has been deprecated, please refer to https://github.com/cloudflare/wrangler2/blob/main/docs/deprecations.md#build for alternatives"
         `);
       });
+    });
+  });
+
+  describe("jeep", () => {
+    it("should direct users to the Jeep Wrangler site", async () => {
+      await expect(runWrangler("jeep")).resolves.toBeUndefined();
+      expect(openInBrowser).lastCalledWith(
+        "https://www.jeep.com/wrangler.html"
+      );
+    });
+
+    it("should open a test-driving simulator when --test-drive is passed", async () => {
+      await expect(runWrangler("jeep --test-drive")).resolves.toBeUndefined();
+      expect(openInBrowser).lastCalledWith(
+        "https://cameronmcgehee.com/flash-game-archive/gamewithemulator?gameid=37485f4343ab780bd"
+      );
+    });
+  });
+
+  describe("jeans", () => {
+    it("should direct users to the Wrangler Jeans site", async () => {
+      await expect(runWrangler("jeans")).resolves.toBeUndefined();
+      expect(openInBrowser).lastCalledWith("https://www.wrangler.com/");
+    });
+
+    it("should respect your gender identity", async () => {
+      await expect(runWrangler("jeans --gender men")).resolves.toBeUndefined();
+      expect(openInBrowser).lastCalledWith(
+        "https://www.wrangler.com/shop/men-jeans"
+      );
+
+      await expect(
+        runWrangler("jeans --gender women")
+      ).resolves.toBeUndefined();
+      expect(openInBrowser).lastCalledWith(
+        "https://www.wrangler.com/shop/women-jeans"
+      );
+
+      await expect(
+        runWrangler("jeans --gender western")
+      ).resolves.toBeUndefined();
+      expect(openInBrowser).lastCalledWith(
+        "https://www.wrangler.com/western-wear.html"
+      );
     });
   });
 });

--- a/packages/wrangler/src/__tests__/jest.setup.ts
+++ b/packages/wrangler/src/__tests__/jest.setup.ts
@@ -1,3 +1,4 @@
+import { ChildProcess } from "node:child_process";
 import fetchMock from "jest-fetch-mock";
 import {
   fetchInternal,
@@ -71,4 +72,10 @@ jest.mock("../dev/dev", () => {
 });
 
 jest.mock("../open-in-browser");
-(openInBrowser as jest.Mock).mockImplementation(mockOpenInBrowserForOAuthFlow);
+(openInBrowser as jest.Mock).mockImplementation((url: string, ...args) => {
+  if (url.includes("cloudflare.com")) {
+    return mockOpenInBrowserForOAuthFlow(url, args);
+  } else {
+    return () => new ChildProcess();
+  }
+});

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -31,6 +31,7 @@ import {
   isKeyValue,
   unexpectedKeyValueProps,
 } from "./kv";
+import openInBrowser from "./open-in-browser";
 import { getPackageManager } from "./package-manager";
 import { pages, pagesBetaWarning } from "./pages";
 import { formatMessage, ParseError, parseJSON, readFileSync } from "./parse";
@@ -2349,6 +2350,62 @@ export async function main(argv: string[]): Promise<void> {
     async () => {
       printWranglerBanner();
       await whoami();
+    }
+  );
+
+  // jeans
+  wrangler.command(
+    "jeans",
+    "👖 Real. Comfortable. Jeans.®",
+    (yargs) => {
+      return yargs.option("gender", {
+        describe: "Select from a subset of available jeans based on gender",
+        // these are the three genders recognized by Wrangler Jeans Co.
+        choices: ["men", "women", "western"],
+      });
+    },
+    async ({ gender }) => {
+      printWranglerBanner();
+      let url = "";
+      switch (gender) {
+        case "men":
+          url = "https://www.wrangler.com/shop/men-jeans";
+          break;
+        case "women":
+          url = "https://www.wrangler.com/shop/women-jeans";
+          break;
+        case "western":
+          url = "https://www.wrangler.com/western-wear.html";
+          break;
+        default:
+          url = "https://www.wrangler.com/";
+          break;
+      }
+
+      await openInBrowser(url);
+    }
+  );
+
+  // jeep
+  wrangler.command(
+    "jeep",
+    "🚙 Go Anywhere, Do Anything®",
+    (yargs) => {
+      return yargs.option("test-drive", {
+        describe: "Test drive your Wrangler online before you buy",
+        boolean: true,
+      });
+    },
+    async ({ testDrive }) => {
+      printWranglerBanner();
+
+      await openInBrowser("https://www.jeep.com/wrangler.html");
+
+      if (testDrive) {
+        await openInBrowser(
+          "https://cameronmcgehee.com/flash-game-archive/gamewithemulator?gameid=37485f4343ab780bd"
+        );
+      }
     }
   );
 


### PR DESCRIPTION
It's no secret that the wrangler 2 release is going to be big. Bigger than big. In fact, I don't think it's too much of a stretch to say it will change the way that software is developed and deployed on a huge scale. Like, on the same level as [git](https://blog.codacy.com/the-impact-of-git-on-software-development), or [CI/CD](https://jhall.io/archive/2021/09/26/a-brief-history-of-ci/cd/), or [debugging](https://revdebug.com/blog/debugging-history-origins/).

As a result, there are bound to be lawsuits incoming. Lawyers clamoring at Cloudflare's door with spurious claims like "You can't monopolize the entire serverless market with your ridiculously sleek, top-of-the-line, dev-friendly CLI!" and "We're suing for damages because our team was unable to work for a month straight after your project became so popular that it single-handedly took down GitHub."

These should be easily dealt with by Cloudflare's legal team. However, there is a potential issue regarding the naming of our CLI tool. Once wrangler becomes popular enough (which it will), and our SEO gets juiced enough (which it will), searches for "wrangler" will lead to our CLI first, and [jeans](https://www.wrangler.com/) and [Jeeps](https://www.jeep.com/wrangler.html) second.

This PR aims to address these complaints before they happen, by incorporating both of those products into our own. Embrace, Extend, Extinguish. Eventually, of course, it will be buying "Cloudflare Jeans" and "Jeep Cloudflares", but until the inevitable merger between the three companies it's probably best to throw a bone their way.

[context](https://en.wikipedia.org/wiki/April_Fools%27_Day)