### PR TITLE
Fix incorrect extension extraction from file paths

### DIFF
--- a/.changeset/large-pets-cheer.md
+++ b/.changeset/large-pets-cheer.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Incorrect extension extraction from file paths. Our extension extraction logic was taking into account folder names, which can include periods. The logic would incorrectly identify a file path of .well-known/foo as having the extension of well-known/foo when in reality it should be an empty string.

--- a/.changeset/large-pets-cheer.md
+++ b/.changeset/large-pets-cheer.md
@@ -2,4 +2,6 @@
 "wrangler": patch
 ---
 
-fix: Incorrect extension extraction from file paths. Our extension extraction logic was taking into account folder names, which can include periods. The logic would incorrectly identify a file path of .well-known/foo as having the extension of well-known/foo when in reality it should be an empty string.
+fix: Incorrect extension extraction from file paths.
+
+Our extension extraction logic was taking into account folder names, which can include periods. The logic would incorrectly identify a file path of .well-known/foo as having the extension of well-known/foo when in reality it should be an empty string.

--- a/packages/wrangler/src/__tests__/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages.test.ts
@@ -1,4 +1,4 @@
-import { writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { setMockResponse, unsetAllMocks } from "./helpers/mock-cfetch";
 import { mockConsoleMethods } from "./helpers/mock-console";
@@ -322,6 +322,29 @@ describe("pages", () => {
 
       //   ✨ Deployment complete! Take a peek over at https://abcxyz.foo.pages.dev/"
       // `);
+    });
+
+    it("should not error when directory names contain periods and houses a extensionless file", async () => {
+      mkdirSync(".well-known");
+      writeFileSync(".well-known/foobar", "foobar");
+
+      setMockResponse(
+        "/accounts/:accountId/pages/projects/foo/file",
+        async () => ({
+          id: "7b764dacfd211bebd8077828a7ddefd7",
+        })
+      );
+
+      setMockResponse(
+        "/accounts/:accountId/pages/projects/foo/deployments",
+        async () => ({
+          url: "https://abcxyz.foo.pages.dev/",
+        })
+      );
+
+      await runWrangler("pages publish . --project-name=foo");
+
+      expect(std.err).toMatchInlineSnapshot(`""`);
     });
   });
 });

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -4,7 +4,7 @@ import { execSync, spawn } from "node:child_process";
 import { existsSync, lstatSync, readFileSync, writeFileSync } from "node:fs";
 import { readdir, readFile, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join, sep } from "node:path";
+import { dirname, join, sep, extname, basename } from "node:path";
 import { cwd } from "node:process";
 import { URL } from "node:url";
 import { hash } from "blake3-wasm";
@@ -1079,8 +1079,7 @@ const createDeployment: CommandModule<
             const fileContent = await readFile(filepath);
 
             const base64Content = fileContent.toString("base64");
-            const extension =
-              name.split(".").length > 1 ? name.split(".").at(-1) || "" : "";
+            const extension = extname(basename(name)).substring(1);
 
             const content = base64Content + extension;
 


### PR DESCRIPTION
Fixes #1029

Our extension extraction logic was taking into account folder names, which can include periods. The logic would incorrectly identify a file path of `.well-known/foo` as having the extension of `well-known/foo` when in reality it should be an empty string.