### PR TITLE
fix: remove timeout on custom builds, and make sure logs are visible

### DIFF
--- a/.changeset/calm-bottles-talk.md
+++ b/.changeset/calm-bottles-talk.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: remove timeout on custom builds, and make sure logs are visible
+
+This removes the timeout we have for custom builds. We shouldn't be applying this timeout anyway, since it doesn't block wrangler, just the user themselves. Further, in https://github.com/cloudflare/wrangler2/pull/759, we changed the custom build's process stdout/stderr config to "pipe" to pass tests, however that meant we wouldn't see logs in the terminal anymore. This patch removes the timeout, and brings back proper logging for custom builds.

--- a/packages/wrangler/src/entry.ts
+++ b/packages/wrangler/src/entry.ts
@@ -89,9 +89,10 @@ export async function runCustomBuild(
     console.log("running:", build.command);
     await execaCommand(build.command, {
       shell: true,
-      stdout: "pipe",
-      stderr: "pipe",
-      timeout: 1000 * 30,
+      // we keep these two as "inherit" so that
+      // logs are still visible.
+      stdout: "inherit",
+      stderr: "inherit",
       ...(build.cwd && { cwd: build.cwd }),
     });
 


### PR DESCRIPTION
This removes the timeout we have for custom builds. We shouldn't be applying this timeout anyway, since it doesn't block wrangler, just the user themselves. Further, in https://github.com/cloudflare/wrangler2/pull/759, we changed the custom build's process stdout/stderr config to "pipe" to pass tests, however that meant we wouldn't see logs in the terminal anymore. This patch removes the timeout, and brings back proper logging for custom builds.