### PR TITLE
chore: setup releases for GA

### DIFF
--- a/.github/workflows/prereleases.yml
+++ b/.github/workflows/prereleases.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   prerelease:
     if: ${{ github.repository_owner == 'cloudflare' }}
-    name: Build & Publish an alpha release to NPM
+    name: Build & Publish a beta release to NPM
     runs-on: ubuntu-latest
 
     steps:
@@ -39,14 +39,14 @@ jobs:
       - name: Check for errors
         run: npm run check
 
-      - name: Publish Alpha to NPM
-        run: npm publish --tag alpha
+      - name: Publish Beta to NPM
+        run: npm publish --tag beta
         env:
           NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
         working-directory: packages/wrangler
 
       - name: Get Package Version
-        run: echo "WRANGLER_VERSION=$(npm view wrangler@alpha version)" >> $GITHUB_ENV
+        run: echo "WRANGLER_VERSION=$(npm view wrangler@beta version)" >> $GITHUB_ENV
         working-directory: packages/wrangler
       # The Sourcemap rewrite script is necessary due to how Sentry handles Events, Sourcemaps and sourcemapping URLs, all of which need to reference each other.
       # The script will rewrite the sourcemap URLs to point to the correct location of the sourcemap and what the Event is being processed (with RewriteFrames)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         uses: changesets/action@v1
         with:
           version: node .github/changeset-version.js
-          publish: npx changeset publish --tag beta
+          publish: npx changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -14,16 +14,16 @@ Further, we will NOT do a general release until we are both feature complete, an
 # Make a javascript file
 $ echo "export default { fetch() { return new Response('hello world') } }" > index.js
 # try it out
-$ npx wrangler@beta dev index.js
+$ npx wrangler dev index.js
 # and then publish it
-$ npx wrangler@beta publish index.js --name my-worker
+$ npx wrangler publish index.js --name my-worker
 # visit https://my-worker.<your workers subdomain>.workers.dev
 ```
 
 ## Installation:
 
 ```bash
-$ npm install wrangler@beta --save-dev
+$ npm install wrangler --save-dev
 ```
 
 ## Commands

--- a/packages/wrangler/CHANGELOG.md
+++ b/packages/wrangler/CHANGELOG.md
@@ -918,7 +918,7 @@
   For example:
 
   ```bash
-  npx wrangler@beta pages dev -- npm run dev
+  npx wrangler pages dev -- npm run dev
   ```
 
   Previously the args after `--` were being dropped.

--- a/packages/wrangler/README.md
+++ b/packages/wrangler/README.md
@@ -14,16 +14,16 @@ Further, we will NOT do a general release until we are both feature complete, an
 # Make a javascript file
 $ echo "export default { fetch() { return new Response('hello world') } }" > index.js
 # try it out
-$ npx wrangler@beta dev index.js
+$ npx wrangler dev index.js
 # and then publish it
-$ npx wrangler@beta publish index.js --name my-worker
+$ npx wrangler publish index.js --name my-worker
 # visit https://my-worker.<your workers subdomain>.workers.dev
 ```
 
 ## Installation:
 
 ```bash
-$ npm install wrangler@beta
+$ npm install wrangler --save-dev
 ```
 
 ## Commands

--- a/packages/wrangler/src/update-check.ts
+++ b/packages/wrangler/src/update-check.ts
@@ -7,7 +7,7 @@ export async function updateCheck(): Promise<string> {
   try {
     // default cache for update check is 1 day
     update = await checkForUpdate(pkg, {
-      distTag: pkg.version.startsWith("0.0.0") ? "alpha" : "beta", // TODO: change this after https://github.com/cloudflare/wrangler2/pull/805 lands
+      distTag: pkg.version.startsWith("0.0.0") ? "beta" : "latest",
     });
   } catch (err) {
     // ignore error


### PR DESCRIPTION
This modifies how we do releases -
- The changesets flow will now publish to latest
- Every commit will now be published as beta instead of alpha