### PR TITLE
Temporarily limit 'pages publish' to 1k files

### DIFF
--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -1109,9 +1109,9 @@ const createDeployment: CommandModule<
 
     const files: Array<Promise<void>> = [];
 
-    if (fileMap.size > 20000) {
+    if (fileMap.size > 1000) {
       throw new Error(
-        `Error: Pages only supports up to 20,000 files in a deployment at the moment\nTry a smaller project perhaps?`
+        `Error: Pages only supports up to 1,000 files in a deployment at the moment.\nTry a smaller project perhaps?`
       );
     }
 


### PR DESCRIPTION
Temporarily limit 'wrangler pages publish' to max 1k files while we optimize things behind the scenes.