### PR TITLE
Windows caching fix in GH Workflows

### DIFF
--- a/.github/workflows/create-pullrequest-prerelease.yml
+++ b/.github/workflows/create-pullrequest-prerelease.yml
@@ -29,7 +29,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install NPM Dependencies
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        if: steps.node-modules-cache.outputs.cache-hit != 'true' || runner.os == 'Windows'
         run: npm ci
 
       - name: Modify package.json version

--- a/.github/workflows/prereleases.yml
+++ b/.github/workflows/prereleases.yml
@@ -31,7 +31,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install NPM Dependencies
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        if: steps.node-modules-cache.outputs.cache-hit != 'true' || runner.os == 'Windows'
         run: npm ci
 
       - name: Modify package.json version
@@ -77,7 +77,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install NPM Dependencies
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        if: steps.node-modules-cache.outputs.cache-hit != 'true' || runner.os == 'Windows'
         run: npm ci
 
       - name: Build wrangler

--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -40,7 +40,7 @@ jobs:
             ${{ runner.os }}-node-
 
       - name: Install NPM Dependencies
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        if: steps.node-modules-cache.outputs.cache-hit != 'true' || runner.os == 'Windows'
         run: npm ci
 
       - name: Check for errors
@@ -82,7 +82,7 @@ jobs:
             ${{ runner.os }}-node-
 
       - name: Install NPM Dependencies
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        if: steps.node-modules-cache.outputs.cache-hit != 'true' || runner.os == 'Windows'
         run: npm ci
 
       - name: Run builds

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
             ${{ runner.os }}-node-
 
       - name: Install NPM Dependencies
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        if: steps.node-modules-cache.outputs.cache-hit != 'true' || runner.os == 'Windows'
         run: npm ci
 
       - name: Check for errors


### PR DESCRIPTION
fix: Windows symlinks are lost during caching, resolution is always running `npm ci` for Windows GitHub Workflows