### PR TITLE
Inconsistent mock types `fetchKVGetValue`

### DIFF
--- a/packages/wrangler/src/__tests__/helpers/mock-cfetch.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-cfetch.ts
@@ -181,6 +181,9 @@ export function unsetAllMocks() {
 
 const kvGetMocks = new Map<string, string>();
 
+/**
+ * @mocked typeof fetchKVGetValue
+ */
 export function mockFetchKVGetValue(
   accountId: string,
   namespaceId: string,
@@ -188,7 +191,8 @@ export function mockFetchKVGetValue(
 ) {
   const mapKey = `${accountId}/${namespaceId}/${key}`;
   if (kvGetMocks.has(mapKey)) {
-    return kvGetMocks.get(mapKey);
+    const value = kvGetMocks.get(mapKey);
+    if (value !== undefined) return Promise.resolve(value);
   }
   throw new Error(`no mock value found for \`kv:key get\` - ${mapKey}`);
 }


### PR DESCRIPTION
fix: Mocked version of `mockFetchKVGetValue` types were inconsistent with the real function being mocked `fetchKVGetValue`