### PR TITLE
Improve Sentry Error Filtering

### DIFF
--- a/.changeset/breezy-steaks-visit.md
+++ b/.changeset/breezy-steaks-visit.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+---
+
+fix: We want to prevent any user created code from sending Events to Sentry,
+which can be captured by `uncaughtExceptionMonitor` listener.
+Miniflare code can run user code on the same process as Wrangler,
+so we want to return `null` if `@miniflare` is present in the Event frames.

--- a/packages/wrangler/src/reporting.ts
+++ b/packages/wrangler/src/reporting.ts
@@ -30,6 +30,15 @@ export function initReporting() {
       // from their worker during development
       return null;
     },
+    beforeSend: (event) => {
+      return !event.exception?.values?.some((value) =>
+        value.stacktrace?.frames?.some((frame) =>
+          frame.module?.includes("@miniflare")
+        )
+      )
+        ? event
+        : null;
+    },
     dsn: "https://5089b76bf8a64a9c949bf5c2b5e8003c@o51786.ingest.sentry.io/6190959",
     tracesSampleRate: 1.0,
     integrations: [

--- a/packages/wrangler/src/reporting.ts
+++ b/packages/wrangler/src/reporting.ts
@@ -30,6 +30,12 @@ export function initReporting() {
       // from their worker during development
       return null;
     },
+    /**
+     * We want to prevent any user created code from sending Events to Sentry,
+     * which can be captured by "uncaughtExceptionMonitor" listener.
+     * Miniflare code runs on the same process as Wrangler, so we want to return `null`
+     * if "@miniflare" is present in the Event frames.
+     */
     beforeSend: (event) => {
       return !event.exception?.values?.some((value) =>
         value.stacktrace?.frames?.some((frame) =>


### PR DESCRIPTION
fix: We want to prevent any user created code from sending Events to Sentry,
which can be captured by `uncaughtExceptionMonitor` listener.
Miniflare code can run user code on the same process as Wrangler, so we want to return `null`
if "@miniflare" is present in the Event frames.