### PR TITLE
chore: disable local-mode-tests on windows

### DIFF
--- a/examples/local-mode-tests/tests/module.test.ts
+++ b/examples/local-mode-tests/tests/module.test.ts
@@ -21,6 +21,9 @@ const isWindows = process.platform === "win32";
 let wranglerProcess: ChildProcess;
 
 beforeAll(async () => {
+  // These tests break in CI for windows, so we're disabling them for now
+  if (isWindows) return;
+
   wranglerProcess = spawn(
     "npx",
     [
@@ -41,6 +44,9 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  // These tests break in CI for windows, so we're disabling them for now
+  if (isWindows) return;
+
   await new Promise((resolve, reject) => {
     wranglerProcess.once("exit", (code) => {
       if (!code) {
@@ -54,6 +60,9 @@ afterAll(async () => {
 });
 
 it("renders", async () => {
+  // These tests break in CI for windows, so we're disabling them for now
+  if (isWindows) return;
+
   const response = await waitUntilReady("http://localhost:9001/");
   const text = await response.text();
   expect(text).toMatchInlineSnapshot(`

--- a/examples/local-mode-tests/tests/sw.test.ts
+++ b/examples/local-mode-tests/tests/sw.test.ts
@@ -21,6 +21,9 @@ const isWindows = process.platform === "win32";
 let wranglerProcess: ChildProcess;
 
 beforeAll(async () => {
+  // These tests break in CI for windows, so we're disabling them for now
+  if (isWindows) return;
+
   wranglerProcess = spawn(
     "npx",
     [
@@ -41,6 +44,9 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  // These tests break in CI for windows, so we're disabling them for now
+  if (isWindows) return;
+
   await new Promise((resolve, reject) => {
     wranglerProcess.once("exit", (code) => {
       if (!code) {
@@ -54,6 +60,9 @@ afterAll(async () => {
 });
 
 it("renders", async () => {
+  // These tests break in CI for windows, so we're disabling them for now
+  if (isWindows) return;
+
   const response = await waitUntilReady("http://localhost:9002/");
   const text = await response.text();
   expect(text).toMatchInlineSnapshot(`


### PR DESCRIPTION
Something about the local mode tests makes it occasionally break in windows on CI. Specifically, the inspector fails to connect to the miniflare process, and ends up spamming "waiting for connection" in the logs. I'm disabling these tests since they're for sanity only right now, and we have a fuller suite of tests for windows in the main package anyway.

Fixes https://github.com/cloudflare/wrangler2/issues/776