### PR TITLE
docs: point wrangler docs link to canon

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,4 +61,4 @@ For more commands and options, refer to the [documentation](https://developers.c
 
 ## Documentation
 
-For the latest Wrangler documentation, [click here](https://6b05b6e1.cloudflare-docs-7ou.pages.dev/workers/wrangler/).
+For the latest Wrangler documentation, [click here](https://developers.cloudflare.com/workers/wrangler/).


### PR DESCRIPTION
The prod docs link is _wrangler:dos_ ready, and it was mildly confusing to find myself in the parallel preview docs world.