### PR TITLE
fix: don't fetch migrations when in `--dry-run` mode

### DIFF
--- a/.changeset/lazy-sheep-rest.md
+++ b/.changeset/lazy-sheep-rest.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: don't fetch migrations when in `--dry-run` mode
+
+Fixes https://github.com/cloudflare/wrangler2/issues/1038

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -4627,7 +4627,14 @@ addEventListener('fetch', event => {});`
 
   describe("--dry-run", () => {
     it("should not publish the worker if --dry-run is specified", async () => {
-      writeWranglerToml();
+      writeWranglerToml({
+        // add a durable object with migrations
+        // to make sure we _don't_ fetch migration status
+        durable_objects: {
+          bindings: [{ name: "NAME", class_name: "SomeClass" }],
+        },
+        migrations: [{ tag: "v1", new_classes: ["SomeClass"] }],
+      });
       writeWorkerSource();
       await runWrangler("publish index.js --dry-run");
       expect(std).toMatchInlineSnapshot(`

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -164,7 +164,7 @@ export default async function publish(props: Props): Promise<void> {
 
     // if config.migrations
     let migrations;
-    if (config.migrations.length > 0) {
+    if (!props.dryRun && config.migrations.length > 0) {
       // get current migration tag
       type ScriptData = { id: string; migration_tag?: string };
       let script: ScriptData | undefined;


### PR DESCRIPTION
Fixes https://github.com/cloudflare/wrangler2/issues/1038