### PR TITLE
polish: accept Enter as a valid key in confirm dialogs

### DIFF
--- a/.changeset/tasty-pets-divide.md
+++ b/.changeset/tasty-pets-divide.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+polish: accept Enter as a valid key in confirm dialogs
+
+Instead of logging "Unrecognised input" when hitting return/enter in a confirm dialog, we should accept it as a confirmation. This patch also makes the default choice "y" bold in the dialog.

--- a/packages/wrangler/src/dialogs.tsx
+++ b/packages/wrangler/src/dialogs.tsx
@@ -1,3 +1,4 @@
+import chalk from "chalk";
 import { Box, Text, useInput, render } from "ink";
 import TextInput from "ink-text-input";
 import * as React from "react";
@@ -8,8 +9,8 @@ type ConfirmProps = {
   onConfirm: (answer: boolean) => void;
 };
 function Confirm(props: ConfirmProps) {
-  useInput((input: string) => {
-    if (input === "y") {
+  useInput((input: string, key) => {
+    if (input === "y" || key.return === true) {
       props.onConfirm(true);
     } else if (input === "n") {
       props.onConfirm(false);
@@ -19,7 +20,9 @@ function Confirm(props: ConfirmProps) {
   });
   return (
     <Box>
-      <Text>{props.text} (y/n) </Text>
+      <Text>
+        {props.text} ({chalk.bold("y")}/n)
+      </Text>
     </Box>
   );
 }


### PR DESCRIPTION
Instead of logging "Unrecognised input" when hitting return/enter in a confirm dialog, we should accept it as a confirmation. This patch also makes the default choice "y" bold in the dialog.