### PR TITLE
fix: read `isLegacyEnv` correctly

### DIFF
--- a/.changeset/silver-dolls-mate.md
+++ b/.changeset/silver-dolls-mate.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: read `isLegacyEnv` correctly
+
+This fixes the signature for `isLegacyEnv()` since it doesn't use args, and we fix reading legacy_env correctly when creating a draft worker when creating a secret.


### PR DESCRIPTION
This fixes the signature for `isLegacyEnv()` since it doesn't use args, and we fix reading legacy_env correctly when creating a draft worker when creating a secret.
