### PR TITLE
fix: add a warning if `dev` is defaulting to the latest compatibility-date

### DIFF
--- a/.changeset/bright-numbers-develop.md
+++ b/.changeset/bright-numbers-develop.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: add a warning if `dev` is defaulting to the latest compatibility-date
+
+Fixes https://github.com/cloudflare/wrangler2/issues/741

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -40,7 +40,7 @@ export type DevProps = {
   crons: Config["triggers"]["crons"];
   public: undefined | string;
   assetPaths: undefined | AssetPaths;
-  compatibilityDate: undefined | string;
+  compatibilityDate: string;
   compatibilityFlags: undefined | string[];
   usageModel: undefined | "bundled" | "unbound";
   build: {

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -17,7 +17,7 @@ interface LocalProps {
   name: undefined | string;
   bundle: EsbuildBundle | undefined;
   format: CfScriptFormat | undefined;
-  compatibilityDate: string | undefined;
+  compatibilityDate: string;
   compatibilityFlags: undefined | string[];
   bindings: CfWorkerInit["bindings"];
   assetPaths: undefined | AssetPaths;

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -24,7 +24,7 @@ export function Remote(props: {
   accountId: undefined | string;
   apiToken: undefined | string;
   bindings: CfWorkerInit["bindings"];
-  compatibilityDate: string | undefined;
+  compatibilityDate: string;
   compatibilityFlags: undefined | string[];
   usageModel: undefined | "bundled" | "unbound";
   env: string | undefined;

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -883,11 +883,10 @@ export async function main(argv: string[]): Promise<void> {
             args["inspector-port"] ?? (await getPort({ port: 9229 }))
           }
           public={args["experimental-public"]}
-          compatibilityDate={
-            args["compatibility-date"] ||
-            config.compatibility_date ||
-            new Date().toISOString().substring(0, 10)
-          }
+          compatibilityDate={getDevCompatibilityDate(
+            config,
+            args["compatibility-date"]
+          )}
           compatibilityFlags={
             (args["compatibility-flags"] as string[]) ||
             config.compatibility_flags
@@ -1268,10 +1267,7 @@ export async function main(argv: string[]): Promise<void> {
           port={config.dev?.port}
           ip={config.dev.ip}
           public={undefined}
-          compatibilityDate={
-            config.compatibility_date ||
-            new Date().toISOString().substring(0, 10)
-          }
+          compatibilityDate={getDevCompatibilityDate(config)}
           compatibilityFlags={
             (args["compatibility-flags"] as string[]) ||
             config.compatibility_flags
@@ -2389,4 +2385,26 @@ export async function main(argv: string[]): Promise<void> {
     }
     throw e;
   }
+}
+
+function getDevCompatibilityDate(
+  config: Config,
+  compatibilityDate = config.compatibility_date
+) {
+  const currentDate = new Date().toISOString().substring(0, 10);
+  if (config.configPath !== undefined && compatibilityDate === undefined) {
+    console.warn(
+      `No compatibility_date was specified. Using today's date: ${currentDate}.\n` +
+        "Add one to your wrangler.toml file:\n" +
+        "```\n" +
+        `compatibility_date = "${currentDate}"\n` +
+        "```\n" +
+        "or pass it in your terminal:\n" +
+        "```\n" +
+        `--compatibility-date=${currentDate}\n` +
+        "```\n" +
+        "See https://developers.cloudflare.com/workers/platform/compatibility-dates for more information."
+    );
+  }
+  return compatibilityDate ?? currentDate;
 }


### PR DESCRIPTION
Fixes https://github.com/cloudflare/wrangler2/issues/741