### PR TITLE
feat: Routes in Preview Worker

### DIFF
--- a/.changeset/heavy-parents-speak.md
+++ b/.changeset/heavy-parents-speak.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+feat: Routes in Preview Worker
+Add all collected routes from config and args to the preview session when generating a remote worker.
+This also matches legacy behavior in wrangler1 in handling routes when generating a preview worker.

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -263,6 +263,7 @@ describe("wrangler dev", () => {
       expect((Dev as jest.Mock).mock.calls[0][0].zone).toEqual({
         host: "some-domain.com",
         id: "some-zone-id",
+        routes: ["https://some-domain.com/*"],
       });
     });
 
@@ -280,6 +281,7 @@ describe("wrangler dev", () => {
         // note that it uses the provided zone_name as a host too
         host: "some-zone.com",
         id: "a-zone-id",
+        routes: ["https://some-domain.com/*"],
       });
     });
 
@@ -313,6 +315,7 @@ describe("wrangler dev", () => {
       expect((Dev as jest.Mock).mock.calls[0][0].zone).toEqual({
         host: "5.some-host.com",
         id: "some-zone-id-5",
+        routes: ["http://5.some-host.com/some/path/*"],
       });
       (Dev as jest.Mock).mockClear();
 
@@ -326,6 +329,7 @@ describe("wrangler dev", () => {
       expect((Dev as jest.Mock).mock.calls[0][0].zone).toEqual({
         host: "4.some-host.com",
         id: "some-zone-id-4",
+        routes: ["https://4.some-host.com/some/path/*"],
       });
       (Dev as jest.Mock).mockClear();
 
@@ -339,6 +343,7 @@ describe("wrangler dev", () => {
       expect((Dev as jest.Mock).mock.calls[0][0].zone).toEqual({
         host: "3.some-host.com",
         id: "some-zone-id-3",
+        routes: ["http://3.some-host.com/some/path/*"],
       });
       (Dev as jest.Mock).mockClear();
 
@@ -355,6 +360,7 @@ describe("wrangler dev", () => {
       expect((Dev as jest.Mock).mock.calls[0][0].zone).toEqual({
         host: "2.some-host.com",
         id: "some-zone-id-2",
+        routes: ["http://3.some-host.com/some/path/*"],
       });
       (Dev as jest.Mock).mockClear();
 
@@ -373,6 +379,7 @@ describe("wrangler dev", () => {
       expect((Dev as jest.Mock).mock.calls[0][0].zone).toEqual({
         host: "1.some-host.com",
         id: "some-zone-id-1",
+        routes: ["http://3.some-host.com/some/path/*"],
       });
       (Dev as jest.Mock).mockClear();
     });

--- a/packages/wrangler/src/create-worker-preview.ts
+++ b/packages/wrangler/src/create-worker-preview.ts
@@ -118,7 +118,7 @@ async function createPreviewToken(
       : `/accounts/${accountId}/workers/scripts/${scriptId}/edge-preview`;
 
   const mode: CfPreviewMode = ctx.zone
-    ? { routes: ["*/*"] } // TODO: should we support routes here? how?
+    ? { routes: [...(ctx.zone.routes ?? "*/*")] }
     : { workers_dev: true };
 
   const formData = createWorkerUploadForm(worker);

--- a/packages/wrangler/src/create-worker-preview.ts
+++ b/packages/wrangler/src/create-worker-preview.ts
@@ -1,5 +1,5 @@
 import { URL } from "node:url";
-import { fetch } from "undici";
+import { fetch, File } from "undici";
 import { fetchResult } from "./cfetch";
 import { createWorkerUploadForm } from "./create-worker-upload-form";
 import { logger } from "./logger";
@@ -122,7 +122,11 @@ async function createPreviewToken(
     : { workers_dev: true };
 
   const formData = createWorkerUploadForm(worker);
-  formData.set("wrangler-session-config", JSON.stringify(mode));
+
+  const modeFile = new File([JSON.stringify(mode)], "", {
+    type: "application/json",
+  });
+  formData.append("wrangler-session-config", modeFile);
 
   const { preview_token } = await fetchResult<{ preview_token: string }>(
     url,

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -83,7 +83,7 @@ export function useWorker(props: {
   usageModel: "bundled" | "unbound" | undefined;
   env: string | undefined;
   legacyEnv: boolean | undefined;
-  zone: { id: string; host: string } | undefined;
+  zone: { id: string; host: string; routes?: string[] } | undefined;
 }): CfPreviewToken | undefined {
   const {
     name,

--- a/packages/wrangler/src/worker.ts
+++ b/packages/wrangler/src/worker.ts
@@ -176,5 +176,5 @@ export interface CfWorkerInit {
 export interface CfWorkerContext {
   env: string | undefined;
   legacyEnv: boolean | undefined;
-  zone: { id: string; host: string } | undefined;
+  zone: { id: string; host: string; routes?: string[] } | undefined;
 }


### PR DESCRIPTION
Add all collected routes from config and args to the preview session when generating a remote worker.
This also matches legacy behavior in wrangler1 in handling routes when generating a preview worker.