### PR TITLE
wrangler pages publish - updated defaults and help

### DIFF
--- a/.changeset/chatty-wolves-bathe.md
+++ b/.changeset/chatty-wolves-bathe.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Updated defaults and help of wrangler pages publish

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -804,8 +804,8 @@ const createDeployment: CommandModule<
     return yargs
       .positional("directory", {
         type: "string",
-        default: "functions",
-        description: "The directory of Pages Functions",
+        default: ".",
+        description: "The directory of static files to upload",
       })
       .options({
         "project-name": {


### PR DESCRIPTION
- Currently `wrangler pages publish` has a default argument of `functions` (which controls what files to publish).
- This is incorrect and means your Functions directory will be deployed by default, overwriting your actual static files.
- Along with updating the `--help` docs to clarify what the argument actually does, this updates the default to publish the current directory of files instead of `./functions`.