### PR TITLE
fix: don't log an error when `wrangler dev` is cancelled early

### DIFF
--- a/.changeset/nice-dingos-fix.md
+++ b/.changeset/nice-dingos-fix.md
@@ -1,0 +1,17 @@
+---
+"wrangler": patch
+---
+
+fix: don't log an error when `wrangler dev` is cancelled early
+
+We currently log an `AbortError` with a stack if we exit `wrangler dev`'s startup process before it's done. This fix skips logging that error (since it's not an exception).
+
+Test plan:
+
+```
+cd packages/wrangler
+npm run build
+cd ../../examples/workers-chat-demo
+npx wrangler dev
+# hit [x] as soon as the hotkey shortcut bar shows
+```

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -182,7 +182,9 @@ export function useWorker(props: {
     start().catch((err) => {
       // we want to log the error, but not end the process
       // since it could recover after the developer fixes whatever's wrong
-      console.error("remote worker:", err);
+      if ((err as { code: string }).code !== "ABORT_ERR") {
+        console.error("remote worker:", err);
+      }
     });
 
     return () => {


### PR DESCRIPTION
We currently log an `AbortError` with a stack if we exit `wrangler dev`'s startup process before it's done. This fix skips logging that error (since it's not an exception).

Test plan:

```
cd packages/wrangler
npm run build
cd ../../examples/workers-chat-demo
npx wrangler dev
# hit [x] as soon as the hotkey shortcut bar shows
```