### PR TITLE
Interactive pages publish prompts

### DIFF
--- a/.changeset/ten-rules-destroy.md
+++ b/.changeset/ten-rules-destroy.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+feat: Adds interactive prompts for the 'wrangler pages publish' and related commands.
+
+Additionally, those commands now read from `node_modules/.cache/wrangler/pages.json` to persist users' account IDs and project names.

--- a/packages/wrangler/src/__tests__/config-cache.test.ts
+++ b/packages/wrangler/src/__tests__/config-cache.test.ts
@@ -1,31 +1,36 @@
 import { getConfigCache, saveToConfigCache } from "../config-cache";
 import { runInTempDir } from "./helpers/run-in-tmp";
 
+interface PagesConfigCache {
+  account_id: string;
+  pages_project_name: string;
+}
+
 describe("config cache", () => {
   runInTempDir();
 
   const pagesConfigCacheFilename = "pages-config-cache.json";
 
   it("should return an empty config if no file exists", () => {
-    expect(getConfigCache(pagesConfigCacheFilename)).toMatchInlineSnapshot(
-      `Object {}`
-    );
+    expect(
+      getConfigCache<PagesConfigCache>(pagesConfigCacheFilename)
+    ).toMatchInlineSnapshot(`Object {}`);
   });
 
   it("should read and write values without overriding old ones", () => {
-    saveToConfigCache(pagesConfigCacheFilename, {
+    saveToConfigCache<PagesConfigCache>(pagesConfigCacheFilename, {
       account_id: "some-account-id",
       pages_project_name: "foo",
     });
-    expect(getConfigCache(pagesConfigCacheFilename).account_id).toEqual(
-      "some-account-id"
-    );
+    expect(
+      getConfigCache<PagesConfigCache>(pagesConfigCacheFilename).account_id
+    ).toEqual("some-account-id");
 
-    saveToConfigCache(pagesConfigCacheFilename, {
+    saveToConfigCache<PagesConfigCache>(pagesConfigCacheFilename, {
       pages_project_name: "bar",
     });
-    expect(getConfigCache(pagesConfigCacheFilename).account_id).toEqual(
-      "some-account-id"
-    );
+    expect(
+      getConfigCache<PagesConfigCache>(pagesConfigCacheFilename).account_id
+    ).toEqual("some-account-id");
   });
 });

--- a/packages/wrangler/src/__tests__/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages.test.ts
@@ -250,7 +250,7 @@ describe("pages", () => {
       ];
 
       const requests = mockListRequest(deployments);
-      await runWrangler("pages deployment list --project=images");
+      await runWrangler("pages deployment list --project-name=images");
 
       expect(requests.count).toBe(1);
     });
@@ -292,7 +292,7 @@ describe("pages", () => {
               --legacy-env  Use legacy environments  [boolean]
 
         Options:
-              --project         The name of the project you want to list deployments for  [string]
+              --project-name    The name of the project you want to list deployments for  [string]
               --branch          The branch of the project you want to list deployments for  [string]
               --commit-hash     The branch of the project you want to list deployments for  [string]
               --commit-message  The branch of the project you want to list deployments for  [string]
@@ -340,7 +340,7 @@ describe("pages", () => {
         }
       );
 
-      await runWrangler("pages publish . --project=foo");
+      await runWrangler("pages publish . --project-name=foo");
 
       // TODO: Unmounting somehow loses this output
 

--- a/packages/wrangler/src/__tests__/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages.test.ts
@@ -155,32 +155,7 @@ describe("pages", () => {
       unsetAllMocks();
     });
 
-    it("should create a project with a the default production branch", async () => {
-      setMockResponse(
-        "/accounts/:accountId/pages/projects",
-        ([_url, accountId], init) => {
-          expect(accountId).toEqual("some-account-id");
-          expect(init.method).toEqual("POST");
-          const body = JSON.parse(init.body as string);
-          expect(body).toEqual({
-            name: "a-new-project",
-            production_branch: "production",
-          });
-          return {
-            name: "a-new-project",
-            subdomain: "a-new-project.pages.dev",
-            production_branch: "production",
-          };
-        }
-      );
-      await runWrangler("pages project create a-new-project");
-      expect(std.out).toMatchInlineSnapshot(`
-        "✨ Successfully created the 'a-new-project' project. It will be available at https://a-new-project.pages.dev/ once you create your first deployment.
-        To deploy a folder of assets, run 'wrangler pages publish [directory]'."
-      `);
-    });
-
-    it("should create a project with a the default production branch", async () => {
+    it("should create a project with a production branch", async () => {
       setMockResponse(
         "/accounts/:accountId/pages/projects",
         ([_url, accountId], init) => {
@@ -316,7 +291,7 @@ describe("pages", () => {
           expect(logoPNGFile.name).toEqual("logo.png");
 
           return {
-            id: "2082190357cfd3617ccfe04f340c6247d4b47484797840635feb491447bcd81c",
+            id: "2082190357cfd3617ccfe04f340c6247",
           };
         }
       );
@@ -330,7 +305,7 @@ describe("pages", () => {
           const manifest = JSON.parse(body.get("manifest") as string);
           expect(manifest).toMatchInlineSnapshot(`
             Object {
-              "logo.png": "2082190357cfd3617ccfe04f340c6247d4b47484797840635feb491447bcd81c",
+              "logo.png": "2082190357cfd3617ccfe04f340c6247",
             }
           `);
 

--- a/packages/wrangler/src/config-cache.ts
+++ b/packages/wrangler/src/config-cache.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, writeFileSync } from "fs";
+import { mkdirSync, readFileSync, rmdirSync, rmSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 
 let cacheMessageShown = false;
@@ -14,9 +14,7 @@ const showCacheMessage = () => {
   }
 };
 
-export const getConfigCache = <T extends Record<string, unknown>>(
-  fileName: string
-): Partial<T> => {
+export const getConfigCache = <T>(fileName: string): Partial<T> => {
   try {
     const configCacheLocation = join(cacheFolder, fileName);
     const configCache = JSON.parse(readFileSync(configCacheLocation, "utf-8"));
@@ -27,7 +25,7 @@ export const getConfigCache = <T extends Record<string, unknown>>(
   }
 };
 
-export const saveToConfigCache = <T extends Record<string, unknown>>(
+export const saveToConfigCache = <T>(
   fileName: string,
   newValues: Partial<T>
 ) => {
@@ -40,4 +38,8 @@ export const saveToConfigCache = <T extends Record<string, unknown>>(
     JSON.stringify({ ...existingValues, ...newValues }, null, 2)
   );
   showCacheMessage();
+};
+
+export const purgeConfigCaches = () => {
+  rmSync(cacheFolder, { recursive: true });
 };

--- a/packages/wrangler/src/config-cache.ts
+++ b/packages/wrangler/src/config-cache.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, rmdirSync, rmSync, writeFileSync } from "fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 
 let cacheMessageShown = false;

--- a/packages/wrangler/src/config-cache.ts
+++ b/packages/wrangler/src/config-cache.ts
@@ -41,5 +41,5 @@ export const saveToConfigCache = <T>(
 };
 
 export const purgeConfigCaches = () => {
-  rmSync(cacheFolder, { recursive: true });
+  rmSync(cacheFolder, { recursive: true, force: true });
 };

--- a/packages/wrangler/src/dialogs.tsx
+++ b/packages/wrangler/src/dialogs.tsx
@@ -43,12 +43,13 @@ export function confirm(text: string): Promise<boolean> {
 
 type PromptProps = {
   text: string;
+  defaultValue?: string;
   type?: "text" | "password";
   onSubmit: (text: string) => void;
 };
 
 function Prompt(props: PromptProps) {
-  const [value, setValue] = useState("");
+  const [value, setValue] = useState(props.defaultValue || "");
 
   return (
     <Box>
@@ -65,11 +66,16 @@ function Prompt(props: PromptProps) {
   );
 }
 
-export async function prompt(text: string, type: "text" | "password" = "text") {
+export async function prompt(
+  text: string,
+  type: "text" | "password" = "text",
+  defaultValue?: string
+): Promise<string> {
   return new Promise((resolve) => {
     const { unmount } = render(
       <Prompt
         text={text}
+        defaultValue={defaultValue}
         type={type}
         onSubmit={(inputText) => {
           unmount();

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -922,7 +922,7 @@ const createDeployment: CommandModule<
             "Enter the production branch name:",
             "text",
             isGitDir
-              ? execSync(`git branch | grep " * "`)
+              ? execSync(`git branch | grep "* "`)
                   .toString()
                   .replace("* ", "")
                   .trim()
@@ -976,7 +976,7 @@ const createDeployment: CommandModule<
         );
 
         if (!branch) {
-          branch = execSync(`git branch | grep " * "`)
+          branch = execSync(`git branch | grep "* "`)
             .toString()
             .replace("* ", "")
             .trim();
@@ -1675,7 +1675,7 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
                 "Enter the production branch name:",
                 "text",
                 isGitDir
-                  ? execSync(`git branch | grep " * "`)
+                  ? execSync(`git branch | grep "* "`)
                       .toString()
                       .replace("* ", "")
                       .trim()

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -1073,7 +1073,7 @@ const createDeployment: CommandModule<
               content: fileContent,
               metadata: {
                 sizeInBytes: filestat.size,
-                hash: hash(content).toString("hex"),
+                hash: hash(content).toString("hex").slice(0, 32),
               },
             });
           }
@@ -1121,7 +1121,7 @@ const createDeployment: CommandModule<
         rerender(<Progress done={counter} total={fileMap.size} />);
         if (response.id != file.metadata.hash) {
           throw new Error(
-            `Looks like there was an issue uploading that ${name}. Try again perhaps?`
+            `Looks like there was an issue uploading '${name}'. Try again perhaps?`
           );
         }
       });

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -946,7 +946,7 @@ const createDeployment: CommandModule<
             project_name: projectName,
           });
 
-          console.log(`✨ Successfully created the '${projectName}' project.`);
+          logger.log(`✨ Successfully created the '${projectName}' project.`);
           break;
         }
       }
@@ -994,7 +994,7 @@ const createDeployment: CommandModule<
       } catch (err) {}
 
       if (isGitDirty && !commitDirty) {
-        console.warn(
+        logger.warn(
           `Warning: Your working directory is a git repo and has uncommitted changes\nTo silense this warning, pass in --commit-dirty=true`
         );
       }
@@ -1135,7 +1135,7 @@ const createDeployment: CommandModule<
 
     const uploadMs = Date.now() - start;
 
-    console.log(
+    logger.log(
       `✨ Success! Uploaded ${fileMap.size} files ${formatTime(uploadMs)}\n`
     );
 
@@ -1228,7 +1228,7 @@ const createDeployment: CommandModule<
       project_name: projectName,
     });
 
-    console.log(
+    logger.log(
       `✨ Deployment complete! Take a peek over at ${deploymentResponse.url}`
     );
   },

--- a/packages/wrangler/src/user.tsx
+++ b/packages/wrangler/src/user.tsx
@@ -228,6 +228,7 @@ import type { Config } from "./config";
 import type { Item as SelectInputItem } from "ink-select-input/build/SelectInput";
 import type { ParsedUrlQuery } from "node:querystring";
 import type { Response } from "undici";
+import { purgeConfigCaches } from "./config-cache";
 
 /**
  * Try to read the API token from the environment.
@@ -979,6 +980,8 @@ export async function login(props?: LoginProps): Promise<boolean> {
             });
             logger.log(`Successfully logged in.`);
 
+            purgeConfigCaches();
+
             return;
           }
         }
@@ -1156,7 +1159,7 @@ export function ChooseAccount(props: {
  * Ensure that a user is logged in, and a valid account_id is available.
  */
 export async function requireAuth(
-  config: Config,
+  config: { account_id?: string },
   isInteractive = true
 ): Promise<string> {
   const loggedIn = await loginOrRefreshIfRequired(isInteractive);

--- a/packages/wrangler/src/user.tsx
+++ b/packages/wrangler/src/user.tsx
@@ -220,15 +220,14 @@ import Table from "ink-table";
 import React from "react";
 import { fetch } from "undici";
 import { getCloudflareApiBaseUrl } from "./cfetch";
+import { purgeConfigCaches } from "./config-cache";
 import { getEnvironmentVariableFactory } from "./environment-variables";
 import { logger } from "./logger";
 import openInBrowser from "./open-in-browser";
 import { parseTOML, readFileSync } from "./parse";
-import type { Config } from "./config";
 import type { Item as SelectInputItem } from "ink-select-input/build/SelectInput";
 import type { ParsedUrlQuery } from "node:querystring";
 import type { Response } from "undici";
-import { purgeConfigCaches } from "./config-cache";
 
 /**
  * Try to read the API token from the environment.


### PR DESCRIPTION
Adds interactive prompts for the 'wrangler pages publish' and related commands.

Additionally, those commands now read from `node_modules/.cache/wrangler/pages.json` to persist users' account IDs and project names (#854). Fixes #874.