### PR TITLE
test: refactor the mock OAuth flow so not to rely upon a real HttpServer

### DIFF
--- a/packages/wrangler/src/__tests__/helpers/mock-http-server.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-http-server.ts
@@ -1,0 +1,46 @@
+import http from "node:http";
+import type { Request } from "undici";
+
+/**
+ * Setup a mock HTTP server that can be triggered directly without interacting with any network.
+ *
+ * @returns a `fetch`-like function that will trigger the mock server to handle the request.
+ */
+export function mockHttpServer() {
+  let listener: http.RequestListener;
+
+  beforeEach(() => {
+    jest
+      .spyOn(http, "createServer")
+      .mockImplementation((...args: unknown[]) => {
+        listener = args.pop() as http.RequestListener;
+        return {
+          listen: jest.fn(),
+          close(callback?: (err?: Error) => void) {
+            callback?.();
+            return this;
+          },
+        } as unknown as http.Server;
+      });
+  });
+
+  return async (req: Request) => {
+    const resp = new http.ServerResponse(
+      // If you squint you can just about see that an `IncomingMessages` is like a `Request`!
+      req as unknown as http.IncomingMessage
+    );
+
+    // The listener will attache a callback to the response by calling `resp.end(callback)`.
+    // We want to capture that so that we can trigger it after the listener has completed its work.
+    const endSpy = jest.spyOn(resp, "end");
+
+    // The `await` here is important to allow the listener to complete its async work before we end the response.
+    await listener(req as unknown as http.IncomingMessage, resp);
+
+    // Now trigger the end callback.
+    const endCallback = endSpy.mock.calls[0].pop();
+    endCallback?.();
+
+    return resp;
+  };
+}

--- a/packages/wrangler/src/__tests__/jest.setup.ts
+++ b/packages/wrangler/src/__tests__/jest.setup.ts
@@ -5,9 +5,7 @@ import {
   getCloudflareAPIBaseURL,
 } from "../cfetch/internal";
 import { confirm, prompt } from "../dialogs";
-import openInBrowser from "../open-in-browser";
 import { mockFetchInternal, mockFetchKVGetValue } from "./helpers/mock-cfetch";
-import { mockOpenInBrowser as mockOpenInBrowserForOAuthFlow } from "./helpers/mock-oauth-flow";
 import { MockWebSocket } from "./helpers/mock-web-socket";
 
 jest.mock("ws", () => {
@@ -70,5 +68,6 @@ jest.mock("../dev/dev", () => {
   });
 });
 
+// Make sure that we don't accidentally try to open a browser window when running tests.
+// We will actually provide a mock implementation for `openInBrowser()` within relevant tests.
 jest.mock("../open-in-browser");
-(openInBrowser as jest.Mock).mockImplementation(mockOpenInBrowserForOAuthFlow);

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -26,7 +26,11 @@ describe("publish", () => {
   mockApiToken();
   runInTempDir({ homedir: "./home" });
   const std = mockConsoleMethods();
-  const { mockGrantAccessToken, mockGrantAuthorization } = mockOAuthFlow();
+  const {
+    mockOAuthServerCallback,
+    mockGrantAccessToken,
+    mockGrantAuthorization,
+  } = mockOAuthFlow();
 
   beforeEach(() => {
     // @ts-expect-error we're using a very simple setTimeout mock here
@@ -55,6 +59,7 @@ describe("publish", () => {
       mockSubDomainRequest();
       mockUploadWorkerRequest();
 
+      mockOAuthServerCallback();
       const accessTokenRequest = mockGrantAccessToken({ respondWith: "ok" });
       mockGrantAuthorization({ respondWith: "success" });
 

--- a/packages/wrangler/src/__tests__/user.test.ts
+++ b/packages/wrangler/src/__tests__/user.test.ts
@@ -17,6 +17,7 @@ describe("wrangler", () => {
   runInTempDir({ homedir: "./home" });
   const std = mockConsoleMethods();
   const {
+    mockOAuthServerCallback,
     mockGrantAccessToken,
     mockGrantAuthorization,
     mockRevokeAuthorization,
@@ -24,6 +25,7 @@ describe("wrangler", () => {
 
   describe("login", () => {
     it("should should log in a user when `wrangler login` is run", async () => {
+      mockOAuthServerCallback();
       const accessTokenRequest = mockGrantAccessToken({ respondWith: "ok" });
       mockGrantAuthorization({ respondWith: "success" });
 


### PR DESCRIPTION
This should allow tests to run when there is no network connection, and should
also speed up the execution of the tests that rely upon the OAuth flow.

Fixes #755