### PR TITLE
Add config cache mechanism

### DIFF
--- a/packages/wrangler/src/__tests__/config-cache.test.ts
+++ b/packages/wrangler/src/__tests__/config-cache.test.ts
@@ -1,0 +1,31 @@
+import { getConfigCache, saveToConfigCache } from "../config-cache";
+import { runInTempDir } from "./helpers/run-in-tmp";
+
+describe("config cache", () => {
+  runInTempDir();
+
+  const pagesConfigCacheFilename = "pages-config-cache.json";
+
+  it("should return an empty config if no file exists", () => {
+    expect(getConfigCache(pagesConfigCacheFilename)).toMatchInlineSnapshot(
+      `Object {}`
+    );
+  });
+
+  it("should read and write values without overriding old ones", () => {
+    saveToConfigCache(pagesConfigCacheFilename, {
+      account_id: "some-account-id",
+      pages_project_name: "foo",
+    });
+    expect(getConfigCache(pagesConfigCacheFilename).account_id).toEqual(
+      "some-account-id"
+    );
+
+    saveToConfigCache(pagesConfigCacheFilename, {
+      pages_project_name: "bar",
+    });
+    expect(getConfigCache(pagesConfigCacheFilename).account_id).toEqual(
+      "some-account-id"
+    );
+  });
+});

--- a/packages/wrangler/src/config-cache.ts
+++ b/packages/wrangler/src/config-cache.ts
@@ -1,0 +1,43 @@
+import { mkdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
+
+let cacheMessageShown = false;
+
+const cacheFolder = "node_modules/.cache/wrangler";
+
+const showCacheMessage = () => {
+  if (!cacheMessageShown) {
+    console.log(
+      `Using cached values in '${cacheFolder}'. This is used as a temporary store to improve the developer experience for some commands. It may be purged at any time. It doesn't contain any sensitive information, but it should not be commited into source control.`
+    );
+    cacheMessageShown = true;
+  }
+};
+
+export const getConfigCache = <T extends Record<string, unknown>>(
+  fileName: string
+): Partial<T> => {
+  try {
+    const configCacheLocation = join(cacheFolder, fileName);
+    const configCache = JSON.parse(readFileSync(configCacheLocation, "utf-8"));
+    showCacheMessage();
+    return configCache;
+  } catch {
+    return {};
+  }
+};
+
+export const saveToConfigCache = <T extends Record<string, unknown>>(
+  fileName: string,
+  newValues: Partial<T>
+) => {
+  const configCacheLocation = join(cacheFolder, fileName);
+  const existingValues = getConfigCache(fileName);
+
+  mkdirSync(dirname(configCacheLocation), { recursive: true });
+  writeFileSync(
+    configCacheLocation,
+    JSON.stringify({ ...existingValues, ...newValues }, null, 2)
+  );
+  showCacheMessage();
+};


### PR DESCRIPTION
@threepointone , can you confirm if this is the sort of thing you had in your mind?

Might be a bit overzealous to log those messages on every read/write, but this introduces a `node_modules/.cache/wrangler/config-cache.json` that we can all just write to with whatever we want to, to persist things that we either:
- don't want to add to config, or
- don't yet know _how_ to add to config

For an example, if a user is running `wrangler dev index.ts` without a `wrangler.toml`, and they have multiple accounts for your user, we could store the `account_id` that they select in the prompt here, saving them from having to select it again the next time they want to run it.

If the user blows away their `node_modules` or switches machines, they'll need to select it again, but this is about _convenience_ for people running commands again and again, rather than acting as an actual source-of-truth.

We (Pages) will use this to store the `account_id` and Pages project name in order to simplify the `CF_ACCOUNT_ID=xyz wrangler pages publish <directory> --project-name=foo` command everyone would ordinarily have to run every time: `wrangler pages publish <directory>`. 