### PR TITLE
polish: add a deprecation warning to `--inspect` on `dev`

### DIFF
--- a/.changeset/loud-wombats-vanish.md
+++ b/.changeset/loud-wombats-vanish.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+polish: add a deprecation warning to `--inspect` on `dev`
+
+We have a blogposts and docs that says you need to pass `--inspect` to use devtools and/or profile your Worker. In wrangler v2, we don't need to pass the flag anymore. Using it right now will throw an error, so this patch makes it a simple warning instead.

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -715,14 +715,32 @@ describe("wrangler dev", () => {
               --jsx-fragment                               The function that is called for each JSX fragment  [string]
               --tsconfig                                   Path to a custom tsconfig.json file  [string]
           -l, --local                                      Run on my machine  [boolean] [default: false]
-              --experimental-enable-local-persistence      Enable persistence for this session (only for local mode)  [boolean]
               --minify                                     Minify the script  [boolean]
               --node-compat                                Enable node.js compatibility  [boolean]
+              --experimental-enable-local-persistence      Enable persistence for this session (only for local mode)  [boolean]
+              --inspect                                    Enable dev tools  [deprecated] [boolean]
         [31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot enough arguments following: site[0m
 
         ",
           "out": "",
           "warn": "",
+        }
+      `);
+    });
+  });
+
+  describe("--inspect", () => {
+    it("should warn if --inspect is used", async () => {
+      fs.writeFileSync("index.js", `export default {};`);
+      await runWrangler("dev index.js --inspect");
+      expect(std).toMatchInlineSnapshot(`
+        Object {
+          "debug": "",
+          "err": "",
+          "out": "",
+          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mPassing --inspect is unnecessary, now you can always connect to devtools.[0m
+
+        ",
         }
       `);
     });

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -753,10 +753,6 @@ export async function main(argv: string[]): Promise<void> {
           type: "boolean",
           default: false, // I bet this will a point of contention. We'll revisit it.
         })
-        .option("experimental-enable-local-persistence", {
-          describe: "Enable persistence for this session (only for local mode)",
-          type: "boolean",
-        })
         .option("minify", {
           describe: "Minify the script",
           type: "boolean",
@@ -764,6 +760,15 @@ export async function main(argv: string[]): Promise<void> {
         .option("node-compat", {
           describe: "Enable node.js compatibility",
           type: "boolean",
+        })
+        .option("experimental-enable-local-persistence", {
+          describe: "Enable persistence for this session (only for local mode)",
+          type: "boolean",
+        })
+        .option("inspect", {
+          describe: "Enable dev tools",
+          type: "boolean",
+          deprecated: true,
         });
     },
     async (args) => {
@@ -773,6 +778,12 @@ export async function main(argv: string[]): Promise<void> {
         (args.script && findWranglerToml(path.dirname(args.script)));
       const config = readConfig(configPath, args);
       const entry = await getEntry(args, config, "dev");
+
+      if (args.inspect) {
+        logger.warn(
+          "Passing --inspect is unnecessary, now you can always connect to devtools."
+        );
+      }
 
       if (args["experimental-public"]) {
         logger.warn(


### PR DESCRIPTION
We have a blogposts and docs that says you need to pass `--inspect` to use devtools and/or profile your Worker. In wrangler v2, we don't need to pass the flag anymore. Using it right now will throw an error, so this patch makes it a simple warning instead.