### PR TITLE
fix: check for updates on the right channel

### DIFF
--- a/.changeset/khaki-mice-decide.md
+++ b/.changeset/khaki-mice-decide.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: check for updates on the right channel
+
+This makes the update checker run on the channel that the version being used runs on.

--- a/packages/wrangler/src/update-check.ts
+++ b/packages/wrangler/src/update-check.ts
@@ -7,7 +7,7 @@ export async function updateCheck(): Promise<string> {
   try {
     // default cache for update check is 1 day
     update = await checkForUpdate(pkg, {
-      distTag: "beta",
+      distTag: pkg.version.startsWith("0.0.0") ? "alpha" : "beta", // TODO: change this after https://github.com/cloudflare/wrangler2/pull/805 lands
     });
   } catch (err) {
     // ignore error


### PR DESCRIPTION
This makes the update checker run on the channel that the version being used runs on.