### PR TITLE
Add leading slashes to Pages manifest

### DIFF
--- a/.changeset/curly-experts-end.md
+++ b/.changeset/curly-experts-end.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Adds the leading slash to Pages deployment manifests that the API expects, and fixes manifest generation on Windows machines.

--- a/packages/wrangler/src/__tests__/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages.test.ts
@@ -305,7 +305,7 @@ describe("pages", () => {
           const manifest = JSON.parse(body.get("manifest") as string);
           expect(manifest).toMatchInlineSnapshot(`
             Object {
-              "logo.png": "2082190357cfd3617ccfe04f340c6247",
+              "/logo.png": "2082190357cfd3617ccfe04f340c6247",
             }
           `);
 

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -1047,7 +1047,7 @@ const createDeployment: CommandModule<
           } else {
             let name;
             if (depth) {
-              name = join(...filepath.split(sep).slice(1));
+              name = filepath.split(sep).slice(1).join("/");
             } else {
               name = file;
             }
@@ -1146,7 +1146,7 @@ const createDeployment: CommandModule<
       JSON.stringify(
         Object.fromEntries(
           [...fileMap.entries()].map(([fileName, file]) => [
-            fileName,
+            `/${fileName}`,
             file.metadata.hash,
           ])
         )


### PR DESCRIPTION
This adds the leading slash to a Pages deployment manifest that the API expects, and also fixes manifest generation on Windows: classic backslash vs. forwardslash problems.