### PR TITLE
chore: minify bundle, don't ship sourcemaps

### DIFF
--- a/.changeset/cold-pianos-bow.md
+++ b/.changeset/cold-pianos-bow.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+chore: minify bundle, don't ship sourcemaps
+
+We haven't found much use for sourcemaps in production, and we should probably minify the bundle anyway. This will also remove an dev only warnings react used to log.

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -118,7 +118,7 @@
     "check:type": "tsc",
     "bundle": "node -r esbuild-register scripts/bundle.ts",
     "build": "npm run clean && npm run bundle",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "SOURCEMAPS=false npm run build",
     "start": "npm run bundle && NODE_OPTIONS=--enable-source-maps ./bin/wrangler.js",
     "test": "jest --silent=false --verbose=true",
     "test-watch": "npm run test -- --runInBand --testTimeout=50000 --watch"

--- a/packages/wrangler/scripts/bundle.ts
+++ b/packages/wrangler/scripts/bundle.ts
@@ -11,7 +11,7 @@ async function run() {
     outdir: "./wrangler-dist",
     platform: "node",
     format: "cjs",
-    // minify: true, // TODO: enable this again
+    minify: true,
     external: [
       "fsevents",
       "esbuild",
@@ -23,7 +23,7 @@ async function run() {
       "@esbuild-plugins/node-globals-polyfill",
       "@esbuild-plugins/node-modules-polyfill",
     ],
-    sourcemap: true,
+    sourcemap: process.env.SOURCEMAPS !== "false",
     inject: [path.join(__dirname, "../import_meta_url.js")],
     define: {
       "import.meta.url": "import_meta_url",
@@ -39,7 +39,7 @@ async function run() {
     format: "esm",
     minify: true,
     external: ["miniflare", "@miniflare/core"],
-    sourcemap: true,
+    sourcemap: process.env.SOURCEMAPS !== "false",
   });
 }
 


### PR DESCRIPTION
We haven't found much use for sourcemaps in production, and we should probably minify the bundle anyway. This will also remove an dev only warnings react used to log.

--- 

My initial testing shows a 10 mb reduction in bundle size, but I'm letting CI run so I can do accurate before - after comparisons with dependencies included. 

Added a changeset because this needs to be visible in case it causes a problem. 