### PR TITLE
fix: toggle `workers.dev` subdomains only when required

### DIFF
--- a/.changeset/dirty-pandas-bake.md
+++ b/.changeset/dirty-pandas-bake.md
@@ -1,0 +1,13 @@
+---
+"wrangler": patch
+---
+
+fix: toggle `workers.dev` subdomains only when required
+
+This fix -
+
+- passes the correct query param to check whether a workers.dev subdomain has already been published/enabled
+- thus enabling it only when it's not been enabled
+- it also disables it only when it's explicitly knows it's already been enabled
+
+The effect of this is that publishes are much faster.


### PR DESCRIPTION
This fix -

- passes the correct query param to check whether a workers.dev subdomain has already been published/enabled
- thus enabling it only when it's not been enabled
- it also disables it only when it's explicitly knows it's already been enabled

The effect of this is that publishes are much faster.