### PR TITLE
fix: strip leading `*`/`*.` from routes when deducing a host for `dev`

### DIFF
--- a/.changeset/forty-mice-travel.md
+++ b/.changeset/forty-mice-travel.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: strip leading `*`/`*.` from routes when deducing a host for `dev`
+
+When given routes, we use the host name from the route to deduce a zone id to pass along with the host to set with dev `session`. Route patterns can include leading `*`/`*.`, which we don't account for when deducing said zone id, resulting in subtle errors for the session. This fix strips those leading characters as appropriate.
+
+Fixes https://github.com/cloudflare/wrangler2/issues/1002

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -225,6 +225,32 @@ describe("wrangler dev", () => {
       );
     });
 
+    it("should strip leading `*` from given host when deducing a zone id", async () => {
+      writeWranglerToml({
+        main: "index.js",
+        route: "*some-host.com/some/path/*",
+      });
+      fs.writeFileSync("index.js", `export default {};`);
+      mockGetZones("some-host.com", [{ id: "some-zone-id" }]);
+      await runWrangler("dev");
+      expect((Dev as jest.Mock).mock.calls[0][0].zone.host).toEqual(
+        "some-host.com"
+      );
+    });
+
+    it("should strip leading `*.` from given host when deducing a zone id", async () => {
+      writeWranglerToml({
+        main: "index.js",
+        route: "*.some-host.com/some/path/*",
+      });
+      fs.writeFileSync("index.js", `export default {};`);
+      mockGetZones("some-host.com", [{ id: "some-zone-id" }]);
+      await runWrangler("dev");
+      expect((Dev as jest.Mock).mock.calls[0][0].zone.host).toEqual(
+        "some-host.com"
+      );
+    });
+
     it("should, when provided, use a configured zone_id", async () => {
       writeWranglerToml({
         main: "index.js",

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -934,6 +934,9 @@ export async function main(argv: string[]): Promise<void> {
        * try to extract a host from it
        */
       function getHost(urlLike: string): string | undefined {
+        // strip leading * / *.
+        urlLike = urlLike.replace(/^\*(\.)?/g, "");
+
         if (
           !(urlLike.startsWith("http://") || urlLike.startsWith("https://"))
         ) {


### PR DESCRIPTION
When given routes, we use the host name from the route to deduce a zone id to pass along with the host to set with dev `session`. Route patterns can include leading `*`/`*.`, which we don't account for when deducing said zone id, resulting in subtle errors for the session. This fix strips those leading characters as appropriate.

Fixes https://github.com/cloudflare/wrangler2/issues/1002