### PR TITLE
Fix path resolution in Pages esbuild

### DIFF
--- a/.changeset/sweet-turtles-rule.md
+++ b/.changeset/sweet-turtles-rule.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: the pathing for the template was resolving using `__dirname` into the esbuild file which then used a relative path back from pages. When ran inside a test would get a resolved absolute path to the template from "pages/pages/functions/template-workers.ts

--- a/packages/wrangler/pages/functions/buildWorker.ts
+++ b/packages/wrangler/pages/functions/buildWorker.ts
@@ -21,9 +21,7 @@ export function buildWorker({
   onEnd = () => {},
 }: Options) {
   return build({
-    entryPoints: [
-      path.resolve(__dirname, "../pages/functions/template-worker.ts"),
-    ],
+    entryPoints: [path.resolve(__dirname, "./template-worker.ts")],
     inject: [routesModule],
     bundle: true,
     format: "esm",


### PR DESCRIPTION
fix: the pathing for the template was resolving using `__dirname` into the esbuild file which then used a relative path back from pages. When ran inside a test would get a resolved absolute path to the template from "pages/pages/functions/template-workers.ts