### PR TITLE
fix: log proper response status codes in `dev`

### DIFF
--- a/.changeset/mighty-hats-sleep.md
+++ b/.changeset/mighty-hats-sleep.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: log proper response status codes in `dev`
+
+During `dev` we log the method/url/statuscode for every req+res. This fix logs the correct details for every request.
+
+Fixes https://github.com/cloudflare/wrangler2/issues/931

--- a/packages/wrangler/src/proxy.ts
+++ b/packages/wrangler/src/proxy.ts
@@ -210,6 +210,10 @@ export function usePreviewServer({
       const request = message.pipe(remote.request(headers));
       request.on("response", (responseHeaders) => {
         const status = responseHeaders[":status"] ?? 500;
+
+        // log all requests to terminal
+        logger.log(new Date().toLocaleTimeString(), method, url, status);
+
         rewriteRemoteHostToLocalHostInHeaders(
           responseHeaders,
           previewToken.host,
@@ -349,15 +353,6 @@ async function createProxyServer(
       : createHttpServer();
 
   return server
-    .on("request", function (req, res) {
-      // log all requests
-      logger.log(
-        new Date().toLocaleTimeString(),
-        req.method,
-        req.url,
-        res.statusCode
-      );
-    })
     .on("upgrade", (req) => {
       // log all websocket connections
       logger.log(


### PR DESCRIPTION
During `dev` we log the method/url/statuscode for every req+res. This fix logs the correct details for every request.

Fixes https://github.com/cloudflare/wrangler2/issues/931