### PR TITLE
fix: resize tearing

### DIFF
--- a/.changeset/proud-guests-count.md
+++ b/.changeset/proud-guests-count.md
@@ -1,0 +1,10 @@
+---
+"wrangler": patch
+---
+
+fix: resize tearing
+The UI would leave behind artifacts in the console during resizing.
+This workaround listens for resize event and clears the console which
+will have the undesirable effect of losing current console context.
+
+resolves #374

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 import { watch } from "chokidar";
 import clipboardy from "clipboardy";
 import commandExists from "command-exists";
-import { Box, Text, useApp, useInput, useStdin } from "ink";
+import { Box, Text, useApp, useInput, useStdin, useStdout } from "ink";
 import React, { useState, useEffect, useRef } from "react";
 import { withErrorBoundary, useErrorHandler } from "react-error-boundary";
 import onExit from "signal-exit";
@@ -63,6 +63,7 @@ export type DevProps = {
 export function DevImplementation(props: DevProps): JSX.Element {
   const apiToken = props.initialMode === "remote" ? getAPIToken() : undefined;
   const directory = useTmpDir();
+  const { stdout } = useStdout();
 
   useCustomBuild(props.entry, props.build);
 
@@ -101,6 +102,13 @@ export function DevImplementation(props: DevProps): JSX.Element {
     tsconfig: props.tsconfig,
     minify: props.minify,
     nodeCompat: props.nodeCompat,
+  });
+
+  // During console resize UI was tearing and leaving artifacts,
+  // this is a workaround that clears the tearing artifacts
+  stdout?.on("resize", () => {
+    console.clear();
+    console.log();
   });
 
   // only load the UI if we're running in a supported environment


### PR DESCRIPTION
The UI would leave behind artifacts in the console during resizing.
This workaround listens for resize event and clears the console which
will have the undesirable effect of losing current console context.

resolves #374