### PR TITLE
chore: Bumping wranglerjs-compat-webpack-plugin to do a release

### DIFF
--- a/.changeset/polite-buses-prove.md
+++ b/.changeset/polite-buses-prove.md
@@ -1,0 +1,5 @@
+---
+"wranglerjs-compat-webpack-plugin": patch
+---
+
+Bumping wranglerjs-compat-webpack-plugin to do a release


### PR DESCRIPTION
Looks like we haven't published the webpack plugin yet, bumping it to include it in the next one. 

Fixes https://github.com/cloudflare/wrangler2/issues/1020