### PR TITLE
feat: optionally send zone_id with a route

### DIFF
--- a/.changeset/dull-jobs-return.md
+++ b/.changeset/dull-jobs-return.md
@@ -1,0 +1,13 @@
+---
+"wrangler": patch
+---
+
+feat: optionally send zone_id with a route
+
+This enables optionally passing a route as `{pattern: string, zone_id: string}`. There are scenarios where we need to explicitly pass a zone_id to the api, so this enables that.
+
+Some nuance: The errors from the api aren't super useful when invalid values are passed, but that's something to further work on.
+
+This also fixes some types in our cli parsing.
+
+Fixes https://github.com/cloudflare/wrangler2/issues/774

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -553,7 +553,12 @@ describe("normalizeAndValidateConfig()", () => {
         compatibility_date: "2022-01-01",
         compatibility_flags: ["FLAG1", "FLAG2"],
         workers_dev: false,
-        routes: ["ROUTE_1", "ROUTE_2"],
+        routes: [
+          "ROUTE_1",
+          "ROUTE_2",
+          { pattern: "ROUTE3", zone_id: "ZONE_ID_3" },
+          "ROUTE_4",
+        ],
         jsx_factory: "JSX_FACTORY",
         jsx_fragment: "JSX_FRAGMENT",
         tsconfig: "path/to/tsconfig",
@@ -630,7 +635,21 @@ describe("normalizeAndValidateConfig()", () => {
         compatibility_date: 333,
         compatibility_flags: [444, 555],
         workers_dev: "BAD",
-        routes: [666, 777],
+        routes: [
+          666,
+          777,
+          // this one's valid, but we add it here to make sure
+          // it doesn't get included in the error message
+          "example.com/*",
+          { pattern: 123, zone_id: "zone_id_1" },
+          { pattern: "route_2", zone_id: 123 },
+          { pattern: "route_3" },
+          { zone_id: "zone_id_4" },
+          { pattern: undefined },
+          { pattern: "route_5", zone_id: "zone_id_5", some_other_key: 123 },
+          // this one's valid too
+          { pattern: "route_6", zone_id: "zone_id_6" },
+        ],
         route: 888,
         jsx_factory: 999,
         jsx_fragment: 1000,
@@ -655,8 +674,8 @@ describe("normalizeAndValidateConfig()", () => {
       expect(diagnostics.hasWarnings()).toBe(false);
       expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
         "Processing wrangler configuration:
-          - Expected \\"route\\" to be of type string but got 888.
-          - Expected \\"routes\\" to be of type string array but got [666,777].
+          - Expected \\"route\\" to be either a string or an object with shape {pattern: string, zone_id: string}, but got 888.
+          - Expected \\"routes\\" to be an array of either strings or objects with the shape {pattern: string, zone_id: string}, but these weren't valid: [666,777,{\\"pattern\\":123,\\"zone_id\\":\\"zone_id_1\\"},{\\"pattern\\":\\"route_2\\",\\"zone_id\\":123},{\\"pattern\\":\\"route_3\\"},{\\"zone_id\\":\\"zone_id_4\\"},{},{\\"pattern\\":\\"route_5\\",\\"zone_id\\":\\"zone_id_5\\",\\"some_other_key\\":123}].
           - Expected exactly one of the following fields [\\"routes\\",\\"route\\"].
           - Expected \\"workers_dev\\" to be of type boolean but got \\"BAD\\".
           - Expected \\"build.command\\" to be of type string but got 1444.
@@ -1797,8 +1816,8 @@ describe("normalizeAndValidateConfig()", () => {
         "Processing wrangler configuration:
 
           - \\"env.ENV1\\" environment configuration
-            - Expected \\"route\\" to be of type string but got 888.
-            - Expected \\"routes\\" to be of type string array but got [666,777].
+            - Expected \\"route\\" to be either a string or an object with shape {pattern: string, zone_id: string}, but got 888.
+            - Expected \\"routes\\" to be an array of either strings or objects with the shape {pattern: string, zone_id: string}, but these weren't valid: [666,777].
             - Expected exactly one of the following fields [\\"routes\\",\\"route\\"].
             - Expected \\"workers_dev\\" to be of type boolean but got \\"BAD\\".
             - Expected \\"build.command\\" to be of type string but got 1444.

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -218,6 +218,21 @@ describe("wrangler dev", () => {
       );
     });
 
+    it("should, when provided, use a configured zone_id", async () => {
+      writeWranglerToml({
+        main: "index.js",
+        routes: [
+          { pattern: "https://some-domain.com/*", zone_id: "some-zone-id" },
+        ],
+      });
+      fs.writeFileSync("index.js", `export default {};`);
+      await runWrangler("dev");
+      expect((Dev as jest.Mock).mock.calls[0][0].zone).toEqual({
+        host: "some-domain.com",
+        id: "some-zone-id",
+      });
+    });
+
     it("given a long host, it should use the longest subdomain that resolves to a zone", async () => {
       writeWranglerToml({
         main: "index.js",

--- a/packages/wrangler/src/config/config.ts
+++ b/packages/wrangler/src/config/config.ts
@@ -183,9 +183,9 @@ export interface DevConfig {
   upstream_protocol: "https" | "http";
 
   /**
-   * Host to forward requests to, defaults to the zone of project
+   * Host to forward requests to, defaults to the host of the first route of project
    */
-  host: string | undefined;
+  host: (string | { pattern: string; zone_id: string }) | undefined;
 }
 
 export type RawDevConfig = Partial<DevConfig>;

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -74,7 +74,7 @@ interface EnvironmentInheritable {
    *
    * @inheritable
    */
-  routes: string[] | undefined;
+  routes: (string | { pattern: string; zone_id: string })[] | undefined;
 
   /**
    * A route that your worker should be published to. Literally
@@ -85,7 +85,7 @@ interface EnvironmentInheritable {
    *
    * @inheritable
    */
-  route: string | undefined;
+  route: (string | { pattern: string; zone_id: string }) | undefined;
 
   /**
    * Path to a custom tsconfig


### PR DESCRIPTION
This enables optionally passing a route as `{pattern: string, zone_id: string}`. There are scenarios where we need to explicitly pass a zone_id to the api, so this is enables that.

Some nuance: The errors from the api aren't super useful when invalid values are passed, but that's something to further work on.

This also fixes some types in our cli parsing.

Fixes https://github.com/cloudflare/wrangler2/issues/774