### PR TITLE
Fix 'pages publish' defaults

### DIFF
--- a/.changeset/chatty-wolves-bathe.md
+++ b/.changeset/chatty-wolves-bathe.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Updated defaults and help of wrangler pages publish

--- a/packages/wrangler/src/__tests__/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages.test.ts
@@ -258,7 +258,7 @@ describe("pages", () => {
         🆙 Publish a directory of static assets as a Pages deployment
 
         Positionals:
-          directory  The directory of Pages Functions  [string] [default: \\"functions\\"]
+          directory  The directory of static files to upload  [string]
 
         Flags:
           -c, --config      Path to .toml configuration file  [string]
@@ -267,11 +267,11 @@ describe("pages", () => {
               --legacy-env  Use legacy environments  [boolean]
 
         Options:
-              --project-name    The name of the project you want to list deployments for  [string]
-              --branch          The branch of the project you want to list deployments for  [string]
-              --commit-hash     The branch of the project you want to list deployments for  [string]
-              --commit-message  The branch of the project you want to list deployments for  [string]
-              --commit-dirty    The branch of the project you want to list deployments for  [boolean]
+              --project-name    The name of the project you want to deploy to  [string]
+              --branch          The name of the branch you want to deploy to  [string]
+              --commit-hash     The SHA to attach to this deployment  [string]
+              --commit-message  The commit message to attach to this deployment  [string]
+              --commit-dirty    Whether or not the workspace should be considered dirty for this deployment  [boolean]
 
         🚧 'wrangler pages <command>' is a beta command. Please report any issues to https://github.com/cloudflare/wrangler2/issues/new/choose"
       `);

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -804,34 +804,30 @@ const createDeployment: CommandModule<
     return yargs
       .positional("directory", {
         type: "string",
-        default: ".",
+        demandOption: true,
         description: "The directory of static files to upload",
       })
       .options({
         "project-name": {
           type: "string",
-          description:
-            "The name of the project you want to list deployments for",
+          description: "The name of the project you want to deploy to",
         },
         branch: {
           type: "string",
-          description:
-            "The branch of the project you want to list deployments for",
+          description: "The name of the branch you want to deploy to",
         },
         "commit-hash": {
           type: "string",
-          description:
-            "The branch of the project you want to list deployments for",
+          description: "The SHA to attach to this deployment",
         },
         "commit-message": {
           type: "string",
-          description:
-            "The branch of the project you want to list deployments for",
+          description: "The commit message to attach to this deployment",
         },
         "commit-dirty": {
           type: "boolean",
           description:
-            "The branch of the project you want to list deployments for",
+            "Whether or not the workspace should be considered dirty for this deployment",
         },
       })
       .epilogue(pagesBetaWarning);
@@ -844,6 +840,10 @@ const createDeployment: CommandModule<
     commitMessage,
     commitDirty,
   }) => {
+    if (!directory) {
+      throw new FatalError("Must specify a directory.", 1);
+    }
+
     const config = getConfigCache<PagesConfigCache>(
       PAGES_CONFIG_CACHE_FILENAME
     );

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -804,8 +804,8 @@ const createDeployment: CommandModule<
     return yargs
       .positional("directory", {
         type: "string",
-        default: "functions",
-        description: "The directory of Pages Functions",
+        default: ".",
+        description: "The directory of static files to upload",
       })
       .options({
         "project-name": {


### PR DESCRIPTION
Thanks @isaac-mcfadyen !

This makes the directory required for `wrangler pages publish` and also improves the help messaging of the CLI args.