### PR TITLE
chore: setup the workflows to cache

### DIFF
--- a/.github/workflows/create-pullrequest-prerelease.yml
+++ b/.github/workflows/create-pullrequest-prerelease.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.7
-          cache: "npm"
+          cache: "npm" # cache ~/.npm in case 'npm ci' needs to run
 
       - uses: actions/cache@v3
         id: node-modules-cache
@@ -29,7 +29,8 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install NPM Dependencies
-        run: npm install
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        run: npm ci
 
       - name: Modify package.json version
         run: node .github/version-script.js

--- a/.github/workflows/experimental-wasm-release.yml
+++ b/.github/workflows/experimental-wasm-release.yml
@@ -19,7 +19,15 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.7
-          cache: "npm"
+          cache: "npm" # cache ~/.npm in case 'npm ci' needs to run
+
+      - uses: actions/cache@v3
+        id: node-modules-cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install NPM Dependencies
         run: npm ci

--- a/.github/workflows/experimental-wasm-release.yml
+++ b/.github/workflows/experimental-wasm-release.yml
@@ -28,6 +28,8 @@ jobs:
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
       - name: Install NPM Dependencies
         run: npm ci

--- a/.github/workflows/prereleases.yml
+++ b/.github/workflows/prereleases.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.7
-          cache: "npm"
+          cache: "npm" # cache ~/.npm in case 'npm ci' needs to run
 
       - uses: actions/cache@v3
         id: node-modules-cache
@@ -31,7 +31,8 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install NPM Dependencies
-        run: npm install
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        run: npm ci
 
       - name: Modify package.json version
         run: node .github/version-script.js
@@ -65,7 +66,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.7
-          cache: "npm"
+          cache: "npm" # cache ~/.npm in case 'npm ci' needs to run
 
       - uses: actions/cache@v3
         id: node-modules-cache
@@ -76,7 +77,8 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install NPM Dependencies
-        run: npm install
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        run: npm ci
 
       - name: Build wrangler
         run: npm run build

--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -36,6 +36,8 @@ jobs:
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
       - name: Install NPM Dependencies
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
@@ -76,6 +78,8 @@ jobs:
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
       - name: Install NPM Dependencies
         if: steps.node-modules-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.7
-          cache: "npm"
+          cache: "npm" # cache ~/.npm in case 'npm ci' needs to run
 
       - uses: actions/cache@v3
         id: eslint-cache
@@ -29,7 +29,16 @@ jobs:
             tsconfig.tsbuildinfo
           key: ${{ matrix.os }}-eslint-tsbuildinfo-${{ hashFiles('**/*.ts','**/*.js', 'package.json', 'tsconfig.json') }}
 
+      - uses: actions/cache@v3
+        id: node-modules-cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+
       - name: Install NPM Dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Check for errors
@@ -51,7 +60,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.7
-          cache: "npm"
+          cache: "npm" # cache ~/.npm in case 'npm ci' needs to run
 
       - name: Restore Wrangler 1 from Cache
         uses: actions/cache@v3
@@ -60,7 +69,16 @@ jobs:
           path: packages/wranglerjs-compat-webpack-plugin/src/__tests__/helpers/.wrangler-1-cache
           key: ${{ matrix.os }}-wrangler-1-cache
 
+      - uses: actions/cache@v3
+        id: node-modules-cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+
       - name: Install NPM Dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Run builds

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
       - name: Install NPM Dependencies
         if: steps.node-modules-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.7
-          cache: "npm"
+          cache: "npm" # cache ~/.npm in case 'npm ci' needs to run
 
       - uses: actions/cache@v3
         id: node-modules-cache
@@ -28,10 +28,11 @@ jobs:
           path: |
             node_modules
             */*/node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install NPM Dependencies
-        run: npm install
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        run: npm ci
 
       - name: Check for errors
         run: npm run check


### PR DESCRIPTION
Added caching of `node_modules` which will skip `npm ci` when nothing has changed in any `package.json`
also using the `setup-node` built-in cache of `~/.npm` which will speed up `npm ci` when it has to run.

Converted `npm install` to `npm ci` there are deterministic advantages, `node_modules` gets blown away when it runs, when lockfile exists it will be quicker and adhere to the lockfile completely (no unintended upgrades in CI)  