### PR TITLE
Suppress beta warning when operating in Pages' CI environment

### DIFF
--- a/.changeset/weak-mangos-admire.md
+++ b/.changeset/weak-mangos-admire.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Suppress beta warning when operating in Pages' CI environment

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -82,6 +82,8 @@ const PAGES_CONFIG_CACHE_FILENAME = "pages.json";
 export const pagesBetaWarning =
   "🚧 'wrangler pages <command>' is a beta command. Please report any issues to https://github.com/cloudflare/wrangler2/issues/new/choose";
 
+const isInPagesCI = !!process.env.CF_PAGES;
+
 const CLEANUP_CALLBACKS: (() => void)[] = [];
 const CLEANUP = () => {
   CLEANUP_CALLBACKS.forEach((callback) => callback());
@@ -1581,8 +1583,10 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
           watch,
           plugin,
         }) => {
-          // Beta message for `wrangler pages <commands>` usage
-          logger.log(pagesBetaWarning);
+          if (!isInPagesCI) {
+            // Beta message for `wrangler pages <commands>` usage
+            logger.log(pagesBetaWarning);
+          }
 
           await buildFunctions({
             outfile,


### PR DESCRIPTION
We've had a couple of people flagging this as weird to show up in our official prod build image logs. This PR suppresses those warnings for the `wrangler build functions` command that we run to generate their Functions Worker.

![image](https://user-images.githubusercontent.com/8484333/167395677-f490438c-6ed8-4ed8-9834-a10f02da20d4.png)

Fixes #855 