### PR TITLE
fix: support Windows line-endings in TOML files

### DIFF
--- a/.changeset/wise-lies-visit.md
+++ b/.changeset/wise-lies-visit.md
@@ -1,0 +1,15 @@
+---
+"wrangler": patch
+---
+
+fix: support Windows line-endings in TOML files
+
+The TOML parser that Wrangler uses crashes if there is a Windows line-ending in a comment.
+See https://github.com/iarna/iarna-toml/issues/33.
+
+According to the TOML spec, we should be able to normalize line-endings as we see fit.
+See https://toml.io/en/v1.0.0#:~:text=normalize%20newline%20to%20whatever%20makes%20sense.
+
+This change normalizes line-endings of TOML strings before parsing to avoid hitting this bug.
+
+Fixes https://github.com/cloudflare/wrangler2/issues/915

--- a/packages/wrangler/src/__tests__/parse.test.ts
+++ b/packages/wrangler/src/__tests__/parse.test.ts
@@ -165,6 +165,10 @@ describe("parseTOML", () => {
       });
     }
   });
+
+  it("should cope with Windows line-endings", () => {
+    expect(parseTOML("# A comment with a Windows line-ending\r\n")).toEqual({});
+  });
 });
 
 describe("parseJSON", () => {

--- a/packages/wrangler/src/parse.ts
+++ b/packages/wrangler/src/parse.ts
@@ -77,7 +77,9 @@ type TomlError = Error & {
  */
 export function parseTOML(input: string, file?: string): TOML.JsonMap | never {
   try {
-    return TOML.parse(input);
+    // Normalize CRLF to LF to avoid hitting https://github.com/iarna/iarna-toml/issues/33.
+    const normalizedInput = input.replace(/\r\n$/g, "\n");
+    return TOML.parse(normalizedInput);
   } catch (err) {
     const { name, message, line, col } = err as TomlError;
     if (name !== TOML_ERROR_NAME) {


### PR DESCRIPTION
The TOML parser that Wrangler uses crashes if there is a Windows line-ending in a comment.
See https://github.com/iarna/iarna-toml/issues/33.

According to the TOML spec, we should be able to normalize line-endings as we see fit.
See https://toml.io/en/v1.0.0#:~:text=normalize%20newline%20to%20whatever%20makes%20sense.

This change normalizes line-endings of TOML strings before parsing to avoid hitting this bug.

Fixes https://github.com/cloudflare/wrangler2/issues/915