### PR TITLE
feat: `publish --outdir <path>` and `publish --dry-run`

### DIFF
--- a/.changeset/fast-cougars-thank.md
+++ b/.changeset/fast-cougars-thank.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+feat: `publish --dry-run`
+
+It can be useful to do a dry run of publishing. Developers want peace of mind that a project will compile before actually publishing to live servers. Combined with `--outdir`, this is also useful for testing the output of `publish`. Further, it gives developers a chance to upload our generated sourcemap to a service like sentry etc, so that errors from the worker can be mapped against actual source code, but before the service actually goes live.

--- a/.changeset/wise-candles-unite.md
+++ b/.changeset/wise-candles-unite.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+feat: `publish --outdir <path>`
+
+It can be useful to introspect built assets. A leading usecase is to upload the sourcemap that we generate to services like sentry etc, so that errors from the worker can be mapped against actual source code. We introduce a `--outdir` cli arg to specify a path to generate built assets at, which doesn't get cleaned up after publishing. We are _not_ adding this to `wrangler.toml` just yet, but could in the future if it looks appropriate there.

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -3943,6 +3943,42 @@ export default{
       `);
     });
   });
+
+  describe("--outdir", () => {
+    it("should generate built assets at --outdir if specified", async () => {
+      writeWranglerToml();
+      writeWorkerSource();
+      mockSubDomainRequest();
+      mockUploadWorkerRequest();
+      await runWrangler("publish index.js --outdir some-dir");
+      expect(fs.existsSync("some-dir/index.js")).toBe(true);
+      expect(fs.existsSync("some-dir/index.js.map")).toBe(true);
+      expect(std).toMatchInlineSnapshot(`
+        Object {
+          "err": "",
+          "out": "Uploaded test-name (TIMINGS)
+        Published test-name (TIMINGS)
+          test-name.test-sub-domain.workers.dev",
+          "warn": "",
+        }
+      `);
+    });
+  });
+
+  describe("--dry-run", () => {
+    it("should not publish the worker if --dry-run is specified", async () => {
+      writeWranglerToml();
+      writeWorkerSource();
+      await runWrangler("publish index.js --dry-run");
+      expect(std).toMatchInlineSnapshot(`
+        Object {
+          "err": "",
+          "out": "--dry-run: exiting now.",
+          "warn": "",
+        }
+      `);
+    });
+  });
 });
 
 /** Write mock assets to the file system so they can be uploaded. */

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -126,7 +126,8 @@ export function useWorker(props: {
         // concept of service environments for kv namespaces yet).
         name + (!props.legacyEnv && props.env ? `-${props.env}` : ""),
         assetPaths,
-        true
+        true,
+        false
       ); // TODO: cancellable?
 
       const content = await readFile(bundle.path, "utf-8");

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -638,6 +638,7 @@ export async function main(argv: string[]): Promise<void> {
         .option("format", {
           choices: ["modules", "service-worker"] as const,
           describe: "Choose an entry type",
+          deprecated: true,
         })
         .option("env", {
           describe: "Perform on a specific environment",
@@ -951,9 +952,14 @@ export async function main(argv: string[]): Promise<void> {
           describe: "Name of the worker",
           type: "string",
         })
+        .option("outdir", {
+          describe: "Output directory for the bundled worker",
+          type: "string",
+        })
         .option("format", {
           choices: ["modules", "service-worker"] as const,
           describe: "Choose an entry type",
+          deprecated: true,
         })
         .option("compatibility-date", {
           describe: "Date to use for compatibility checks",
@@ -1017,6 +1023,10 @@ export async function main(argv: string[]): Promise<void> {
         .option("minify", {
           describe: "Minify the script",
           type: "boolean",
+        })
+        .option("dry-run", {
+          describe: "Don't actually publish",
+          type: "boolean",
         });
     },
     async (args) => {
@@ -1072,6 +1082,8 @@ export async function main(argv: string[]): Promise<void> {
         legacyEnv: isLegacyEnv(config),
         minify: args.minify,
         experimentalPublic: args["experimental-public"] !== undefined,
+        outDir: args.outdir,
+        dryRun: args.dryRun,
       });
     }
   );


### PR DESCRIPTION
### feat: `publish --outdir <path>`

It can be useful to introspect built assets. A leading usecase is to upload the sourcemap that we generate to services like sentry etc, so that errors from the worker can be mapped against actual sourcce code. We introduce a `--outdir` cli arg to specify a path to generate built assets at, which doesn't get cleaned up after publishing. We are _not_ adding this to `wrangler.toml` just yet, but could in the future if it looks appropriate there.

### feat: `publish --dry-run`

It can be useful to do a dry run of publishing. Developers want peace of mind that a project will compile before actually publishing to live servers. Combined with `--outdir`, this is also useful for testing the output of `publish`. Further, it gives developers a chance to upload our generated sourcemap to a service like sentry etc, so that errors from the worker can be mapped against actual source code, but before the service actually goes live.