### PR TITLE
Jest cleanup fix

### DIFF
--- a/packages/wrangler/src/__tests__/helpers/run-in-tmp.ts
+++ b/packages/wrangler/src/__tests__/helpers/run-in-tmp.ts
@@ -8,6 +8,13 @@ const originalCwd = process.cwd();
 export function runInTempDir({ homedir }: { homedir?: string } = {}) {
   let tmpDir: string;
 
+  beforeAll(() => {
+    if (tmpDir !== undefined) {
+      process.chdir(originalCwd);
+      fs.rmSync(tmpDir, { recursive: true });
+    }
+  });
+
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "wrangler-tests"));
     process.chdir(tmpDir);


### PR DESCRIPTION
When creating some files and rewriting others in the temp directory, the test crashed and was unable to complete cleanup. The crash prevented all subsequent tests to fail until I manually tracked the temp directory down and deleted it which looked something like this `/var/<tempDir>/<hash>/brokenFile`. 

The fix checks for the `tempDir` at test start and removes it before creating tempDir and running tests.