### PR TITLE
Properly copy headers to preserve duplicate set-cookie headers.

### DIFF
--- a/examples/pages-functions-app/functions/_middleware.ts
+++ b/examples/pages-functions-app/functions/_middleware.ts
@@ -1,5 +1,7 @@
 export const onRequest = async ({ next }) => {
   const response = await next();
   response.headers.set("x-custom", "header value");
+  response.headers.set("set-cookie", "numberOne=Riker");
+  response.headers.append("set-cookie", "otherNumberOne=NumberOne");
   return response;
 };


### PR DESCRIPTION
Browser have a lot of bugs in relation to parsing concatenated set-cookie headers. This fixes that.

It used the new `getAll()` method which can be used with the `set-cookie` header to get an array back. And when using `.set` and `.append`, the Worker runtime will emit multiple headers.

This fixes the bug with multiple `set-cookie` headers that was introduced by #796.

Unfortunately I could not add a test case to the end-to-end tests, because the udici library has no support for `getAll()`, so I can't determine if the `set-cookie` headers were concatenated or not.