### PR TITLE
DO NOT LAND fix: pass tests on node 17+

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20681,10 +20681,6 @@
         "tosource": "^2.0.0-alpha.3",
         "typescript": "^4.6.3",
         "undici": "^5.0.0",
-        "webpack": "^4.46.0",
-        "wrangler": "../wrangler"
-      },
-      "peerDependencies": {
         "webpack": "^4.46.0"
       }
     },
@@ -35189,8 +35185,7 @@
         "tosource": "^2.0.0-alpha.3",
         "typescript": "^4.6.3",
         "undici": "^5.0.0",
-        "webpack": "^4.46.0",
-        "wrangler": "../wrangler"
+        "webpack": "^4.46.0"
       },
       "dependencies": {
         "esbuild": {

--- a/packages/wranglerjs-compat-webpack-plugin/package.json
+++ b/packages/wranglerjs-compat-webpack-plugin/package.json
@@ -15,7 +15,7 @@
     "build": "run-p build:*",
     "build:d.ts": "tsc",
     "build:js": "esbuild src/index.ts --bundle --platform=node --external:execa --external:webpack --external:esbuild --external:rimraf --target=node16.7 --outfile=lib/index.js --format=cjs --sourcemap",
-    "test": "jest"
+    "test": "NODE_OPTIONS=--openssl-legacy-provider jest"
   },
   "dependencies": {
     "esbuild": "^0.14.31",


### PR DESCRIPTION
node 17 requires a special flag `--openssl-legacy-provider` for webpack to run correctly. We use 16 in our tests, but some of us use 17 locally and require this flag.

--- 

Let's see how CI does with this. 