### PR TITLE
check for an implementation of AsyncLocalStorage

### DIFF
--- a/.changeset/many-numbers-cheer.md
+++ b/.changeset/many-numbers-cheer.md
@@ -1,0 +1,19 @@
+---
+"wrangler": patch
+---
+
+Add a runtime check for `wrangler dev` local mode to avoid erroring in environments with no `AsyncLocalStorage` class
+
+Certain runtime APIs are only available to workers during the "request context",
+which is any code that returns after receiving a request and before returning
+a response.
+
+Miniflare emulates this behavior by using an [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage) and
+[checking at runtime](https://github.com/cloudflare/miniflare/blob/master/packages/shared/src/context.ts#L21-L36)
+to see if you're using those APIs during the request context.
+
+In certain environments `AsyncLocalStorage` is unavailable, such as in a
+[webcontainer](https://github.com/stackblitz/webcontainer-core).
+This function figures out if we're able to run those "request context" checks
+and returns [a set of options](https://miniflare.dev/core/standards#global-functionality-limits)
+that indicate to miniflare whether to run the checks or not.

--- a/packages/wrangler/src/miniflare-cli/index.ts
+++ b/packages/wrangler/src/miniflare-cli/index.ts
@@ -27,31 +27,14 @@ const requestContextCheckOptions = async (): Promise<
   try {
     // ripped from  the example here https://nodejs.org/api/async_context.html#class-asynclocalstorage
     const { AsyncLocalStorage } = await import("node:async_hooks");
-    const storage = new AsyncLocalStorage();
-    const STORED_VALUE = "some-stored-value";
+    const storage = new AsyncLocalStorage<string>();
 
-    const testStorage = () => {
-      const value = storage.getStore();
-      return value === STORED_VALUE;
-    };
-
-    storage.run("some-stored-value", () => {
-      setImmediate(() => {
-        hasAsyncLocalStorage = testStorage();
-      });
+    hasAsyncLocalStorage = storage.run("some-value", () => {
+      return storage.getStore() === "some-value";
     });
   } catch (e) {
     hasAsyncLocalStorage = false;
   }
-
-  // // check if we're running in a webcontainer
-  // const runningInWebContainer = "webcontainer" in process.versions;
-
-  // // check if we're running in CodeSandbox
-  // const runningInCodeSandbox = process.env.CODESANDBOX_SSE === "true";
-
-  // const canUseRequestContextChecks =
-  //   hasAsyncLocalStorage && !runningInWebContainer && !runningInCodeSandbox;
 
   return {
     globalAsyncIO: hasAsyncLocalStorage,

--- a/packages/wrangler/src/miniflare-cli/index.ts
+++ b/packages/wrangler/src/miniflare-cli/index.ts
@@ -2,6 +2,53 @@ import { Log, LogLevel, Miniflare } from "miniflare";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { enumKeys } from "./enum-keys";
+import type { MiniflareOptions } from "miniflare";
+
+/**
+ * Certain runtime APIs are only available to workers during the "request context",
+ * which is any code that returns after receiving a request and before returning
+ * a response.
+ *
+ * Miniflare emulates this behavior by using an [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage) and
+ * [checking at runtime](https://github.com/cloudflare/miniflare/blob/master/packages/shared/src/context.ts#L21-L36)
+ * to see if you're using those APIs during the request context.
+ *
+ * In certain environments `AsyncLocalStorage` is unavailable, such as in a
+ * [webcontainer](https://github.com/stackblitz/webcontainer-core).
+ * This function figures out if we're able to run those "request context" checks
+ * and returns [a set of options](https://miniflare.dev/core/standards#global-functionality-limits)
+ * that indicate to miniflare whether to run the checks or not.
+ */
+const requestContextCheckOptions = async (): Promise<
+  Pick<MiniflareOptions, "globalAsyncIO" | "globalTimers" | "globalRandom">
+> => {
+  // check that there's an implementation of AsyncLocalStorage
+  let hasAsyncLocalStorage = true;
+  try {
+    const { AsyncLocalStorage } = await import("node:async_hooks");
+    const storage = new AsyncLocalStorage();
+    storage.run(undefined, () => {
+      storage.getStore();
+    });
+  } catch (e) {
+    hasAsyncLocalStorage = false;
+  }
+
+  // // check if we're running in a webcontainer
+  // const runningInWebContainer = "webcontainer" in process.versions;
+
+  // // check if we're running in CodeSandbox
+  // const runningInCodeSandbox = process.env.CODESANDBOX_SSE === "true";
+
+  // const canUseRequestContextChecks =
+  //   hasAsyncLocalStorage && !runningInWebContainer && !runningInCodeSandbox;
+
+  return {
+    globalAsyncIO: hasAsyncLocalStorage,
+    globalRandom: hasAsyncLocalStorage,
+    globalTimers: hasAsyncLocalStorage,
+  };
+};
 
 async function main() {
   const args = await yargs(hideBin(process.argv))
@@ -14,6 +61,7 @@ async function main() {
   const logLevel = LogLevel[args.log ?? "INFO"];
   const config = {
     ...JSON.parse((args._[0] as string) ?? "{}"),
+    ...(await requestContextCheckOptions()),
     log: new Log(logLevel),
   };
 

--- a/packages/wrangler/src/miniflare-cli/index.ts
+++ b/packages/wrangler/src/miniflare-cli/index.ts
@@ -2,46 +2,7 @@ import { Log, LogLevel, Miniflare } from "miniflare";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { enumKeys } from "./enum-keys";
-import type { MiniflareOptions } from "miniflare";
-
-/**
- * Certain runtime APIs are only available to workers during the "request context",
- * which is any code that returns after receiving a request and before returning
- * a response.
- *
- * Miniflare emulates this behavior by using an [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage) and
- * [checking at runtime](https://github.com/cloudflare/miniflare/blob/master/packages/shared/src/context.ts#L21-L36)
- * to see if you're using those APIs during the request context.
- *
- * In certain environments `AsyncLocalStorage` is unavailable, such as in a
- * [webcontainer](https://github.com/stackblitz/webcontainer-core).
- * This function figures out if we're able to run those "request context" checks
- * and returns [a set of options](https://miniflare.dev/core/standards#global-functionality-limits)
- * that indicate to miniflare whether to run the checks or not.
- */
-const requestContextCheckOptions = async (): Promise<
-  Pick<MiniflareOptions, "globalAsyncIO" | "globalTimers" | "globalRandom">
-> => {
-  // check that there's an implementation of AsyncLocalStorage
-  let hasAsyncLocalStorage = true;
-  try {
-    // ripped from  the example here https://nodejs.org/api/async_context.html#class-asynclocalstorage
-    const { AsyncLocalStorage } = await import("node:async_hooks");
-    const storage = new AsyncLocalStorage<string>();
-
-    hasAsyncLocalStorage = storage.run("some-value", () => {
-      return storage.getStore() === "some-value";
-    });
-  } catch (e) {
-    hasAsyncLocalStorage = false;
-  }
-
-  return {
-    globalAsyncIO: hasAsyncLocalStorage,
-    globalRandom: hasAsyncLocalStorage,
-    globalTimers: hasAsyncLocalStorage,
-  };
-};
+import { getRequestContextCheckOptions } from "./request-context";
 
 async function main() {
   const args = await yargs(hideBin(process.argv))
@@ -52,9 +13,10 @@ async function main() {
     }).argv;
 
   const logLevel = LogLevel[args.log ?? "INFO"];
-  const config: MiniflareOptions = {
+  const requestContextCheckOptions = await getRequestContextCheckOptions();
+  const config = {
     ...JSON.parse((args._[0] as string) ?? "{}"),
-    ...(await requestContextCheckOptions()),
+    ...requestContextCheckOptions,
     log: new Log(logLevel),
   };
 

--- a/packages/wrangler/src/miniflare-cli/request-context.ts
+++ b/packages/wrangler/src/miniflare-cli/request-context.ts
@@ -1,0 +1,40 @@
+import type { MiniflareOptions } from "miniflare";
+
+/**
+ * Certain runtime APIs are only available to workers during the "request context",
+ * which is any code that returns after receiving a request and before returning
+ * a response.
+ *
+ * Miniflare emulates this behavior by using an [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage) and
+ * [checking at runtime](https://github.com/cloudflare/miniflare/blob/master/packages/shared/src/context.ts#L21-L36)
+ * to see if you're using those APIs during the request context.
+ *
+ * In certain environments `AsyncLocalStorage` is unavailable, such as in a
+ * [webcontainer](https://github.com/stackblitz/webcontainer-core).
+ * This function figures out if we're able to run those "request context" checks
+ * and returns [a set of options](https://miniflare.dev/core/standards#global-functionality-limits)
+ * that indicate to miniflare whether to run the checks or not.
+ */
+export const getRequestContextCheckOptions = async (): Promise<
+  Pick<MiniflareOptions, "globalAsyncIO" | "globalTimers" | "globalRandom">
+> => {
+  // check that there's an implementation of AsyncLocalStorage
+  let hasAsyncLocalStorage = true;
+  try {
+    // ripped from  the example here https://nodejs.org/api/async_context.html#class-asynclocalstorage
+    const { AsyncLocalStorage } = await import("node:async_hooks");
+    const storage = new AsyncLocalStorage<string>();
+
+    hasAsyncLocalStorage = storage.run("some-value", () => {
+      return storage.getStore() === "some-value";
+    });
+  } catch (e) {
+    hasAsyncLocalStorage = false;
+  }
+
+  return {
+    globalAsyncIO: hasAsyncLocalStorage,
+    globalRandom: hasAsyncLocalStorage,
+    globalTimers: hasAsyncLocalStorage,
+  };
+};

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -33,6 +33,7 @@ import type { Headers, Request, fetch } from "@miniflare/core";
 import type { BuildResult } from "esbuild";
 import type { MiniflareOptions } from "miniflare";
 import type { BuilderCallback, CommandModule } from "yargs";
+import { getRequestContextCheckOptions } from "./miniflare-cli/request-context";
 
 type ConfigPath = string | undefined;
 
@@ -1287,6 +1288,9 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
             ? await generateAssetsFetch(directory)
             : invalidAssetsFetch;
 
+        const requestContextCheckOptions =
+          await getRequestContextCheckOptions();
+
         const miniflare = new Miniflare({
           port,
           watch: true,
@@ -1351,6 +1355,7 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
           cachePersist: true,
           liveReload,
 
+          ...requestContextCheckOptions,
           ...miniflareArgs,
         });
 

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -25,6 +25,7 @@ import { fetchResult } from "./cfetch";
 import { readConfig } from "./config";
 import { FatalError } from "./errors";
 import { logger } from "./logger";
+import { getRequestContextCheckOptions } from "./miniflare-cli/request-context";
 import openInBrowser from "./open-in-browser";
 import { toUrlPath } from "./paths";
 import { requireAuth } from "./user";
@@ -33,7 +34,6 @@ import type { Headers, Request, fetch } from "@miniflare/core";
 import type { BuildResult } from "esbuild";
 import type { MiniflareOptions } from "miniflare";
 import type { BuilderCallback, CommandModule } from "yargs";
-import { getRequestContextCheckOptions } from "./miniflare-cli/request-context";
 
 type ConfigPath = string | undefined;
 


### PR DESCRIPTION
Certain runtime APIs are only available to workers during the "request context", which is any code that returns after receiving a request and before returning a response.

Miniflare emulates this behavior by using an [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage) and [checking at runtime](https://github.com/cloudflare/miniflare/blob/master/packages/shared/src/context.ts#L21-L36) to see if you're using those APIs during the request context.

In certain environments `AsyncLocalStorage` is unavailable, such as in a [webcontainer](https://github.com/stackblitz/webcontainer-core). This function figures out if we're able to run those "request context" checks and returns [a set of options](https://miniflare.dev/core/standards#global-functionality-limits) that indicate to miniflare whether to run the checks or not.

Closes #863