### PR TITLE
chore: upgrade `miniflare` to `2.4.0`

### DIFF
--- a/.changeset/grumpy-chairs-itch.md
+++ b/.changeset/grumpy-chairs-itch.md
@@ -1,0 +1,6 @@
+---
+"jest-environment-wrangler": patch
+"wrangler": patch
+---
+
+Upgrade `miniflare` to [`2.4.0`](https://github.com/cloudflare/miniflare/releases/tag/v2.4.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2395,12 +2395,12 @@
       }
     },
     "node_modules/@miniflare/cache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.3.0.tgz",
-      "integrity": "sha512-lOf3WVtrs0ac7KOtsQ+JOGHWR90zsqqJbolE+Wt4hIZuvM2U3t1RD2Ms7U20J301msVIsBAd02IL57H95LXQtQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.4.0.tgz",
+      "integrity": "sha512-tMDXlUVlThgFubJmlxZoKmLK8kBxDmuMbVMt7csHpXegzkuo2TmIsDqBE/C3CRiJ5xeCQgpD6iZtKBu5Zn5fRA==",
       "dependencies": {
-        "@miniflare/core": "2.3.0",
-        "@miniflare/shared": "2.3.0",
+        "@miniflare/core": "2.4.0",
+        "@miniflare/shared": "2.4.0",
         "http-cache-semantics": "^4.1.0",
         "undici": "4.13.0"
       },
@@ -2409,11 +2409,11 @@
       }
     },
     "node_modules/@miniflare/cli-parser": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.3.0.tgz",
-      "integrity": "sha512-yQzU+OBBvWshr9qVxAe6bWXJLNfpmLYrfkfR3u+rPOo2LYnccWg0f/8jtxrXM1TIyu+tCOJGqCODpO//XtrwWw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.4.0.tgz",
+      "integrity": "sha512-Xr5lO8f+oIr9r/b2dfo0on1p0MNN+pkwRHWoY5ACSnp9FaGnwm/g71DM7AajIQPIk0TpRsSVNDx8Ygj1LPT+sQ==",
       "dependencies": {
-        "@miniflare/shared": "2.3.0",
+        "@miniflare/shared": "2.4.0",
         "kleur": "^4.1.4"
       },
       "engines": {
@@ -2421,13 +2421,13 @@
       }
     },
     "node_modules/@miniflare/core": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.3.0.tgz",
-      "integrity": "sha512-Dltb3p+Uq5Lx53DuInckHYaDoMrBq49HE/p/oUDXmzHmQy7EAM6v+nJGKmiM9Uen4OqyqsmlmPWqntSMjaX7Jg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.4.0.tgz",
+      "integrity": "sha512-vYl8xaWTFzxtkbzx3IkT4Py0OAFdfmFnVo627O1HKHWVGlkjVr8UKtxBpIR+f5pq/HCMzzqA1HM9FXO0dQfy3A==",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/shared": "2.3.0",
-        "@miniflare/watcher": "2.3.0",
+        "@miniflare/shared": "2.4.0",
+        "@miniflare/watcher": "2.4.0",
         "busboy": "^0.3.1",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
@@ -2447,13 +2447,13 @@
       }
     },
     "node_modules/@miniflare/durable-objects": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.3.0.tgz",
-      "integrity": "sha512-YuzxBBu9xBU3xxD4TzGdeVVMXrE76AWJE4MIqkJR5UmASqayyv//cApGw3+C01NHe07cpbrTM1QTgFo2eBncwQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.4.0.tgz",
+      "integrity": "sha512-VVLaUXXcAQcYE/3YmDLTacZf5OzR8bib6q1T9NqVb0uK5sLMQqyHvQdsG5rMqs7iyxfJxyZ0bL2OW9XGALOkoQ==",
       "dependencies": {
-        "@miniflare/core": "2.3.0",
-        "@miniflare/shared": "2.3.0",
-        "@miniflare/storage-memory": "2.3.0",
+        "@miniflare/core": "2.4.0",
+        "@miniflare/shared": "2.4.0",
+        "@miniflare/storage-memory": "2.4.0",
         "undici": "4.13.0"
       },
       "engines": {
@@ -2461,12 +2461,12 @@
       }
     },
     "node_modules/@miniflare/html-rewriter": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.3.0.tgz",
-      "integrity": "sha512-cyWhmQgzhtRlBeg0mxP5FmAq/75ChuLwWQlhokx88XkGnteuh0/DOk3OxIMaveF2oDHKmIlLFgSlzv4NbT1Mng==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.4.0.tgz",
+      "integrity": "sha512-ZG8819N7LelDD+8+Ss5FZpVyQQq/V2igod0qE68JK4he/w4/yn57Rk6Efb49y15HoHAXl2RpCCsnCyIow/Xjug==",
       "dependencies": {
-        "@miniflare/core": "2.3.0",
-        "@miniflare/shared": "2.3.0",
+        "@miniflare/core": "2.4.0",
+        "@miniflare/shared": "2.4.0",
         "html-rewriter-wasm": "^0.4.1",
         "undici": "4.13.0"
       },
@@ -2475,13 +2475,13 @@
       }
     },
     "node_modules/@miniflare/http-server": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.3.0.tgz",
-      "integrity": "sha512-jTzsRuro3yWVb4T85znBGw1w+ydimgi2PJvHrTuGFKDjFam+R037fGH+HZCAjAgPiBHTroXfkeSXypJLXbQBEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.4.0.tgz",
+      "integrity": "sha512-r6Z/nqxE0oa1z63L95yvnG0PUeLRxZOeGS7ADxZMFKan4WD5lvYtSKDuDEm0lkbQshCOHQ3uXFr0cotOm8JoMQ==",
       "dependencies": {
-        "@miniflare/core": "2.3.0",
-        "@miniflare/shared": "2.3.0",
-        "@miniflare/web-sockets": "2.3.0",
+        "@miniflare/core": "2.4.0",
+        "@miniflare/shared": "2.4.0",
+        "@miniflare/web-sockets": "2.4.0",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
         "undici": "4.13.0",
@@ -2513,34 +2513,34 @@
       }
     },
     "node_modules/@miniflare/kv": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.3.0.tgz",
-      "integrity": "sha512-m0zu5sRoaFDm+WVTnLRrz8+77b6eVxQN7cLN6ZQiKP3Nd8cAggPdaIIef8dVksWbPvOW9DztoUVZTB1v9EOaLA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.4.0.tgz",
+      "integrity": "sha512-1UW7f1386xR6EDEXNZOR1TpFwQfRRSxUPqD6m/U0WprlsbM0cIYGz+AUeaVbkFf8lfE2MeXCUrjbWsLOvsnw3g==",
       "dependencies": {
-        "@miniflare/shared": "2.3.0"
+        "@miniflare/shared": "2.4.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/runner-vm": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.3.0.tgz",
-      "integrity": "sha512-/aB997YodNcRFxtlnvEn4BJSIqKXRw29FexOqCWwWv+b7XQkTTxd4IfSocIFi6du3265gp85icqP/hxsLAQBVg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.4.0.tgz",
+      "integrity": "sha512-7sdwBYzXQTwYeR3tTvQ+vJfzc7BXwqR8AUPK9l5gvCtg+Geq9sMslr5SikIJpgcvbYqKDjvC9DQEPJ3sqr9cSQ==",
       "dependencies": {
-        "@miniflare/shared": "2.3.0"
+        "@miniflare/shared": "2.4.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/scheduler": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.3.0.tgz",
-      "integrity": "sha512-Er80srMNXbxqGbYXtiZkD8UlveHsw4cpwcytQgsEJCHG7/48vC/rpmtN0zKOWFEHifaOUvHhURZRJu+S2E4Stg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.4.0.tgz",
+      "integrity": "sha512-dfMCXoAS8Y+3xABNxYju62I2xIBS54Op7ohCHoatvAM5RvualJUPICEMPZzX6/z29q5xPIeSLhLDhl/asAQ19w==",
       "dependencies": {
-        "@miniflare/core": "2.3.0",
-        "@miniflare/shared": "2.3.0",
+        "@miniflare/core": "2.4.0",
+        "@miniflare/shared": "2.4.0",
         "cron-schedule": "^3.0.4"
       },
       "engines": {
@@ -2548,9 +2548,9 @@
       }
     },
     "node_modules/@miniflare/shared": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.3.0.tgz",
-      "integrity": "sha512-TvCSUe1op5AKINx3zHSSdfAbdoV3eSF3MzeVQA4+1NmtuefY8cjujQCdILeAxg3oPbHXaZkc7j1zZ13rYdvwGQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.4.0.tgz",
+      "integrity": "sha512-lPQFzBUVGNQ93gQ/dliToWnO0OqAgsD3/902Pd/IixVSRwRj3BTnYv2dHMUKZcODBPrhnbqZeqcPWdBLzEx8uw==",
       "dependencies": {
         "ignore": "^5.1.8",
         "kleur": "^4.1.4"
@@ -2560,59 +2560,59 @@
       }
     },
     "node_modules/@miniflare/sites": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.3.0.tgz",
-      "integrity": "sha512-WkRBxQbf6k/eS1D/D1mw30Zs253TFeIkWFh8HQ8Z36Kdt79rNVezT9YmRpahUfvYXmubTquV5JftNOAhvbOJXA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.4.0.tgz",
+      "integrity": "sha512-YZy/TujnR1lkBvCncDDQ8tsWsXRE4JJ4x9a0bKN/XnZh7r6OhDM0sw4BFcBQhT6Ukdtttam1O3FlJxnMitrDGg==",
       "dependencies": {
-        "@miniflare/kv": "2.3.0",
-        "@miniflare/shared": "2.3.0",
-        "@miniflare/storage-file": "2.3.0"
+        "@miniflare/kv": "2.4.0",
+        "@miniflare/shared": "2.4.0",
+        "@miniflare/storage-file": "2.4.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/storage-file": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.3.0.tgz",
-      "integrity": "sha512-1rda/MC0R8wVC6N7Na2EdSGNAZv6o/yugp7Z+GikJ1vbgi1+9soAczDzFtaq4jrBzAkCFOMT79DgkSKSl59vxg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.4.0.tgz",
+      "integrity": "sha512-f1AUMz8xps/4VhNJMb8JeCevZFeU4pg2lIWmC11gG4xeq2nibTPBi6Qtx594Le7ZKij/tF6rRsoNfGau2Q5gdw==",
       "dependencies": {
-        "@miniflare/shared": "2.3.0",
-        "@miniflare/storage-memory": "2.3.0"
+        "@miniflare/shared": "2.4.0",
+        "@miniflare/storage-memory": "2.4.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/storage-memory": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.3.0.tgz",
-      "integrity": "sha512-cMqQK9neRySchoNUVhQYOmLFrYkAjT5V113Wfxmsz93dladQ1/mXOsndqPrlb+5hhnwbw4Ns67nyzkHUe9sX/g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.4.0.tgz",
+      "integrity": "sha512-mhWwgHhDNtEa7y1bYbdVucV0lqUmzagYXUSppAdSGS5JPyJMyw3HseqRNTk6gC/vKlvEYlFf3ugWcREGCedr9A==",
       "dependencies": {
-        "@miniflare/shared": "2.3.0"
+        "@miniflare/shared": "2.4.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/watcher": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.3.0.tgz",
-      "integrity": "sha512-G0ZE9WHIcdR2TlPXwwQabULDIMZ9LujfC0tn+yXmPXKxgWoJWcWFmUbkhVDcOJzkIz2TAhRlLbW11n8nChUHFQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.4.0.tgz",
+      "integrity": "sha512-gDQRUxwOjmctvowyd4Hcdy3fjxz3ERKzirp6TvA3AWUohKZk3IhwGlaA8aCwbdP+ELYQlG5wK44AfLSGi956fg==",
       "dependencies": {
-        "@miniflare/shared": "2.3.0"
+        "@miniflare/shared": "2.4.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/web-sockets": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.3.0.tgz",
-      "integrity": "sha512-3xcPG1vfiMb2obVC4jNtS5VzUxzM1rdUrWPCG86gpZaHky0xC1U7Tp+eFdxQFTty99HPYrrVKXl1ww2h1LGWRA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.4.0.tgz",
+      "integrity": "sha512-cz/cN0GoQOXRLh80UmlcEJODPIw2ijKBK3PLRzvfTzqQ5avK6wp2M8Fj8C/5JIT6g7siwvBANyKXD3U3RpKGHQ==",
       "dependencies": {
-        "@miniflare/core": "2.3.0",
-        "@miniflare/shared": "2.3.0",
+        "@miniflare/core": "2.4.0",
+        "@miniflare/shared": "2.4.0",
         "undici": "4.13.0",
         "ws": "^8.2.2"
       },
@@ -4924,9 +4924,9 @@
       "link": true
     },
     "node_modules/cron-schedule": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/cron-schedule/-/cron-schedule-3.0.4.tgz",
-      "integrity": "sha512-wEspID2dNPfWyh7t2ZvE4Izunzk20QacZg8oZcqfTrN1j5kImj0CEYT3ZGZo+KqGQUgRc9tKlEJmY4uFVt4ccA=="
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/cron-schedule/-/cron-schedule-3.0.5.tgz",
+      "integrity": "sha512-YjtB4jy7RJEX8j9GokHp+y8S/ihCHjrD2Z3E13LSGP/+G0Sdv+MEKsZu5wPLLWwW1HQc4HwpGMFU3GUTStZTaA=="
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
@@ -9814,21 +9814,21 @@
       }
     },
     "node_modules/jest-environment-miniflare": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-miniflare/-/jest-environment-miniflare-2.3.0.tgz",
-      "integrity": "sha512-/VgwMWwEqNoXAHBBC//1rUzkY6gvCfh7WsmOSpzeWXsROIeP1vog4v2gBY4N0ZuSI+5PxGnDZH8hahjYQQVcEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-miniflare/-/jest-environment-miniflare-2.4.0.tgz",
+      "integrity": "sha512-WTsUBXrjyX1yNWCnKyzTSNFfBNm3QxT+f4AXaaSBrZEHCjE4/zl08/BE0fSmVQah6Vp/N3pgrM2efYQD6xiaHw==",
       "dependencies": {
-        "@miniflare/cache": "2.3.0",
-        "@miniflare/core": "2.3.0",
-        "@miniflare/durable-objects": "2.3.0",
-        "@miniflare/html-rewriter": "2.3.0",
-        "@miniflare/kv": "2.3.0",
-        "@miniflare/runner-vm": "2.3.0",
-        "@miniflare/shared": "2.3.0",
-        "@miniflare/sites": "2.3.0",
-        "@miniflare/storage-memory": "2.3.0",
-        "@miniflare/web-sockets": "2.3.0",
-        "miniflare": "2.3.0"
+        "@miniflare/cache": "2.4.0",
+        "@miniflare/core": "2.4.0",
+        "@miniflare/durable-objects": "2.4.0",
+        "@miniflare/html-rewriter": "2.4.0",
+        "@miniflare/kv": "2.4.0",
+        "@miniflare/runner-vm": "2.4.0",
+        "@miniflare/shared": "2.4.0",
+        "@miniflare/sites": "2.4.0",
+        "@miniflare/storage-memory": "2.4.0",
+        "@miniflare/web-sockets": "2.4.0",
+        "miniflare": "2.4.0"
       },
       "engines": {
         "node": ">=16.7"
@@ -13175,24 +13175,24 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.3.0.tgz",
-      "integrity": "sha512-0lK4Df+jfqLDSDDgj4AOJffb1G6sN7XvB5QGUaquEakW+qPdurydyNhFKcFKBgpk4ozN6WTmB2x802iPXQcJJQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.4.0.tgz",
+      "integrity": "sha512-xOBL/dQsUL95rxIYO+KrrVPPpm2TAf6TKl4AvhcjSfUeVkzDWd/y9f7hXCt8x6srDoK0Z2LpYouatvSfSUzGOw==",
       "dependencies": {
-        "@miniflare/cache": "2.3.0",
-        "@miniflare/cli-parser": "2.3.0",
-        "@miniflare/core": "2.3.0",
-        "@miniflare/durable-objects": "2.3.0",
-        "@miniflare/html-rewriter": "2.3.0",
-        "@miniflare/http-server": "2.3.0",
-        "@miniflare/kv": "2.3.0",
-        "@miniflare/runner-vm": "2.3.0",
-        "@miniflare/scheduler": "2.3.0",
-        "@miniflare/shared": "2.3.0",
-        "@miniflare/sites": "2.3.0",
-        "@miniflare/storage-file": "2.3.0",
-        "@miniflare/storage-memory": "2.3.0",
-        "@miniflare/web-sockets": "2.3.0",
+        "@miniflare/cache": "2.4.0",
+        "@miniflare/cli-parser": "2.4.0",
+        "@miniflare/core": "2.4.0",
+        "@miniflare/durable-objects": "2.4.0",
+        "@miniflare/html-rewriter": "2.4.0",
+        "@miniflare/http-server": "2.4.0",
+        "@miniflare/kv": "2.4.0",
+        "@miniflare/runner-vm": "2.4.0",
+        "@miniflare/scheduler": "2.4.0",
+        "@miniflare/shared": "2.4.0",
+        "@miniflare/sites": "2.4.0",
+        "@miniflare/storage-file": "2.4.0",
+        "@miniflare/storage-memory": "2.4.0",
+        "@miniflare/web-sockets": "2.4.0",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
@@ -13205,7 +13205,7 @@
         "node": ">=16.7"
       },
       "peerDependencies": {
-        "@miniflare/storage-redis": "2.3.0",
+        "@miniflare/storage-redis": "2.4.0",
         "cron-schedule": "^3.0.4",
         "ioredis": "^4.27.9"
       },
@@ -16633,7 +16633,8 @@
     },
     "node_modules/undici": {
       "version": "4.13.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-4.13.0.tgz",
+      "integrity": "sha512-8lk8S/f2V0VUNGf2scU2b+KI2JSzEQLdCyRNRF3XmHu+5jectlSDaPSBCXAHFaUlt1rzngzOBVDgJS9/Gue/KA==",
       "engines": {
         "node": ">=12.18"
       }
@@ -17416,7 +17417,7 @@
       "version": "0.0.23",
       "license": "ISC",
       "dependencies": {
-        "jest-environment-miniflare": "2.3.0"
+        "jest-environment-miniflare": "2.4.0"
       }
     },
     "packages/local-mode-tests": {
@@ -17443,7 +17444,7 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "esbuild": "0.14.23",
-        "miniflare": "2.3.0",
+        "miniflare": "2.4.0",
         "path-to-regexp": "^6.2.0",
         "selfsigned": "^2.0.0",
         "semiver": "^1.1.0",
@@ -19257,33 +19258,33 @@
       }
     },
     "@miniflare/cache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.3.0.tgz",
-      "integrity": "sha512-lOf3WVtrs0ac7KOtsQ+JOGHWR90zsqqJbolE+Wt4hIZuvM2U3t1RD2Ms7U20J301msVIsBAd02IL57H95LXQtQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.4.0.tgz",
+      "integrity": "sha512-tMDXlUVlThgFubJmlxZoKmLK8kBxDmuMbVMt7csHpXegzkuo2TmIsDqBE/C3CRiJ5xeCQgpD6iZtKBu5Zn5fRA==",
       "requires": {
-        "@miniflare/core": "2.3.0",
-        "@miniflare/shared": "2.3.0",
+        "@miniflare/core": "2.4.0",
+        "@miniflare/shared": "2.4.0",
         "http-cache-semantics": "^4.1.0",
         "undici": "4.13.0"
       }
     },
     "@miniflare/cli-parser": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.3.0.tgz",
-      "integrity": "sha512-yQzU+OBBvWshr9qVxAe6bWXJLNfpmLYrfkfR3u+rPOo2LYnccWg0f/8jtxrXM1TIyu+tCOJGqCODpO//XtrwWw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.4.0.tgz",
+      "integrity": "sha512-Xr5lO8f+oIr9r/b2dfo0on1p0MNN+pkwRHWoY5ACSnp9FaGnwm/g71DM7AajIQPIk0TpRsSVNDx8Ygj1LPT+sQ==",
       "requires": {
-        "@miniflare/shared": "2.3.0",
+        "@miniflare/shared": "2.4.0",
         "kleur": "^4.1.4"
       }
     },
     "@miniflare/core": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.3.0.tgz",
-      "integrity": "sha512-Dltb3p+Uq5Lx53DuInckHYaDoMrBq49HE/p/oUDXmzHmQy7EAM6v+nJGKmiM9Uen4OqyqsmlmPWqntSMjaX7Jg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.4.0.tgz",
+      "integrity": "sha512-vYl8xaWTFzxtkbzx3IkT4Py0OAFdfmFnVo627O1HKHWVGlkjVr8UKtxBpIR+f5pq/HCMzzqA1HM9FXO0dQfy3A==",
       "requires": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/shared": "2.3.0",
-        "@miniflare/watcher": "2.3.0",
+        "@miniflare/shared": "2.4.0",
+        "@miniflare/watcher": "2.4.0",
         "busboy": "^0.3.1",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
@@ -19299,35 +19300,35 @@
       }
     },
     "@miniflare/durable-objects": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.3.0.tgz",
-      "integrity": "sha512-YuzxBBu9xBU3xxD4TzGdeVVMXrE76AWJE4MIqkJR5UmASqayyv//cApGw3+C01NHe07cpbrTM1QTgFo2eBncwQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.4.0.tgz",
+      "integrity": "sha512-VVLaUXXcAQcYE/3YmDLTacZf5OzR8bib6q1T9NqVb0uK5sLMQqyHvQdsG5rMqs7iyxfJxyZ0bL2OW9XGALOkoQ==",
       "requires": {
-        "@miniflare/core": "2.3.0",
-        "@miniflare/shared": "2.3.0",
-        "@miniflare/storage-memory": "2.3.0",
+        "@miniflare/core": "2.4.0",
+        "@miniflare/shared": "2.4.0",
+        "@miniflare/storage-memory": "2.4.0",
         "undici": "4.13.0"
       }
     },
     "@miniflare/html-rewriter": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.3.0.tgz",
-      "integrity": "sha512-cyWhmQgzhtRlBeg0mxP5FmAq/75ChuLwWQlhokx88XkGnteuh0/DOk3OxIMaveF2oDHKmIlLFgSlzv4NbT1Mng==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.4.0.tgz",
+      "integrity": "sha512-ZG8819N7LelDD+8+Ss5FZpVyQQq/V2igod0qE68JK4he/w4/yn57Rk6Efb49y15HoHAXl2RpCCsnCyIow/Xjug==",
       "requires": {
-        "@miniflare/core": "2.3.0",
-        "@miniflare/shared": "2.3.0",
+        "@miniflare/core": "2.4.0",
+        "@miniflare/shared": "2.4.0",
         "html-rewriter-wasm": "^0.4.1",
         "undici": "4.13.0"
       }
     },
     "@miniflare/http-server": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.3.0.tgz",
-      "integrity": "sha512-jTzsRuro3yWVb4T85znBGw1w+ydimgi2PJvHrTuGFKDjFam+R037fGH+HZCAjAgPiBHTroXfkeSXypJLXbQBEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.4.0.tgz",
+      "integrity": "sha512-r6Z/nqxE0oa1z63L95yvnG0PUeLRxZOeGS7ADxZMFKan4WD5lvYtSKDuDEm0lkbQshCOHQ3uXFr0cotOm8JoMQ==",
       "requires": {
-        "@miniflare/core": "2.3.0",
-        "@miniflare/shared": "2.3.0",
-        "@miniflare/web-sockets": "2.3.0",
+        "@miniflare/core": "2.4.0",
+        "@miniflare/shared": "2.4.0",
+        "@miniflare/web-sockets": "2.4.0",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
         "undici": "4.13.0",
@@ -19344,82 +19345,82 @@
       }
     },
     "@miniflare/kv": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.3.0.tgz",
-      "integrity": "sha512-m0zu5sRoaFDm+WVTnLRrz8+77b6eVxQN7cLN6ZQiKP3Nd8cAggPdaIIef8dVksWbPvOW9DztoUVZTB1v9EOaLA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.4.0.tgz",
+      "integrity": "sha512-1UW7f1386xR6EDEXNZOR1TpFwQfRRSxUPqD6m/U0WprlsbM0cIYGz+AUeaVbkFf8lfE2MeXCUrjbWsLOvsnw3g==",
       "requires": {
-        "@miniflare/shared": "2.3.0"
+        "@miniflare/shared": "2.4.0"
       }
     },
     "@miniflare/runner-vm": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.3.0.tgz",
-      "integrity": "sha512-/aB997YodNcRFxtlnvEn4BJSIqKXRw29FexOqCWwWv+b7XQkTTxd4IfSocIFi6du3265gp85icqP/hxsLAQBVg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.4.0.tgz",
+      "integrity": "sha512-7sdwBYzXQTwYeR3tTvQ+vJfzc7BXwqR8AUPK9l5gvCtg+Geq9sMslr5SikIJpgcvbYqKDjvC9DQEPJ3sqr9cSQ==",
       "requires": {
-        "@miniflare/shared": "2.3.0"
+        "@miniflare/shared": "2.4.0"
       }
     },
     "@miniflare/scheduler": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.3.0.tgz",
-      "integrity": "sha512-Er80srMNXbxqGbYXtiZkD8UlveHsw4cpwcytQgsEJCHG7/48vC/rpmtN0zKOWFEHifaOUvHhURZRJu+S2E4Stg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.4.0.tgz",
+      "integrity": "sha512-dfMCXoAS8Y+3xABNxYju62I2xIBS54Op7ohCHoatvAM5RvualJUPICEMPZzX6/z29q5xPIeSLhLDhl/asAQ19w==",
       "requires": {
-        "@miniflare/core": "2.3.0",
-        "@miniflare/shared": "2.3.0",
+        "@miniflare/core": "2.4.0",
+        "@miniflare/shared": "2.4.0",
         "cron-schedule": "^3.0.4"
       }
     },
     "@miniflare/shared": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.3.0.tgz",
-      "integrity": "sha512-TvCSUe1op5AKINx3zHSSdfAbdoV3eSF3MzeVQA4+1NmtuefY8cjujQCdILeAxg3oPbHXaZkc7j1zZ13rYdvwGQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.4.0.tgz",
+      "integrity": "sha512-lPQFzBUVGNQ93gQ/dliToWnO0OqAgsD3/902Pd/IixVSRwRj3BTnYv2dHMUKZcODBPrhnbqZeqcPWdBLzEx8uw==",
       "requires": {
         "ignore": "^5.1.8",
         "kleur": "^4.1.4"
       }
     },
     "@miniflare/sites": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.3.0.tgz",
-      "integrity": "sha512-WkRBxQbf6k/eS1D/D1mw30Zs253TFeIkWFh8HQ8Z36Kdt79rNVezT9YmRpahUfvYXmubTquV5JftNOAhvbOJXA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.4.0.tgz",
+      "integrity": "sha512-YZy/TujnR1lkBvCncDDQ8tsWsXRE4JJ4x9a0bKN/XnZh7r6OhDM0sw4BFcBQhT6Ukdtttam1O3FlJxnMitrDGg==",
       "requires": {
-        "@miniflare/kv": "2.3.0",
-        "@miniflare/shared": "2.3.0",
-        "@miniflare/storage-file": "2.3.0"
+        "@miniflare/kv": "2.4.0",
+        "@miniflare/shared": "2.4.0",
+        "@miniflare/storage-file": "2.4.0"
       }
     },
     "@miniflare/storage-file": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.3.0.tgz",
-      "integrity": "sha512-1rda/MC0R8wVC6N7Na2EdSGNAZv6o/yugp7Z+GikJ1vbgi1+9soAczDzFtaq4jrBzAkCFOMT79DgkSKSl59vxg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.4.0.tgz",
+      "integrity": "sha512-f1AUMz8xps/4VhNJMb8JeCevZFeU4pg2lIWmC11gG4xeq2nibTPBi6Qtx594Le7ZKij/tF6rRsoNfGau2Q5gdw==",
       "requires": {
-        "@miniflare/shared": "2.3.0",
-        "@miniflare/storage-memory": "2.3.0"
+        "@miniflare/shared": "2.4.0",
+        "@miniflare/storage-memory": "2.4.0"
       }
     },
     "@miniflare/storage-memory": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.3.0.tgz",
-      "integrity": "sha512-cMqQK9neRySchoNUVhQYOmLFrYkAjT5V113Wfxmsz93dladQ1/mXOsndqPrlb+5hhnwbw4Ns67nyzkHUe9sX/g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.4.0.tgz",
+      "integrity": "sha512-mhWwgHhDNtEa7y1bYbdVucV0lqUmzagYXUSppAdSGS5JPyJMyw3HseqRNTk6gC/vKlvEYlFf3ugWcREGCedr9A==",
       "requires": {
-        "@miniflare/shared": "2.3.0"
+        "@miniflare/shared": "2.4.0"
       }
     },
     "@miniflare/watcher": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.3.0.tgz",
-      "integrity": "sha512-G0ZE9WHIcdR2TlPXwwQabULDIMZ9LujfC0tn+yXmPXKxgWoJWcWFmUbkhVDcOJzkIz2TAhRlLbW11n8nChUHFQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.4.0.tgz",
+      "integrity": "sha512-gDQRUxwOjmctvowyd4Hcdy3fjxz3ERKzirp6TvA3AWUohKZk3IhwGlaA8aCwbdP+ELYQlG5wK44AfLSGi956fg==",
       "requires": {
-        "@miniflare/shared": "2.3.0"
+        "@miniflare/shared": "2.4.0"
       }
     },
     "@miniflare/web-sockets": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.3.0.tgz",
-      "integrity": "sha512-3xcPG1vfiMb2obVC4jNtS5VzUxzM1rdUrWPCG86gpZaHky0xC1U7Tp+eFdxQFTty99HPYrrVKXl1ww2h1LGWRA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.4.0.tgz",
+      "integrity": "sha512-cz/cN0GoQOXRLh80UmlcEJODPIw2ijKBK3PLRzvfTzqQ5avK6wp2M8Fj8C/5JIT6g7siwvBANyKXD3U3RpKGHQ==",
       "requires": {
-        "@miniflare/core": "2.3.0",
-        "@miniflare/shared": "2.3.0",
+        "@miniflare/core": "2.4.0",
+        "@miniflare/shared": "2.4.0",
         "undici": "4.13.0",
         "ws": "^8.2.2"
       },
@@ -20947,9 +20948,9 @@
       "version": "file:packages/create-workers-app"
     },
     "cron-schedule": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/cron-schedule/-/cron-schedule-3.0.4.tgz",
-      "integrity": "sha512-wEspID2dNPfWyh7t2ZvE4Izunzk20QacZg8oZcqfTrN1j5kImj0CEYT3ZGZo+KqGQUgRc9tKlEJmY4uFVt4ccA=="
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/cron-schedule/-/cron-schedule-3.0.5.tgz",
+      "integrity": "sha512-YjtB4jy7RJEX8j9GokHp+y8S/ihCHjrD2Z3E13LSGP/+G0Sdv+MEKsZu5wPLLWwW1HQc4HwpGMFU3GUTStZTaA=="
     },
     "cross-env": {
       "version": "7.0.3",
@@ -24084,21 +24085,21 @@
       }
     },
     "jest-environment-miniflare": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-miniflare/-/jest-environment-miniflare-2.3.0.tgz",
-      "integrity": "sha512-/VgwMWwEqNoXAHBBC//1rUzkY6gvCfh7WsmOSpzeWXsROIeP1vog4v2gBY4N0ZuSI+5PxGnDZH8hahjYQQVcEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-miniflare/-/jest-environment-miniflare-2.4.0.tgz",
+      "integrity": "sha512-WTsUBXrjyX1yNWCnKyzTSNFfBNm3QxT+f4AXaaSBrZEHCjE4/zl08/BE0fSmVQah6Vp/N3pgrM2efYQD6xiaHw==",
       "requires": {
-        "@miniflare/cache": "2.3.0",
-        "@miniflare/core": "2.3.0",
-        "@miniflare/durable-objects": "2.3.0",
-        "@miniflare/html-rewriter": "2.3.0",
-        "@miniflare/kv": "2.3.0",
-        "@miniflare/runner-vm": "2.3.0",
-        "@miniflare/shared": "2.3.0",
-        "@miniflare/sites": "2.3.0",
-        "@miniflare/storage-memory": "2.3.0",
-        "@miniflare/web-sockets": "2.3.0",
-        "miniflare": "2.3.0"
+        "@miniflare/cache": "2.4.0",
+        "@miniflare/core": "2.4.0",
+        "@miniflare/durable-objects": "2.4.0",
+        "@miniflare/html-rewriter": "2.4.0",
+        "@miniflare/kv": "2.4.0",
+        "@miniflare/runner-vm": "2.4.0",
+        "@miniflare/shared": "2.4.0",
+        "@miniflare/sites": "2.4.0",
+        "@miniflare/storage-memory": "2.4.0",
+        "@miniflare/web-sockets": "2.4.0",
+        "miniflare": "2.4.0"
       }
     },
     "jest-environment-node": {
@@ -24195,7 +24196,7 @@
     "jest-environment-wrangler": {
       "version": "file:packages/jest-environment-wrangler",
       "requires": {
-        "jest-environment-miniflare": "2.3.0"
+        "jest-environment-miniflare": "2.4.0"
       }
     },
     "jest-fetch-mock": {
@@ -26389,24 +26390,24 @@
       "version": "1.0.1"
     },
     "miniflare": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.3.0.tgz",
-      "integrity": "sha512-0lK4Df+jfqLDSDDgj4AOJffb1G6sN7XvB5QGUaquEakW+qPdurydyNhFKcFKBgpk4ozN6WTmB2x802iPXQcJJQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.4.0.tgz",
+      "integrity": "sha512-xOBL/dQsUL95rxIYO+KrrVPPpm2TAf6TKl4AvhcjSfUeVkzDWd/y9f7hXCt8x6srDoK0Z2LpYouatvSfSUzGOw==",
       "requires": {
-        "@miniflare/cache": "2.3.0",
-        "@miniflare/cli-parser": "2.3.0",
-        "@miniflare/core": "2.3.0",
-        "@miniflare/durable-objects": "2.3.0",
-        "@miniflare/html-rewriter": "2.3.0",
-        "@miniflare/http-server": "2.3.0",
-        "@miniflare/kv": "2.3.0",
-        "@miniflare/runner-vm": "2.3.0",
-        "@miniflare/scheduler": "2.3.0",
-        "@miniflare/shared": "2.3.0",
-        "@miniflare/sites": "2.3.0",
-        "@miniflare/storage-file": "2.3.0",
-        "@miniflare/storage-memory": "2.3.0",
-        "@miniflare/web-sockets": "2.3.0",
+        "@miniflare/cache": "2.4.0",
+        "@miniflare/cli-parser": "2.4.0",
+        "@miniflare/core": "2.4.0",
+        "@miniflare/durable-objects": "2.4.0",
+        "@miniflare/html-rewriter": "2.4.0",
+        "@miniflare/http-server": "2.4.0",
+        "@miniflare/kv": "2.4.0",
+        "@miniflare/runner-vm": "2.4.0",
+        "@miniflare/scheduler": "2.4.0",
+        "@miniflare/shared": "2.4.0",
+        "@miniflare/sites": "2.4.0",
+        "@miniflare/storage-file": "2.4.0",
+        "@miniflare/storage-memory": "2.4.0",
+        "@miniflare/web-sockets": "2.4.0",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
@@ -28680,7 +28681,9 @@
       }
     },
     "undici": {
-      "version": "4.13.0"
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-4.13.0.tgz",
+      "integrity": "sha512-8lk8S/f2V0VUNGf2scU2b+KI2JSzEQLdCyRNRF3XmHu+5jectlSDaPSBCXAHFaUlt1rzngzOBVDgJS9/Gue/KA=="
     },
     "unified": {
       "version": "10.1.1",
@@ -29053,7 +29056,7 @@
         "jest-fetch-mock": "^3.0.3",
         "jest-websocket-mock": "^2.3.0",
         "mime": "^3.0.0",
-        "miniflare": "2.3.0",
+        "miniflare": "2.4.0",
         "open": "^8.4.0",
         "path-to-regexp": "^6.2.0",
         "prompts": "^2.4.2",

--- a/packages/jest-environment-wrangler/package.json
+++ b/packages/jest-environment-wrangler/package.json
@@ -17,6 +17,6 @@
   "author": "wrangler@cloudflare.com",
   "license": "ISC",
   "dependencies": {
-    "jest-environment-miniflare": "2.3.0"
+    "jest-environment-miniflare": "2.4.0"
   }
 }

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -37,7 +37,7 @@
   ],
   "dependencies": {
     "esbuild": "0.14.23",
-    "miniflare": "2.3.0",
+    "miniflare": "2.4.0",
     "path-to-regexp": "^6.2.0",
     "selfsigned": "^2.0.0",
     "semiver": "^1.1.0",


### PR DESCRIPTION
Hey! 👋 This PR upgrades `miniflare` to version `2.4.0`. See the [full changelog here](https://github.com/cloudflare/miniflare/releases/tag/v2.4.0).