### PR TITLE
polish: s/DEPRECATION/Deprecation

### DIFF
--- a/.changeset/tiny-beds-hope.md
+++ b/.changeset/tiny-beds-hope.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+polish: s/DEPRECATION/Deprecation
+
+This removes the scary uppercase from DEPRECATION warnings. It also moves the service environment usage warning into `diagnostics` instead of logging it directly.

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -250,7 +250,7 @@ describe("normalizeAndValidateConfig()", () => {
         expect(normalizeSlashes(diagnostics.renderWarnings()))
           .toMatchInlineSnapshot(`
           "Processing wrangler configuration:
-            - DEPRECATION: \\"site.entry-point\\":
+            - Deprecation: \\"site.entry-point\\":
               Delete the \`site.entry-point\` field, then add the top level \`main\` field to your configuration file:
               \`\`\`
               main = \\"my-site/index.js\\"
@@ -281,7 +281,7 @@ describe("normalizeAndValidateConfig()", () => {
         expect(normalizeSlashes(diagnostics.renderWarnings()))
           .toMatchInlineSnapshot(`
           "Processing wrangler configuration:
-            - DEPRECATION: \\"site.entry-point\\":
+            - Deprecation: \\"site.entry-point\\":
               Delete the \`site.entry-point\` field, then add the top level \`main\` field to your configuration file:
               \`\`\`
               main = \\"workers-site/index.js\\"
@@ -324,7 +324,7 @@ describe("normalizeAndValidateConfig()", () => {
         expect(normalizeSlashes(diagnostics.renderWarnings()))
           .toMatchInlineSnapshot(`
           "Processing wrangler configuration:
-            - DEPRECATION: \\"site.entry-point\\":
+            - Deprecation: \\"site.entry-point\\":
               Delete the \`site.entry-point\` field, then add the top level \`main\` field to your configuration file:
               \`\`\`
               main = \\"111/index.js\\"
@@ -358,7 +358,7 @@ describe("normalizeAndValidateConfig()", () => {
         expect(normalizeSlashes(diagnostics.renderWarnings()))
           .toMatchInlineSnapshot(`
           "Processing wrangler configuration:
-            - DEPRECATION: \\"site.entry-point\\":
+            - Deprecation: \\"site.entry-point\\":
               Delete the \`site.entry-point\` field, then add the top level \`main\` field to your configuration file:
               \`\`\`
               main = \\"some/other/script.js\\"
@@ -571,9 +571,9 @@ describe("normalizeAndValidateConfig()", () => {
         expect(diagnostics.hasWarnings()).toBe(true);
         expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
           "Processing wrangler configuration:
-            - DEPRECATION: \\"type\\":
+            - Deprecation: \\"type\\":
               DO NOT USE THIS. Most common features now work out of the box with wrangler, including modules, jsx, typescript, etc. If you need anything more, use a custom build.
-            - DEPRECATION: \\"webpack_config\\":
+            - Deprecation: \\"webpack_config\\":
               DO NOT USE THIS. Most common features now work out of the box with wrangler, including modules, jsx, typescript, etc. If you need anything more, use a custom build."
         `);
       });
@@ -869,17 +869,17 @@ describe("normalizeAndValidateConfig()", () => {
       expect(normalizePath(diagnostics.renderWarnings()))
         .toMatchInlineSnapshot(`
         "Processing project/wrangler.toml configuration:
-          - DEPRECATION: \\"build.upload.format\\":
+          - Deprecation: \\"build.upload.format\\":
             The format is inferred automatically from the code.
-          - DEPRECATION: \\"build.upload.main\\":
+          - Deprecation: \\"build.upload.main\\":
             Delete the \`build.upload.main\` and \`build.upload.dir\` fields.
             Then add the top level \`main\` field to your configuration file:
             \`\`\`
             main = \\"src/index.ts\\"
             \`\`\`
-          - DEPRECATION: \\"build.upload.dir\\":
+          - Deprecation: \\"build.upload.dir\\":
             Use the top level \\"main\\" field or a command-line argument to specify the entry-point for the Worker.
-          - DEPRECATION: The \`build.upload.rules\` config field is no longer used, the rules should be specified via the \`rules\` config field. Delete the \`build.upload\` field from the configuration file, and add this:
+          - Deprecation: The \`build.upload.rules\` config field is no longer used, the rules should be specified via the \`rules\` config field. Delete the \`build.upload\` field from the configuration file, and add this:
             \`\`\`
             [[rules]]
             type = \\"Text\\"
@@ -1619,9 +1619,9 @@ describe("normalizeAndValidateConfig()", () => {
         expect(diagnostics.hasWarnings()).toBe(true);
         expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
           "Processing wrangler configuration:
-            - DEPRECATION: \\"zone_id\\":
+            - Deprecation: \\"zone_id\\":
               This is unnecessary since we can deduce this from routes directly.
-            - DEPRECATION: \\"experimental_services\\":
+            - Deprecation: \\"experimental_services\\":
               The \\"experimental_services\\" field is no longer supported. Instead, use [[unsafe.bindings]] to enable experimental features. Add this to your wrangler.toml:
               \`\`\`
               [[unsafe.bindings]]
@@ -1815,7 +1815,11 @@ describe("normalizeAndValidateConfig()", () => {
 
         expect(config.name).toEqual("mock-name");
         expect(diagnostics.hasErrors()).toBe(false);
-        expect(diagnostics.hasWarnings()).toBe(false);
+        expect(diagnostics.hasWarnings()).toBe(true);
+        expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+          "Processing wrangler configuration:
+            - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION."
+        `);
       });
 
       it("should error if named environment contains a `name` field, even if there is no top-level name", () => {
@@ -1835,6 +1839,12 @@ describe("normalizeAndValidateConfig()", () => {
         );
 
         expect(config.name).toBeUndefined();
+        expect(diagnostics.hasWarnings()).toBe(true);
+        expect(diagnostics.hasErrors()).toBe(true);
+        expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+          "Processing wrangler configuration:
+            - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION."
+        `);
         expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
           "Processing wrangler configuration:
 
@@ -1842,7 +1852,6 @@ describe("normalizeAndValidateConfig()", () => {
               - The \\"name\\" field is not allowed in named service environments.
                 Please remove the field from this environment."
         `);
-        expect(diagnostics.hasWarnings()).toBe(false);
       });
 
       it("should error if top-level config and a named environment both contain a `name` field", () => {
@@ -1863,6 +1872,12 @@ describe("normalizeAndValidateConfig()", () => {
         );
 
         expect(config.name).toEqual("mock-name");
+        expect(diagnostics.hasWarnings()).toBe(true);
+        expect(diagnostics.hasErrors()).toBe(true);
+        expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+          "Processing wrangler configuration:
+            - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION."
+        `);
         expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
           "Processing wrangler configuration:
 
@@ -1870,7 +1885,6 @@ describe("normalizeAndValidateConfig()", () => {
               - The \\"name\\" field is not allowed in named service environments.
                 Please remove the field from this environment."
         `);
-        expect(diagnostics.hasWarnings()).toBe(false);
       });
     });
 
@@ -1890,7 +1904,12 @@ describe("normalizeAndValidateConfig()", () => {
         { env: "DEV" }
       );
 
+      expect(diagnostics.hasWarnings()).toBe(true);
       expect(config.account_id).toBeUndefined();
+      expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+        "Processing wrangler configuration:
+          - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION."
+      `);
       expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
         "Processing wrangler configuration:
 
@@ -1898,7 +1917,6 @@ describe("normalizeAndValidateConfig()", () => {
             - The \\"account_id\\" field is not allowed in named service environments.
               Please remove the field from this environment."
       `);
-      expect(diagnostics.hasWarnings()).toBe(false);
     });
 
     it("should error if top-level config and a named environment both contain a `account_id` field", () => {
@@ -1919,6 +1937,12 @@ describe("normalizeAndValidateConfig()", () => {
       );
 
       expect(config.account_id).toEqual("ACCOUNT_ID");
+      expect(diagnostics.hasErrors()).toBe(true);
+      expect(diagnostics.hasWarnings()).toBe(true);
+      expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+        "Processing wrangler configuration:
+          - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION."
+      `);
       expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
         "Processing wrangler configuration:
 
@@ -1926,7 +1950,6 @@ describe("normalizeAndValidateConfig()", () => {
             - The \\"account_id\\" field is not allowed in named service environments.
               Please remove the field from this environment."
       `);
-      expect(diagnostics.hasWarnings()).toBe(false);
     });
 
     it("should warn for non-inherited fields that are missing in environments", () => {
@@ -2843,9 +2866,9 @@ describe("normalizeAndValidateConfig()", () => {
           "Processing wrangler configuration:
 
             - \\"env.ENV1\\" environment configuration
-              - DEPRECATION: \\"zone_id\\":
+              - Deprecation: \\"zone_id\\":
                 This is unnecessary since we can deduce this from routes directly.
-              - DEPRECATION: \\"experimental_services\\":
+              - Deprecation: \\"experimental_services\\":
                 The \\"experimental_services\\" field is no longer supported. Instead, use [[unsafe.bindings]] to enable experimental features. Add this to your wrangler.toml:
                 \`\`\`
                 [[unsafe.bindings]]

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -97,14 +97,14 @@ describe("wrangler", () => {
     it("should throw an error if the deprecated command is used with positional arguments", async () => {
       await expect(runWrangler("preview GET")).rejects
         .toThrowErrorMatchingInlineSnapshot(`
-              "DEPRECATION:
+              "Deprecation:
               The \`wrangler preview\` command has been deprecated.
               Try using \`wrangler dev\` to to try out a worker during development.
               "
             `);
       await expect(runWrangler(`preview GET "SomeBody"`)).rejects
         .toThrowErrorMatchingInlineSnapshot(`
-              "DEPRECATION:
+              "Deprecation:
               The \`wrangler preview\` command has been deprecated.
               Try using \`wrangler dev\` to to try out a worker during development.
               "
@@ -222,7 +222,7 @@ describe("wrangler", () => {
     it("should print a deprecation message for 'generate'", async () => {
       await runWrangler("generate").catch((err) => {
         expect(err.message).toMatchInlineSnapshot(`
-          "DEPRECATION:
+          "Deprecation:
           \`wrangler generate\` has been deprecated, please refer to https://github.com/cloudflare/wrangler2/blob/main/docs/deprecations.md#generate for alternatives"
         `);
       });
@@ -230,7 +230,7 @@ describe("wrangler", () => {
     it("should print a deprecation message for 'build'", async () => {
       await runWrangler("build").catch((err) => {
         expect(err.message).toMatchInlineSnapshot(`
-          "DEPRECATION:
+          "Deprecation:
           \`wrangler build\` has been deprecated, please refer to https://github.com/cloudflare/wrangler2/blob/main/docs/deprecations.md#build for alternatives"
         `);
       });

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -256,7 +256,8 @@ describe("publish", () => {
         `);
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.warn).toMatchInlineSnapshot(`
-          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mService environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION.[0m
+          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:
+            - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION.[0m
 
           "
         `);
@@ -278,7 +279,8 @@ describe("publish", () => {
         `);
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.warn).toMatchInlineSnapshot(`
-          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mService environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION.[0m
+          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:
+            - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION.[0m
 
           "
         `);
@@ -430,7 +432,8 @@ describe("publish", () => {
           *another-boring-website.com (zone name: some-zone.com)
           example.com/some-route/* (zone id: JGHFHG654gjcj)
           more-examples.com/*",
-          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mService environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION.[0m
+          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:
+          - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION.[0m
 
         ",
         }
@@ -569,7 +572,7 @@ describe("publish", () => {
       expect(std.err).toMatchInlineSnapshot(`""`);
       expect(std.warn).toMatchInlineSnapshot(`
         "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:
-          - DEPRECATION: \\"build.upload.main\\":
+          - Deprecation: \\"build.upload.main\\":
             Delete the \`build.upload.main\` and \`build.upload.dir\` fields.
             Then add the top level \`main\` field to your configuration file:
             \`\`\`
@@ -603,13 +606,13 @@ describe("publish", () => {
       expect(std.err).toMatchInlineSnapshot(`""`);
       expect(std.warn).toMatchInlineSnapshot(`
         "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing ../wrangler.toml configuration:
-          - DEPRECATION: \\"build.upload.main\\":
+          - Deprecation: \\"build.upload.main\\":
             Delete the \`build.upload.main\` and \`build.upload.dir\` fields.
             Then add the top level \`main\` field to your configuration file:
             \`\`\`
             main = \\"foo/index.js\\"
             \`\`\`
-          - DEPRECATION: \\"build.upload.dir\\":
+          - Deprecation: \\"build.upload.dir\\":
             Use the top level \\"main\\" field or a command-line argument to specify the entry-point for the Worker.[0m
 
         "
@@ -808,7 +811,7 @@ export default{
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev",
           "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:
-          - DEPRECATION: \\"site.entry-point\\":
+          - Deprecation: \\"site.entry-point\\":
             Delete the \`site.entry-point\` field, then add the top level \`main\` field to your configuration file:
             \`\`\`
             main = \\"index.js\\"
@@ -860,7 +863,7 @@ export default{
       expect(std.err).toMatchInlineSnapshot(`""`);
       expect(normalizeSlashes(std.warn)).toMatchInlineSnapshot(`
         "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing my-site/wrangler.toml configuration:
-          - DEPRECATION: \\"site.entry-point\\":
+          - Deprecation: \\"site.entry-point\\":
             Delete the \`site.entry-point\` field, then add the top level \`main\` field to your configuration file:
             \`\`\`
             main = \\"my-entry/index.js\\"
@@ -2609,7 +2612,8 @@ export default{
         `);
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.warn).toMatchInlineSnapshot(`
-          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mService environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION.[0m
+          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:
+            - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION.[0m
 
           "
         `);
@@ -2664,7 +2668,8 @@ export default{
         `);
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.warn).toMatchInlineSnapshot(`
-          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mService environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION.[0m
+          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:
+            - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION.[0m
 
           "
         `);
@@ -2712,7 +2717,8 @@ export default{
             "out": "Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
             test-name.test-sub-domain.workers.dev",
-            "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mService environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION.[0m
+            "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:
+            - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION.[0m
 
           ",
           }
@@ -2773,7 +2779,8 @@ export default{
             "out": "Uploaded test-name (xyz) (TIMINGS)
           Published test-name (xyz) (TIMINGS)
             xyz.test-name.test-sub-domain.workers.dev",
-            "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mService environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION.[0m
+            "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:
+            - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION.[0m
 
           ",
           }
@@ -3985,7 +3992,7 @@ export default{
       expect(std.err).toMatchInlineSnapshot(`""`);
       expect(std.warn).toMatchInlineSnapshot(`
         "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:
-          - DEPRECATION: The \`build.upload.rules\` config field is no longer used, the rules should be specified via the \`rules\` config field. Delete the \`build.upload\` field from the configuration file, and add this:
+          - Deprecation: The \`build.upload.rules\` config field is no longer used, the rules should be specified via the \`rules\` config field. Delete the \`build.upload\` field from the configuration file, and add this:
             \`\`\`
             [[rules]]
             type = \\"Text\\"
@@ -4154,7 +4161,7 @@ export default{
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
       expect(std.warn).toMatchInlineSnapshot(`
-        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mDEPRECATION: detected a legacy module import in \\"./index.js\\". This will stop working in the future. Replace references to \\"text.file\\" with \\"./text.file\\";[0m
+        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mDeprecation: detected a legacy module import in \\"./index.js\\". This will stop working in the future. Replace references to \\"text.file\\" with \\"./text.file\\";[0m
 
         "
       `);
@@ -4182,7 +4189,7 @@ export default{
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
       expect(std.warn).toMatchInlineSnapshot(`
-        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mDEPRECATION: detected a legacy module import in \\"./index.js\\". This will stop working in the future. Replace references to \\"index.wasm\\" with \\"./index.wasm\\";[0m
+        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mDeprecation: detected a legacy module import in \\"./index.js\\". This will stop working in the future. Replace references to \\"index.wasm\\" with \\"./index.wasm\\";[0m
 
         "
       `);

--- a/packages/wrangler/src/__tests__/route.test.ts
+++ b/packages/wrangler/src/__tests__/route.test.ts
@@ -9,7 +9,7 @@ describe("wrangler route", () => {
   it("shows a deprecation notice when `wrangler route` is run", async () => {
     await expect(runWrangler("route")).rejects
       .toThrowErrorMatchingInlineSnapshot(`
-            "DEPRECATION:
+            "Deprecation:
             \`wrangler route\` has been deprecated.
             Please use wrangler.toml and/or \`wrangler publish --routes\` to modify routes"
           `);
@@ -18,7 +18,7 @@ describe("wrangler route", () => {
   it("shows a deprecation notice when `wrangler route delete` is run", async () => {
     await expect(runWrangler("route delete")).rejects
       .toThrowErrorMatchingInlineSnapshot(`
-            "DEPRECATION:
+            "Deprecation:
             \`wrangler route delete\` has been deprecated.
             Remove the unwanted route(s) from wrangler.toml and run \`wrangler publish\` to remove your worker from those routes."
           `);
@@ -27,7 +27,7 @@ describe("wrangler route", () => {
   it("shows a deprecation notice when `wrangler route delete <id>` is run", async () => {
     await expect(runWrangler("route delete some-zone-id")).rejects
       .toThrowErrorMatchingInlineSnapshot(`
-            "DEPRECATION:
+            "Deprecation:
             \`wrangler route delete\` has been deprecated.
             Remove the unwanted route(s) from wrangler.toml and run \`wrangler publish\` to remove your worker from those routes."
           `);
@@ -36,7 +36,7 @@ describe("wrangler route", () => {
   it("shows a deprecation notice when `wrangler route list` is run", async () => {
     await expect(runWrangler("route list")).rejects
       .toThrowErrorMatchingInlineSnapshot(`
-            "DEPRECATION:
+            "Deprecation:
             \`wrangler route list\` has been deprecated.
             Refer to wrangler.toml for a list of routes the worker will be deployed to upon publishing.
             Refer to the Cloudflare Dashboard to see the routes this worker is currently running on."

--- a/packages/wrangler/src/config/validation-helpers.ts
+++ b/packages/wrangler/src/config/validation-helpers.ts
@@ -14,7 +14,7 @@ export function deprecated<T extends object>(
   fieldPath: DeepKeyOf<T>,
   message: string,
   remove: boolean,
-  title = "DEPRECATION",
+  title = "Deprecation",
   type: "warning" | "error" = "warning"
 ): void {
   const diagnosticMessage = `${title}: "${fieldPath}":\n${message}`;

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -1,6 +1,5 @@
 import path from "node:path";
 import TOML from "@iarna/toml";
-import { logger } from "../logger";
 import { Diagnostics } from "./diagnostics";
 import {
   deprecated,
@@ -117,8 +116,8 @@ export function normalizeAndValidateConfig(
 
   // TODO: remove this once service environments goes GA.
   if (!isLegacyEnv) {
-    logger.warn(
-      "Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION."
+    diagnostics.warnings.push(
+      "Experimental: Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION."
     );
   }
 
@@ -937,7 +936,7 @@ const validateAndNormalizeRules = (
       );
     } else if (deprecatedRules) {
       diagnostics.warnings.push(
-        `DEPRECATION: The \`build.upload.rules\` config field is no longer used, the rules should be specified via the \`rules\` config field. Delete the \`build.upload\` field from the configuration file, and add this:\n` +
+        `Deprecation: The \`build.upload.rules\` config field is no longer used, the rules should be specified via the \`rules\` config field. Delete the \`build.upload\` field from the configuration file, and add this:\n` +
           "```\n" +
           TOML.stringify({ rules: deprecatedRules }) +
           "```"

--- a/packages/wrangler/src/errors.ts
+++ b/packages/wrangler/src/errors.ts
@@ -1,6 +1,6 @@
 export class DeprecationError extends Error {
   constructor(message: string) {
-    super(`DEPRECATION:\n${message}`);
+    super(`Deprecation:\n${message}`);
   }
 }
 

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -83,7 +83,7 @@ function getRules(config: Config): Config["rules"] {
 
   if (config.build?.upload?.rules) {
     logger.warn(
-      `DEPRECATION: The \`build.upload.rules\` config field is no longer used, the rules should be specified via the \`rules\` config field. Delete the \`build.upload\` field from the configuration file, and add this:
+      `Deprecation: The \`build.upload.rules\` config field is no longer used, the rules should be specified via the \`rules\` config field. Delete the \`build.upload\` field from the configuration file, and add this:
 
 ${TOML.stringify({ rules: config.build.upload.rules })}`
     );

--- a/packages/wrangler/src/module-collection.ts
+++ b/packages/wrangler/src/module-collection.ts
@@ -138,7 +138,7 @@ export default function createModuleCollector(props: {
               }
               // In the future, this will simply throw an error
               logger.warn(
-                `DEPRECATION: detected a legacy module import in "./${path.relative(
+                `Deprecation: detected a legacy module import in "./${path.relative(
                   process.cwd(),
                   args.importer
                 )}". This will stop working in the future. Replace references to "${


### PR DESCRIPTION
This removes the scary uppercase from DEPRECATION warnings. It also moves the service environment usage warning into `diagnostics` instead of logging it directly.