### PR TITLE
Revert "Use bulk upload api for 'pages publish'"

### DIFF
--- a/.changeset/beige-carpets-return.md
+++ b/.changeset/beige-carpets-return.md
@@ -1,7 +1,0 @@
----
-"wrangler": patch
----
-
-feat: Use new bulk upload API for 'wrangler pages publish'
-
-This will improve upload speed and reliability of 'pages publish'.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7964,11 +7964,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
-    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -15615,32 +15610,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-queue": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.2.0.tgz",
-      "integrity": "sha512-Kvv7p13M46lTYLQ/PsZdaj/1Vj6u/8oiIJgyQyx4oVkOfHdd7M2EZvXigDvcsSzRwanCzQirV5bJPQFoSQt5MA==",
-      "dependencies": {
-        "eventemitter3": "^4.0.7",
-        "p-timeout": "^5.0.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-timeout": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.0.2.tgz",
-      "integrity": "sha512-sEmji9Yaq+Tw+STwsGAE56hf7gMy9p0tQfJojIAamB7WHJYJKf1qlsg9jqBWG8q9VCxKPhZaP/AcXwEoBcYQhQ==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "license": "MIT",
@@ -20342,7 +20311,6 @@
         "esbuild": "0.14.34",
         "miniflare": "2.4.0",
         "nanoid": "^3.3.3",
-        "p-queue": "^7.2.0",
         "path-to-regexp": "^6.2.0",
         "selfsigned": "^2.0.1",
         "semiver": "^1.1.0",
@@ -26281,11 +26249,6 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
-    "eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
-    },
     "events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -31511,20 +31474,6 @@
         "aggregate-error": "^3.0.0"
       }
     },
-    "p-queue": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.2.0.tgz",
-      "integrity": "sha512-Kvv7p13M46lTYLQ/PsZdaj/1Vj6u/8oiIJgyQyx4oVkOfHdd7M2EZvXigDvcsSzRwanCzQirV5bJPQFoSQt5MA==",
-      "requires": {
-        "eventemitter3": "^4.0.7",
-        "p-timeout": "^5.0.2"
-      }
-    },
-    "p-timeout": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.0.2.tgz",
-      "integrity": "sha512-sEmji9Yaq+Tw+STwsGAE56hf7gMy9p0tQfJojIAamB7WHJYJKf1qlsg9jqBWG8q9VCxKPhZaP/AcXwEoBcYQhQ=="
-    },
     "p-try": {
       "version": "2.2.0"
     },
@@ -35004,7 +34953,6 @@
         "miniflare": "2.4.0",
         "nanoid": "^3.3.3",
         "open": "^8.4.0",
-        "p-queue": "*",
         "path-to-regexp": "^6.2.0",
         "pretty-bytes": "^6.0.0",
         "prompts": "^2.4.2",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -42,7 +42,6 @@
     "esbuild": "0.14.34",
     "miniflare": "2.4.0",
     "nanoid": "^3.3.3",
-    "p-queue": "^7.2.0",
     "path-to-regexp": "^6.2.0",
     "selfsigned": "^2.0.1",
     "semiver": "^1.1.0",
@@ -130,7 +129,7 @@
     "testTimeout": 30000,
     "testRegex": ".*.(test|spec)\\.[jt]sx?$",
     "transformIgnorePatterns": [
-      "node_modules/(?!find-up|locate-path|p-locate|p-limit|p-timeout|p-queue|yocto-queue|path-exists|execa|strip-final-newline|npm-run-path|path-key|onetime|mimic-fn|human-signals|is-stream|get-port|supports-color|pretty-bytes)"
+      "node_modules/(?!find-up|locate-path|p-locate|p-limit|yocto-queue|path-exists|execa|strip-final-newline|npm-run-path|path-key|onetime|mimic-fn|human-signals|is-stream|get-port|supports-color|pretty-bytes)"
     ],
     "moduleNameMapper": {
       "clipboardy": "<rootDir>/src/__tests__/helpers/clipboardy-mock.js",

--- a/packages/wrangler/src/__tests__/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages.test.ts
@@ -1,10 +1,11 @@
-import { mkdirSync, writeFileSync } from "node:fs";
+import { writeFileSync } from "node:fs";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { setMockResponse, unsetAllMocks } from "./helpers/mock-cfetch";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import type { Project, Deployment } from "../pages";
+import type { File, FormData } from "undici";
 
 describe("pages", () => {
   runInTempDir();
@@ -277,59 +278,44 @@ describe("pages", () => {
     });
 
     it("should upload a directory of files", async () => {
-      mkdirSync("assets");
-      writeFileSync("assets/logo.png", "foobar");
+      writeFileSync("logo.png", "foobar");
 
       setMockResponse(
-        "/accounts/:accountId/pages/projects/foo/upload-token",
-        async ([_url, accountId]) => {
+        "/accounts/:accountId/pages/projects/foo/file",
+        async ([_url, accountId], init) => {
           expect(accountId).toEqual("some-account-id");
+          expect(init.method).toEqual("POST");
+          const body = init.body as FormData;
+          const logoPNGFile = body.get("file") as File;
+          expect(await logoPNGFile.text()).toEqual("foobar");
+          expect(logoPNGFile.name).toEqual("logo.png");
 
           return {
-            jwt: "ey.my.jwt",
+            id: "2082190357cfd3617ccfe04f340c6247",
           };
         }
       );
 
-      // setMockResponse(
-      //   "/accounts/:accountId/pages/projects/foo/file",
-      //   async ([_url, accountId], init) => {
-      //     expect(accountId).toEqual("some-account-id");
-      //     expect(init.method).toEqual("POST");
-      //     const body = init.body as FormData;
-      //     const logoPNGFile = body.get("file") as File;
-      //     expect(await logoPNGFile.text()).toEqual("foobar");
-      //     expect(logoPNGFile.name).toEqual("logo.png");
+      setMockResponse(
+        "/accounts/:accountId/pages/projects/foo/deployments",
+        async ([_url, accountId], init) => {
+          expect(accountId).toEqual("some-account-id");
+          expect(init.method).toEqual("POST");
+          const body = init.body as FormData;
+          const manifest = JSON.parse(body.get("manifest") as string);
+          expect(manifest).toMatchInlineSnapshot(`
+            Object {
+              "/logo.png": "2082190357cfd3617ccfe04f340c6247",
+            }
+          `);
 
-      //     return {
-      //       id: "2082190357cfd3617ccfe04f340c6247",
-      //     };
-      //   }
-      // );
+          return {
+            url: "https://abcxyz.foo.pages.dev/",
+          };
+        }
+      );
 
-      // setMockResponse(
-      //   "/accounts/:accountId/pages/projects/foo/deployments",
-      //   async ([_url, accountId], init) => {
-      //     expect(accountId).toEqual("some-account-id");
-      //     expect(init.method).toEqual("POST");
-      //     const body = init.body as FormData;
-      //     const manifest = JSON.parse(body.get("manifest") as string);
-      //     expect(manifest).toMatchInlineSnapshot(`
-      //       Object {
-      //         "/logo.png": "2082190357cfd3617ccfe04f340c6247",
-      //       }
-      //     `);
-
-      //     return {
-      //       url: "https://abcxyz.foo.pages.dev/",
-      //     };
-      //   }
-      // );
-
-      // TODO: I think p-queue broke jest a bit.
-      // It's complaining that `Jest worker encountered 4 child process exceptions, exceeding retry limit`.
-
-      // await runWrangler("pages publish assets --project-name=foo");
+      await runWrangler("pages publish . --project-name=foo");
 
       // TODO: Unmounting somehow loses this output
 


### PR DESCRIPTION
We're backing out of cloudflare/wrangler2#940. Bulk upload proves slower than the previous single-file upload, so until we work out how to improve this, we'll stick with the 1k file limit and single-file uploading.