### PR TITLE
feat: allow miniflare to load .env file locally

### DIFF
--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -196,6 +196,7 @@ function useLocalWorker({
         sourceMap: true,
         logUnhandledRejections: true,
         crons,
+        envPath: true,
       };
 
       // The path to the Miniflare CLI assumes that this file is being run from


### PR DESCRIPTION
During a pure `--local` mode it would be nice to hide secrets in a git ignored `.env` file (which is already supported by miniflare)

This PR aims to reintroduce this.

One could get fancy with the `--env` cli flag already used such that `--env dev` would yield the `./.env.dev` file for example.