### PR TITLE
chore: update link to deprecations.md

### DIFF
--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -234,7 +234,7 @@ describe("wrangler", () => {
       await runWrangler("build").catch((err) => {
         expect(err.message).toMatchInlineSnapshot(`
           "Deprecation:
-          \`wrangler build\` has been deprecated, please refer to https://github.com/cloudflare/wrangler2/blob/main/docs/deprecations.md#build for alternatives"
+          \`wrangler build\` has been deprecated, please refer to https://github.com/cloudflare/cloudflare-docs/blob/production/content/workers/wrangler/migration/deprecations.md#build for alternatives"
         `);
       });
     });

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -234,7 +234,7 @@ describe("wrangler", () => {
       await runWrangler("build").catch((err) => {
         expect(err.message).toMatchInlineSnapshot(`
           "Deprecation:
-          \`wrangler build\` has been deprecated, please refer to https://github.com/cloudflare/cloudflare-docs/blob/production/content/workers/wrangler/migration/deprecations.md#build for alternatives"
+          \`wrangler build\` has been deprecated, please refer to https://developers.cloudflare.com/workers/wrangler/migration/deprecations/#build for alternatives"
         `);
       });
     });

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -723,7 +723,7 @@ export async function main(argv: string[]): Promise<void> {
     () => {
       // "[DEPRECATED] 🦀 Build your project (if applicable)",
       throw new DeprecationError(
-        "`wrangler build` has been deprecated, please refer to https://github.com/cloudflare/cloudflare-docs/blob/production/content/workers/wrangler/migration/deprecations.md#build for alternatives"
+        "`wrangler build` has been deprecated, please refer to https://developers.cloudflare.com/workers/wrangler/migration/deprecations/#build for alternatives"
       );
     }
   );
@@ -736,7 +736,7 @@ export async function main(argv: string[]): Promise<void> {
     () => {
       // "🕵️  Authenticate Wrangler with a Cloudflare API Token",
       throw new DeprecationError(
-        "`wrangler config` has been deprecated, please refer to https://github.com/cloudflare/cloudflare-docs/blob/production/content/workers/wrangler/migration/deprecations.md#config for alternatives"
+        "`wrangler config` has been deprecated, please refer to https://developers.cloudflare.com/workers/wrangler/migration/deprecations/#config for alternatives"
       );
     }
   );
@@ -1653,7 +1653,7 @@ export async function main(argv: string[]): Promise<void> {
     },
     () => {
       throw new DeprecationError(
-        "`wrangler subdomain` has been deprecated, please refer to https://github.com/cloudflare/cloudflare-docs/blob/production/content/workers/wrangler/migration/deprecations.md#subdomain for alternatives"
+        "`wrangler subdomain` has been deprecated, please refer to https://developers.cloudflare.com/workers/wrangler/migration/deprecations/#subdomain for alternatives"
       );
     }
   );

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -723,7 +723,7 @@ export async function main(argv: string[]): Promise<void> {
     () => {
       // "[DEPRECATED] 🦀 Build your project (if applicable)",
       throw new DeprecationError(
-        "`wrangler build` has been deprecated, please refer to https://github.com/cloudflare/wrangler2/blob/main/docs/deprecations.md#build for alternatives"
+        "`wrangler build` has been deprecated, please refer to https://github.com/cloudflare/cloudflare-docs/blob/production/content/workers/wrangler/migration/deprecations.md#build for alternatives"
       );
     }
   );
@@ -736,7 +736,7 @@ export async function main(argv: string[]): Promise<void> {
     () => {
       // "🕵️  Authenticate Wrangler with a Cloudflare API Token",
       throw new DeprecationError(
-        "`wrangler config` has been deprecated, please refer to https://github.com/cloudflare/wrangler2/blob/main/docs/deprecations.md#config for alternatives"
+        "`wrangler config` has been deprecated, please refer to https://github.com/cloudflare/cloudflare-docs/blob/production/content/workers/wrangler/migration/deprecations.md#config for alternatives"
       );
     }
   );
@@ -1653,7 +1653,7 @@ export async function main(argv: string[]): Promise<void> {
     },
     () => {
       throw new DeprecationError(
-        "`wrangler subdomain` has been deprecated, please refer to https://github.com/cloudflare/wrangler2/blob/main/docs/deprecations.md#subdomain for alternatives"
+        "`wrangler subdomain` has been deprecated, please refer to https://github.com/cloudflare/cloudflare-docs/blob/production/content/workers/wrangler/migration/deprecations.md#subdomain for alternatives"
       );
     }
   );


### PR DESCRIPTION
I noticed the link to `deprecations.md` was 404ing since it got moved to the cloudflare-docs repo.