### PR TITLE
feat: `--dev-vars` as a path to a custom `.dev.vars` file

### DIFF
--- a/.changeset/kind-days-share.md
+++ b/.changeset/kind-days-share.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+feat: `--dev-vars` as a path to a custom `.dev.vars` file
+
+Followup from https://github.com/cloudflare/wrangler2/pull/879, this adds a command line flag in `dev` for passing a custom path to a file to populate `.dev.vars`

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -736,11 +736,14 @@ export async function main(argv: string[]): Promise<void> {
           alias: "l",
           describe: "Run on my machine",
           type: "boolean",
-          default: false, // I bet this will a point of contention. We'll revisit it.
         })
         .option("experimental-enable-local-persistence", {
           describe: "Enable persistence for this session (only for local mode)",
           type: "boolean",
+        })
+        .option("dev-vars", {
+          describe: "Path to a custom .dev.vars file",
+          type: "string",
         })
         .option("minify", {
           describe: "Minify the script",
@@ -938,7 +941,7 @@ export async function main(argv: string[]): Promise<void> {
                 };
               }
             ),
-            vars: getVarsForDev(config),
+            vars: getVarsForDev(config, args.devVars),
             wasm_modules: config.wasm_modules,
             text_blobs: config.text_blobs,
             data_blobs: config.data_blobs,


### PR DESCRIPTION
Followup from https://github.com/cloudflare/wrangler2/pull/879, this adds a command line flag in `dev` for passing a custom path to a file to populate `.dev.vars`