### PR TITLE
refactor: Moving `--legacy-env` out of global

### DIFF
--- a/.changeset/hungry-bugs-marry.md
+++ b/.changeset/hungry-bugs-marry.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+refactor: Moving `--legacy-env` out of global
+The `--legacy-env` flag was in global scope, which only certain commands
+utilize the flag for functionality, and doesnt do anything for the other commands.
+
+resolves #933

--- a/package-lock.json
+++ b/package-lock.json
@@ -34938,7 +34938,7 @@
         "@types/supports-color": "^8.1.1",
         "@types/ws": "^8.5.3",
         "@types/yargs": "^17.0.10",
-        "@webcontainer/env": "*",
+        "@webcontainer/env": "^1.0.1",
         "blake3-wasm": "^2.1.5",
         "chokidar": "^3.5.3",
         "clipboardy": "^3.0.0",

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -754,10 +754,9 @@ describe("wrangler dev", () => {
           script  The path to an entry point for your worker  [string]
 
         Flags:
-          -c, --config      Path to .toml configuration file  [string]
-          -h, --help        Show help  [boolean]
-          -v, --version     Show version number  [boolean]
-              --legacy-env  Use legacy environments  [boolean]
+          -c, --config   Path to .toml configuration file  [string]
+          -h, --help     Show help  [boolean]
+          -v, --version  Show version number  [boolean]
 
         Options:
               --name                                       Name of the worker  [string]

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -44,10 +44,9 @@ describe("wrangler", () => {
           wrangler whoami            🕵️  Retrieve your user info and test your auth config
 
         Flags:
-          -c, --config      Path to .toml configuration file  [string]
-          -h, --help        Show help  [boolean]
-          -v, --version     Show version number  [boolean]
-              --legacy-env  Use legacy environments  [boolean]"
+          -c, --config   Path to .toml configuration file  [string]
+          -h, --help     Show help  [boolean]
+          -v, --version  Show version number  [boolean]"
       `);
 
       expect(std.err).toMatchInlineSnapshot(`""`);
@@ -85,10 +84,9 @@ describe("wrangler", () => {
           wrangler whoami            🕵️  Retrieve your user info and test your auth config
 
         Flags:
-          -c, --config      Path to .toml configuration file  [string]
-          -h, --help        Show help  [boolean]
-          -v, --version     Show version number  [boolean]
-              --legacy-env  Use legacy environments  [boolean]
+          -c, --config   Path to .toml configuration file  [string]
+          -h, --help     Show help  [boolean]
+          -v, --version  Show version number  [boolean]
         [31mX [41;31m[[41;97mERROR[41;31m][0m [1mUnknown argument: invalid-command[0m
 
         "
@@ -133,10 +131,9 @@ describe("wrangler", () => {
           wrangler secret list          List all secrets for a script
 
         Flags:
-          -c, --config      Path to .toml configuration file  [string]
-          -h, --help        Show help  [boolean]
-          -v, --version     Show version number  [boolean]
-              --legacy-env  Use legacy environments  [boolean]"
+          -c, --config   Path to .toml configuration file  [string]
+          -h, --help     Show help  [boolean]
+          -v, --version  Show version number  [boolean]"
       `);
     });
 
@@ -144,20 +141,19 @@ describe("wrangler", () => {
       await runWrangler("kv:namespace");
       await endEventLoop();
       expect(std.out).toMatchInlineSnapshot(`
-         "wrangler kv:namespace
+        "wrangler kv:namespace
 
-         🗂️  Interact with your Workers KV Namespaces
+        🗂️  Interact with your Workers KV Namespaces
 
-         Commands:
-           wrangler kv:namespace create <namespace>  Create a new namespace
-           wrangler kv:namespace list                Outputs a list of all KV namespaces associated with your account id.
-           wrangler kv:namespace delete              Deletes a given namespace.
+        Commands:
+          wrangler kv:namespace create <namespace>  Create a new namespace
+          wrangler kv:namespace list                Outputs a list of all KV namespaces associated with your account id.
+          wrangler kv:namespace delete              Deletes a given namespace.
 
-         Flags:
-           -c, --config      Path to .toml configuration file  [string]
-           -h, --help        Show help  [boolean]
-           -v, --version     Show version number  [boolean]
-               --legacy-env  Use legacy environments  [boolean]"
+        Flags:
+          -c, --config   Path to .toml configuration file  [string]
+          -h, --help     Show help  [boolean]
+          -v, --version  Show version number  [boolean]"
       `);
     });
 
@@ -165,60 +161,57 @@ describe("wrangler", () => {
       await runWrangler("kv:key");
       await endEventLoop();
       expect(std.out).toMatchInlineSnapshot(`
-               "wrangler kv:key
+        "wrangler kv:key
 
-               🔑 Individually manage Workers KV key-value pairs
+        🔑 Individually manage Workers KV key-value pairs
 
-               Commands:
-                 wrangler kv:key put <key> [value]  Writes a single key/value pair to the given namespace.
-                 wrangler kv:key list               Outputs a list of all keys in a given namespace.
-                 wrangler kv:key get <key>          Reads a single value by key from the given namespace.
-                 wrangler kv:key delete <key>       Removes a single key value pair from the given namespace.
+        Commands:
+          wrangler kv:key put <key> [value]  Writes a single key/value pair to the given namespace.
+          wrangler kv:key list               Outputs a list of all keys in a given namespace.
+          wrangler kv:key get <key>          Reads a single value by key from the given namespace.
+          wrangler kv:key delete <key>       Removes a single key value pair from the given namespace.
 
-               Flags:
-                 -c, --config      Path to .toml configuration file  [string]
-                 -h, --help        Show help  [boolean]
-                 -v, --version     Show version number  [boolean]
-                     --legacy-env  Use legacy environments  [boolean]"
-            `);
+        Flags:
+          -c, --config   Path to .toml configuration file  [string]
+          -h, --help     Show help  [boolean]
+          -v, --version  Show version number  [boolean]"
+      `);
     });
 
     it("no subcommand 'kv:bulk' should display a list of available subcommands", async () => {
       await runWrangler("kv:bulk");
       await endEventLoop();
       expect(std.out).toMatchInlineSnapshot(`
-               "wrangler kv:bulk
+        "wrangler kv:bulk
 
-               💪 Interact with multiple Workers KV key-value pairs at once
+        💪 Interact with multiple Workers KV key-value pairs at once
 
-               Commands:
-                 wrangler kv:bulk put <filename>     Upload multiple key-value pairs to a namespace
-                 wrangler kv:bulk delete <filename>  Delete multiple key-value pairs from a namespace
+        Commands:
+          wrangler kv:bulk put <filename>     Upload multiple key-value pairs to a namespace
+          wrangler kv:bulk delete <filename>  Delete multiple key-value pairs from a namespace
 
-               Flags:
-                 -c, --config      Path to .toml configuration file  [string]
-                 -h, --help        Show help  [boolean]
-                 -v, --version     Show version number  [boolean]
-                     --legacy-env  Use legacy environments  [boolean]"
-            `);
+        Flags:
+          -c, --config   Path to .toml configuration file  [string]
+          -h, --help     Show help  [boolean]
+          -v, --version  Show version number  [boolean]"
+      `);
     });
     it("no subcommand 'r2' should display a list of available subcommands", async () => {
       await runWrangler("r2");
       await endEventLoop();
       expect(std.out).toMatchInlineSnapshot(`
-               "wrangler r2
+        "wrangler r2
 
-               📦 Interact with an R2 store
+        📦 Interact with an R2 store
 
-               Commands:
-                 wrangler r2 bucket  Manage R2 buckets
+        Commands:
+          wrangler r2 bucket  Manage R2 buckets
 
-               Flags:
-                 -c, --config      Path to .toml configuration file  [string]
-                 -h, --help        Show help  [boolean]
-                 -v, --version     Show version number  [boolean]
-                     --legacy-env  Use legacy environments  [boolean]"
-            `);
+        Flags:
+          -c, --config   Path to .toml configuration file  [string]
+          -h, --help     Show help  [boolean]
+          -v, --version  Show version number  [boolean]"
+      `);
     });
   });
   describe("Deprecated commands", () => {

--- a/packages/wrangler/src/__tests__/kv.test.ts
+++ b/packages/wrangler/src/__tests__/kv.test.ts
@@ -59,10 +59,9 @@ describe("wrangler", () => {
             namespace  The name of the new namespace  [string] [required]
 
           Flags:
-            -c, --config      Path to .toml configuration file  [string]
-            -h, --help        Show help  [boolean]
-            -v, --version     Show version number  [boolean]
-                --legacy-env  Use legacy environments  [boolean]
+            -c, --config   Path to .toml configuration file  [string]
+            -h, --help     Show help  [boolean]
+            -v, --version  Show version number  [boolean]
 
           Options:
             -e, --env      Perform on a specific environment  [string]
@@ -92,10 +91,9 @@ describe("wrangler", () => {
             namespace  The name of the new namespace  [string] [required]
 
           Flags:
-            -c, --config      Path to .toml configuration file  [string]
-            -h, --help        Show help  [boolean]
-            -v, --version     Show version number  [boolean]
-                --legacy-env  Use legacy environments  [boolean]
+            -c, --config   Path to .toml configuration file  [string]
+            -h, --help     Show help  [boolean]
+            -v, --version  Show version number  [boolean]
 
           Options:
             -e, --env      Perform on a specific environment  [string]
@@ -126,10 +124,9 @@ describe("wrangler", () => {
             namespace  The name of the new namespace  [string] [required]
 
           Flags:
-            -c, --config      Path to .toml configuration file  [string]
-            -h, --help        Show help  [boolean]
-            -v, --version     Show version number  [boolean]
-                --legacy-env  Use legacy environments  [boolean]
+            -c, --config   Path to .toml configuration file  [string]
+            -h, --help     Show help  [boolean]
+            -v, --version  Show version number  [boolean]
 
           Options:
             -e, --env      Perform on a specific environment  [string]
@@ -291,10 +288,9 @@ describe("wrangler", () => {
           Deletes a given namespace.
 
           Flags:
-            -c, --config      Path to .toml configuration file  [string]
-            -h, --help        Show help  [boolean]
-            -v, --version     Show version number  [boolean]
-                --legacy-env  Use legacy environments  [boolean]
+            -c, --config   Path to .toml configuration file  [string]
+            -h, --help     Show help  [boolean]
+            -v, --version  Show version number  [boolean]
 
           Options:
                 --binding       The name of the namespace to delete  [string]
@@ -490,10 +486,9 @@ describe("wrangler", () => {
             value  The value to write  [string]
 
           Flags:
-            -c, --config      Path to .toml configuration file  [string]
-            -h, --help        Show help  [boolean]
-            -v, --version     Show version number  [boolean]
-                --legacy-env  Use legacy environments  [boolean]
+            -c, --config   Path to .toml configuration file  [string]
+            -h, --help     Show help  [boolean]
+            -v, --version  Show version number  [boolean]
 
           Options:
                 --binding       The binding of the namespace to write to  [string]
@@ -530,10 +525,9 @@ describe("wrangler", () => {
             value  The value to write  [string]
 
           Flags:
-            -c, --config      Path to .toml configuration file  [string]
-            -h, --help        Show help  [boolean]
-            -v, --version     Show version number  [boolean]
-                --legacy-env  Use legacy environments  [boolean]
+            -c, --config   Path to .toml configuration file  [string]
+            -h, --help     Show help  [boolean]
+            -v, --version  Show version number  [boolean]
 
           Options:
                 --binding       The binding of the namespace to write to  [string]
@@ -570,10 +564,9 @@ describe("wrangler", () => {
             value  The value to write  [string]
 
           Flags:
-            -c, --config      Path to .toml configuration file  [string]
-            -h, --help        Show help  [boolean]
-            -v, --version     Show version number  [boolean]
-                --legacy-env  Use legacy environments  [boolean]
+            -c, --config   Path to .toml configuration file  [string]
+            -h, --help     Show help  [boolean]
+            -v, --version  Show version number  [boolean]
 
           Options:
                 --binding       The binding of the namespace to write to  [string]
@@ -610,10 +603,9 @@ describe("wrangler", () => {
             value  The value to write  [string]
 
           Flags:
-            -c, --config      Path to .toml configuration file  [string]
-            -h, --help        Show help  [boolean]
-            -v, --version     Show version number  [boolean]
-                --legacy-env  Use legacy environments  [boolean]
+            -c, --config   Path to .toml configuration file  [string]
+            -h, --help     Show help  [boolean]
+            -v, --version  Show version number  [boolean]
 
           Options:
                 --binding       The binding of the namespace to write to  [string]
@@ -650,10 +642,9 @@ describe("wrangler", () => {
             value  The value to write  [string]
 
           Flags:
-            -c, --config      Path to .toml configuration file  [string]
-            -h, --help        Show help  [boolean]
-            -v, --version     Show version number  [boolean]
-                --legacy-env  Use legacy environments  [boolean]
+            -c, --config   Path to .toml configuration file  [string]
+            -h, --help     Show help  [boolean]
+            -v, --version  Show version number  [boolean]
 
           Options:
                 --binding       The binding of the namespace to write to  [string]
@@ -956,10 +947,9 @@ describe("wrangler", () => {
             key  The key value to get.  [string] [required]
 
           Flags:
-            -c, --config      Path to .toml configuration file  [string]
-            -h, --help        Show help  [boolean]
-            -v, --version     Show version number  [boolean]
-                --legacy-env  Use legacy environments  [boolean]
+            -c, --config   Path to .toml configuration file  [string]
+            -h, --help     Show help  [boolean]
+            -v, --version  Show version number  [boolean]
 
           Options:
                 --binding       The name of the namespace to get from  [string]
@@ -991,10 +981,9 @@ describe("wrangler", () => {
             key  The key value to get.  [string] [required]
 
           Flags:
-            -c, --config      Path to .toml configuration file  [string]
-            -h, --help        Show help  [boolean]
-            -v, --version     Show version number  [boolean]
-                --legacy-env  Use legacy environments  [boolean]
+            -c, --config   Path to .toml configuration file  [string]
+            -h, --help     Show help  [boolean]
+            -v, --version  Show version number  [boolean]
 
           Options:
                 --binding       The name of the namespace to get from  [string]
@@ -1027,10 +1016,9 @@ describe("wrangler", () => {
             key  The key value to get.  [string] [required]
 
           Flags:
-            -c, --config      Path to .toml configuration file  [string]
-            -h, --help        Show help  [boolean]
-            -v, --version     Show version number  [boolean]
-                --legacy-env  Use legacy environments  [boolean]
+            -c, --config   Path to .toml configuration file  [string]
+            -h, --help     Show help  [boolean]
+            -v, --version  Show version number  [boolean]
 
           Options:
                 --binding       The name of the namespace to get from  [string]

--- a/packages/wrangler/src/__tests__/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages.test.ts
@@ -30,10 +30,9 @@ describe("pages", () => {
         wrangler pages publish [directory]           🆙 Publish a directory of static assets as a Pages deployment
 
       Flags:
-        -c, --config      Path to .toml configuration file  [string]
-        -h, --help        Show help  [boolean]
-        -v, --version     Show version number  [boolean]
-            --legacy-env  Use legacy environments  [boolean]
+        -c, --config   Path to .toml configuration file  [string]
+        -h, --help     Show help  [boolean]
+        -v, --version  Show version number  [boolean]
 
       🚧 'wrangler pages <command>' is a beta command. Please report any issues to https://github.com/cloudflare/wrangler2/issues/new/choose"
     `);
@@ -261,10 +260,9 @@ describe("pages", () => {
           directory  The directory of static files to upload  [string]
 
         Flags:
-          -c, --config      Path to .toml configuration file  [string]
-          -h, --help        Show help  [boolean]
-          -v, --version     Show version number  [boolean]
-              --legacy-env  Use legacy environments  [boolean]
+          -c, --config   Path to .toml configuration file  [string]
+          -h, --help     Show help  [boolean]
+          -v, --version  Show version number  [boolean]
 
         Options:
               --project-name    The name of the project you want to deploy to  [string]

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -80,10 +80,9 @@ describe("wrangler", () => {
               name  The name of the new bucket  [string] [required]
 
             Flags:
-              -c, --config      Path to .toml configuration file  [string]
-              -h, --help        Show help  [boolean]
-              -v, --version     Show version number  [boolean]
-                  --legacy-env  Use legacy environments  [boolean]
+              -c, --config   Path to .toml configuration file  [string]
+              -h, --help     Show help  [boolean]
+              -v, --version  Show version number  [boolean]
             [31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot enough non-option arguments: got 0, need at least 1[0m
 
             "
@@ -109,10 +108,9 @@ describe("wrangler", () => {
               name  The name of the new bucket  [string] [required]
 
             Flags:
-              -c, --config      Path to .toml configuration file  [string]
-              -h, --help        Show help  [boolean]
-              -v, --version     Show version number  [boolean]
-                  --legacy-env  Use legacy environments  [boolean]
+              -c, --config   Path to .toml configuration file  [string]
+              -h, --help     Show help  [boolean]
+              -v, --version  Show version number  [boolean]
             [31mX [41;31m[[41;97mERROR[41;31m][0m [1mUnknown arguments: def, ghi[0m
 
             "
@@ -164,10 +162,9 @@ describe("wrangler", () => {
               name  The name of the bucket to delete  [string] [required]
 
             Flags:
-              -c, --config      Path to .toml configuration file  [string]
-              -h, --help        Show help  [boolean]
-              -v, --version     Show version number  [boolean]
-                  --legacy-env  Use legacy environments  [boolean]
+              -c, --config   Path to .toml configuration file  [string]
+              -h, --help     Show help  [boolean]
+              -v, --version  Show version number  [boolean]
             [31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot enough non-option arguments: got 0, need at least 1[0m
 
             "
@@ -193,10 +190,9 @@ describe("wrangler", () => {
               name  The name of the bucket to delete  [string] [required]
 
             Flags:
-              -c, --config      Path to .toml configuration file  [string]
-              -h, --help        Show help  [boolean]
-              -v, --version     Show version number  [boolean]
-                  --legacy-env  Use legacy environments  [boolean]
+              -c, --config   Path to .toml configuration file  [string]
+              -h, --help     Show help  [boolean]
+              -v, --version  Show version number  [boolean]
             [31mX [41;31m[[41;97mERROR[41;31m][0m [1mUnknown arguments: def, ghi[0m
 
             "

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -870,6 +870,11 @@ export async function main(argv: string[]): Promise<void> {
           describe: "Enable dev tools",
           type: "boolean",
           deprecated: true,
+        })
+        .option("legacy-env", {
+          type: "boolean",
+          describe: "Use legacy environments",
+          hidden: true,
         });
     },
     async (args) => {
@@ -1209,6 +1214,11 @@ export async function main(argv: string[]): Promise<void> {
         .option("dry-run", {
           describe: "Don't actually publish",
           type: "boolean",
+        })
+        .option("legacy-env", {
+          type: "boolean",
+          describe: "Use legacy environments",
+          hidden: true,
         });
     },
     async (args) => {
@@ -1330,6 +1340,11 @@ export async function main(argv: string[]): Promise<void> {
           default: false,
           describe:
             "If a log would have been filtered out, send it through anyway alongside the filter which would have blocked it.",
+        })
+        .option("legacy-env", {
+          type: "boolean",
+          describe: "Use legacy environments",
+          hidden: true,
         });
     },
     async (args) => {
@@ -1640,6 +1655,11 @@ export async function main(argv: string[]): Promise<void> {
     (secretYargs) => {
       return secretYargs
         .command(subHelp)
+        .option("legacy-env", {
+          type: "boolean",
+          describe: "Use legacy environments",
+          hidden: true,
+        })
         .command(
           "put <key>",
           "Create or update a secret variable for a script",
@@ -2609,19 +2629,14 @@ export async function main(argv: string[]): Promise<void> {
     }
   );
 
-  wrangler
-    .option("legacy-env", {
-      type: "boolean",
-      describe: "Use legacy environments",
-    })
-    .option("config", {
-      alias: "c",
-      describe: "Path to .toml configuration file",
-      type: "string",
-      requiresArg: true,
-    });
+  wrangler.option("config", {
+    alias: "c",
+    describe: "Path to .toml configuration file",
+    type: "string",
+    requiresArg: true,
+  });
 
-  wrangler.group(["config", "help", "version", "legacy-env"], "Flags:");
+  wrangler.group(["config", "help", "version"], "Flags:");
   wrangler.help().alias("h", "help");
   wrangler.version(wranglerVersion).alias("v", "version");
   wrangler.exitProcess(false);


### PR DESCRIPTION
The `--legacy-env` flag was in global scope, which only certain commands
utilize the flag for functionality, and doesnt do anything for the other commands.

resolves #933