### PR TITLE
polish: replace 🦺 with ⚠️

### DIFF
--- a/.changeset/wet-shirts-vanish.md
+++ b/.changeset/wet-shirts-vanish.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+polish: replace 🦺 with ⚠️
+
+I got some feedback that the construction worker jacket (?) icon for deprecations is confusing, especially because it's an uncommon icon and not very big in the terminal. This patch replaces it with a more familiar warning symbol.

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -534,9 +534,9 @@ describe("normalizeAndValidateConfig()", () => {
         expect(diagnostics.hasWarnings()).toBe(true);
         expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
           "Processing wrangler configuration:
-            - 🦺 DEPRECATION: \\"type\\":
+            - ⚠️  DEPRECATION: \\"type\\":
               DO NOT USE THIS. Most common features now work out of the box with wrangler, including modules, jsx, typescript, etc. If you need anything more, use a custom build.
-            - 🦺 DEPRECATION: \\"webpack_config\\":
+            - ⚠️  DEPRECATION: \\"webpack_config\\":
               DO NOT USE THIS. Most common features now work out of the box with wrangler, including modules, jsx, typescript, etc. If you need anything more, use a custom build."
         `);
       });
@@ -759,15 +759,15 @@ describe("normalizeAndValidateConfig()", () => {
       expect(normalizePath(diagnostics.renderWarnings()))
         .toMatchInlineSnapshot(`
         "Processing project/wrangler.toml configuration:
-          - 🦺 DEPRECATION: \\"build.upload.format\\":
+          - ⚠️  DEPRECATION: \\"build.upload.format\\":
             The format is inferred automatically from the code.
-          - 🦺 DEPRECATION: \\"build.upload.main\\":
+          - ⚠️  DEPRECATION: \\"build.upload.main\\":
             Delete the \`build.upload.main\` and \`build.upload.dir\` fields.
             Then add the top level \`main\` field to your configuration file:
             \`\`\`
             main = \\"src/index.ts\\"
             \`\`\`
-          - 🦺 DEPRECATION: \\"build.upload.dir\\":
+          - ⚠️  DEPRECATION: \\"build.upload.dir\\":
             Use the top level \\"main\\" field or a command-line argument to specify the entry-point for the Worker.
           - DEPRECATION: The \`build.upload.rules\` config field is no longer used, the rules should be specified via the \`rules\` config field. Delete the \`build.upload\` field from the configuration file, and add this:
             \`\`\`
@@ -1509,9 +1509,9 @@ describe("normalizeAndValidateConfig()", () => {
         expect(diagnostics.hasWarnings()).toBe(true);
         expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
           "Processing wrangler configuration:
-            - 🦺 DEPRECATION: \\"zone_id\\":
+            - ⚠️  DEPRECATION: \\"zone_id\\":
               This is unnecessary since we can deduce this from routes directly.
-            - 🦺 DEPRECATION: \\"experimental_services\\":
+            - ⚠️  DEPRECATION: \\"experimental_services\\":
               The \\"experimental_services\\" field is no longer supported. Instead, use [[unsafe.bindings]] to enable experimental features. Add this to your wrangler.toml:
               \`\`\`
               [[unsafe.bindings]]
@@ -2733,9 +2733,9 @@ describe("normalizeAndValidateConfig()", () => {
           "Processing wrangler configuration:
 
             - \\"env.ENV1\\" environment configuration
-              - 🦺 DEPRECATION: \\"zone_id\\":
+              - ⚠️  DEPRECATION: \\"zone_id\\":
                 This is unnecessary since we can deduce this from routes directly.
-              - 🦺 DEPRECATION: \\"experimental_services\\":
+              - ⚠️  DEPRECATION: \\"experimental_services\\":
                 The \\"experimental_services\\" field is no longer supported. Instead, use [[unsafe.bindings]] to enable experimental features. Add this to your wrangler.toml:
                 \`\`\`
                 [[unsafe.bindings]]

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -845,14 +845,14 @@ describe("wrangler", () => {
     it("should throw an error if the deprecated command is used with positional arguments", async () => {
       await expect(runWrangler("preview GET")).rejects
         .toThrowErrorMatchingInlineSnapshot(`
-              "🦺 DEPRECATION:
+              "⚠️  DEPRECATION:
               The \`wrangler preview\` command has been deprecated.
               Try using \`wrangler dev\` to to try out a worker during development.
               "
             `);
       await expect(runWrangler(`preview GET "SomeBody"`)).rejects
         .toThrowErrorMatchingInlineSnapshot(`
-              "🦺 DEPRECATION:
+              "⚠️  DEPRECATION:
               The \`wrangler preview\` command has been deprecated.
               Try using \`wrangler dev\` to to try out a worker during development.
               "
@@ -970,7 +970,7 @@ describe("wrangler", () => {
     it("should print a deprecation message for 'generate'", async () => {
       await runWrangler("generate").catch((err) => {
         expect(err.message).toMatchInlineSnapshot(`
-          "🦺 DEPRECATION:
+          "⚠️  DEPRECATION:
           \`wrangler generate\` has been deprecated, please refer to https://github.com/cloudflare/wrangler2/blob/main/docs/deprecations.md#generate for alternatives"
         `);
       });
@@ -978,7 +978,7 @@ describe("wrangler", () => {
     it("should print a deprecation message for 'build'", async () => {
       await runWrangler("build").catch((err) => {
         expect(err.message).toMatchInlineSnapshot(`
-          "🦺 DEPRECATION:
+          "⚠️  DEPRECATION:
           \`wrangler build\` has been deprecated, please refer to https://github.com/cloudflare/wrangler2/blob/main/docs/deprecations.md#build for alternatives"
         `);
       });

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -557,7 +557,7 @@ describe("publish", () => {
       expect(std.err).toMatchInlineSnapshot(`""`);
       expect(std.warn).toMatchInlineSnapshot(`
         "Processing wrangler.toml configuration:
-          - 🦺 DEPRECATION: \\"build.upload.main\\":
+          - ⚠️  DEPRECATION: \\"build.upload.main\\":
             Delete the \`build.upload.main\` and \`build.upload.dir\` fields.
             Then add the top level \`main\` field to your configuration file:
             \`\`\`
@@ -589,13 +589,13 @@ describe("publish", () => {
       expect(std.err).toMatchInlineSnapshot(`""`);
       expect(std.warn).toMatchInlineSnapshot(`
         "Processing ../wrangler.toml configuration:
-          - 🦺 DEPRECATION: \\"build.upload.main\\":
+          - ⚠️  DEPRECATION: \\"build.upload.main\\":
             Delete the \`build.upload.main\` and \`build.upload.dir\` fields.
             Then add the top level \`main\` field to your configuration file:
             \`\`\`
             main = \\"foo/index.js\\"
             \`\`\`
-          - 🦺 DEPRECATION: \\"build.upload.dir\\":
+          - ⚠️  DEPRECATION: \\"build.upload.dir\\":
             Use the top level \\"main\\" field or a command-line argument to specify the entry-point for the Worker."
       `);
     });

--- a/packages/wrangler/src/__tests__/route.test.ts
+++ b/packages/wrangler/src/__tests__/route.test.ts
@@ -9,7 +9,7 @@ describe("wrangler route", () => {
   it("shows a deprecation notice when `wrangler route` is run", async () => {
     await expect(runWrangler("route")).rejects
       .toThrowErrorMatchingInlineSnapshot(`
-            "🦺 DEPRECATION:
+            "⚠️  DEPRECATION:
             \`wrangler route\` has been deprecated.
             Please use wrangler.toml and/or \`wrangler publish --routes\` to modify routes"
           `);
@@ -18,7 +18,7 @@ describe("wrangler route", () => {
   it("shows a deprecation notice when `wrangler route delete` is run", async () => {
     await expect(runWrangler("route delete")).rejects
       .toThrowErrorMatchingInlineSnapshot(`
-            "🦺 DEPRECATION:
+            "⚠️  DEPRECATION:
             \`wrangler route delete\` has been deprecated.
             Remove the unwanted route(s) from wrangler.toml and run \`wrangler publish\` to remove your worker from those routes."
           `);
@@ -27,7 +27,7 @@ describe("wrangler route", () => {
   it("shows a deprecation notice when `wrangler route delete <id>` is run", async () => {
     await expect(runWrangler("route delete some-zone-id")).rejects
       .toThrowErrorMatchingInlineSnapshot(`
-            "🦺 DEPRECATION:
+            "⚠️  DEPRECATION:
             \`wrangler route delete\` has been deprecated.
             Remove the unwanted route(s) from wrangler.toml and run \`wrangler publish\` to remove your worker from those routes."
           `);
@@ -36,7 +36,7 @@ describe("wrangler route", () => {
   it("shows a deprecation notice when `wrangler route list` is run", async () => {
     await expect(runWrangler("route list")).rejects
       .toThrowErrorMatchingInlineSnapshot(`
-            "🦺 DEPRECATION:
+            "⚠️  DEPRECATION:
             \`wrangler route list\` has been deprecated.
             Refer to wrangler.toml for a list of routes the worker will be deployed to upon publishing.
             Refer to the Cloudflare Dashboard to see the routes this worker is currently running on."

--- a/packages/wrangler/src/config/validation-helpers.ts
+++ b/packages/wrangler/src/config/validation-helpers.ts
@@ -14,7 +14,7 @@ export function deprecated<T extends object>(
   fieldPath: DeepKeyOf<T>,
   message: string,
   remove: boolean,
-  title = "🦺 DEPRECATION",
+  title = "⚠️  DEPRECATION",
   type: "warning" | "error" = "warning"
 ): void {
   const diagnosticMessage = `${title}: "${fieldPath}":\n${message}`;

--- a/packages/wrangler/src/errors.ts
+++ b/packages/wrangler/src/errors.ts
@@ -1,6 +1,6 @@
 export class DeprecationError extends Error {
   constructor(message: string) {
-    super(`🦺 DEPRECATION:\n${message}`);
+    super(`⚠️  DEPRECATION:\n${message}`);
   }
 }
 


### PR DESCRIPTION
I got some feedback that the construction worker jacket (?) icon for deprecations is confusing, especially because it's an uncommon icon and not very big in the terminal. This patch replaces it with a more familiar warning symbol.