### PR TITLE
Stop unnecessarily amalgamating duplicate headers in Functions

### DIFF
--- a/.changeset/bright-olives-wonder.md
+++ b/.changeset/bright-olives-wonder.md
@@ -4,4 +4,4 @@
 
 fix: Stop unnecessarily amalgamating duplicate headers in Pages Functions
 
-Previously, `set-cookie` mulitple headers would be combined because of unexpected behavior in [the spec](https://github.com/whatwg/fetch/pull/1346).
+Previously, `set-cookie` multiple headers would be combined because of unexpected behavior in [the spec](https://github.com/whatwg/fetch/pull/1346).

--- a/.changeset/bright-olives-wonder.md
+++ b/.changeset/bright-olives-wonder.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: Stop unnecessarily amalgamating duplicate headers in Pages Functions
+
+Previously, `set-cookie` mulitple headers would be combined because of unexpected behavior in [the spec](https://github.com/whatwg/fetch/pull/1346).

--- a/packages/wrangler/pages/functions/template-plugin.ts
+++ b/packages/wrangler/pages/functions/template-plugin.ts
@@ -132,7 +132,7 @@ export default function (pluginArgs) {
         // https://fetch.spec.whatwg.org/#null-body-status
         return new Response(
           [101, 204, 205, 304].includes(response.status) ? null : response.body,
-          response
+          { ...response, headers: new Headers(response.headers) }
         );
       } else {
         return next();

--- a/packages/wrangler/pages/functions/template-worker.ts
+++ b/packages/wrangler/pages/functions/template-worker.ts
@@ -123,7 +123,7 @@ export default {
         // https://fetch.spec.whatwg.org/#null-body-status
         return new Response(
           [101, 204, 205, 304].includes(response.status) ? null : response.body,
-          { ...response, headers: new Headers([...response.headers.entries()]) }
+          { ...response, headers: new Headers(response.headers) }
         );
       } else if (__FALLBACK_SERVICE__) {
         // There are no more handlers so finish with the fallback service (`env.ASSETS.fetch` in Pages' case)


### PR DESCRIPTION
Replaces #872 .

Previously, `set-cookie` mulitple headers would be combined because of unexpected behavior in [the spec](https://github.com/whatwg/fetch/pull/1346).

See previous PR for details.

Unfortunately, not easily testable because of https://github.com/cloudflare/miniflare/issues/183.