### PR TITLE
feat: implement support for service bindings

### DIFF
--- a/.changeset/hot-insects-cry.md
+++ b/.changeset/hot-insects-cry.md
@@ -1,0 +1,26 @@
+---
+"wrangler": patch
+---
+
+feat: implement support for service bindings
+
+This adds experimental support for service bindings, aka worker-to-worker bindings. It's lets you "call" a worker from another worker, without incurring any network cost, and (ideally) with much less latency. To use it, define a `[services]` field in `wrangler.toml`, which is a map of bindings to worker names (and environment). Let's say you already have a worker named "my-worker" deployed. In another worker's configuration, you can create a service binding to it like so:
+
+```toml
+[[services]]
+binding = "MYWORKER"
+service = "my-worker"
+environment = "production" # optional, defaults to the worker's `default_environment` for now
+```
+
+And in your worker, you can call it like so:
+
+```js
+export default {
+  fetch(req, env, ctx) {
+    return env.MYWORKER.fetch(new Request("http://domain/some-path"));
+  },
+};
+```
+
+Fixes https://github.com/cloudflare/wrangler2/issues/1026

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -839,6 +839,34 @@ describe("wrangler dev", () => {
       `);
     });
   });
+
+  describe("service bindings", () => {
+    it("should warn when using service bindings", async () => {
+      writeWranglerToml({
+        services: [
+          { binding: "WorkerA", service: "A" },
+          { binding: "WorkerB", service: "B", environment: "staging" },
+        ],
+      });
+      fs.writeFileSync("index.js", `export default {};`);
+      await runWrangler("dev index.js");
+      expect(std).toMatchInlineSnapshot(`
+        Object {
+          "debug": "",
+          "err": "",
+          "out": "",
+          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+
+            - \\"services\\" fields are experimental and may change or break at any time.
+
+
+        [33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThis worker is bound to live services: WorkerA (A), WorkerB (B@staging)[0m
+
+        ",
+        }
+      `);
+    });
+  });
 });
 
 function mockGetZones(domain: string, zones: { id: string }[] = []) {

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -282,6 +282,24 @@ interface EnvironmentNonInheritable {
   }[];
 
   /**
+   * Specifies service bindings (worker-to-worker) that are bound to this Worker environment.
+   *
+   * NOTE: This field is not automatically inherited from the top level environment,
+   * and so must be specified in every named environment.
+   *
+   * @default `[]`
+   * @nonInheritable
+   */
+  services: {
+    /** The binding name used to refer to the bound service. */
+    binding: string;
+    /** The name of the service. */
+    service: string;
+    /** The environment of the service (e.g. production, staging, etc). */
+    environment?: string;
+  }[];
+
+  /**
    * "Unsafe" tables for features that aren't directly supported by wrangler.
    *
    * NOTE: This field is not automatically inherited from the top level environment,

--- a/packages/wrangler/src/create-worker-upload-form.ts
+++ b/packages/wrangler/src/create-worker-upload-form.ts
@@ -32,13 +32,15 @@ export interface WorkerMetadata {
   compatibility_flags?: string[];
   usage_model?: "bundled" | "unbound";
   migrations?: CfDurableObjectMigrations;
+  // If you add any new binding types here, also add it to safeBindings
+  // under validateUnsafeBinding in config/validation.ts
   bindings: (
-    | { type: "kv_namespace"; name: string; namespace_id: string }
     | { type: "plain_text"; name: string; text: string }
     | { type: "json"; name: string; json: unknown }
     | { type: "wasm_module"; name: string; part: string }
     | { type: "text_blob"; name: string; part: string }
     | { type: "data_blob"; name: string; part: string }
+    | { type: "kv_namespace"; name: string; namespace_id: string }
     | {
         type: "durable_object_namespace";
         name: string;
@@ -47,6 +49,7 @@ export interface WorkerMetadata {
         environment?: string;
       }
     | { type: "r2_bucket"; name: string; bucket_name: string }
+    | { type: "service"; name: string; service: string; environment?: string }
   )[];
 }
 
@@ -67,6 +70,14 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
   let { modules } = worker;
 
   const metadataBindings: WorkerMetadata["bindings"] = [];
+
+  Object.entries(bindings.vars || {})?.forEach(([key, value]) => {
+    if (typeof value === "string") {
+      metadataBindings.push({ name: key, type: "plain_text", text: value });
+    } else {
+      metadataBindings.push({ name: key, type: "json", json: value });
+    }
+  });
 
   bindings.kv_namespaces?.forEach(({ id, binding }) => {
     metadataBindings.push({
@@ -96,12 +107,13 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
     });
   });
 
-  Object.entries(bindings.vars || {})?.forEach(([key, value]) => {
-    if (typeof value === "string") {
-      metadataBindings.push({ name: key, type: "plain_text", text: value });
-    } else {
-      metadataBindings.push({ name: key, type: "json", json: value });
-    }
+  bindings.services?.forEach(({ binding, service, environment }) => {
+    metadataBindings.push({
+      name: binding,
+      type: "service",
+      service,
+      ...(environment && { environment }),
+    });
   });
 
   for (const [name, filePath] of Object.entries(bindings.wasm_modules || {})) {

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -87,6 +87,11 @@ function useLocalWorker({
           '⎔ A "public" folder is not yet supported in local mode.'
         );
       }
+      if (bindings.services && bindings.services.length > 0) {
+        throw new Error(
+          "⎔ Service bindings are not yet supported in local mode."
+        );
+      }
 
       // In local mode, we want to copy all referenced modules into
       // the output bundle directory before starting up
@@ -297,6 +302,7 @@ function useLocalWorker({
     bindings.durable_objects?.bindings,
     bindings.kv_namespaces,
     bindings.vars,
+    bindings.services,
     compatibilityDate,
     compatibilityFlags,
     localPersistencePath,

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -892,6 +892,19 @@ export async function main(argv: string[]): Promise<void> {
       const config = readConfig(configPath, args);
       const entry = await getEntry(args, config, "dev");
 
+      if (config.services && config.services.length > 0) {
+        logger.warn(
+          `This worker is bound to live services: ${config.services
+            .map(
+              (service) =>
+                `${service.binding} (${service.service}${
+                  service.environment ? `@${service.environment}` : ""
+                })`
+            )
+            .join(", ")}`
+        );
+      }
+
       if (args.inspect) {
         logger.warn(
           "Passing --inspect is unnecessary, now you can always connect to devtools."
@@ -1102,6 +1115,7 @@ export async function main(argv: string[]): Promise<void> {
                 };
               }
             ),
+            services: config.services,
             unsafe: config.unsafe?.bindings,
           }}
           crons={config.triggers.crons}
@@ -1554,6 +1568,7 @@ export async function main(argv: string[]): Promise<void> {
                 };
               }
             ),
+            services: config.services,
             unsafe: config.unsafe?.bindings,
           }}
           crons={config.triggers.crons}
@@ -1751,6 +1766,7 @@ export async function main(argv: string[]): Promise<void> {
                       vars: {},
                       durable_objects: { bindings: [] },
                       r2_buckets: [],
+                      services: [],
                       wasm_modules: {},
                       text_blobs: {},
                       data_blobs: {},

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -271,6 +271,7 @@ export default async function publish(props: Props): Promise<void> {
       data_blobs: config.data_blobs,
       durable_objects: config.durable_objects,
       r2_buckets: config.r2_buckets,
+      services: config.services,
       unsafe: config.unsafe?.bindings,
     };
 

--- a/packages/wrangler/src/worker.ts
+++ b/packages/wrangler/src/worker.ts
@@ -113,6 +113,12 @@ interface CfR2Bucket {
   bucket_name: string;
 }
 
+interface CfService {
+  binding: string;
+  service: string;
+  environment?: string;
+}
+
 interface CfUnsafeBinding {
   name: string;
   type: string;
@@ -158,6 +164,7 @@ export interface CfWorkerInit {
     data_blobs: CfDataBlobBindings | undefined;
     durable_objects: { bindings: CfDurableObject[] } | undefined;
     r2_buckets: CfR2Bucket[] | undefined;
+    services: CfService[] | undefined;
     unsafe: CfUnsafeBinding[] | undefined;
   };
   migrations: CfDurableObjectMigrations | undefined;


### PR DESCRIPTION
This adds experimental support for service bindings, aka worker-to-worker bindings. It's lets you "call" a worker from another worker, without incurring any network cost, and (ideally) with much less latency. To use it, define a `[services]` field in `wrangler.toml`, which is a map of bindings to worker names (and environment). Let's say you already have a worker named "my-worker" deployed. In another worker's configuration, you can create a service binding to it like so:

```toml
[[services]]
binding = "MYWORKER"
service = "my-worker"
environment = "production" # optional, defaults to the worker's `default_environment` for now  
```

And in your worker, you can call it like so:

```js
export default {
  fetch(req, env, ctx) {
    return env.MYWORKER.fetch(new Request("./some-path"));
  },
};
```

### Current critical drawbacks: 


- The api is a little buggy at the moment. We're investigating that internally.
- It connects to, by default, the 'production' worker. If that has a KV or Durable Object or whatever, you could have data loss in production
- Following which, say you run wrangler dev on two bound workers, then the requests do not go the development versions, and it's not obvious
- No local mode support 
- Hard to test

Fixes https://github.com/cloudflare/wrangler2/issues/1026