### PR TITLE
disable webpack plugin's tests from running in CI

### DIFF
--- a/packages/wranglerjs-compat-webpack-plugin/package.json
+++ b/packages/wranglerjs-compat-webpack-plugin/package.json
@@ -15,7 +15,7 @@
     "build": "run-p build:*",
     "build:d.ts": "tsc",
     "build:js": "esbuild src/index.ts --bundle --platform=node --external:execa --external:webpack --external:esbuild --external:rimraf --target=node16.7 --outfile=lib/index.js --format=cjs --sourcemap",
-    "test": "jest"
+    "test:plugin": "jest"
   },
   "dependencies": {
     "esbuild": "^0.14.31",


### PR DESCRIPTION
we have an issue where we're getting rate limited by github when trying to run the tests for the webpack plugin, probably because we're not caching artifacts correctly. This disables those tests from running on CI till we figure out a fix.