### PR TITLE
fix: support preview buckets for r2 bindings

### DIFF
--- a/.changeset/swift-bees-share.md
+++ b/.changeset/swift-bees-share.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: support preview buckets for r2 bindings
+
+Allows wrangler2 to perform preview & dev sessions with a different bucket than the published worker's binding.
+
+This matches kv's preview_id behavior, and brings the wrangler2 implementation in sync with wrangler1.

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -1290,7 +1290,7 @@ const validateKVBinding: ValidatorFn = (diagnostics, field, value) => {
 const validateR2Binding: ValidatorFn = (diagnostics, field, value) => {
   if (typeof value !== "object" || value === null) {
     diagnostics.errors.push(
-      `"kv_namespaces" bindings should be objects, but got ${JSON.stringify(
+      `"r2_buckets" bindings should be objects, but got ${JSON.stringify(
         value
       )}`
     );

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -958,7 +958,21 @@ export async function main(argv: string[]): Promise<void> {
             text_blobs: config.text_blobs,
             data_blobs: config.data_blobs,
             durable_objects: config.durable_objects,
-            r2_buckets: config.r2_buckets,
+            r2_buckets: config.r2_buckets?.map(
+              ({ binding, preview_bucket_name, bucket_name: _bucket_name }) => {
+                // same idea as kv namespace preview id,
+                // same copy-on-write TODO
+                if (!preview_bucket_name) {
+                  throw new Error(
+                    `In development, you should use a separate r2 bucket than the one you'd use in production. Please create a new r2 bucket with "wrangler r2 bucket create <name>" and add its name as preview_bucket_name to the r2_buckets "${binding}" in your wrangler.toml`
+                  );
+                }
+                return {
+                  binding,
+                  bucket_name: preview_bucket_name,
+                };
+              }
+            ),
             unsafe: config.unsafe?.bindings,
           }}
           crons={config.triggers.crons}
@@ -1384,7 +1398,21 @@ export async function main(argv: string[]): Promise<void> {
             text_blobs: config.text_blobs,
             data_blobs: config.data_blobs,
             durable_objects: config.durable_objects,
-            r2_buckets: config.r2_buckets,
+            r2_buckets: config.r2_buckets?.map(
+              ({ binding, preview_bucket_name, bucket_name: _bucket_name }) => {
+                // same idea as kv namespace preview id,
+                // same copy-on-write TODO
+                if (!preview_bucket_name) {
+                  throw new Error(
+                    `In development, you should use a separate r2 bucket than the one you'd use in production. Please create a new r2 bucket with "wrangler r2 bucket create <name>" and add its name as preview_bucket_name to the r2_buckets "${binding}" in your wrangler.toml`
+                  );
+                }
+                return {
+                  binding,
+                  bucket_name: preview_bucket_name,
+                };
+              }
+            ),
             unsafe: config.unsafe?.bindings,
           }}
           crons={config.triggers.crons}


### PR DESCRIPTION
Allows wrangler2 to perform preview & dev sessions with a different
bucket than the published worker's binding.

This matches kv's preview_id behavior, and brings the wrangler2
implementation in sync with wrangler1.