### PR TITLE
fix: with`wrangler init`, test for existence of `package.json`/ `tsconfig.json` / `.git` in the right locations

### DIFF
--- a/.changeset/fresh-dots-explode.md
+++ b/.changeset/fresh-dots-explode.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: with`wrangler init`, test for existence of `package.json`/ `tsconfig.json` / `.git` in the right locations
+
+When running `wrangler.init`, we look for the existence of `package.json`, / `tsconfig.json` / `.git` when deciding whether we should create them ourselves or not. Because `name` can be a relative path, we had a bug where we don't starting look from the right directory. We also had a bug where we weren't even testing for the existence of the `.git` directory correctly. This patch fixes that initial starting location, tests for `.git` as a directory, and correctly decides when to create those files.

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -390,7 +390,9 @@ export async function main(argv: string[]): Promise<void> {
 
       const yesFlag = args.yes ?? false;
 
-      const isInsideGitProject = Boolean(await findUp(".git"));
+      const isInsideGitProject = Boolean(
+        await findUp(".git", { cwd: creationDirectory, type: "directory" })
+      );
       const isGitInstalled = (await execa("git", ["--version"])).exitCode === 0;
       if (!isInsideGitProject && isGitInstalled) {
         const shouldInitGit =
@@ -406,7 +408,9 @@ export async function main(argv: string[]): Promise<void> {
         }
       }
 
-      let pathToPackageJson = await findUp("package.json");
+      let pathToPackageJson = await findUp("package.json", {
+        cwd: creationDirectory,
+      });
       let shouldCreatePackageJson = false;
 
       if (!pathToPackageJson) {
@@ -466,7 +470,9 @@ export async function main(argv: string[]): Promise<void> {
       }
 
       let isTypescriptProject = false;
-      let pathToTSConfig = await findUp("tsconfig.json");
+      let pathToTSConfig = await findUp("tsconfig.json", {
+        cwd: creationDirectory,
+      });
       if (!pathToTSConfig) {
         // If there's no tsconfig, offer to create one
         // and install @cloudflare/workers-types


### PR DESCRIPTION
When running `wrangler.init`, we look for the existence of `package.json`, / `tsconfig.json` / `.git` when deciding whether we should create them ourselves or not. Because `name` can be a relative path, we had a bug where we don't starting look from the right directory. We also had a bug where we weren't even testing for the existence of the `.git` directory correctly. This patch fixes that initial starting location, tests for `.git` as a directory, and correctly decides when to create those files.