### PR TITLE
non-TTY required variables checks

### DIFF
--- a/.changeset/eighty-yaks-jump.md
+++ b/.changeset/eighty-yaks-jump.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+feat: non-TTY check for required variables
+Added a check in non-TTY environments for `account_id`, `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN`. If `account_id` exists in `wrangler.toml`
+then `CLOUDFLARE_ACCOUNT_ID` is not needed in non-TTY scope. The `CLOUDFLARE_API_TOKEN` is necessary in non-TTY scope and will always error if missing.
+
+resolves #827

--- a/packages/wrangler/src/__tests__/helpers/mock-istty.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-istty.ts
@@ -1,4 +1,5 @@
-const ORIGINAL_ISTTY = process.stdout.isTTY;
+const ORIGINAL_STDOUT_ISTTY = process.stdout.isTTY;
+const ORIGINAL_STDIN_ISTTY = process.stdin.isTTY;
 
 /**
  * Mock `process.stdout.isTTY`
@@ -9,14 +10,17 @@ export function useMockIsTTY() {
    */
   const setIsTTY = (isTTY: boolean) => {
     process.stdout.isTTY = isTTY;
+    process.stdin.isTTY = isTTY;
   };
 
   beforeEach(() => {
-    process.stdout.isTTY = ORIGINAL_ISTTY;
+    process.stdout.isTTY = ORIGINAL_STDOUT_ISTTY;
+    process.stdin.isTTY = ORIGINAL_STDIN_ISTTY;
   });
 
   afterEach(() => {
-    process.stdout.isTTY = ORIGINAL_ISTTY;
+    process.stdout.isTTY = ORIGINAL_STDOUT_ISTTY;
+    process.stdin.isTTY = ORIGINAL_STDIN_ISTTY;
   });
 
   return { setIsTTY };

--- a/packages/wrangler/src/__tests__/helpers/mock-oauth-flow.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-oauth-flow.ts
@@ -1,5 +1,6 @@
 import fetchMock from "jest-fetch-mock";
 import { Request } from "undici";
+import { getCloudflareApiBaseUrl } from "../../cfetch";
 import openInBrowser from "../../open-in-browser";
 import { mockHttpServer } from "./mock-http-server";
 
@@ -85,6 +86,28 @@ export const mockOAuthFlow = () => {
     return outcome;
   };
 
+  const mockGetMemberships = (args: {
+    success: boolean;
+    result: { id: string; account: { id: string; name: string } }[];
+  }) => {
+    const outcome = {
+      actual: new Request("https://example.org"),
+      expected: new Request(`${getCloudflareApiBaseUrl()}/memberships`, {
+        method: "GET",
+      }),
+    };
+
+    fetchMock.mockIf(outcome.expected.url, async (req) => {
+      outcome.actual = req;
+      return {
+        status: 200,
+        body: JSON.stringify(args),
+      };
+    });
+
+    return outcome;
+  };
+
   const mockGrantAccessToken = ({
     respondWith,
   }: {
@@ -150,10 +173,11 @@ export const mockOAuthFlow = () => {
   };
 
   return {
-    mockOAuthServerCallback,
-    mockGrantAuthorization,
-    mockRevokeAuthorization,
+    mockGetMemberships,
     mockGrantAccessToken,
+    mockGrantAuthorization,
+    mockOAuthServerCallback,
+    mockRevokeAuthorization,
     mockExchangeRefreshTokenForAccessToken,
   };
 };

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -4,7 +4,6 @@ import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { setMockResponse, unsetAllMocks } from "./helpers/mock-cfetch";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { mockConfirm, mockPrompt } from "./helpers/mock-dialogs";
-import { useMockIsTTY } from "./helpers/mock-istty";
 import { mockOAuthFlow } from "./helpers/mock-oauth-flow";
 import { useMockStdin } from "./helpers/mock-stdin";
 import { runInTempDir } from "./helpers/run-in-tmp";
@@ -13,14 +12,13 @@ import { runWrangler } from "./helpers/run-wrangler";
 describe("wrangler secret", () => {
   const std = mockConsoleMethods();
   const { mockGetMemberships } = mockOAuthFlow();
-  const { setIsTTY } = useMockIsTTY();
+
   runInTempDir();
   mockAccountId();
   mockApiToken();
 
   afterEach(() => {
     unsetAllMocks();
-    setIsTTY(true);
   });
 
   describe("put", () => {
@@ -180,7 +178,7 @@ describe("wrangler secret", () => {
           await expect(
             runWrangler("secret put the-key --name script-name")
           ).rejects.toThrowErrorMatchingInlineSnapshot(
-            `"No account id found, quitting..."`
+            `"Failed to automatically retrieve account IDs for the logged in user. In a non-interactive environment, it is mandatory to specify an account ID, either by assigning its value to CLOUDFLARE_ACCOUNT_ID, or as \`account_id\` in your \`wrangler.toml\` file."`
           );
         });
 
@@ -204,7 +202,6 @@ describe("wrangler secret", () => {
         });
 
         it("should error if a user has multiple accounts, and has not specified an account in wrangler.toml", async () => {
-          setIsTTY(false);
           mockGetMemberships({
             success: true,
             result: [

--- a/packages/wrangler/src/__tests__/whoami.test.tsx
+++ b/packages/wrangler/src/__tests__/whoami.test.tsx
@@ -4,12 +4,18 @@ import { writeAuthConfigFile } from "../user";
 import { getUserInfo, WhoAmI } from "../whoami";
 import { setMockResponse } from "./helpers/mock-cfetch";
 import { mockConsoleMethods } from "./helpers/mock-console";
+import { useMockIsTTY } from "./helpers/mock-istty";
 import { runInTempDir } from "./helpers/run-in-tmp";
 import type { UserInfo } from "../whoami";
 
 describe("getUserInfo()", () => {
   runInTempDir({ homedir: "./home" });
   const std = mockConsoleMethods();
+  const { setIsTTY } = useMockIsTTY();
+
+  beforeEach(() => {
+    setIsTTY(true);
+  });
 
   it("should return undefined if there is no config file", async () => {
     const userInfo = await getUserInfo();

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -1485,9 +1485,9 @@ export async function main(argv: string[]): Promise<void> {
               throw new Error("Missing script name");
             }
 
-            const isInteractive = process.stdin.isTTY;
-            const accountId = await requireAuth(config, isInteractive);
+            const accountId = await requireAuth(config);
 
+            const isInteractive = process.stdin.isTTY;
             const secretValue = isInteractive
               ? await prompt("Enter a secret value:", "password")
               : await readFromStdin();

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -842,11 +842,11 @@ const createDeployment: CommandModule<
     const config = getConfigCache<PagesConfigCache>(
       PAGES_CONFIG_CACHE_FILENAME
     );
-    const isInteractive = process.stdin.isTTY;
-    const accountId = await requireAuth(config, isInteractive);
+    const accountId = await requireAuth(config);
 
     projectName ??= config.project_name;
 
+    const isInteractive = process.stdin.isTTY;
     if (!projectName && isInteractive) {
       const existingOrNew = await new Promise<"new" | "existing">((resolve) => {
         const { unmount } = render(
@@ -1605,8 +1605,8 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
             const config = getConfigCache<PagesConfigCache>(
               PAGES_CONFIG_CACHE_FILENAME
             );
-            const isInteractive = process.stdin.isTTY;
-            const accountId = await requireAuth(config, isInteractive);
+
+            const accountId = await requireAuth(config);
 
             const projects: Array<Project> = await listProjects({ accountId });
 
@@ -1650,9 +1650,9 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
             const config = getConfigCache<PagesConfigCache>(
               PAGES_CONFIG_CACHE_FILENAME
             );
-            const isInteractive = process.stdin.isTTY;
-            const accountId = await requireAuth(config, isInteractive);
+            const accountId = await requireAuth(config);
 
+            const isInteractive = process.stdin.isTTY;
             if (!projectName && isInteractive) {
               projectName = await prompt("Enter the name of your new project:");
             }
@@ -1735,11 +1735,11 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
               const config = getConfigCache<PagesConfigCache>(
                 PAGES_CONFIG_CACHE_FILENAME
               );
-              const isInteractive = process.stdin.isTTY;
-              const accountId = await requireAuth(config, isInteractive);
+              const accountId = await requireAuth(config);
 
               projectName ??= config.project_name;
 
+              const isInteractive = process.stdin.isTTY;
               if (!projectName && isInteractive) {
                 const projects = await listProjects({ accountId });
                 projectName = await new Promise((resolve) => {

--- a/packages/wrangler/src/reporting.ts
+++ b/packages/wrangler/src/reporting.ts
@@ -93,7 +93,8 @@ function exceptionTransaction(error: Error, origin = "") {
 }
 
 export async function reportError(err: Error, origin = "") {
-  if (!process.stdout.isTTY) return await appendReportingDecision("false");
+  // If the user has not opted in to error reporting, we don't want to do anything in CI or non-interactive environments
+  if (!process.stdout.isTTY) return;
 
   const errorTrackingOpt = await reportingPermission();
 

--- a/packages/wrangler/src/user.tsx
+++ b/packages/wrangler/src/user.tsx
@@ -418,11 +418,9 @@ export function getAPIToken(): string | undefined {
     !localAPIToken &&
     !LocalState.accessToken?.value
   ) {
-    logger.error(
-      "Missing 'CLOUDFLARE_API_TOKEN' from non-TTY environment, please see docs for more info: TBD"
+    throw new Error(
+      "In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work. Please go to https://developers.cloudflare.com/api/tokens/create/ for instructions on how to create an api token, and assign its value to CLOUDFLARE_API_TOKEN."
     );
-
-    return;
   }
 
   return localAPIToken ?? LocalState.accessToken?.value;
@@ -1142,6 +1140,11 @@ export async function getAccountId(
             .join("\n")
       );
     }
+  } else {
+    if (!isInteractive)
+      throw new Error(
+        `Failed to automatically retrieve account IDs for the logged in user. In a non-interactive environment, it is mandatory to specify an account ID, either by assigning its value to CLOUDFLARE_ACCOUNT_ID, or as \`account_id\` in your \`wrangler.toml\` file.`
+      );
   }
   return accountId;
 }


### PR DESCRIPTION
Added a check in non-TTY environments for `account_id`, `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN`. If `account_id` exists in `wrangler.toml`
then `CLOUDFLARE_ACCOUNT_ID` is not needed in non-TTY scope. The `CLOUDFLARE_API_TOKEN` is necessary in non-TTY scope and will always error if missing.

resolves #827