### PR TITLE
Add support for publishing to Custom domains

### DIFF
--- a/.changeset/shy-eels-march.md
+++ b/.changeset/shy-eels-march.md
@@ -1,0 +1,11 @@
+---
+"wrangler": minor
+---
+
+feature: add support for publishing to Custom Domains
+
+With the release of Custom Domains for workers, users can publish directly to a custom domain on a route, rather than creating a dummy DNS record first and manually pointing the worker over - this adds the same support to wrangler.
+
+Users declare routes as normal, but to indicate that a route should be treated as a custom domain, a user simply uses the object format in the toml file, but with a new key: custom_domain (i.e. `routes = [{ pattern = "api.example.com", custom_domain = true }]`)
+
+When wrangler sees a route like this, it peels them off from the rest of the routes and publishes them separately, using the /domains api. This api is very defensive, erroring eagerly if there are conflicts in existing Custom Domains or managed DNS records. In the case of conflicts, wrangler prompts for confirmation, and then retries with parameters to indicate overriding is allowed.

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -732,8 +732,8 @@ describe("normalizeAndValidateConfig()", () => {
       expect(diagnostics.hasWarnings()).toBe(false);
       expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
         "Processing wrangler configuration:
-          - Expected \\"route\\" to be either a string, or an object with shape { pattern, zone_id | zone_name }, but got 888.
-          - Expected \\"routes\\" to be an array of either strings or objects with the shape { pattern, zone_id | zone_name }, but these weren't valid: [
+          - Expected \\"route\\" to be either a string, or an object with shape { pattern, custom_domain, zone_id | zone_name }, but got 888.
+          - Expected \\"routes\\" to be an array of either strings or objects with the shape { pattern, custom_domain, zone_id | zone_name }, but these weren't valid: [
               666,
               777,
               {
@@ -2229,8 +2229,8 @@ describe("normalizeAndValidateConfig()", () => {
         "Processing wrangler configuration:
 
           - \\"env.ENV1\\" environment configuration
-            - Expected \\"route\\" to be either a string, or an object with shape { pattern, zone_id | zone_name }, but got 888.
-            - Expected \\"routes\\" to be an array of either strings or objects with the shape { pattern, zone_id | zone_name }, but these weren't valid: [
+            - Expected \\"route\\" to be either a string, or an object with shape { pattern, custom_domain, zone_id | zone_name }, but got 888.
+            - Expected \\"routes\\" to be an array of either strings or objects with the shape { pattern, custom_domain, zone_id | zone_name }, but these weren't valid: [
                 666,
                 777
               ].

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -8,6 +8,24 @@ export interface Environment
   extends EnvironmentInheritable,
     EnvironmentNonInheritable {}
 
+export type SimpleRoute = string;
+export type ZoneIdRoute = {
+  pattern: string;
+  zone_id: string;
+  custom_domain?: boolean;
+};
+export type ZoneNameRoute = {
+  pattern: string;
+  zone_name: string;
+  custom_domain?: boolean;
+};
+export type CustomDomainRoute = { pattern: string; custom_domain: boolean };
+export type Route =
+  | SimpleRoute
+  | ZoneIdRoute
+  | ZoneNameRoute
+  | CustomDomainRoute;
+
 /**
  * The `EnvironmentInheritable` interface declares all the configuration fields for an environment
  * that can be inherited (and overridden) from the top-level environment.
@@ -74,14 +92,7 @@ interface EnvironmentInheritable {
    *
    * @inheritable
    */
-  routes:
-    | (
-        | string
-        | { pattern: string; zone_id: string; custom_domain?: boolean }
-        | { pattern: string; zone_name: string; custom_domain?: boolean }
-        | { pattern: string; custom_domain: boolean }
-      )[]
-    | undefined;
+  routes: Route[] | undefined;
 
   /**
    * A route that your worker should be published to. Literally
@@ -92,14 +103,7 @@ interface EnvironmentInheritable {
    *
    * @inheritable
    */
-  route:
-    | (
-        | string
-        | { pattern: string; zone_id: string; custom_domain?: boolean }
-        | { pattern: string; zone_name: string; custom_domain?: boolean }
-        | { pattern: string; custom_domain: boolean }
-      )
-    | undefined;
+  route: Route | undefined;
 
   /**
    * Path to a custom tsconfig

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -77,8 +77,9 @@ interface EnvironmentInheritable {
   routes:
     | (
         | string
-        | { pattern: string; zone_id: string }
-        | { pattern: string; zone_name: string }
+        | { pattern: string; zone_id: string; custom_domain?: boolean }
+        | { pattern: string; zone_name: string; custom_domain?: boolean }
+        | { pattern: string; custom_domain: boolean }
       )[]
     | undefined;
 
@@ -94,8 +95,9 @@ interface EnvironmentInheritable {
   route:
     | (
         | string
-        | { pattern: string; zone_id: string }
-        | { pattern: string; zone_name: string }
+        | { pattern: string; zone_id: string; custom_domain?: boolean }
+        | { pattern: string; zone_name: string; custom_domain?: boolean }
+        | { pattern: string; custom_domain: boolean }
       )
     | undefined;
 

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -575,13 +575,20 @@ function isValidRouteValue(item: unknown): boolean {
 
     const otherKeys = Object.keys(item).length - 1; // minus one to subtract "pattern"
 
-    const hasZoneId = hasProperty(item, "zone_id") && typeof item.zone_id === "string";
-    const hasZoneName = hasProperty(item, "zone_name") && typeof item.zone_name === "string";
-    const hasCustomDomainFlag = hasProperty(item, "custom_domain") && typeof item.custom_domain === "boolean";
+    const hasZoneId =
+      hasProperty(item, "zone_id") && typeof item.zone_id === "string";
+    const hasZoneName =
+      hasProperty(item, "zone_name") && typeof item.zone_name === "string";
+    const hasCustomDomainFlag =
+      hasProperty(item, "custom_domain") &&
+      typeof item.custom_domain === "boolean";
 
-    if (otherKeys === 2 && (hasCustomDomainFlag && (hasZoneId || hasZoneName))) {
+    if (otherKeys === 2 && hasCustomDomainFlag && (hasZoneId || hasZoneName)) {
       return true;
-    } else if (otherKeys === 1 && (hasZoneId || hasZoneName || hasCustomDomainFlag)) {
+    } else if (
+      otherKeys === 1 &&
+      (hasZoneId || hasZoneName || hasCustomDomainFlag)
+    ) {
       return true;
     }
   }

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -89,7 +89,7 @@ function getQuoteBoundedSubstring(content: string) {
 
 function isOriginConflictError(
   e: unknown
-): e is { code: 100116; message: string, notes: Array<{ text: string }> } {
+): e is { code: 100116; message: string; notes: Array<{ text: string }> } {
   return (
     typeof e === "object" &&
     e !== null &&
@@ -99,7 +99,7 @@ function isOriginConflictError(
 
 function isDNSConflictError(
   e: unknown
-): e is { code: 100117; message: string, notes: Array<{ text: string }> } {
+): e is { code: 100117; message: string; notes: Array<{ text: string }> } {
   return (
     typeof e === "object" &&
     e !== null &&
@@ -139,7 +139,7 @@ function publishCustomDomains(
       zone_name: "zone_name" in domainRoute ? domainRoute.zone_name : undefined,
     };
   });
-    
+
   if (!process.stdout.isTTY) {
     // running in non-interactive mode.
     // existing origins / dns records are not indicative of errors,
@@ -187,7 +187,6 @@ function publishCustomDomains(
         const shouldContinue = await confirm(
           `You already have conflicting DNS records for these domains: "${conflictingOrigins}"\nUpdate them to point to this script instead?`
         );
-        console.log({shouldContinue})
         if (!shouldContinue) {
           throw new CustomDomainOverrideRejected();
         }

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -6,9 +6,16 @@ import tmp from "tmp-promise";
 import { bundleWorker } from "./bundle";
 import { fetchResult } from "./cfetch";
 import { createWorkerUploadForm } from "./create-worker-upload-form";
+import { confirm } from "./dialogs";
 import { logger } from "./logger";
 import { syncAssets } from "./sites";
 import type { Config } from "./config";
+import type {
+  Route,
+  ZoneIdRoute,
+  ZoneNameRoute,
+  CustomDomainRoute,
+} from "./config/environment";
 import type { Entry } from "./entry";
 import type { AssetPaths } from "./sites";
 import type { CfWorkerInit } from "./worker";
@@ -36,30 +43,177 @@ type Props = {
   dryRun: boolean | undefined;
 };
 
+type RouteObject = ZoneIdRoute | ZoneNameRoute | CustomDomainRoute;
+
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function renderRoute(route: Exclude<Config["routes"], undefined>[number]): string {
+function renderRoute(route: Route): string {
   let result = "";
   if (typeof route === "string") {
     result = route;
   } else {
     result = route.pattern;
-    const isCustomDomain = !!("custom_domain" in route && route.custom_domain);
+    const isCustomDomain = Boolean(
+      "custom_domain" in route && route.custom_domain
+    );
     if (isCustomDomain && "zone_id" in route) {
       result += ` (custom domain - zone id: ${route.zone_id})`;
     } else if (isCustomDomain && "zone_name" in route) {
-      result += ` (custom domain - zone id: ${route.zone_name})`;
+      result += ` (custom domain - zone name: ${route.zone_name})`;
     } else if (isCustomDomain) {
       result += ` (custom domain)`;
     } else if ("zone_id" in route) {
       result += ` (zone id: ${route.zone_id})`;
     } else if ("zone_name" in route) {
-      result += ` (zone id: ${route.zone_name})`;
+      result += ` (zone name: ${route.zone_name})`;
     }
   }
   return result;
+}
+
+// this function takes a string with quotes in it
+// (i.e. `hello "world", if that really is your name`)
+// and peels out the first instance of a substring
+// bounded by quotes (so, in the example above, `world`)
+//
+// this is useful because the /domains api will return
+// which domains conflicted in an error message, bounded
+// by a string, which we can use to provide helpful
+// messages to a user
+function getQuoteBoundedSubstring(content: string) {
+  const matches = content.split('"');
+  return matches[1] ?? "";
+}
+
+function isOriginConflictError(
+  e: unknown
+): e is { code: 100116; message: string, notes: Array<{ text: string }> } {
+  return (
+    typeof e === "object" &&
+    e !== null &&
+    (e as { code: number }).code === 100116
+  );
+}
+
+function isDNSConflictError(
+  e: unknown
+): e is { code: 100117; message: string, notes: Array<{ text: string }> } {
+  return (
+    typeof e === "object" &&
+    e !== null &&
+    (e as { code: number }).code === 100117
+  );
+}
+
+// empty error class to throw and then explicitly catch via `instanceof`
+class CustomDomainOverrideRejected extends Error {}
+
+// publishing to custom domains involves a few more steps than just updating
+// the routing table, and thus the api implementing it is fairly defensive -
+// it will error eagerly on conflicts against existing domains or existing
+// managed DNS records
+//
+// however, you can pass params to override the errors. we start on the
+// defensive path, and if one of these errors occur, we prompt the user
+// for confirmation that they do indeed want to override the conflicts, and
+// then retry the request with the right override added
+//
+// if a user does not confirm that they want to override, we skip publishing
+// to these custom domains, but continue on through the rest of the
+// publish stage
+function publishCustomDomains(
+  workerUrl: string,
+  domains: Array<RouteObject>
+): Promise<string[]> {
+  const config = {
+    override_scope: true,
+    override_existing_origin: false,
+    override_existing_dns_record: false,
+  };
+  const origins = domains.map((domainRoute) => {
+    return {
+      hostname: domainRoute.pattern,
+      zone_id: "zone_id" in domainRoute ? domainRoute.zone_id : undefined,
+      zone_name: "zone_name" in domainRoute ? domainRoute.zone_name : undefined,
+    };
+  });
+    
+  if (!process.stdout.isTTY) {
+    // running in non-interactive mode.
+    // existing origins / dns records are not indicative of errors,
+    // so we aggressively update rather than aggressively fail
+    config.override_existing_origin = true;
+    config.override_existing_dns_record = true;
+  }
+
+  // Mixing promise chains with async/await is funky, but it allows us to keep related
+  // logic synchronous-looking (i.e. prompting for confirmation and then re-requesting)
+  // while retaining the flexibility of promise chain fall-throughs. We can group error
+  // handling logic in dedicated catch calls, and all we have to do is re-throw an
+  // error and it will pass down to the next catch call
+  return fetchResult(`${workerUrl}/domains`, {
+    method: "PUT",
+    body: JSON.stringify({ ...config, origins }),
+    headers: {
+      "Content-Type": "application/json",
+    },
+  })
+    .catch(async (err) => {
+      if (isOriginConflictError(err)) {
+        const conflictingOrigins = getQuoteBoundedSubstring(err.notes[0].text);
+        const shouldContinue = await confirm(
+          `Custom Domains already exist for these domains: "${conflictingOrigins}"\nUpdate them to point to this script instead?`
+        );
+        if (!shouldContinue) {
+          throw new CustomDomainOverrideRejected();
+        }
+        config.override_existing_origin = true;
+        await fetchResult(`${workerUrl}/domains`, {
+          method: "PUT",
+          body: JSON.stringify({ ...config, origins }),
+          headers: {
+            "Content-Type": "application/json",
+          },
+        });
+      } else {
+        throw err;
+      }
+    })
+    .catch(async (err) => {
+      if (isDNSConflictError(err)) {
+        const conflictingOrigins = getQuoteBoundedSubstring(err.notes[0].text);
+        const shouldContinue = await confirm(
+          `You already have conflicting DNS records for these domains: "${conflictingOrigins}"\nUpdate them to point to this script instead?`
+        );
+        console.log({shouldContinue})
+        if (!shouldContinue) {
+          throw new CustomDomainOverrideRejected();
+        }
+        config.override_existing_dns_record = true;
+        await fetchResult(`${workerUrl}/domains`, {
+          method: "PUT",
+          body: JSON.stringify({ ...config, origins }),
+          headers: {
+            "Content-Type": "application/json",
+          },
+        });
+      } else {
+        throw err;
+      }
+    })
+    .then(() => domains.map((domain) => renderRoute(domain)))
+    .catch((err) => {
+      if (err instanceof CustomDomainOverrideRejected) {
+        return [
+          domains.length > 1
+            ? `Publishing to ${domains.length} Custom Domains was skipped, fix conflicts and try again`
+            : `Publishing to Custom Domain "${domains[0].pattern}" was skipped, fix conflict and try again`,
+        ];
+      }
+      throw err;
+    });
 }
 
 export default async function publish(props: Props): Promise<void> {
@@ -74,6 +228,25 @@ export default async function publish(props: Props): Promise<void> {
   const triggers = props.triggers || config.triggers?.crons;
   const routes =
     props.routes ?? config.routes ?? (config.route ? [config.route] : []) ?? [];
+  const routesOnly: Array<Route> = [];
+  const customDomainsOnly: Array<RouteObject> = [];
+  for (const route of routes) {
+    if (typeof route !== "string" && route.custom_domain) {
+      if (route.pattern.includes("*")) {
+        throw new Error(
+          `Cannot use "${route.pattern}" as a Custom Domain; wildcard operators (*) are not allowed`
+        );
+      }
+      if (route.pattern.includes("/")) {
+        throw new Error(
+          `Cannot use "${route.pattern}" as a Custom Domain; paths are not allowed`
+        );
+      }
+      customDomainsOnly.push(route);
+    } else {
+      routesOnly.push(route);
+    }
+  }
 
   // deployToWorkersDev defaults to true only if there aren't any routes defined
   const deployToWorkersDev = config.workers_dev ?? routes.length === 0;
@@ -398,13 +571,13 @@ export default async function publish(props: Props): Promise<void> {
   logger.log("Uploaded", workerName, formatTime(uploadMs));
 
   // Update routing table for the script.
-  if (routes.length > 0) {
+  if (routesOnly.length > 0) {
     deployments.push(
       fetchResult(`${workerUrl}/routes`, {
         // Note: PUT will delete previous routes on this script.
         method: "PUT",
         body: JSON.stringify(
-          routes.map((route) =>
+          routesOnly.map((route) =>
             typeof route !== "object" ? { pattern: route } : route
           )
         ),
@@ -412,15 +585,20 @@ export default async function publish(props: Props): Promise<void> {
           "Content-Type": "application/json",
         },
       }).then(() => {
-        if (routes.length > 10) {
-          return routes
+        if (routesOnly.length > 10) {
+          return routesOnly
             .slice(0, 9)
             .map((route) => renderRoute(route))
-            .concat([`...and ${routes.length - 10} more routes`]);
+            .concat([`...and ${routesOnly.length - 10} more routes`]);
         }
-        return routes.map((route) => renderRoute(route));
+        return routesOnly.map((route) => renderRoute(route));
       })
     );
+  }
+
+  // Update custom domains for the script
+  if (customDomainsOnly.length > 0) {
+    deployments.push(publishCustomDomains(workerUrl, customDomainsOnly));
   }
 
   // Configure any schedules for the script.


### PR DESCRIPTION
With the release of Custom Domains for workers, users can publish directly to a custom domain on a route, rather than creating a dummy DNS record first and manually pointing the worker over - this adds the same support to wrangler.

Users declare routes as normal, but to indicate that a route should be treated as a custom domain, a user simply uses the object format in the toml file, but with a new key: custom_domain (i.e. `routes = [{ pattern = "api.example.com", custom_domain = true }]`)

When wrangler sees a route like this, it peels them off from the rest of the routes and publishes them separately, using the /domains api. This api is very defensive, erroring eagerly if there are conflicts in existing Custom Domains or managed DNS records. In the case of conflicts, wrangler prompts for confirmation, and then retries with parameters to indicate overriding is allowed.