### PR TITLE
fix: make wrangler work on node v18

### DIFF
--- a/.changeset/eleven-cheetahs-clean.md
+++ b/.changeset/eleven-cheetahs-clean.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+---
+
+fix: make wrangler work on node v18
+
+There's some interference between our data fetching library `undici` and node 18's new `fetch` and co. (powered by `undici` internally) which replaces the filename of `File`s attached to `FormData`s with a generic `blob` (likely this code - https://github.com/nodejs/undici/blob/615f6170f4bd39630224c038d1ea5bf505d292af/lib/fetch/formdata.js#L246-L250). It's still not clear why it does so, and it's hard to make an isolated example of this.
+
+Regardless, disabling the new `fetch` functionality makes `undici` use its own base classes, avoiding the problem for now, and unblocking our release. We'll keep investigating and look for a proper fix.
+
+Unblocks https://github.com/cloudflare/wrangler2/issues/834

--- a/packages/wrangler/bin/wrangler.js
+++ b/packages/wrangler/bin/wrangler.js
@@ -23,6 +23,9 @@ Consider using a Node.js version manager such as https://volta.sh/ or https://gi
   wranglerProcess = spawn(
     process.execPath,
     [
+      ...(semiver(process.versions.node, "18.0.0") >= 0
+        ? ["--no-experimental-fetch"] // TODO: remove this when https://github.com/cloudflare/wrangler2/issues/834 is properly fixed
+        : []),
       "--no-warnings",
       "--experimental-vm-modules",
       ...process.execArgv,


### PR DESCRIPTION
There's some interference between our data fetching library `undici` and node 18's new `fetch` and co. (powered by `undici` internally) which replaces the filename of `File`s attached to `FormData`s with a generic `blob` (likely this code - https://github.com/nodejs/undici/blob/615f6170f4bd39630224c038d1ea5bf505d292af/lib/fetch/formdata.js#L246-L250). It's still not clear why it does so, and it's hard to make an isolated example of this.

Regardless, disabling the new `fetch` functionality makes `undici` use its own base classes, avoiding the problem for now, and unblocking our release. We'll keep investigating and look for a proper fix.

Unblocks https://github.com/cloudflare/wrangler2/issues/834
