### PR TITLE
fix: disallow setting account_id in named service environments

### DIFF
--- a/.changeset/little-roses-invite.md
+++ b/.changeset/little-roses-invite.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: disallow setting account_id in named service environments
+
+Much like https://github.com/cloudflare/wrangler2/pull/641, we don't want to allow setting account_id with named service environments. This is so that we use the same account_id for multiple environments, and have them group together in the dashboard.

--- a/packages/wrangler/src/config/validation-helpers.ts
+++ b/packages/wrangler/src/config/validation-helpers.ts
@@ -82,7 +82,7 @@ export function inheritableInLegacyEnvironments<K extends keyof Environment>(
   rawEnv: RawEnvironment,
   field: K,
   validate: ValidatorFn,
-  transformFn: TransformFn<Environment[K]>,
+  transformFn: TransformFn<Environment[K]> = (v) => v,
   defaultValue: Environment[K]
 ): Environment[K] {
   return topLevelEnv === undefined || isLegacyEnv === true

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -651,12 +651,14 @@ function normalizeAndValidateEnvironment(
 
   const environment: Environment = {
     // Inherited fields
-    account_id: inheritable(
+    account_id: inheritableInLegacyEnvironments(
       diagnostics,
+      isLegacyEnv,
       topLevelEnv,
       rawEnv,
       "account_id",
       isString,
+      undefined,
       undefined
     ),
     compatibility_date: inheritable(


### PR DESCRIPTION
Much like https://github.com/cloudflare/wrangler2/pull/641, we don't want to allow setting account_id with named service environments. This is so that we use the same account_id for multiple environments, and have them group together in the dashboard.