### PR TITLE
feat: optionally send `zone_name` with routes

### DIFF
--- a/.changeset/fast-news-dress.md
+++ b/.changeset/fast-news-dress.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+feat: optionally send `zone_name` with routes
+
+A followup to https://github.com/cloudflare/wrangler2/pull/778, this lets you send an optional `zone_name` with routes. This is particularly useful when using ssl for saas (https://developers.cloudflare.com/ssl/ssl-for-saas/).
+
+Fixes https://github.com/cloudflare/wrangler2/issues/793

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -643,12 +643,17 @@ describe("normalizeAndValidateConfig()", () => {
           "example.com/*",
           { pattern: 123, zone_id: "zone_id_1" },
           { pattern: "route_2", zone_id: 123 },
+          { pattern: "route_2", zone_name: 123 },
           { pattern: "route_3" },
           { zone_id: "zone_id_4" },
+          { zone_name: "zone_name_4" },
           { pattern: undefined },
           { pattern: "route_5", zone_id: "zone_id_5", some_other_key: 123 },
+          { pattern: "route_5", zone_name: "zone_name_5", some_other_key: 123 },
           // this one's valid too
           { pattern: "route_6", zone_id: "zone_id_6" },
+          // as well as this one
+          { pattern: "route_6", zone_name: "zone_name_6" },
         ],
         route: 888,
         jsx_factory: 999,
@@ -674,8 +679,43 @@ describe("normalizeAndValidateConfig()", () => {
       expect(diagnostics.hasWarnings()).toBe(false);
       expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
         "Processing wrangler configuration:
-          - Expected \\"route\\" to be either a string or an object with shape {pattern: string, zone_id: string}, but got 888.
-          - Expected \\"routes\\" to be an array of either strings or objects with the shape {pattern: string, zone_id: string}, but these weren't valid: [666,777,{\\"pattern\\":123,\\"zone_id\\":\\"zone_id_1\\"},{\\"pattern\\":\\"route_2\\",\\"zone_id\\":123},{\\"pattern\\":\\"route_3\\"},{\\"zone_id\\":\\"zone_id_4\\"},{},{\\"pattern\\":\\"route_5\\",\\"zone_id\\":\\"zone_id_5\\",\\"some_other_key\\":123}].
+          - Expected \\"route\\" to be either a string, or an object with shape { pattern, zone_id | zone_name }, but got 888.
+          - Expected \\"routes\\" to be an array of either strings or objects with the shape { pattern, zone_id | zone_name }, but these weren't valid: [
+              666,
+              777,
+              {
+                \\"pattern\\": 123,
+                \\"zone_id\\": \\"zone_id_1\\"
+              },
+              {
+                \\"pattern\\": \\"route_2\\",
+                \\"zone_id\\": 123
+              },
+              {
+                \\"pattern\\": \\"route_2\\",
+                \\"zone_name\\": 123
+              },
+              {
+                \\"pattern\\": \\"route_3\\"
+              },
+              {
+                \\"zone_id\\": \\"zone_id_4\\"
+              },
+              {
+                \\"zone_name\\": \\"zone_name_4\\"
+              },
+              {},
+              {
+                \\"pattern\\": \\"route_5\\",
+                \\"zone_id\\": \\"zone_id_5\\",
+                \\"some_other_key\\": 123
+              },
+              {
+                \\"pattern\\": \\"route_5\\",
+                \\"zone_name\\": \\"zone_name_5\\",
+                \\"some_other_key\\": 123
+              }
+            ].
           - Expected exactly one of the following fields [\\"routes\\",\\"route\\"].
           - Expected \\"workers_dev\\" to be of type boolean but got \\"BAD\\".
           - Expected \\"build.command\\" to be of type string but got 1444.
@@ -1816,8 +1856,11 @@ describe("normalizeAndValidateConfig()", () => {
         "Processing wrangler configuration:
 
           - \\"env.ENV1\\" environment configuration
-            - Expected \\"route\\" to be either a string or an object with shape {pattern: string, zone_id: string}, but got 888.
-            - Expected \\"routes\\" to be an array of either strings or objects with the shape {pattern: string, zone_id: string}, but these weren't valid: [666,777].
+            - Expected \\"route\\" to be either a string, or an object with shape { pattern, zone_id | zone_name }, but got 888.
+            - Expected \\"routes\\" to be an array of either strings or objects with the shape { pattern, zone_id | zone_name }, but these weren't valid: [
+                666,
+                777
+              ].
             - Expected exactly one of the following fields [\\"routes\\",\\"route\\"].
             - Expected \\"workers_dev\\" to be of type boolean but got \\"BAD\\".
             - Expected \\"build.command\\" to be of type string but got 1444.

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -233,6 +233,23 @@ describe("wrangler dev", () => {
       });
     });
 
+    it("should, when provided, use a zone_name to get a zone_id", async () => {
+      writeWranglerToml({
+        main: "index.js",
+        routes: [
+          { pattern: "https://some-domain.com/*", zone_name: "some-zone.com" },
+        ],
+      });
+      fs.writeFileSync("index.js", `export default {};`);
+      mockGetZones("some-zone.com", [{ id: "a-zone-id" }]);
+      await runWrangler("dev");
+      expect((Dev as jest.Mock).mock.calls[0][0].zone).toEqual({
+        // note that it uses the provided zone_name as a host too
+        host: "some-zone.com",
+        id: "a-zone-id",
+      });
+    });
+
     it("given a long host, it should use the longest subdomain that resolves to a zone", async () => {
       writeWranglerToml({
         main: "index.js",

--- a/packages/wrangler/src/config/config.ts
+++ b/packages/wrangler/src/config/config.ts
@@ -185,7 +185,7 @@ export interface DevConfig {
   /**
    * Host to forward requests to, defaults to the host of the first route of project
    */
-  host: (string | { pattern: string; zone_id: string }) | undefined;
+  host: Config["route"];
 }
 
 export type RawDevConfig = Partial<DevConfig>;

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -74,7 +74,13 @@ interface EnvironmentInheritable {
    *
    * @inheritable
    */
-  routes: (string | { pattern: string; zone_id: string })[] | undefined;
+  routes:
+    | (
+        | string
+        | { pattern: string; zone_id: string }
+        | { pattern: string; zone_name: string }
+      )[]
+    | undefined;
 
   /**
    * A route that your worker should be published to. Literally
@@ -85,7 +91,13 @@ interface EnvironmentInheritable {
    *
    * @inheritable
    */
-  route: (string | { pattern: string; zone_id: string }) | undefined;
+  route:
+    | (
+        | string
+        | { pattern: string; zone_id: string }
+        | { pattern: string; zone_name: string }
+      )
+    | undefined;
 
   /**
    * Path to a custom tsconfig

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -472,8 +472,11 @@ function isValidRouteValue(item: unknown): boolean {
       (typeof item === "object" &&
         hasProperty(item, "pattern") &&
         typeof item.pattern === "string" &&
-        hasProperty(item, "zone_id") &&
-        typeof item.zone_id === "string" &&
+        // it could have a zone_name
+        ((hasProperty(item, "zone_name") &&
+          typeof item.zone_name === "string") ||
+          // or a zone_id
+          (hasProperty(item, "zone_id") && typeof item.zone_id === "string")) &&
         Object.keys(item).length === 2))
   );
 }
@@ -484,7 +487,7 @@ function isValidRouteValue(item: unknown): boolean {
 const isRoute: ValidatorFn = (diagnostics, field, value) => {
   if (value !== undefined && !isValidRouteValue(value)) {
     diagnostics.errors.push(
-      `Expected "${field}" to be either a string or an object with shape {pattern: string, zone_id: string}, but got ${JSON.stringify(
+      `Expected "${field}" to be either a string, or an object with shape { pattern, zone_id | zone_name }, but got ${JSON.stringify(
         value
       )}.`
     );
@@ -514,8 +517,10 @@ const isRouteArray: ValidatorFn = (diagnostics, field, value) => {
   }
   if (invalidRoutes.length > 0) {
     diagnostics.errors.push(
-      `Expected "${field}" to be an array of either strings or objects with the shape {pattern: string, zone_id: string}, but these weren't valid: ${JSON.stringify(
-        invalidRoutes
+      `Expected "${field}" to be an array of either strings or objects with the shape { pattern, zone_id | zone_name }, but these weren't valid: ${JSON.stringify(
+        invalidRoutes,
+        null,
+        2
       )}.`
     );
   }

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -813,13 +813,17 @@ export async function main(argv: string[]): Promise<void> {
           (config.routes && config.routes[0]);
 
         let zoneId: string | undefined =
-          typeof hostLike === "object" ? hostLike.zone_id : undefined;
+          typeof hostLike === "object" && "zone_id" in hostLike
+            ? hostLike.zone_id
+            : undefined;
 
         const host =
           typeof hostLike === "string"
             ? getHost(hostLike)
             : typeof hostLike === "object"
-            ? getHost(hostLike.pattern)
+            ? "zone_name" in hostLike
+              ? getHost(hostLike.zone_name)
+              : getHost(hostLike.pattern)
             : undefined;
 
         const hostPieces =

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -319,14 +319,18 @@ export default async function publish(props: Props): Promise<void> {
               .map((route) =>
                 typeof route === "string"
                   ? route
-                  : `${route.pattern} (zone: ${route.zone_id})`
+                  : "zone_id" in route
+                  ? `${route.pattern} (zone id: ${route.zone_id})`
+                  : `${route.pattern} (zone name: ${route.zone_name})`
               )
               .concat([`...and ${routes.length - 10} more routes`]);
           }
           return routes.map((route) =>
             typeof route === "string"
               ? route
-              : `${route.pattern} (zone: ${route.zone_id})`
+              : "zone_id" in route
+              ? `${route.pattern} (zone id: ${route.zone_id})`
+              : `${route.pattern} (zone name: ${route.zone_name})`
           );
         })
       );


### PR DESCRIPTION
A followup to https://github.com/cloudflare/wrangler2/pull/778, this lets you send an optional `zone_name` with routes. This is particularly useful when using ssl for saas (https://developers.cloudflare.com/ssl/ssl-for-saas/).

Fixes https://github.com/cloudflare/wrangler2/issues/793
