### PR TITLE
fix: pages "command" can consist of multiple words

### DIFF
--- a/.changeset/tame-tigers-impress.md
+++ b/.changeset/tame-tigers-impress.md
@@ -1,0 +1,14 @@
+---
+"wrangler": patch
+---
+
+fix: pages "command" can consist of multiple words
+
+On Windows, the following command `wrangler pages dev -- foo bar` would error
+saying that `bar` was not a known argument. This is because `foo` and `bar` are
+passed to Yargs as separate arguments.
+
+A workaround is to put the command in quotes: `wrangler pages dev -- "foo bar"`.
+But this fix makes the `command` argument variadic, which also solves the problem.
+
+Fixes [#965](https://github.com/cloudflare/wrangler2/issues/965)

--- a/packages/wrangler/src/__tests__/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages.test.ts
@@ -24,10 +24,10 @@ describe("pages", () => {
       ⚡️ Configure Cloudflare Pages
 
       Commands:
-        wrangler pages dev [directory] [-- command]  🧑‍💻 Develop your full-stack Pages application locally
-        wrangler pages project                       ⚡️ Interact with your Pages projects
-        wrangler pages deployment                    🚀 Interact with the deployments of a project
-        wrangler pages publish [directory]           🆙 Publish a directory of static assets as a Pages deployment
+        wrangler pages dev [directory] [-- command..]  🧑‍💻 Develop your full-stack Pages application locally
+        wrangler pages project                         ⚡️ Interact with your Pages projects
+        wrangler pages deployment                      🚀 Interact with the deployments of a project
+        wrangler pages publish [directory]             🆙 Publish a directory of static assets as a Pages deployment
 
       Flags:
         -c, --config   Path to .toml configuration file  [string]

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -1244,7 +1244,7 @@ const createDeployment: CommandModule<
 export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
   return yargs
     .command(
-      "dev [directory] [-- command]",
+      "dev [directory] [-- command..]",
       "🧑‍💻 Develop your full-stack Pages application locally",
       (yargs) => {
         return yargs


### PR DESCRIPTION
On Windows, the following command `wrangler pages dev -- foo bar` would error
saying that `bar` was not a known argument. This is because `foo` and `bar` are
passed to Yargs as separate arguments.

A workaround is to put the command in quotes: `wrangler pages dev -- "foo bar"`.
But this fix makes the `command` argument variadic, which also solves the problem.

Fixes [#965](https://github.com/cloudflare/wrangler2/issues/965)