### PR TITLE
feat: implement service environments + durable objects

### DIFF
--- a/.changeset/nasty-teachers-drop.md
+++ b/.changeset/nasty-teachers-drop.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+feat: implement service environments + durable objects
+
+Now that the APIs for getting migrations tags of services works as expected, this lands support for publishing durable objects to service environments, including migrations. It also removes the error we used to throw when attempting to use service envs + durable objects.
+
+Fixes https://github.com/cloudflare/wrangler2/issues/739

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -1050,7 +1050,7 @@ const validateBindingsProperty =
           diagnostics.warnings.push(
             `The following bindings are at the top level, but not on "env.${envName}".\n` +
               `This is not what you probably want, since "${field}" configuration is not inherited by environments.\n` +
-              `Please add a binding for each to "${fieldPath}.bindings".` +
+              `Please add a binding for each to "${fieldPath}.bindings":\n` +
               missingBindings.map((name) => `- ${name}`).join("\n")
           );
         }

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -145,13 +145,6 @@ export default async function publish(props: Props): Promise<void> {
 
     // Some validation of durable objects + migrations
     if (config.durable_objects.bindings.length > 0) {
-      // TODO: implement durable objects for service environments
-      if (!props.legacyEnv) {
-        throw new Error(
-          "Publishing Durable Objects to a service environment is not currently supported. This is being tracked at https://github.com/cloudflare/wrangler2/issues/739"
-        );
-      }
-
       // intrinsic [durable_objects] implies [migrations]
       const exportedDurableObjects = config.durable_objects.bindings.filter(
         (binding) => !binding.script_name
@@ -173,14 +166,48 @@ export default async function publish(props: Props): Promise<void> {
     let migrations;
     if (config.migrations.length > 0) {
       // get current migration tag
-      const scripts = await fetchResult<
-        { id: string; migration_tag: string }[]
-      >(`/accounts/${accountId}/workers/scripts`);
-      const script = scripts.find(({ id }) => id === scriptName);
+      type ScriptData = { id: string; migration_tag?: string };
+      let script: ScriptData | undefined;
+      if (!props.legacyEnv) {
+        try {
+          if (props.env) {
+            const scriptData = await fetchResult<{
+              script: ScriptData;
+            }>(
+              `/accounts/${accountId}/workers/services/${scriptName}/environments/${props.env}`
+            );
+            script = scriptData.script;
+          } else {
+            const scriptData = await fetchResult<{
+              default_environment: {
+                script: ScriptData;
+              };
+            }>(`/accounts/${accountId}/workers/services/${scriptName}`);
+            script = scriptData.default_environment.script;
+          }
+        } catch (err) {
+          if (
+            ![
+              10090, // corresponds to workers.api.error.service_not_found, so the script wasn't previously published at all
+              10092, // workers.api.error.environment_not_found, so the script wasn't published to this environment yet
+            ].includes((err as { code: number }).code)
+          ) {
+            throw err;
+          }
+          // else it's a 404, no script found, and we can proceed
+        }
+      } else {
+        const scripts = await fetchResult<ScriptData[]>(
+          `/accounts/${accountId}/workers/scripts`
+        );
+        script = scripts.find(({ id }) => id === scriptName);
+      }
+
       if (script?.migration_tag) {
         // was already published once
+        const scriptMigrationTag = script.migration_tag;
         const foundIndex = config.migrations.findIndex(
-          (migration) => migration.tag === script.migration_tag
+          (migration) => migration.tag === scriptMigrationTag
         );
         if (foundIndex === -1) {
           logger.warn(


### PR DESCRIPTION
Now that the APIs for getting migrations tags of services works as expected, this lands support for publishing durable objects to service environments, including migrations. It also removes the error we used to throw when attempting to use service envs + durable objects.

Fixes https://github.com/cloudflare/wrangler2/issues/739