### PR TITLE
polish: don't log all errors when logging in

### DIFF
--- a/.changeset/gentle-cats-destroy.md
+++ b/.changeset/gentle-cats-destroy.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+polish: don't log all errors when logging in
+
+This removes a couple of logs we had for literally every error in our oauth flow. We throw the error and handle it separately anyway, so this is a safe cleanup.
+
+Fixes https://github.com/cloudflare/wrangler2/issues/788

--- a/packages/wrangler/src/user.tsx
+++ b/packages/wrangler/src/user.tsx
@@ -699,18 +699,6 @@ async function exchangeRefreshTokenForAccessToken(): Promise<AccessContext> {
       };
       return accessContext;
     } catch (error) {
-      switch (error) {
-        case "invalid_grant":
-          console.warn(
-            "Expired! Auth code or refresh token needs to be renewed."
-          );
-          // alert("Redirecting to auth server to obtain a new auth grant code.");
-          // TODO: return refreshAuthCodeOrRefreshToken();
-          break;
-        default:
-          console.error(error);
-          break;
-      }
       if (typeof error === "string") {
         throw toErrorClass(error);
       } else {


### PR DESCRIPTION
This removes a couple of logs we had for literally every error in our oauth flow. We throw the error and handle it separately anyway, so this is a safe cleanup.

Fixes https://github.com/cloudflare/wrangler2/issues/788