### PR TITLE
wrangler tail tty-awareness and json-respecting

### DIFF
--- a/.changeset/unlucky-terms-film.md
+++ b/.changeset/unlucky-terms-film.md
@@ -1,0 +1,12 @@
+---
+"wrangler": patch
+---
+
+Make `wrangler tail` TTY-aware, and stop printing non-JSON in JSON mode
+
+Closes #493
+
+2 quick fixes:
+
+- Check `process.stdout.isTTY` at runtime to determine whether to default to "pretty" or "json" output for tailing.
+- Only print messages like "Connected to {worker}" if in "pretty" mode (errors still throw strings)

--- a/packages/wrangler/src/__tests__/helpers/mock-istty.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-istty.ts
@@ -1,0 +1,19 @@
+const ORIGINAL_ISTTY = process.stdout.isTTY;
+
+/**
+ * Mock `process.stdout.isTTY`
+ */
+export function useMockIsTTY() {
+  /**
+   * Explicitly set `process.stdout.isTTY` to a given value
+   */
+  const setIsTTY = (isTTY: boolean) => {
+    process.stdout.isTTY = isTTY;
+  };
+
+  afterEach(() => {
+    process.stdout.isTTY = ORIGINAL_ISTTY;
+  });
+
+  return { setIsTTY };
+}

--- a/packages/wrangler/src/__tests__/helpers/mock-istty.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-istty.ts
@@ -11,6 +11,10 @@ export function useMockIsTTY() {
     process.stdout.isTTY = isTTY;
   };
 
+  beforeEach(() => {
+    process.stdout.isTTY = ORIGINAL_ISTTY;
+  });
+
   afterEach(() => {
     process.stdout.isTTY = ORIGINAL_ISTTY;
   });

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -1071,7 +1071,7 @@ export async function main(argv: string[]): Promise<void> {
           type: "string",
         })
         .option("format", {
-          default: "pretty",
+          default: process.stdout.isTTY ? "pretty" : "json",
           choices: ["json", "pretty"],
           describe: "The format of log entries",
         })
@@ -1155,9 +1155,11 @@ export async function main(argv: string[]): Promise<void> {
         args.env && !isLegacyEnv(args, config) ? ` (${args.env})` : ""
       }`;
 
-      console.log(
-        `successfully created tail, expires at ${expiration.toLocaleString()}`
-      );
+      if (args.format === "pretty") {
+        console.log(
+          `successfully created tail, expires at ${expiration.toLocaleString()}`
+        );
+      }
 
       onExit(async () => {
         tail.terminate();
@@ -1184,7 +1186,9 @@ export async function main(argv: string[]): Promise<void> {
         }
       }
 
-      console.log(`Connected to ${scriptDisplayName}, waiting for logs...`);
+      if (args.format === "pretty") {
+        console.log(`Connected to ${scriptDisplayName}, waiting for logs...`);
+      }
 
       tail.on("close", async () => {
         tail.terminate();

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -1065,59 +1065,56 @@ export async function main(argv: string[]): Promise<void> {
     "tail [name]",
     "🦚 Starts a log tailing session for a published Worker.",
     (yargs) => {
-      return (
-        yargs
-          .positional("name", {
-            describe: "Name of the worker",
-            type: "string",
-          })
-          // TODO: auto-detect if this should be json or pretty based on atty
-          .option("format", {
-            default: "pretty",
-            choices: ["json", "pretty"],
-            describe: "The format of log entries",
-          })
-          .option("status", {
-            choices: ["ok", "error", "canceled"],
-            describe: "Filter by invocation status",
-            array: true,
-          })
-          .option("header", {
-            type: "string",
-            describe: "Filter by HTTP header",
-          })
-          .option("method", {
-            type: "string",
-            describe: "Filter by HTTP method",
-            array: true,
-          })
-          .option("sampling-rate", {
-            type: "number",
-            describe: "Adds a percentage of requests to log sampling rate",
-          })
-          .option("search", {
-            type: "string",
-            describe: "Filter by a text match in console.log messages",
-          })
-          .option("ip", {
-            type: "string",
-            describe:
-              'Filter by the IP address the request originates from. Use "self" to filter for your own IP',
-            array: true,
-          })
-          .option("env", {
-            type: "string",
-            describe: "Perform on a specific environment",
-            alias: "e",
-          })
-          .option("debug", {
-            type: "boolean",
-            hidden: true,
-            default: false,
-            describe:
-              "If a log would have been filtered out, send it through anyway alongside the filter which would have blocked it.",
-          })
-      );
+      return yargs
+        .positional("name", {
+          describe: "Name of the worker",
+          type: "string",
+        })
+        .option("format", {
+          default: "pretty",
+          choices: ["json", "pretty"],
+          describe: "The format of log entries",
+        })
+        .option("status", {
+          choices: ["ok", "error", "canceled"],
+          describe: "Filter by invocation status",
+          array: true,
+        })
+        .option("header", {
+          type: "string",
+          describe: "Filter by HTTP header",
+        })
+        .option("method", {
+          type: "string",
+          describe: "Filter by HTTP method",
+          array: true,
+        })
+        .option("sampling-rate", {
+          type: "number",
+          describe: "Adds a percentage of requests to log sampling rate",
+        })
+        .option("search", {
+          type: "string",
+          describe: "Filter by a text match in console.log messages",
+        })
+        .option("ip", {
+          type: "string",
+          describe:
+            'Filter by the IP address the request originates from. Use "self" to filter for your own IP',
+          array: true,
+        })
+        .option("env", {
+          type: "string",
+          describe: "Perform on a specific environment",
+          alias: "e",
+        })
+        .option("debug", {
+          type: "boolean",
+          hidden: true,
+          default: false,
+          describe:
+            "If a log would have been filtered out, send it through anyway alongside the filter which would have blocked it.",
+        });
     },
     async (args) => {
       if (args.format === "pretty") {


### PR DESCRIPTION
Make `wrangler tail` TTY-aware, and stop printing non-JSON in JSON mode

Closes #493

2 quick fixes:

- Check `process.stdout.isTTY` at runtime to determine whether to default to "pretty" or "json" output for tailing.
- Only print messages like "Connected to {worker}" if in "pretty" mode (errors still throw strings)
