### PR TITLE
fix: don't crash during `init` if `git` is not installed

### DIFF
--- a/.changeset/afraid-cows-count.md
+++ b/.changeset/afraid-cows-count.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: don't crash during `init` if `git` is not installed
+
+When a command isn't available on a system, calling `execa()` on it throws an error, and not just a non zero exitCode. This patches fixes the flow so we don't crash the whole process when that happens on testing the presence of `git` when calling `wrangler init`.
+
+Fixes https://github.com/cloudflare/wrangler2/issues/950

--- a/.changeset/afraid-cows-count.md
+++ b/.changeset/afraid-cows-count.md
@@ -4,6 +4,6 @@
 
 fix: don't crash during `init` if `git` is not installed
 
-When a command isn't available on a system, calling `execa()` on it throws an error, and not just a non zero exitCode. This patches fixes the flow so we don't crash the whole process when that happens on testing the presence of `git` when calling `wrangler init`.
+When a command isn't available on a system, calling `execa()` on it throws an error, and not just a non zero exitCode. This patch fixes the flow so we don't crash the whole process when that happens on testing the presence of `git` when calling `wrangler init`.
 
 Fixes https://github.com/cloudflare/wrangler2/issues/950

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -407,7 +407,17 @@ export async function main(argv: string[]): Promise<void> {
       const isInsideGitProject = Boolean(
         await findUp(".git", { cwd: creationDirectory, type: "directory" })
       );
-      const isGitInstalled = (await execa("git", ["--version"])).exitCode === 0;
+      let isGitInstalled;
+      try {
+        isGitInstalled = (await execa("git", ["--version"])).exitCode === 0;
+      } catch (err) {
+        if ((err as { code: string | undefined }).code !== "ENOENT") {
+          // only throw if the error is not because git is not installed
+          throw err;
+        } else {
+          isGitInstalled = false;
+        }
+      }
       if (!isInsideGitProject && isGitInstalled) {
         const shouldInitGit =
           yesFlag ||


### PR DESCRIPTION
When a command isn't available on a system, calling `execa()` on it throws an error, and not just a non zero exitCode. This patches fixes the flow so we don't crash the whole process when that happens on testing the presence of `git` when calling `wrangler init`.

Fixes https://github.com/cloudflare/wrangler2/issues/950

--- 

I still dunno a good way of testing this without hacks... mocking `execa` is painful. I did test this locally as well as I could, by replacing `git` with `gi` (which I'm certain doesn't exist on my machine ha)