### PR TITLE
chore: update CloudflareDev Discord link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Support
-    url: https://discord.gg/fS5CC9fFS3
+    url: https://discord.gg/CloudflareDev
     about: 'Join us on Discord!'


### PR DESCRIPTION
The current invite in the issue template is invalid - updating to the vanity invite link.