### PR TITLE
refactor: remove `process.exit()` from the pages code

### DIFF
--- a/.changeset/polite-lemons-shop.md
+++ b/.changeset/polite-lemons-shop.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+---
+
+refactor: remove `process.exit()` from the pages code
+
+This enables simpler testing, as we do not have to spawn new child processes
+to avoid the `process.exit()` from killing the jest process.
+
+As part of the refactor, some of the `Error` classes have been moved to a
+shared `errors.ts` file.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,6 +17,7 @@
     "pgrep",
     "PKCE",
     "Positionals",
+    "scandir",
     "selfsigned",
     "textfile",
     "tsbuildinfo",
@@ -28,7 +29,12 @@
     "websockets",
     "xxhash"
   ],
-  "cSpell.ignoreWords": ["TESTTEXTBLOBNAME", "TESTWASMNAME", "yxxx"],
+  "cSpell.ignoreWords": [
+    "TESTTEXTBLOBNAME",
+    "TESTWASMNAME",
+    "extensionless",
+    "yxxx"
+  ],
   "eslint.runtime": "node",
   "files.trimTrailingWhitespace": true
 }

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -845,14 +845,14 @@ describe("wrangler", () => {
     it("should throw an error if the deprecated command is used with positional arguments", async () => {
       await expect(runWrangler("preview GET")).rejects
         .toThrowErrorMatchingInlineSnapshot(`
-              "DEPRECATION WARNING:
+              "DEPRECATION:
               The \`wrangler preview\` command has been deprecated.
               Try using \`wrangler dev\` to to try out a worker during development.
               "
             `);
       await expect(runWrangler(`preview GET "SomeBody"`)).rejects
         .toThrowErrorMatchingInlineSnapshot(`
-              "DEPRECATION WARNING:
+              "DEPRECATION:
               The \`wrangler preview\` command has been deprecated.
               Try using \`wrangler dev\` to to try out a worker during development.
               "
@@ -970,7 +970,7 @@ describe("wrangler", () => {
     it("should print a deprecation message for 'generate'", async () => {
       await runWrangler("generate").catch((err) => {
         expect(err.message).toMatchInlineSnapshot(`
-          "DEPRECATION WARNING:
+          "DEPRECATION:
           \`wrangler generate\` has been deprecated, please refer to https://github.com/cloudflare/wrangler2/blob/main/docs/deprecations.md#generate for alternatives"
         `);
       });
@@ -978,7 +978,7 @@ describe("wrangler", () => {
     it("should print a deprecation message for 'build'", async () => {
       await runWrangler("build").catch((err) => {
         expect(err.message).toMatchInlineSnapshot(`
-          "DEPRECATION WARNING:
+          "DEPRECATION:
           \`wrangler build\` has been deprecated, please refer to https://github.com/cloudflare/wrangler2/blob/main/docs/deprecations.md#build for alternatives"
         `);
       });

--- a/packages/wrangler/src/__tests__/route.test.ts
+++ b/packages/wrangler/src/__tests__/route.test.ts
@@ -9,7 +9,7 @@ describe("wrangler route", () => {
   it("shows a deprecation notice when `wrangler route` is run", async () => {
     await expect(runWrangler("route")).rejects
       .toThrowErrorMatchingInlineSnapshot(`
-            "DEPRECATION WARNING:
+            "DEPRECATION:
             \`wrangler route\` has been deprecated.
             Please use wrangler.toml and/or \`wrangler publish --routes\` to modify routes"
           `);
@@ -18,7 +18,7 @@ describe("wrangler route", () => {
   it("shows a deprecation notice when `wrangler route delete` is run", async () => {
     await expect(runWrangler("route delete")).rejects
       .toThrowErrorMatchingInlineSnapshot(`
-            "DEPRECATION WARNING:
+            "DEPRECATION:
             \`wrangler route delete\` has been deprecated.
             Remove the unwanted route(s) from wrangler.toml and run \`wrangler publish\` to remove your worker from those routes."
           `);
@@ -27,7 +27,7 @@ describe("wrangler route", () => {
   it("shows a deprecation notice when `wrangler route delete <id>` is run", async () => {
     await expect(runWrangler("route delete some-zone-id")).rejects
       .toThrowErrorMatchingInlineSnapshot(`
-            "DEPRECATION WARNING:
+            "DEPRECATION:
             \`wrangler route delete\` has been deprecated.
             Remove the unwanted route(s) from wrangler.toml and run \`wrangler publish\` to remove your worker from those routes."
           `);
@@ -36,7 +36,7 @@ describe("wrangler route", () => {
   it("shows a deprecation notice when `wrangler route list` is run", async () => {
     await expect(runWrangler("route list")).rejects
       .toThrowErrorMatchingInlineSnapshot(`
-            "DEPRECATION WARNING:
+            "DEPRECATION:
             \`wrangler route list\` has been deprecated.
             Refer to wrangler.toml for a list of routes the worker will be deployed to upon publishing.
             Refer to the Cloudflare Dashboard to see the routes this worker is currently running on."

--- a/packages/wrangler/src/cli.ts
+++ b/packages/wrangler/src/cli.ts
@@ -1,5 +1,6 @@
 import process from "process";
 import { hideBin } from "yargs/helpers";
+import { FatalError } from "./errors";
 import { reportError, initReporting } from "./reporting";
 import { main } from ".";
 
@@ -11,9 +12,10 @@ process.on("uncaughtExceptionMonitor", async (err, origin) => {
   await reportError(err, origin);
 });
 
-main(hideBin(process.argv)).catch(() => {
+main(hideBin(process.argv)).catch((e) => {
   // The logging of any error that was thrown from `main()` is handled in the `yargs.fail()` handler.
   // Here we just want to ensure that the process exits with a non-zero code.
   // We don't want to do this inside the `main()` function, since that would kill the process when running our tests.
-  process.exit(1);
+  const exitCode = (e instanceof FatalError && e.code) || 1;
+  process.exit(exitCode);
 });

--- a/packages/wrangler/src/errors.ts
+++ b/packages/wrangler/src/errors.ts
@@ -1,0 +1,11 @@
+export class DeprecationError extends Error {
+  constructor(message: string) {
+    super(`DEPRECATION:\n${message}`);
+  }
+}
+
+export class FatalError extends Error {
+  constructor(message?: string, readonly code?: number) {
+    super(message);
+  }
+}

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -18,6 +18,7 @@ import { createWorkerUploadForm } from "./create-worker-upload-form";
 import Dev from "./dev/dev";
 import { confirm, prompt } from "./dialogs";
 import { getEntry } from "./entry";
+import { DeprecationError } from "./errors";
 import {
   getNamespaceId,
   listNamespaces,
@@ -211,11 +212,6 @@ function demandOneOfOption(...options: string[]) {
 }
 
 class CommandLineArgsError extends Error {}
-class DeprecationError extends Error {
-  constructor(message: string) {
-    super(`DEPRECATION WARNING:\n${message}`);
-  }
-}
 
 export async function main(argv: string[]): Promise<void> {
   const wrangler = makeCLI(argv)


### PR DESCRIPTION
This enables simpler testing, as we do not have to spawn new child processes
to avoid the `process.exit()` from killing the jest process.