### PR TITLE
add a warning if service environments are being used.

### DIFF
--- a/.changeset/flat-emus-share.md
+++ b/.changeset/flat-emus-share.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+add a warning if service environments are being used.
+
+Service environments are not ready for widespread usage, and their behaviour is going to change. This adds a warning if anyone uses them.
+
+Closes https://github.com/cloudflare/wrangler2/issues/809

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -244,14 +244,16 @@ describe("publish", () => {
         mockUploadWorkerRequest({
           legacyEnv: false,
         });
-        await runWrangler("publish index.js");
+        await runWrangler("publish index.js --legacy-env false");
         expect(std.out).toMatchInlineSnapshot(`
           "Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
             test-name.test-sub-domain.workers.dev"
         `);
         expect(std.err).toMatchInlineSnapshot(`""`);
-        expect(std.warn).toMatchInlineSnapshot(`""`);
+        expect(std.warn).toMatchInlineSnapshot(
+          `"Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION."`
+        );
       });
 
       it("publishes as an environment when provided", async () => {
@@ -269,7 +271,9 @@ describe("publish", () => {
             some-env.test-name.test-sub-domain.workers.dev"
         `);
         expect(std.err).toMatchInlineSnapshot(`""`);
-        expect(std.warn).toMatchInlineSnapshot(`""`);
+        expect(std.warn).toMatchInlineSnapshot(
+          `"Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION."`
+        );
       });
     });
   });
@@ -416,7 +420,7 @@ describe("publish", () => {
           *another-boring-website.com (zone name: some-zone.com)
           example.com/some-route/* (zone id: JGHFHG654gjcj)
           more-examples.com/*",
-          "warn": "",
+          "warn": "Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION.",
         }
       `);
     });
@@ -2374,7 +2378,7 @@ export default{
 
           [32m%s[0m If you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.",
             "out": "",
-            "warn": "",
+            "warn": "Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION.",
           }
         `);
       });

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -97,6 +97,13 @@ export function normalizeAndValidateConfig(
     rawConfig.legacy_env ??
     true;
 
+  // TODO: remove this once service environments goes GA.
+  if (!isLegacyEnv) {
+    console.warn(
+      "Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION."
+    );
+  }
+
   const topLevelEnv = normalizeAndValidateEnvironment(
     diagnostics,
     configPath,


### PR DESCRIPTION
Service environments are not ready for widespread usage, and their behaviour is going to change. This adds a warning if anyone uses them.

Closes https://github.com/cloudflare/wrangler2/issues/809