### PR TITLE
fix: remove superfluous debugger log messages from local dev

### DIFF
--- a/.changeset/thin-buckets-cross.md
+++ b/.changeset/thin-buckets-cross.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: remove superfluous debugger log messages from local dev
+
+Closes #387

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -191,7 +191,6 @@ function useLocalWorker({
       });
 
       local.current.stderr?.on("data", (data: Buffer) => {
-        console.error(`${data.toString()}`);
         const matches =
           /Debugger listening on (ws:\/\/127\.0\.0\.1:\d+\/[A-Za-z0-9-]+)/.exec(
             data.toString()


### PR DESCRIPTION
This simple change results in:

```
npx wrangler -c packages/example-worker-app/wrangler.toml dev --local
 ⛅️ wrangler 0.0.24 
--------------------
⎔ Starting a local server...
[mf:inf] Worker reloaded! (470B)

[mf:inf] Listening on localhost:8787

[mf:inf] - http://localhost:8787

[mf:inf] Updated Request cf object cache!

╭──────────────────────────────────────────────────────────────────────────────╮
│ B to open a browser, D to open Devtools, L to turn off local mode, X to exit │
╰──────────────────────────────────────────────────────────────────────────────╯
```

which removes the debugger messages and is an improvement.

Note that messages containing build errors, runtime errors and request/response values are not affected.

Closes #387