### PR TITLE
fix: don't crash when tail event is null

### DIFF
--- a/.changeset/khaki-starfishes-draw.md
+++ b/.changeset/khaki-starfishes-draw.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: don't crash when tail event is null
+
+Sometime the "event" on a tail can be null. This patch makes sure we don't crash when that happens. Fixes https://github.com/cloudflare/wrangler2/issues/918

--- a/packages/wrangler/src/tail/index.ts
+++ b/packages/wrangler/src/tail/index.ts
@@ -179,7 +179,7 @@ export type TailEventMessage = {
    * Until workers-types exposes individual types for export, we'll have
    * to just re-define these types ourselves.
    */
-  event: RequestEvent | ScheduledEvent;
+  event: RequestEvent | ScheduledEvent | undefined | null;
 };
 
 /**

--- a/packages/wrangler/src/tail/printing.ts
+++ b/packages/wrangler/src/tail/printing.ts
@@ -15,12 +15,16 @@ export function prettyPrintLogs(data: WebSocket.RawData): void {
 
     logger.log(`"${cronPattern}" @ ${datetime} - ${outcome}`);
   } else {
-    const requestMethod = eventMessage.event.request.method.toUpperCase();
-    const url = eventMessage.event.request.url;
+    const requestMethod = eventMessage.event?.request.method.toUpperCase();
+    const url = eventMessage.event?.request.url;
     const outcome = prettifyOutcome(eventMessage.outcome);
     const datetime = new Date(eventMessage.eventTimestamp).toLocaleString();
 
-    logger.log(`${requestMethod} ${url} - ${outcome} @ ${datetime}`);
+    logger.log(
+      url
+        ? `${requestMethod} ${url} - ${outcome} @ ${datetime}`
+        : `[missing request] - ${outcome} @ ${datetime}`
+    );
   }
 
   if (eventMessage.logs.length > 0) {
@@ -41,9 +45,9 @@ export function jsonPrintLogs(data: WebSocket.RawData): void {
 }
 
 function isScheduledEvent(
-  event: RequestEvent | ScheduledEvent
+  event: RequestEvent | ScheduledEvent | undefined | null
 ): event is ScheduledEvent {
-  return "cron" in event;
+  return Boolean(event && "cron" in event);
 }
 
 function prettifyOutcome(outcome: Outcome): string {


### PR DESCRIPTION
Sometime the "event" on a tail can be null. This patch makes sure we don't crash when that happens. Fixes https://github.com/cloudflare/wrangler2/issues/918