### PR TITLE
fix: remove bold font from additional lines of warnings and errors

### DIFF
--- a/.changeset/itchy-windows-attack.md
+++ b/.changeset/itchy-windows-attack.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: remove bold font from additional lines of warnings and errors
+
+Previously, when a warning or error was logged, the entire message
+was formatted in bold font. This change makes only the first line of
+the message bold, and the rest is formatted with a normal font.

--- a/.changeset/ninety-ducks-glow.md
+++ b/.changeset/ninety-ducks-glow.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: add bold to the `Deprecated` warning title

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -157,7 +157,7 @@ describe("normalizeAndValidateConfig()", () => {
       expect(diagnostics.hasErrors()).toBe(false);
       expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
         "Processing wrangler configuration:
-          - 😶 Ignored: \\"miniflare\\":
+          - [1m😶 Ignored[0m: \\"miniflare\\":
             Wrangler does not use configuration in the \`miniflare\` section. Unless you are using Miniflare directly you can remove this section."
       `);
     });
@@ -250,7 +250,7 @@ describe("normalizeAndValidateConfig()", () => {
         expect(normalizeSlashes(diagnostics.renderWarnings()))
           .toMatchInlineSnapshot(`
           "Processing wrangler configuration:
-            - Deprecation: \\"site.entry-point\\":
+            - [1mDeprecation[0m: \\"site.entry-point\\":
               Delete the \`site.entry-point\` field, then add the top level \`main\` field to your configuration file:
               \`\`\`
               main = \\"my-site/index.js\\"
@@ -281,7 +281,7 @@ describe("normalizeAndValidateConfig()", () => {
         expect(normalizeSlashes(diagnostics.renderWarnings()))
           .toMatchInlineSnapshot(`
           "Processing wrangler configuration:
-            - Deprecation: \\"site.entry-point\\":
+            - [1mDeprecation[0m: \\"site.entry-point\\":
               Delete the \`site.entry-point\` field, then add the top level \`main\` field to your configuration file:
               \`\`\`
               main = \\"workers-site/index.js\\"
@@ -324,7 +324,7 @@ describe("normalizeAndValidateConfig()", () => {
         expect(normalizeSlashes(diagnostics.renderWarnings()))
           .toMatchInlineSnapshot(`
           "Processing wrangler configuration:
-            - Deprecation: \\"site.entry-point\\":
+            - [1mDeprecation[0m: \\"site.entry-point\\":
               Delete the \`site.entry-point\` field, then add the top level \`main\` field to your configuration file:
               \`\`\`
               main = \\"111/index.js\\"
@@ -358,7 +358,7 @@ describe("normalizeAndValidateConfig()", () => {
         expect(normalizeSlashes(diagnostics.renderWarnings()))
           .toMatchInlineSnapshot(`
           "Processing wrangler configuration:
-            - Deprecation: \\"site.entry-point\\":
+            - [1mDeprecation[0m: \\"site.entry-point\\":
               Delete the \`site.entry-point\` field, then add the top level \`main\` field to your configuration file:
               \`\`\`
               main = \\"some/other/script.js\\"
@@ -571,9 +571,9 @@ describe("normalizeAndValidateConfig()", () => {
         expect(diagnostics.hasWarnings()).toBe(true);
         expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
           "Processing wrangler configuration:
-            - 😶 Ignored: \\"type\\":
+            - [1m😶 Ignored[0m: \\"type\\":
               Most common features now work out of the box with wrangler, including modules, jsx, typescript, etc. If you need anything more, use a custom build.
-            - 😶 Ignored: \\"webpack_config\\":
+            - [1m😶 Ignored[0m: \\"webpack_config\\":
               Most common features now work out of the box with wrangler, including modules, jsx, typescript, etc. If you need anything more, use a custom build."
         `);
       });
@@ -869,15 +869,15 @@ describe("normalizeAndValidateConfig()", () => {
       expect(normalizePath(diagnostics.renderWarnings()))
         .toMatchInlineSnapshot(`
         "Processing project/wrangler.toml configuration:
-          - Deprecation: \\"build.upload.format\\":
+          - [1mDeprecation[0m: \\"build.upload.format\\":
             The format is inferred automatically from the code.
-          - Deprecation: \\"build.upload.main\\":
+          - [1mDeprecation[0m: \\"build.upload.main\\":
             Delete the \`build.upload.main\` and \`build.upload.dir\` fields.
             Then add the top level \`main\` field to your configuration file:
             \`\`\`
             main = \\"src/index.ts\\"
             \`\`\`
-          - Deprecation: \\"build.upload.dir\\":
+          - [1mDeprecation[0m: \\"build.upload.dir\\":
             Use the top level \\"main\\" field or a command-line argument to specify the entry-point for the Worker.
           - Deprecation: The \`build.upload.rules\` config field is no longer used, the rules should be specified via the \`rules\` config field. Delete the \`build.upload\` field from the configuration file, and add this:
             \`\`\`
@@ -1619,9 +1619,9 @@ describe("normalizeAndValidateConfig()", () => {
         expect(diagnostics.hasWarnings()).toBe(true);
         expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
           "Processing wrangler configuration:
-            - Deprecation: \\"zone_id\\":
+            - [1mDeprecation[0m: \\"zone_id\\":
               This is unnecessary since we can deduce this from routes directly.
-            - Deprecation: \\"experimental_services\\":
+            - [1mDeprecation[0m: \\"experimental_services\\":
               The \\"experimental_services\\" field is no longer supported. Instead, use [[unsafe.bindings]] to enable experimental features. Add this to your wrangler.toml:
               \`\`\`
               [[unsafe.bindings]]
@@ -2866,9 +2866,9 @@ describe("normalizeAndValidateConfig()", () => {
           "Processing wrangler configuration:
 
             - \\"env.ENV1\\" environment configuration
-              - Deprecation: \\"zone_id\\":
+              - [1mDeprecation[0m: \\"zone_id\\":
                 This is unnecessary since we can deduce this from routes directly.
-              - Deprecation: \\"experimental_services\\":
+              - [1mDeprecation[0m: \\"experimental_services\\":
                 The \\"experimental_services\\" field is no longer supported. Instead, use [[unsafe.bindings]] to enable experimental features. Add this to your wrangler.toml:
                 \`\`\`
                 [[unsafe.bindings]]

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -40,16 +40,17 @@ describe("wrangler dev", () => {
       expect(std.out).toMatchInlineSnapshot(`""`);
       expect(std.warn.replaceAll(currentDate, "<current-date>"))
         .toMatchInlineSnapshot(`
-        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mNo compatibility_date was specified. Using today's date: <current-date>.
-        Add one to your wrangler.toml file:
-        \`\`\`
-        compatibility_date = \\"<current-date>\\"
-        \`\`\`
-        or pass it in your terminal:
-        \`\`\`
-        --compatibility-date=<current-date>
-        \`\`\`
-        See https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.[0m
+        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mNo compatibility_date was specified. Using today's date: <current-date>.[0m
+
+          Add one to your wrangler.toml file:
+          \`\`\`
+          compatibility_date = \\"<current-date>\\"
+          \`\`\`
+          or pass it in your terminal:
+          \`\`\`
+          --compatibility-date=<current-date>
+          \`\`\`
+          See [4mhttps://developers.cloudflare.com/workers/platform/compatibility-dates[0m for more information.
 
         "
       `);
@@ -476,9 +477,10 @@ describe("wrangler dev", () => {
       );
       expect(std.out).toMatchInlineSnapshot(`""`);
       expect(std.warn).toMatchInlineSnapshot(`
-        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mSetting upstream-protocol to http is not currently implemented.
-        If this is required in your project, please add your use case to the following issue:
-        https://github.com/cloudflare/wrangler2/issues/583.[0m
+        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mSetting upstream-protocol to http is not currently implemented.[0m
+
+          If this is required in your project, please add your use case to the following issue:
+          [4mhttps://github.com/cloudflare/wrangler2/issues/583[0m.
 
         "
       `);
@@ -604,11 +606,13 @@ describe("wrangler dev", () => {
       expect((Dev as jest.Mock).mock.calls[0][0].ip).toEqual("localhost");
       expect(std.out).toMatchInlineSnapshot(`""`);
       expect(std.warn).toMatchInlineSnapshot(`
-        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mWARNING: You have Durable Object bindings that are not defined locally in the worker being developed.
-        Be aware that changes to the data stored in these Durable Objects will be permanent and affect the live instances.
-        Remote Durable Objects that are affected:
-        - {\\"name\\":\\"NAME_2\\",\\"class_name\\":\\"CLASS_2\\",\\"script_name\\":\\"SCRIPT_A\\"}
-        - {\\"name\\":\\"NAME_4\\",\\"class_name\\":\\"CLASS_4\\",\\"script_name\\":\\"SCRIPT_B\\"}[0m
+        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mWARNING: You have Durable Object bindings that are not defined locally in the worker being developed.[0m
+
+          Be aware that changes to the data stored in these Durable Objects will be permanent and affect the
+          live instances.
+          Remote Durable Objects that are affected:
+          - {\\"name\\":\\"NAME_2\\",\\"class_name\\":\\"CLASS_2\\",\\"script_name\\":\\"SCRIPT_A\\"}
+          - {\\"name\\":\\"NAME_4\\",\\"class_name\\":\\"CLASS_4\\",\\"script_name\\":\\"SCRIPT_B\\"}
 
         "
       `);

--- a/packages/wrangler/src/__tests__/helpers/mock-console.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-console.ts
@@ -1,4 +1,5 @@
 import * as util from "node:util";
+import { logger } from "../../logger";
 
 /**
  * We use this module to mock console methods, and optionally
@@ -39,6 +40,7 @@ function captureCalls(spy: jest.SpyInstance): string {
 
 export function mockConsoleMethods() {
   beforeEach(() => {
+    logger.columns = 100;
     debugSpy = jest.spyOn(console, "debug").mockImplementation();
     logSpy = jest.spyOn(console, "log").mockImplementation();
     errorSpy = jest.spyOn(console, "error").mockImplementation();

--- a/packages/wrangler/src/__tests__/https-options.test.ts
+++ b/packages/wrangler/src/__tests__/https-options.test.ts
@@ -97,8 +97,9 @@ describe("getHttpsOptions()", () => {
       `"Generating new self-signed certificate..."`
     );
     expect(std.warn).toMatchInlineSnapshot(`
-      "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mUnable to cache generated self-signed certificate in home/.wrangler/local-cert.
-      ERROR: Cannot write file[0m
+      "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mUnable to cache generated self-signed certificate in home/.wrangler/local-cert.[0m
+
+        ERROR: Cannot write file
 
       "
     `);

--- a/packages/wrangler/src/__tests__/kv.test.ts
+++ b/packages/wrangler/src/__tests__/kv.test.ts
@@ -291,8 +291,9 @@ describe("wrangler", () => {
                 --namespace-id  The id of the namespace to delete  [string]
             -e, --env           Perform on a specific environment  [string]
                 --preview       Interact with a preview namespace  [boolean]
-          [31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot able to delete namespace.
-          A namespace with binding name \\"otherBinding\\" was not found in the configured \\"kv_namespaces\\".[0m
+          [31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot able to delete namespace.[0m
+
+            A namespace with binding name \\"otherBinding\\" was not found in the configured \\"kv_namespaces\\".
 
           "
         `);
@@ -1229,8 +1230,9 @@ describe("wrangler", () => {
           [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
         `);
         expect(std.warn).toMatchInlineSnapshot(`
-          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mUnexpected key-value properties in \\"keys.json\\".
-          The item at index 4 contains unexpected properties: [\\"invalid\\"].[0m
+          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mUnexpected key-value properties in \\"keys.json\\".[0m
+
+            The item at index 4 contains unexpected properties: [\\"invalid\\"].
 
           "
         `);

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -108,9 +108,11 @@ describe("publish", () => {
           test-name.test-sub-domain.workers.dev"
       `);
       expect(std.warn).toMatchInlineSnapshot(`
-        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mIt looks like you have used Wrangler 1's \`config\` command to login with an API token.
-        This is no longer supported in the current version of Wrangler.
-        If you wish to authenticate via an API token then please set the \`CLOUDFLARE_API_TOKEN\` environment variable.[0m
+        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mIt looks like you have used Wrangler 1's \`config\` command to login with an API token.[0m
+
+          This is no longer supported in the current version of Wrangler.
+          If you wish to authenticate via an API token then please set the \`CLOUDFLARE_API_TOKEN\`
+          environment variable.
 
         "
       `);
@@ -189,15 +191,17 @@ describe("publish", () => {
         `);
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.warn).toMatchInlineSnapshot(`
-          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:
-            - No environment found in configuration with name \\"some-env\\".
-              Before using \`--env=some-env\` there should be an equivalent environment section in the configuration.
+          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
 
-              Consider adding an environment configuration section to the wrangler.toml file:
-              \`\`\`
-              [env.some-env]
-              \`\`\`
-          [0m
+              - No environment found in configuration with name \\"some-env\\".
+                Before using \`--env=some-env\` there should be an equivalent environment section in the
+            configuration.
+
+                Consider adding an environment configuration section to the wrangler.toml file:
+                \`\`\`
+                [env.some-env]
+                \`\`\`
+
 
           "
         `);
@@ -256,8 +260,10 @@ describe("publish", () => {
         `);
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.warn).toMatchInlineSnapshot(`
-          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:
-            - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION.[0m
+          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+
+              - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in
+            the future. DO NOT USE IN PRODUCTION.
 
           "
         `);
@@ -279,8 +285,10 @@ describe("publish", () => {
         `);
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.warn).toMatchInlineSnapshot(`
-          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:
-            - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION.[0m
+          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+
+              - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in
+            the future. DO NOT USE IN PRODUCTION.
 
           "
         `);
@@ -432,8 +440,10 @@ describe("publish", () => {
           *another-boring-website.com (zone name: some-zone.com)
           example.com/some-route/* (zone id: JGHFHG654gjcj)
           more-examples.com/*",
-          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:
-          - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION.[0m
+          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+
+            - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in
+          the future. DO NOT USE IN PRODUCTION.
 
         ",
         }
@@ -571,13 +581,14 @@ describe("publish", () => {
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
       expect(std.warn).toMatchInlineSnapshot(`
-        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:
-          - Deprecation: \\"build.upload.main\\":
-            Delete the \`build.upload.main\` and \`build.upload.dir\` fields.
-            Then add the top level \`main\` field to your configuration file:
-            \`\`\`
-            main = \\"dist/index.js\\"
-            \`\`\`[0m
+        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+
+            - Deprecation: \\"build.upload.main\\":
+              Delete the \`build.upload.main\` and \`build.upload.dir\` fields.
+              Then add the top level \`main\` field to your configuration file:
+              \`\`\`
+              main = \\"dist/index.js\\"
+              \`\`\`
 
         "
       `);
@@ -605,15 +616,17 @@ describe("publish", () => {
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
       expect(std.warn).toMatchInlineSnapshot(`
-        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing ../wrangler.toml configuration:
-          - Deprecation: \\"build.upload.main\\":
-            Delete the \`build.upload.main\` and \`build.upload.dir\` fields.
-            Then add the top level \`main\` field to your configuration file:
-            \`\`\`
-            main = \\"foo/index.js\\"
-            \`\`\`
-          - Deprecation: \\"build.upload.dir\\":
-            Use the top level \\"main\\" field or a command-line argument to specify the entry-point for the Worker.[0m
+        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing ../wrangler.toml configuration:[0m
+
+            - Deprecation: \\"build.upload.main\\":
+              Delete the \`build.upload.main\` and \`build.upload.dir\` fields.
+              Then add the top level \`main\` field to your configuration file:
+              \`\`\`
+              main = \\"foo/index.js\\"
+              \`\`\`
+            - Deprecation: \\"build.upload.dir\\":
+              Use the top level \\"main\\" field or a command-line argument to specify the entry-point for the
+          Worker.
 
         "
       `);
@@ -756,18 +769,21 @@ export default{
         [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
       `);
       expect(std.err).toMatchInlineSnapshot(`
-        "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mProcessing wrangler.toml configuration:
-          - \\"site.bucket\\" is a required field.[0m
+        "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mProcessing wrangler.toml configuration:[0m
+
+            - \\"site.bucket\\" is a required field.
 
         "
       `);
       expect(normalizeSlashes(std.warn)).toMatchInlineSnapshot(`
-        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:
-          - Because you've defined a [site] configuration, we're defaulting to \\"workers-site\\" for the deprecated \`site.entry-point\`field.
-            Add the top level \`main\` field to your configuration file:
-            \`\`\`
-            main = \\"workers-site/index.js\\"
-            \`\`\`[0m
+        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+
+            - Because you've defined a [site] configuration, we're defaulting to \\"workers-site\\" for the
+          deprecated \`site.entry-point\`field.
+              Add the top level \`main\` field to your configuration file:
+              \`\`\`
+              main = \\"workers-site/index.js\\"
+              \`\`\`
 
         "
       `);
@@ -810,12 +826,14 @@ export default{
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev",
-          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:
-          - Deprecation: \\"site.entry-point\\":
-            Delete the \`site.entry-point\` field, then add the top level \`main\` field to your configuration file:
-            \`\`\`
-            main = \\"index.js\\"
-            \`\`\`[0m
+          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+
+            - Deprecation: \\"site.entry-point\\":
+              Delete the \`site.entry-point\` field, then add the top level \`main\` field to your configuration
+          file:
+              \`\`\`
+              main = \\"index.js\\"
+              \`\`\`
 
         ",
         }
@@ -862,12 +880,14 @@ export default{
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
       expect(normalizeSlashes(std.warn)).toMatchInlineSnapshot(`
-        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing my-site/wrangler.toml configuration:
-          - Deprecation: \\"site.entry-point\\":
-            Delete the \`site.entry-point\` field, then add the top level \`main\` field to your configuration file:
-            \`\`\`
-            main = \\"my-entry/index.js\\"
-            \`\`\`[0m
+        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing my-site/wrangler.toml configuration:[0m
+
+            - Deprecation: \\"site.entry-point\\":
+              Delete the \`site.entry-point\` field, then add the top level \`main\` field to your configuration
+          file:
+              \`\`\`
+              main = \\"my-entry/index.js\\"
+              \`\`\`
 
         "
       `);
@@ -2612,8 +2632,10 @@ export default{
         `);
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.warn).toMatchInlineSnapshot(`
-          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:
-            - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION.[0m
+          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+
+              - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in
+            the future. DO NOT USE IN PRODUCTION.
 
           "
         `);
@@ -2668,8 +2690,10 @@ export default{
         `);
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.warn).toMatchInlineSnapshot(`
-          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:
-            - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION.[0m
+          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+
+              - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in
+            the future. DO NOT USE IN PRODUCTION.
 
           "
         `);
@@ -2717,8 +2741,10 @@ export default{
             "out": "Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
             test-name.test-sub-domain.workers.dev",
-            "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:
-            - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION.[0m
+            "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+
+              - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in
+            the future. DO NOT USE IN PRODUCTION.
 
           ",
           }
@@ -2779,8 +2805,10 @@ export default{
             "out": "Uploaded test-name (xyz) (TIMINGS)
           Published test-name (xyz) (TIMINGS)
             xyz.test-name.test-sub-domain.workers.dev",
-            "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:
-            - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION.[0m
+            "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+
+              - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in
+            the future. DO NOT USE IN PRODUCTION.
 
           ",
           }
@@ -2942,8 +2970,9 @@ export default{
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
       expect(std.warn).toMatchInlineSnapshot(`
-        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:
-          - \\"unsafe\\" fields are experimental and may change or break at any time.[0m
+        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+
+            - \\"unsafe\\" fields are experimental and may change or break at any time.
 
         "
       `);
@@ -3035,19 +3064,22 @@ export default{
         [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
       `);
       expect(std.err).toMatchInlineSnapshot(`
-        "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mProcessing wrangler.toml configuration:
-          - CONFLICTING_NAME_ONE assigned to Durable Object, KV Namespace, and R2 Bucket bindings.
-          - CONFLICTING_NAME_TWO assigned to Durable Object and KV Namespace bindings.
-          - CONFLICTING_NAME_THREE assigned to R2 Bucket, Text Blob, Unsafe, Environment Variable, WASM Module, and Data Blob bindings.
-          - CONFLICTING_NAME_FOUR assigned to Text Blob and Unsafe bindings.
-          - Bindings must have unique names, so that they can all be referenced in the worker.
-            Please change your bindings to have unique names.[0m
+        "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mProcessing wrangler.toml configuration:[0m
+
+            - CONFLICTING_NAME_ONE assigned to Durable Object, KV Namespace, and R2 Bucket bindings.
+            - CONFLICTING_NAME_TWO assigned to Durable Object and KV Namespace bindings.
+            - CONFLICTING_NAME_THREE assigned to R2 Bucket, Text Blob, Unsafe, Environment Variable, WASM
+          Module, and Data Blob bindings.
+            - CONFLICTING_NAME_FOUR assigned to Text Blob and Unsafe bindings.
+            - Bindings must have unique names, so that they can all be referenced in the worker.
+              Please change your bindings to have unique names.
 
         "
       `);
       expect(std.warn).toMatchInlineSnapshot(`
-        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:
-          - \\"unsafe\\" fields are experimental and may change or break at any time.[0m
+        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+
+            - \\"unsafe\\" fields are experimental and may change or break at any time.
 
         "
       `);
@@ -3131,19 +3163,21 @@ export default{
         [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
       `);
       expect(std.err).toMatchInlineSnapshot(`
-        "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mProcessing wrangler.toml configuration:
-          - CONFLICTING_DURABLE_OBJECT_NAME assigned to multiple Durable Object bindings.
-          - CONFLICTING_KV_NAMESPACE_NAME assigned to multiple KV Namespace bindings.
-          - CONFLICTING_R2_BUCKET_NAME assigned to multiple R2 Bucket bindings.
-          - CONFLICTING_UNSAFE_NAME assigned to multiple Unsafe bindings.
-          - Bindings must have unique names, so that they can all be referenced in the worker.
-            Please change your bindings to have unique names.[0m
+        "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mProcessing wrangler.toml configuration:[0m
+
+            - CONFLICTING_DURABLE_OBJECT_NAME assigned to multiple Durable Object bindings.
+            - CONFLICTING_KV_NAMESPACE_NAME assigned to multiple KV Namespace bindings.
+            - CONFLICTING_R2_BUCKET_NAME assigned to multiple R2 Bucket bindings.
+            - CONFLICTING_UNSAFE_NAME assigned to multiple Unsafe bindings.
+            - Bindings must have unique names, so that they can all be referenced in the worker.
+              Please change your bindings to have unique names.
 
         "
       `);
       expect(std.warn).toMatchInlineSnapshot(`
-        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:
-          - \\"unsafe\\" fields are experimental and may change or break at any time.[0m
+        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+
+            - \\"unsafe\\" fields are experimental and may change or break at any time.
 
         "
       `);
@@ -3263,21 +3297,24 @@ export default{
         [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
       `);
       expect(std.err).toMatchInlineSnapshot(`
-        "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mProcessing wrangler.toml configuration:
-          - CONFLICTING_DURABLE_OBJECT_NAME assigned to multiple Durable Object bindings.
-          - CONFLICTING_KV_NAMESPACE_NAME assigned to multiple KV Namespace bindings.
-          - CONFLICTING_R2_BUCKET_NAME assigned to multiple R2 Bucket bindings.
-          - CONFLICTING_NAME_THREE assigned to R2 Bucket, Text Blob, Unsafe, Environment Variable, WASM Module, and Data Blob bindings.
-          - CONFLICTING_NAME_FOUR assigned to R2 Bucket, Text Blob, and Unsafe bindings.
-          - CONFLICTING_UNSAFE_NAME assigned to multiple Unsafe bindings.
-          - Bindings must have unique names, so that they can all be referenced in the worker.
-            Please change your bindings to have unique names.[0m
+        "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mProcessing wrangler.toml configuration:[0m
+
+            - CONFLICTING_DURABLE_OBJECT_NAME assigned to multiple Durable Object bindings.
+            - CONFLICTING_KV_NAMESPACE_NAME assigned to multiple KV Namespace bindings.
+            - CONFLICTING_R2_BUCKET_NAME assigned to multiple R2 Bucket bindings.
+            - CONFLICTING_NAME_THREE assigned to R2 Bucket, Text Blob, Unsafe, Environment Variable, WASM
+          Module, and Data Blob bindings.
+            - CONFLICTING_NAME_FOUR assigned to R2 Bucket, Text Blob, and Unsafe bindings.
+            - CONFLICTING_UNSAFE_NAME assigned to multiple Unsafe bindings.
+            - Bindings must have unique names, so that they can all be referenced in the worker.
+              Please change your bindings to have unique names.
 
         "
       `);
       expect(std.warn).toMatchInlineSnapshot(`
-        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:
-          - \\"unsafe\\" fields are experimental and may change or break at any time.[0m
+        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+
+            - \\"unsafe\\" fields are experimental and may change or break at any time.
 
         "
       `);
@@ -3850,8 +3887,9 @@ export default{
               `);
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.warn).toMatchInlineSnapshot(`
-          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:
-            - \\"unsafe\\" fields are experimental and may change or break at any time.[0m
+          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+
+              - \\"unsafe\\" fields are experimental and may change or break at any time.
 
           "
         `);
@@ -3888,12 +3926,14 @@ export default{
               `);
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.warn).toMatchInlineSnapshot(`
-          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:
-            - \\"unsafe\\" fields are experimental and may change or break at any time.
-            - \\"unsafe.bindings[0]\\": {\\"name\\":\\"my-binding\\",\\"type\\":\\"plain_text\\",\\"text\\":\\"text\\"}
-              - The binding type \\"plain_text\\" is directly supported by wrangler.
-                Consider migrating this unsafe binding to a format for 'plain_text' bindings that is supported by wrangler for optimal support.
-                For more details, see https://developers.cloudflare.com/workers/cli-wrangler/configuration[0m
+          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+
+              - \\"unsafe\\" fields are experimental and may change or break at any time.
+              - \\"unsafe.bindings[0]\\": {\\"name\\":\\"my-binding\\",\\"type\\":\\"plain_text\\",\\"text\\":\\"text\\"}
+                - The binding type \\"plain_text\\" is directly supported by wrangler.
+                  Consider migrating this unsafe binding to a format for 'plain_text' bindings that is
+            supported by wrangler for optimal support.
+                  For more details, see [4mhttps://developers.cloudflare.com/workers/cli-wrangler/configuration[0m
 
           "
         `);
@@ -3991,14 +4031,17 @@ export default{
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
       expect(std.warn).toMatchInlineSnapshot(`
-        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:
-          - Deprecation: The \`build.upload.rules\` config field is no longer used, the rules should be specified via the \`rules\` config field. Delete the \`build.upload\` field from the configuration file, and add this:
-            \`\`\`
-            [[rules]]
-            type = \\"Text\\"
-            globs = [ \\"**/*.file\\" ]
-            fallthrough = true
-            \`\`\`[0m
+        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+
+            - Deprecation: The \`build.upload.rules\` config field is no longer used, the rules should be
+          specified via the \`rules\` config field. Delete the \`build.upload\` field from the configuration
+          file, and add this:
+              \`\`\`
+              [[rules]]
+              type = \\"Text\\"
+              globs = [ \\"**/*.file\\" ]
+              fallthrough = true
+              \`\`\`
 
         "
       `);

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -583,7 +583,7 @@ describe("publish", () => {
       expect(std.warn).toMatchInlineSnapshot(`
         "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
 
-            - Deprecation: \\"build.upload.main\\":
+            - [1mDeprecation[0m: \\"build.upload.main\\":
               Delete the \`build.upload.main\` and \`build.upload.dir\` fields.
               Then add the top level \`main\` field to your configuration file:
               \`\`\`
@@ -618,13 +618,13 @@ describe("publish", () => {
       expect(std.warn).toMatchInlineSnapshot(`
         "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing ../wrangler.toml configuration:[0m
 
-            - Deprecation: \\"build.upload.main\\":
+            - [1mDeprecation[0m: \\"build.upload.main\\":
               Delete the \`build.upload.main\` and \`build.upload.dir\` fields.
               Then add the top level \`main\` field to your configuration file:
               \`\`\`
               main = \\"foo/index.js\\"
               \`\`\`
-            - Deprecation: \\"build.upload.dir\\":
+            - [1mDeprecation[0m: \\"build.upload.dir\\":
               Use the top level \\"main\\" field or a command-line argument to specify the entry-point for the
           Worker.
 
@@ -828,7 +828,7 @@ export default{
           test-name.test-sub-domain.workers.dev",
           "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
 
-            - Deprecation: \\"site.entry-point\\":
+            - [1mDeprecation[0m: \\"site.entry-point\\":
               Delete the \`site.entry-point\` field, then add the top level \`main\` field to your configuration
           file:
               \`\`\`
@@ -882,7 +882,7 @@ export default{
       expect(normalizeSlashes(std.warn)).toMatchInlineSnapshot(`
         "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing my-site/wrangler.toml configuration:[0m
 
-            - Deprecation: \\"site.entry-point\\":
+            - [1mDeprecation[0m: \\"site.entry-point\\":
               Delete the \`site.entry-point\` field, then add the top level \`main\` field to your configuration
           file:
               \`\`\`

--- a/packages/wrangler/src/__tests__/whoami.test.tsx
+++ b/packages/wrangler/src/__tests__/whoami.test.tsx
@@ -54,9 +54,11 @@ describe("getUserInfo()", () => {
     writeAuthConfigFile({ api_token: "API_TOKEN" });
     await getUserInfo();
     expect(std.warn).toMatchInlineSnapshot(`
-      "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mIt looks like you have used Wrangler 1's \`config\` command to login with an API token.
-      This is no longer supported in the current version of Wrangler.
-      If you wish to authenticate via an API token then please set the \`CLOUDFLARE_API_TOKEN\` environment variable.[0m
+      "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mIt looks like you have used Wrangler 1's \`config\` command to login with an API token.[0m
+
+        This is no longer supported in the current version of Wrangler.
+        If you wish to authenticate via an API token then please set the \`CLOUDFLARE_API_TOKEN\`
+        environment variable.
 
       "
     `);

--- a/packages/wrangler/src/config/validation-helpers.ts
+++ b/packages/wrangler/src/config/validation-helpers.ts
@@ -17,7 +17,9 @@ export function deprecated<T extends object>(
   title = "Deprecation",
   type: "warning" | "error" = "warning"
 ): void {
-  const diagnosticMessage = `${title}: "${fieldPath}":\n${message}`;
+  const BOLD = "\x1b[1m";
+  const NORMAL = "\x1b[0m";
+  const diagnosticMessage = `${BOLD}${title}${NORMAL}: "${fieldPath}":\n${message}`;
   const result = unwindPropertyPath(config, fieldPath);
   if (result !== undefined && result.field in result.container) {
     diagnostics[`${type}s`].push(diagnosticMessage);

--- a/packages/wrangler/src/logger.ts
+++ b/packages/wrangler/src/logger.ts
@@ -21,6 +21,8 @@ const LOGGER_LEVEL_FORMAT_TYPE_MAP = {
 class Logger {
   constructor(public loggerLevel: LoggerLevel = "log") {}
 
+  columns = process.stdout.columns;
+
   debug = (...args: unknown[]) => this.doLog("debug", args);
   log = (...args: unknown[]) => this.doLog("log", args);
   warn = (...args: unknown[]) => this.doLog("warn", args);
@@ -32,16 +34,24 @@ class Logger {
     }
   }
 
-  formatMessage(level: LoggerLevel, text: string): string {
+  private formatMessage(level: LoggerLevel, message: string): string {
     const kind = LOGGER_LEVEL_FORMAT_TYPE_MAP[level];
     if (kind) {
-      return formatMessagesSync([{ text }], {
+      // Format the message using the esbuild formatter.
+      // The first line of the message is the main `text`,
+      // subsequent lines are put into the `notes`.
+      const [firstLine, ...otherLines] = message.split("\n");
+      const notes =
+        otherLines.length > 0
+          ? otherLines.map((text) => ({ text }))
+          : undefined;
+      return formatMessagesSync([{ text: firstLine, notes }], {
         color: true,
         kind,
-        terminalWidth: process.stdout.columns,
+        terminalWidth: this.columns,
       })[0];
     } else {
-      return text;
+      return message;
     }
   }
 }


### PR DESCRIPTION
Previously, when a warning or error was logged, the entire message
was formatted in bold font. This change makes only the first line of
the message bold, and the rest is formatted with a normal font.

Before

<img width="643" alt="Screenshot 2022-05-04 at 14 50 08" src="https://user-images.githubusercontent.com/15655/166695344-a6d67a8a-9b9f-49f3-812c-c9d8a18f5b22.png">


After

<img width="607" alt="Screenshot 2022-05-04 at 14 49 04" src="https://user-images.githubusercontent.com/15655/166695365-1955cc1c-0947-440c-bd72-cad19fc6d2c8.png">
