### PR TITLE
polish: tweak the message when `.dev.vars` is used

### DIFF
--- a/.changeset/brave-pens-march.md
+++ b/.changeset/brave-pens-march.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+polish: tweak the message when `.dev.vars` is used
+
+This tweaks the mssage when a `.dev.vars` file is used so that it doesn't imply that the user has to copy the values from it into their `wrangler.toml`.

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -658,7 +658,7 @@ describe("wrangler dev", () => {
         UNQUOTED: "unquoted value", // Note that whitespace is trimmed
       });
       expect(std.out).toMatchInlineSnapshot(
-        `"Add vars defined in \\".dev.vars\\" to the \\"vars\\" bindings."`
+        `"Using vars defined in .dev.vars"`
       );
       expect(std.warn).toMatchInlineSnapshot(`""`);
       expect(std.err).toMatchInlineSnapshot(`""`);

--- a/packages/wrangler/src/dev/dev-vars.ts
+++ b/packages/wrangler/src/dev/dev-vars.ts
@@ -24,9 +24,7 @@ export function getVarsForDev(config: Config): Config["vars"] {
   const devVarsPath = path.resolve(configDir, ".dev.vars");
   if (fs.existsSync(devVarsPath)) {
     const devVarsRelativePath = path.relative(process.cwd(), devVarsPath);
-    logger.log(
-      `Add vars defined in "${devVarsRelativePath}" to the "vars" bindings.`
-    );
+    logger.log(`Using vars defined in ${devVarsRelativePath}`);
     const devVars = dotenv.parse(fs.readFileSync(devVarsPath, "utf8"));
     return {
       ...config.vars,


### PR DESCRIPTION
This tweaks the mssage when a `.dev.vars` file is used so that it doesn't imply that the user has to copy the values from it into their `wrangler.toml`.