### PR TITLE
Mutable headers for next() responses in Pages Functions

### DIFF
--- a/.changeset/large-beans-accept.md
+++ b/.changeset/large-beans-accept.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Makes Response Headers object mutable after a call to `next()` in Pages Functions

--- a/examples/pages-functions-app/functions/_middleware.ts
+++ b/examples/pages-functions-app/functions/_middleware.ts
@@ -1,0 +1,5 @@
+export const onRequest = async ({ next }) => {
+  const response = await next();
+  response.headers.set("x-custom", "header value");
+  return response;
+};

--- a/examples/pages-functions-app/tests/index.test.ts
+++ b/examples/pages-functions-app/tests/index.test.ts
@@ -52,6 +52,7 @@ describe("Pages Functions", () => {
 
   it("renders static pages", async () => {
     const response = await waitUntilReady("http://localhost:8789/");
+    expect(response.headers.get("x-custom")).toBe("header value");
     const text = await response.text();
     expect(text).toContain("Hello, world!");
   });

--- a/packages/wrangler/pages/functions/template-worker.ts
+++ b/packages/wrangler/pages/functions/template-worker.ts
@@ -110,7 +110,7 @@ export default {
         // https://fetch.spec.whatwg.org/#null-body-status
         return new Response(
           [101, 204, 205, 304].includes(response.status) ? null : response.body,
-          response
+          { ...response, headers: new Headers([...response.headers.entries()]) }
         );
       } else if (__FALLBACK_SERVICE__) {
         // There are no more handlers so finish with the fallback service (`env.ASSETS.fetch` in Pages' case)


### PR DESCRIPTION
Previously, `next()` would return an unlocked Response with locked headers. With this PR, we now also return unlocked (mutable) headers.