### PR TITLE
chore: don't minify bundles

### DIFF
--- a/.changeset/popular-ants-walk.md
+++ b/.changeset/popular-ants-walk.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+chore: don't minify bundles
+
+When errors in wrangler happen, it's hard to tell where the error is coming from in a minified bundle. This patch removes the minification. We still set `process.env.NODE_ENV = 'production'` in the bundle so we don't run dev-only paths in things like React.
+
+This adds about 2 mb to the bundle, but imo it's worth it.

--- a/packages/wrangler/scripts/bundle.ts
+++ b/packages/wrangler/scripts/bundle.ts
@@ -11,7 +11,6 @@ async function run() {
     outdir: "./wrangler-dist",
     platform: "node",
     format: "cjs",
-    minify: true,
     external: [
       "fsevents",
       "esbuild",
@@ -27,6 +26,7 @@ async function run() {
     inject: [path.join(__dirname, "../import_meta_url.js")],
     define: {
       "import.meta.url": "import_meta_url",
+      "process.env.NODE_ENV": '"production"',
     },
   });
 
@@ -37,9 +37,11 @@ async function run() {
     outfile: "./miniflare-dist/index.mjs",
     platform: "node",
     format: "esm",
-    minify: true,
     external: ["miniflare", "@miniflare/core"],
     sourcemap: process.env.SOURCEMAPS !== "false",
+    define: {
+      "process.env.NODE_ENV": '"production"',
+    },
   });
 }
 


### PR DESCRIPTION
When errors in wrangler happen, it's hard to tell where the error is coming from in a minified bundle. This patch removes the minification. We still set `process.env.NODE_ENV = 'production'` in the bundle so we don't run dev-only paths in things like React.

This adds about 2 mb to the bundle, but imo it's worth it.