### PR TITLE
polish: do not log the error object when refreshing a token fails

### DIFF
--- a/.changeset/early-timers-camp.md
+++ b/.changeset/early-timers-camp.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+polish: do not log the error object when refreshing a token fails
+
+We handle the error anyway (by doing a fresh login) which has its own logging and messaging. In the future we should add a DEBUG mode that logs all requests/errors/warnings, but that's for later.

--- a/packages/wrangler/src/__tests__/user.test.ts
+++ b/packages/wrangler/src/__tests__/user.test.ts
@@ -87,7 +87,7 @@ describe("User", () => {
   });
 
   // TODO: Improve OAuth mocking to handle `/token` endpoints from different calls
-  it("should report error message for failed token refresh", async () => {
+  it("should handle errors for failed token refresh", async () => {
     mockOAuthServerCallback();
     writeAuthConfigFile({
       oauth_token: "hunter2",
@@ -100,9 +100,10 @@ describe("User", () => {
     });
 
     // Handles the requireAuth error throw from failed login that is unhandled due to directly calling it here
-    await expect(requireAuth({} as Config, false)).rejects.toThrowError();
-    expect(std.err).toContain(
-      `Error: <html> <body> This shouldn't be sent, but should be handled </body> </html>`
+    await expect(
+      requireAuth({} as Config, false)
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Did not login, quitting..."`
     );
   });
 

--- a/packages/wrangler/src/user.tsx
+++ b/packages/wrangler/src/user.tsx
@@ -1013,7 +1013,6 @@ async function refreshToken(): Promise<boolean> {
     writeAuthConfigFile({ oauth_token, expiration_time, refresh_token });
     return true;
   } catch (err) {
-    console.error(err);
     return false;
   }
 }


### PR DESCRIPTION
We handle the error anyway (by doing a fresh login) which has its own logging and messaging. In the future we should add a DEBUG mode that logs all requests/errors/warnings, but that's for later.