### PR TITLE
fix: encode key when calling `kv:ket get`, don't encode when deleting a namespace

### DIFF
--- a/.changeset/chatty-penguins-help.md
+++ b/.changeset/chatty-penguins-help.md
@@ -1,0 +1,12 @@
+---
+"wrangler": patch
+---
+
+fix: encode key when calling `kv:ket get`, don't encode when deleting a namespace
+
+This cleans up some logic from https://github.com/cloudflare/wrangler2/pull/964.
+
+- we shouldn't be encoding the id when deleting a namespace, since that'll already be an alphanumeric id
+- we should be encoding the key when we call kv:key get, or we get a similar issue as in https://github.com/cloudflare/wrangler2/issues/961
+- adds `KV` to all the KV-related function names
+- moves the api calls to `kv:namespace delete` and `kv:key delete` inside `kv.ts` helpers.

--- a/packages/wrangler/src/__tests__/kv.test.ts
+++ b/packages/wrangler/src/__tests__/kv.test.ts
@@ -257,14 +257,6 @@ describe("wrangler", () => {
         expect(requests.count).toEqual(1);
       });
 
-      it("should encode URI id properly for deleting namespace", async () => {
-        const requests = mockDeleteRequest("%2Fvoyager");
-        await runWrangler(`kv:namespace delete --namespace-id /voyager`);
-        expect(requests.count).toEqual(1);
-        expect(std.out).toMatchInlineSnapshot(`""`);
-        expect(std.err).toMatchInlineSnapshot(`""`);
-      });
-
       it("should delete a namespace specified by binding name", async () => {
         writeWranglerConfig();
         const requests = mockDeleteRequest("bound-id");
@@ -389,7 +381,7 @@ describe("wrangler", () => {
         expect(std.err).toMatchInlineSnapshot(`""`);
       });
 
-      it("should encode URI key's properly for putting in a key request", async () => {
+      it("should encode the key in the api request to put a value", async () => {
         const requests = mockKeyPutRequest("DS9", {
           key: "%2Fmy-key",
           value: "my-value",
@@ -951,6 +943,20 @@ describe("wrangler", () => {
         expect(std.err).toMatchInlineSnapshot(`""`);
       });
 
+      it("should encode the key in the api request to get a value", async () => {
+        setMockFetchKVGetValue(
+          "some-account-id",
+          "some-namespace-id",
+          "%2Fmy%2Ckey",
+          "my-value"
+        );
+        await runWrangler(
+          "kv:key get /my,key --namespace-id some-namespace-id"
+        );
+        expect(std.out).toMatchInlineSnapshot(`"my-value"`);
+        expect(std.err).toMatchInlineSnapshot(`""`);
+      });
+
       it("should error if no key is provided", async () => {
         await expect(
           runWrangler("kv:key get")
@@ -1101,7 +1107,7 @@ describe("wrangler", () => {
         expect(requests.count).toEqual(1);
       });
 
-      it("should encode the URI properly for deleting a key requests", async () => {
+      it("should encode the key in the api request to delete a value", async () => {
         const requests = mockDeleteRequest("voyager", "%2FNCC-74656");
         await runWrangler(`kv:key delete --namespace-id voyager /NCC-74656`);
         expect(requests.count).toEqual(1);

--- a/packages/wrangler/src/cfetch/internal.ts
+++ b/packages/wrangler/src/cfetch/internal.ts
@@ -112,6 +112,9 @@ function addAuthorizationHeader(
  * doesn't return json. We inline the implementation and try not to share
  * any code with the other calls. We should push back on any new APIs that
  * try to introduce non-"standard" response structures.
+ *
+ * Note: any calls to fetchKVGetValue must call encodeURIComponent on key
+ * before passing it
  */
 
 export async function fetchKVGetValue(

--- a/packages/wrangler/src/kv.ts
+++ b/packages/wrangler/src/kv.ts
@@ -19,7 +19,7 @@ type KvArgs = {
  *
  * @returns the generated id of the created namespace.
  */
-export async function createNamespace(
+export async function createKVNamespace(
   accountId: string,
   title: string
 ): Promise<string> {
@@ -51,7 +51,7 @@ export interface KVNamespaceInfo {
 /**
  * Fetch a list of all the namespaces under the given `accountId`.
  */
-export async function listNamespaces(
+export async function listKVNamespaces(
   accountId: string
 ): Promise<KVNamespaceInfo[]> {
   const pageSize = 100;
@@ -83,7 +83,7 @@ export interface NamespaceKeyInfo {
   metadata?: { [key: string]: unknown };
 }
 
-export async function listNamespaceKeys(
+export async function listKVNamespaceKeys(
   accountId: string,
   namespaceId: string,
   prefix = ""
@@ -92,6 +92,16 @@ export async function listNamespaceKeys(
     `/accounts/${accountId}/storage/kv/namespaces/${namespaceId}/keys`,
     {},
     new URLSearchParams({ prefix })
+  );
+}
+
+export async function deleteKVNamespace(
+  accountId: string,
+  namespaceId: string
+) {
+  return await fetchResult<{ id: string }>(
+    `/accounts/${accountId}/storage/kv/namespaces/${namespaceId}`,
+    { method: "DELETE" }
   );
 }
 
@@ -119,7 +129,7 @@ const KeyValueKeys = new Set([
 /**
  * Is the given object a valid `KeyValue` type?
  */
-export function isKeyValue(keyValue: object): keyValue is KeyValue {
+export function isKVKeyValue(keyValue: object): keyValue is KeyValue {
   const props = Object.keys(keyValue);
   if (!props.includes("key") || !props.includes("value")) {
     return false;
@@ -130,12 +140,12 @@ export function isKeyValue(keyValue: object): keyValue is KeyValue {
 /**
  * Get all the properties on the `keyValue` that are not expected.
  */
-export function unexpectedKeyValueProps(keyValue: KeyValue): string[] {
+export function unexpectedKVKeyValueProps(keyValue: KeyValue): string[] {
   const props = Object.keys(keyValue);
   return props.filter((prop) => !KeyValueKeys.has(prop));
 }
 
-export async function putKeyValue(
+export async function putKVKeyValue(
   accountId: string,
   namespaceId: string,
   keyValue: KeyValue
@@ -159,15 +169,28 @@ export async function putKeyValue(
   );
 }
 
-export async function getKeyValue(
+export async function getKVKeyValue(
   accountId: string,
   namespaceId: string,
   key: string
 ): Promise<string> {
-  return await fetchKVGetValue(accountId, namespaceId, key);
+  return await fetchKVGetValue(accountId, namespaceId, encodeURIComponent(key));
 }
 
-export async function putBulkKeyValue(
+export async function deleteKVKeyValue(
+  accountId: string,
+  namespaceId: string,
+  key: string
+) {
+  return await fetchResult(
+    `/accounts/${accountId}/storage/kv/namespaces/${namespaceId}/values/${encodeURIComponent(
+      key
+    )}`,
+    { method: "DELETE" }
+  );
+}
+
+export async function putKVBulkKeyValue(
   accountId: string,
   namespaceId: string,
   keyValues: KeyValue[],
@@ -192,7 +215,7 @@ export async function putBulkKeyValue(
   }
 }
 
-export async function deleteBulkKeyValue(
+export async function deleteKVBulkKeyValue(
   accountId: string,
   namespaceId: string,
   keys: string[],
@@ -217,7 +240,7 @@ export async function deleteBulkKeyValue(
   }
 }
 
-export function getNamespaceId(
+export function getKVNamespaceId(
   { preview, binding, "namespace-id": namespaceId }: KvArgs,
   config: Config
 ): string {
@@ -312,7 +335,7 @@ export function getNamespaceId(
 /**
  * KV namespace binding names must be valid JS identifiers.
  */
-export function isValidNamespaceBinding(
+export function isValidKVNamespaceBinding(
   binding: string | undefined
 ): binding is string {
   return (

--- a/packages/wrangler/src/sites.tsx
+++ b/packages/wrangler/src/sites.tsx
@@ -3,11 +3,11 @@ import * as path from "node:path";
 import ignore from "ignore";
 import xxhash from "xxhash-wasm";
 import {
-  createNamespace,
-  listNamespaceKeys,
-  listNamespaces,
-  putBulkKeyValue,
-  deleteBulkKeyValue,
+  createKVNamespace,
+  listKVNamespaceKeys,
+  listKVNamespaces,
+  putKVBulkKeyValue,
+  deleteKVBulkKeyValue,
 } from "./kv";
 import { logger } from "./logger";
 import type { Config } from "./config";
@@ -75,14 +75,14 @@ async function createKVNamespaceIfNotAlreadyExisting(
 ) {
   // check if it already exists
   // TODO: this is super inefficient, should be made better
-  const namespaces = await listNamespaces(accountId);
+  const namespaces = await listKVNamespaces(accountId);
   const found = namespaces.find((x) => x.title === title);
   if (found) {
     return { created: false, id: found.id };
   }
 
   // else we make the namespace
-  const id = await createNamespace(accountId, title);
+  const id = await createKVNamespace(accountId, title);
   logger.log(`🌀 Created namespace for Workers Site "${title}"`);
 
   return {
@@ -131,7 +131,7 @@ export async function syncAssets(
   );
 
   // let's get all the keys in this namespace
-  const namespaceKeysResponse = await listNamespaceKeys(accountId, namespace);
+  const namespaceKeysResponse = await listKVNamespaceKeys(accountId, namespace);
   const namespaceKeys = new Set(namespaceKeysResponse.map((x) => x.name));
 
   const manifest: Record<string, string> = {};
@@ -185,9 +185,9 @@ export async function syncAssets(
 
   await Promise.all([
     // upload all the new assets
-    putBulkKeyValue(accountId, namespace, toUpload, () => {}),
+    putKVBulkKeyValue(accountId, namespace, toUpload, () => {}),
     // delete all the unused assets
-    deleteBulkKeyValue(
+    deleteKVBulkKeyValue(
       accountId,
       namespace,
       Array.from(namespaceKeys),


### PR DESCRIPTION
This cleans up some logic from https://github.com/cloudflare/wrangler2/pull/964.

- we shouldn't be encoding the id when deleting a namespace, since that'll already be an alphanumeric id
- we should be encoding the key when we call `kv:key get`, or we get a similar issue as in https://github.com/cloudflare/wrangler2/issues/961
- adds `KV` to all the KV-related function names
- moves the api calls to `kv:namespace delete` and `kv:key delete` inside `kv.ts` helpers.
