### PR TITLE
fix: look for an alternate port in the dev command if the configured one is in use

### DIFF
--- a/.changeset/ninety-donkeys-reflect.md
+++ b/.changeset/ninety-donkeys-reflect.md
@@ -1,0 +1,10 @@
+---
+"wrangler": patch
+---
+
+fix: look for an alternate port in the dev command if the configured one is in use
+
+Previously, we were only calling `getPort()` if the configured port was undefined.
+But since we were setting the default for this during validation, it was never undefined.
+
+Fixes [#949](https://github.com/cloudflare/wrangler2/issues/949)

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -27,7 +27,7 @@ describe("normalizeAndValidateConfig()", () => {
       dev: {
         ip: "localhost",
         local_protocol: "http",
-        port: 8787,
+        port: undefined, // the default of 8787 is set at runtime
         upstream_protocol: "https",
         host: undefined,
       },

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import getPort from "get-port";
 import patchConsole from "patch-console";
 import dedent from "ts-dedent";
 import Dev from "../dev/dev";
@@ -574,6 +575,95 @@ describe("wrangler dev", () => {
       fs.writeFileSync("index.js", `export default {};`);
       await runWrangler("dev --ip=0.0.0.0");
       expect((Dev as jest.Mock).mock.calls[0][0].ip).toEqual("0.0.0.0");
+      expect(std.out).toMatchInlineSnapshot(`""`);
+      expect(std.warn).toMatchInlineSnapshot(`""`);
+      expect(std.err).toMatchInlineSnapshot(`""`);
+    });
+  });
+
+  describe("port", () => {
+    it("should default port to 8787", async () => {
+      writeWranglerToml({
+        main: "index.js",
+      });
+      fs.writeFileSync("index.js", `export default {};`);
+      await runWrangler("dev");
+      expect((Dev as jest.Mock).mock.calls[0][0].port).toEqual(8787);
+      expect(std.out).toMatchInlineSnapshot(`""`);
+      expect(std.warn).toMatchInlineSnapshot(`""`);
+      expect(std.err).toMatchInlineSnapshot(`""`);
+    });
+
+    it("should use to `port` from `wrangler.toml`, if available", async () => {
+      writeWranglerToml({
+        main: "index.js",
+        dev: {
+          port: 8888,
+        },
+      });
+      fs.writeFileSync("index.js", `export default {};`);
+      await runWrangler("dev");
+      expect((Dev as jest.Mock).mock.calls[0][0].port).toEqual(8888);
+      expect(std.out).toMatchInlineSnapshot(`""`);
+      expect(std.warn).toMatchInlineSnapshot(`""`);
+      expect(std.err).toMatchInlineSnapshot(`""`);
+    });
+
+    it("should use --port command line arg, if provided", async () => {
+      writeWranglerToml({
+        main: "index.js",
+        dev: {
+          port: 8888,
+        },
+      });
+      fs.writeFileSync("index.js", `export default {};`);
+      await runWrangler("dev --port=9999");
+      expect((Dev as jest.Mock).mock.calls[0][0].port).toEqual(9999);
+      expect(std.out).toMatchInlineSnapshot(`""`);
+      expect(std.warn).toMatchInlineSnapshot(`""`);
+      expect(std.err).toMatchInlineSnapshot(`""`);
+    });
+
+    it("should use a different port to the command line arg if it is in use", async () => {
+      writeWranglerToml({
+        main: "index.js",
+      });
+      fs.writeFileSync("index.js", `export default {};`);
+      // Mock `getPort()` to resolve to a completely different port.
+      (getPort as jest.Mock).mockResolvedValue(12345);
+      await runWrangler("dev --port=9999");
+      expect((Dev as jest.Mock).mock.calls[0][0].port).toEqual(12345);
+      expect(std.out).toMatchInlineSnapshot(`""`);
+      expect(std.warn).toMatchInlineSnapshot(`""`);
+      expect(std.err).toMatchInlineSnapshot(`""`);
+    });
+
+    it("should use a different port to the configured port if it is in use", async () => {
+      writeWranglerToml({
+        main: "index.js",
+        dev: {
+          port: 8888,
+        },
+      });
+      fs.writeFileSync("index.js", `export default {};`);
+      // Mock `getPort()` to resolve to a completely different port.
+      (getPort as jest.Mock).mockResolvedValue(246810);
+      await runWrangler("dev");
+      expect((Dev as jest.Mock).mock.calls[0][0].port).toEqual(246810);
+      expect(std.out).toMatchInlineSnapshot(`""`);
+      expect(std.warn).toMatchInlineSnapshot(`""`);
+      expect(std.err).toMatchInlineSnapshot(`""`);
+    });
+
+    it("should use a different port to the default if it is in use", async () => {
+      writeWranglerToml({
+        main: "index.js",
+      });
+      fs.writeFileSync("index.js", `export default {};`);
+      // Mock `getPort()` to resolve to a completely different port.
+      (getPort as jest.Mock).mockResolvedValue(98765);
+      await runWrangler("dev");
+      expect((Dev as jest.Mock).mock.calls[0][0].port).toEqual(98765);
       expect(std.out).toMatchInlineSnapshot(`""`);
       expect(std.warn).toMatchInlineSnapshot(`""`);
       expect(std.err).toMatchInlineSnapshot(`""`);

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -582,7 +582,7 @@ describe("wrangler dev", () => {
   });
 
   describe("port", () => {
-    it("should default port to 8787", async () => {
+    it("should default port to 8787 if it is not in use", async () => {
       writeWranglerToml({
         main: "index.js",
       });
@@ -602,6 +602,9 @@ describe("wrangler dev", () => {
         },
       });
       fs.writeFileSync("index.js", `export default {};`);
+      // Mock `getPort()` to resolve to a completely different port.
+      (getPort as jest.Mock).mockResolvedValue(98765);
+
       await runWrangler("dev");
       expect((Dev as jest.Mock).mock.calls[0][0].port).toEqual(8888);
       expect(std.out).toMatchInlineSnapshot(`""`);
@@ -617,39 +620,11 @@ describe("wrangler dev", () => {
         },
       });
       fs.writeFileSync("index.js", `export default {};`);
+      // Mock `getPort()` to resolve to a completely different port.
+      (getPort as jest.Mock).mockResolvedValue(98765);
+
       await runWrangler("dev --port=9999");
       expect((Dev as jest.Mock).mock.calls[0][0].port).toEqual(9999);
-      expect(std.out).toMatchInlineSnapshot(`""`);
-      expect(std.warn).toMatchInlineSnapshot(`""`);
-      expect(std.err).toMatchInlineSnapshot(`""`);
-    });
-
-    it("should use a different port to the command line arg if it is in use", async () => {
-      writeWranglerToml({
-        main: "index.js",
-      });
-      fs.writeFileSync("index.js", `export default {};`);
-      // Mock `getPort()` to resolve to a completely different port.
-      (getPort as jest.Mock).mockResolvedValue(12345);
-      await runWrangler("dev --port=9999");
-      expect((Dev as jest.Mock).mock.calls[0][0].port).toEqual(12345);
-      expect(std.out).toMatchInlineSnapshot(`""`);
-      expect(std.warn).toMatchInlineSnapshot(`""`);
-      expect(std.err).toMatchInlineSnapshot(`""`);
-    });
-
-    it("should use a different port to the configured port if it is in use", async () => {
-      writeWranglerToml({
-        main: "index.js",
-        dev: {
-          port: 8888,
-        },
-      });
-      fs.writeFileSync("index.js", `export default {};`);
-      // Mock `getPort()` to resolve to a completely different port.
-      (getPort as jest.Mock).mockResolvedValue(246810);
-      await runWrangler("dev");
-      expect((Dev as jest.Mock).mock.calls[0][0].port).toEqual(246810);
       expect(std.out).toMatchInlineSnapshot(`""`);
       expect(std.warn).toMatchInlineSnapshot(`""`);
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -662,6 +637,7 @@ describe("wrangler dev", () => {
       fs.writeFileSync("index.js", `export default {};`);
       // Mock `getPort()` to resolve to a completely different port.
       (getPort as jest.Mock).mockResolvedValue(98765);
+
       await runWrangler("dev");
       expect((Dev as jest.Mock).mock.calls[0][0].port).toEqual(98765);
       expect(std.out).toMatchInlineSnapshot(`""`);

--- a/packages/wrangler/src/__tests__/jest.setup.ts
+++ b/packages/wrangler/src/__tests__/jest.setup.ts
@@ -8,6 +8,14 @@ import { confirm, prompt } from "../dialogs";
 import { mockFetchInternal, mockFetchKVGetValue } from "./helpers/mock-cfetch";
 import { MockWebSocket } from "./helpers/mock-web-socket";
 
+// Mock out getPort since we don't actually care about what ports are open in unit tests.
+jest.mock("get-port", () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(async (options) => options.port),
+  };
+});
+
 jest.mock("ws", () => {
   return {
     __esModule: true,

--- a/packages/wrangler/src/config/config.ts
+++ b/packages/wrangler/src/config/config.ts
@@ -161,7 +161,7 @@ export interface DevConfig {
    *
    * @default `8787`
    */
-  port: number;
+  port: number | undefined;
 
   /**
    * Protocol that local wrangler dev server listens to requests on.

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -352,7 +352,7 @@ function normalizeAndValidateDev(
 ): DevConfig {
   const {
     ip = "localhost",
-    port = 8787,
+    port,
     local_protocol = "http",
     upstream_protocol = "https",
     host,

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -73,6 +73,7 @@ type ConfigPath = string | undefined;
 
 const resetColor = "\x1b[0m";
 const fgGreenColor = "\x1b[32m";
+const DEFAULT_LOCAL_PORT = 8787;
 
 function getRules(config: Config): Config["rules"] {
   const rules = config.rules ?? config.build?.upload?.rules ?? [];
@@ -1026,7 +1027,11 @@ export async function main(argv: string[]): Promise<void> {
             args.siteInclude,
             args.siteExclude
           )}
-          port={await getPort({ port: args.port || config.dev.port })}
+          port={
+            args.port ||
+            config.dev.port ||
+            (await getPort({ port: DEFAULT_LOCAL_PORT }))
+          }
           ip={args.ip || config.dev.ip}
           inspectorPort={
             args["inspector-port"] ?? (await getPort({ port: 9229 }))
@@ -1474,7 +1479,9 @@ export async function main(argv: string[]): Promise<void> {
           enableLocalPersistence={false}
           accountId={accountId}
           assetPaths={undefined}
-          port={await getPort({ port: config.dev.port })}
+          port={
+            config.dev.port || (await getPort({ port: DEFAULT_LOCAL_PORT }))
+          }
           ip={config.dev.ip}
           public={undefined}
           compatibilityDate={getDevCompatibilityDate(config)}

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -995,7 +995,7 @@ export async function main(argv: string[]): Promise<void> {
       const nodeCompat = args.nodeCompat ?? config.node_compat;
       if (nodeCompat) {
         logger.warn(
-          "Enabling node.js compatibility mode for builtins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details."
+          "Enabling node.js compatibility mode for built-ins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details."
         );
       }
 
@@ -1026,9 +1026,7 @@ export async function main(argv: string[]): Promise<void> {
             args.siteInclude,
             args.siteExclude
           )}
-          port={
-            args.port || config.dev?.port || (await getPort({ port: 8787 }))
-          }
+          port={await getPort({ port: args.port || config.dev.port })}
           ip={args.ip || config.dev.ip}
           inspectorPort={
             args["inspector-port"] ?? (await getPort({ port: 9229 }))
@@ -1476,7 +1474,7 @@ export async function main(argv: string[]): Promise<void> {
           enableLocalPersistence={false}
           accountId={accountId}
           assetPaths={undefined}
-          port={config.dev?.port}
+          port={await getPort({ port: config.dev.port })}
           ip={config.dev.ip}
           public={undefined}
           compatibilityDate={getDevCompatibilityDate(config)}


### PR DESCRIPTION
Previously, we were only calling `getPort()` if the configured port was undefined.
But since we were setting the default for this during validation, it was never undefined.

Fixes [#949](https://github.com/cloudflare/wrangler2/issues/949)