### PR TITLE
feat: use host specific callback url

### DIFF
--- a/.changeset/nice-mangos-matter.md
+++ b/.changeset/nice-mangos-matter.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+feat: use host specific callback url
+
+To allow OAuth to work on environments such as WebContainer we have to generate a host-specific callback URL. This PR uses `@webcontainer/env` to generate such URL only for running in WebContainer. Otherwise the callback URL stays unmodified.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4275,6 +4275,12 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "node_modules/@webcontainer/env": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@webcontainer/env/-/env-1.0.1.tgz",
+      "integrity": "sha512-q5sD2asa7IY/elCA37zbzTH1DiiIooTuUcW9O5Zvrtfyy7PtqAmPpgpDCbWzA/fRWShfUnPp6yDzmpq5K4YtjA==",
+      "dev": true
+    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -20332,6 +20338,7 @@
         "@types/supports-color": "^8.1.1",
         "@types/ws": "^8.5.3",
         "@types/yargs": "^17.0.10",
+        "@webcontainer/env": "^1.0.1",
         "chokidar": "^3.5.3",
         "clipboardy": "^3.0.0",
         "cmd-shim": "^4.1.0",
@@ -23818,6 +23825,12 @@
         "@webassemblyjs/wast-parser": "1.9.0",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "@webcontainer/env": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@webcontainer/env/-/env-1.0.1.tgz",
+      "integrity": "sha512-q5sD2asa7IY/elCA37zbzTH1DiiIooTuUcW9O5Zvrtfyy7PtqAmPpgpDCbWzA/fRWShfUnPp6yDzmpq5K4YtjA==",
+      "dev": true
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -34925,6 +34938,7 @@
         "@types/supports-color": "^8.1.1",
         "@types/ws": "^8.5.3",
         "@types/yargs": "^17.0.10",
+        "@webcontainer/env": "*",
         "blake3-wasm": "^2.1.5",
         "chokidar": "^3.5.3",
         "clipboardy": "^3.0.0",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -62,6 +62,7 @@
     "@types/supports-color": "^8.1.1",
     "@types/ws": "^8.5.3",
     "@types/yargs": "^17.0.10",
+    "@webcontainer/env": "^1.0.1",
     "chokidar": "^3.5.3",
     "clipboardy": "^3.0.0",
     "cmd-shim": "^4.1.0",

--- a/packages/wrangler/src/user.tsx
+++ b/packages/wrangler/src/user.tsx
@@ -214,6 +214,7 @@ import path from "node:path";
 import url from "node:url";
 import { TextEncoder } from "node:util";
 import TOML from "@iarna/toml";
+import { HostURL } from "@webcontainer/env";
 import { render, Text } from "ink";
 import SelectInput from "ink-select-input";
 import Table from "ink-table";
@@ -339,8 +340,17 @@ export function validateScopeKeys(
 const CLIENT_ID = "54d11594-84e4-41aa-b438-e81b8fa78ee7";
 const AUTH_URL = "https://dash.cloudflare.com/oauth2/auth";
 const TOKEN_URL = "https://dash.cloudflare.com/oauth2/token";
-const CALLBACK_URL = "http://localhost:8976/oauth/callback";
 const REVOKE_URL = "https://dash.cloudflare.com/oauth2/revoke";
+
+/**
+ * To allow OAuth callbacks in environments such as WebContainer we need to
+ * create a host URL which only resolves `localhost` to a WebContainer
+ * hostname if the process is running in a WebContainer. On local this will
+ * be a no-op and it leaves the URL unmodified.
+ *
+ * @see https://www.npmjs.com/package/@webcontainer/env
+ */
+const CALLBACK_URL = HostURL.parse("http://localhost:8976/oauth/callback").href;
 
 let LocalState: State = getAuthTokens();
 


### PR DESCRIPTION
To allow OAuth to work on environments such as WebContainer we have to generate a host-specific callback URL. This PR uses `@webcontainer/env` to generate such URL only for running in WebContainer. Otherwise the callback URL stays unmodified.