### PR TITLE
feat: add pnpm support

### DIFF
--- a/.changeset/late-suits-vanish.md
+++ b/.changeset/late-suits-vanish.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+feat: add pnpm support

--- a/packages/wrangler/src/__tests__/package-manager.test.ts
+++ b/packages/wrangler/src/__tests__/package-manager.test.ts
@@ -7,100 +7,210 @@ const { getPackageManager, getPackageManagerName } =
   jest.requireActual("../package-manager");
 interface TestCase {
   npm: boolean;
+  pnpm: boolean;
   yarn: boolean;
   npmLockFile: boolean;
   yarnLockFile: boolean;
+  pnpmLockFile: boolean;
   expectedPackageManager: string;
 }
 
 const testCases: TestCase[] = [
-  // npm binary - no yarn binary
+  // npm binary only
   {
     npm: true,
     yarn: false,
+    pnpm: false,
     npmLockFile: false,
     yarnLockFile: false,
+    pnpmLockFile: false,
     expectedPackageManager: "npm",
   },
   {
     npm: true,
     yarn: false,
+    pnpm: false,
     npmLockFile: true,
     yarnLockFile: false,
+    pnpmLockFile: false,
     expectedPackageManager: "npm",
   },
   {
     npm: true,
     yarn: false,
+    pnpm: false,
     npmLockFile: false,
     yarnLockFile: true,
+    pnpmLockFile: false,
     expectedPackageManager: "npm",
   },
   {
     npm: true,
     yarn: false,
+    pnpm: false,
     npmLockFile: true,
     yarnLockFile: true,
+    pnpmLockFile: false,
     expectedPackageManager: "npm",
   },
 
-  // yarn binary - no npm binary
+  // yarn binary only
   {
     npm: false,
     yarn: true,
+    pnpm: false,
     npmLockFile: false,
     yarnLockFile: false,
+    pnpmLockFile: false,
     expectedPackageManager: "yarn",
   },
   {
     npm: false,
     yarn: true,
+    pnpm: false,
     npmLockFile: true,
     yarnLockFile: false,
+    pnpmLockFile: false,
     expectedPackageManager: "yarn",
   },
   {
     npm: false,
     yarn: true,
+    pnpm: false,
     npmLockFile: false,
     yarnLockFile: true,
+    pnpmLockFile: false,
     expectedPackageManager: "yarn",
   },
   {
     npm: false,
     yarn: true,
+    pnpm: false,
     npmLockFile: true,
     yarnLockFile: true,
+    pnpmLockFile: false,
     expectedPackageManager: "yarn",
+  },
+
+  // pnpm binary only
+  {
+    npm: false,
+    yarn: false,
+    pnpm: true,
+    npmLockFile: false,
+    yarnLockFile: false,
+    pnpmLockFile: true,
+    expectedPackageManager: "pnpm",
+  },
+  {
+    npm: false,
+    yarn: false,
+    pnpm: true,
+    npmLockFile: true,
+    yarnLockFile: false,
+    pnpmLockFile: false,
+    expectedPackageManager: "pnpm",
+  },
+  {
+    npm: false,
+    yarn: false,
+    pnpm: true,
+    npmLockFile: false,
+    yarnLockFile: true,
+    pnpmLockFile: false,
+    expectedPackageManager: "pnpm",
+  },
+  {
+    npm: false,
+    yarn: false,
+    pnpm: true,
+    npmLockFile: true,
+    yarnLockFile: true,
+    pnpmLockFile: true,
+    expectedPackageManager: "pnpm",
   },
 
   // npm and yarn binaries
   {
     npm: true,
     yarn: true,
+    pnpm: false,
     npmLockFile: false,
     yarnLockFile: false,
+    pnpmLockFile: false,
     expectedPackageManager: "npm",
   },
   {
     npm: true,
     yarn: true,
+    pnpm: false,
     npmLockFile: true,
     yarnLockFile: false,
+    pnpmLockFile: false,
     expectedPackageManager: "npm",
   },
   {
     npm: true,
     yarn: true,
+    pnpm: false,
     npmLockFile: false,
     yarnLockFile: true,
+    pnpmLockFile: false,
     expectedPackageManager: "yarn",
   },
   {
     npm: true,
     yarn: true,
+    pnpm: false,
     npmLockFile: true,
     yarnLockFile: true,
+    pnpmLockFile: false,
+    expectedPackageManager: "npm",
+  },
+  // npm, yarn and pnpm binaries
+  {
+    npm: true,
+    yarn: true,
+    pnpm: true,
+    npmLockFile: false,
+    yarnLockFile: false,
+    pnpmLockFile: false,
+    expectedPackageManager: "npm",
+  },
+  {
+    npm: true,
+    yarn: true,
+    pnpm: true,
+    npmLockFile: true,
+    yarnLockFile: false,
+    pnpmLockFile: false,
+    expectedPackageManager: "npm",
+  },
+  {
+    npm: true,
+    yarn: true,
+    pnpm: true,
+    npmLockFile: false,
+    yarnLockFile: true,
+    pnpmLockFile: false,
+    expectedPackageManager: "yarn",
+  },
+  {
+    npm: true,
+    yarn: true,
+    pnpm: true,
+    npmLockFile: false,
+    yarnLockFile: false,
+    pnpmLockFile: true,
+    expectedPackageManager: "pnpm",
+  },
+  {
+    npm: true,
+    yarn: true,
+    pnpm: true,
+    npmLockFile: true,
+    yarnLockFile: true,
+    pnpmLockFile: true,
     expectedPackageManager: "npm",
   },
 ];
@@ -112,12 +222,13 @@ describe("getPackageManager()", () => {
   describe("no supported package manager", () => {
     mockYarn(false);
     mockNpm(false);
+    mockPnpm(false);
 
     it("should throw an error", async () => {
       await expect(() =>
         getPackageManager(process.cwd())
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Unable to find a package manager. Supported managers are: npm and yarn."`
+        `"Unable to find a package manager. Supported managers are: npm, yarn, and pnpm."`
       );
     });
   });
@@ -125,16 +236,26 @@ describe("getPackageManager()", () => {
   for (const {
     npm,
     yarn,
+    pnpm,
     npmLockFile,
     yarnLockFile,
+    pnpmLockFile,
     expectedPackageManager,
   } of testCases) {
     describe(
-      getTestCaseDescription(npm, yarn, npmLockFile, yarnLockFile),
+      getTestCaseDescription(
+        npm,
+        yarn,
+        pnpm,
+        npmLockFile,
+        yarnLockFile,
+        pnpmLockFile
+      ),
       () => {
         mockYarn(yarn);
         mockNpm(npm);
-        mockLockFiles(npmLockFile, yarnLockFile);
+        mockPnpm(pnpm);
+        mockLockFiles(npmLockFile, yarnLockFile, pnpmLockFile);
 
         it(`should return the ${expectedPackageManager} package manager`, async () => {
           const actualPackageManager = await getPackageManager(process.cwd());
@@ -170,9 +291,24 @@ function mockNpm(succeed: boolean): void {
 }
 
 /**
+ * Create a fake pnpm binary
+ */
+function mockPnpm(succeed: boolean): void {
+  let unMock: () => void;
+  beforeEach(async () => {
+    unMock = await mockBinary("pnpm", `process.exit(${succeed ? 0 : 1})`);
+  });
+  afterEach(() => unMock());
+}
+
+/**
  * Create a fake lock files.
  */
-function mockLockFiles(npmLockFile: boolean, yarnLockFile: boolean) {
+function mockLockFiles(
+  npmLockFile: boolean,
+  yarnLockFile: boolean,
+  pnpmLockFile: boolean
+) {
   beforeEach(() => {
     if (npmLockFile) {
       writeFileSync("package-lock.json", "");
@@ -180,14 +316,19 @@ function mockLockFiles(npmLockFile: boolean, yarnLockFile: boolean) {
     if (yarnLockFile) {
       writeFileSync("yarn.lock", "");
     }
+    if (pnpmLockFile) {
+      writeFileSync("pnpm-lock.yaml", "");
+    }
   });
 }
 
 function getTestCaseDescription(
   npm: boolean,
   yarn: boolean,
+  pnpm: boolean,
   npmLockFile: boolean,
-  yarnLockFile: boolean
+  yarnLockFile: boolean,
+  pnpmLockFile: boolean
 ): string {
   const criteria: string[] = [];
   if (npm) {
@@ -201,6 +342,12 @@ function getTestCaseDescription(
   }
   if (yarnLockFile) {
     criteria.push("yarn.lock");
+  }
+  if (pnpm) {
+    criteria.push("pnpm");
+  }
+  if (pnpmLockFile) {
+    criteria.push("pnpm-lock.yaml");
   }
   return "using " + criteria.join("; ");
 }

--- a/packages/wrangler/src/package-manager.ts
+++ b/packages/wrangler/src/package-manager.ts
@@ -11,7 +11,11 @@ export interface PackageManager {
 }
 
 export async function getPackageManager(cwd: string): Promise<PackageManager> {
-  const [hasYarn, hasNpm, hasPnpm] = await Promise.all([supportsYarn(), supportsNpm(), supportsPnpm()]);
+  const [hasYarn, hasNpm, hasPnpm] = await Promise.all([
+    supportsYarn(),
+    supportsNpm(),
+    supportsPnpm(),
+  ]);
   const hasYarnLock = existsSync(join(cwd, "yarn.lock"));
   const hasNpmLock = existsSync(join(cwd, "package-lock.json"));
   const hasPnpmLock = existsSync(join(cwd, "pnpm-lock.yaml"));

--- a/packages/wrangler/src/package-manager.ts
+++ b/packages/wrangler/src/package-manager.ts
@@ -71,7 +71,7 @@ export async function getPackageManager(cwd: string): Promise<PackageManager> {
     return { ...PnpmPackageManager, cwd };
   } else {
     throw new Error(
-      "Unable to find a package manager. Supported managers are: npm and yarn."
+      "Unable to find a package manager. Supported managers are: npm, yarn, and pnpm."
     );
   }
 }


### PR DESCRIPTION
Adds support for `pnpm` projects - if `pnpm-lock.yaml` is found, it will use `pnpm` to install the packages.
If `npm` and `yarn` isn't found, it defaults to `pnpm` even without `pnpm-lock.yaml`.

(I'd personally argue that it should try `yarn` and `pnpm` before `npm`, as it's installed by default with node, but I tried to respect the current behaviour)