### PR TITLE
refactor: detect missing `[migrations]` during config validation

### DIFF
--- a/.changeset/gold-books-beam.md
+++ b/.changeset/gold-books-beam.md
@@ -1,0 +1,10 @@
+---
+"wrangler": patch
+---
+
+refactor: detect missing `[migrations]` during config validation
+
+This does a small refactor -
+
+- During publish, we were checking whether `[migrations]` were defined in the presence of `[durable_objects]`, and warning if not. This moves it into the config validation step, which means it'll check for all commands (but notably `dev`)
+- It moves the code to determine current migration tag/migrations to upload into a helper. We'll be reusing this soon when we upload migrations to `dev`.

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -677,7 +677,8 @@ describe("normalizeAndValidateConfig()", () => {
       expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
         "Processing wrangler configuration:
           - \\"unsafe\\" fields are experimental and may change or break at any time.
-          - \\"services\\" fields are experimental and may change or break at any time."
+          - \\"services\\" fields are experimental and may change or break at any time.
+          - In wrangler.toml, you have configured [durable_objects] exported by this Worker (CLASS1), but no [migrations] for them. This may not work as expected until you add a [migrations] section to your wrangler.toml. Refer to https://developers.cloudflare.com/workers/learning/using-durable-objects/#durable-object-migrations-in-wranglertoml for more details."
       `);
     });
 
@@ -1156,7 +1157,12 @@ describe("normalizeAndValidateConfig()", () => {
             durable_objects: { bindings: expect.anything },
           })
         );
-        expect(diagnostics.hasWarnings()).toBe(false);
+        expect(diagnostics.hasWarnings()).toBe(true);
+        expect(diagnostics.hasErrors()).toBe(true);
+        expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+          "Processing wrangler configuration:
+            - In wrangler.toml, you have configured [durable_objects] exported by this Worker ((unnamed), (unnamed), 1666, SomeClass, 1883), but no [migrations] for them. This may not work as expected until you add a [migrations] section to your wrangler.toml. Refer to https://developers.cloudflare.com/workers/learning/using-durable-objects/#durable-object-migrations-in-wranglertoml for more details."
+        `);
         expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
           "Processing wrangler configuration:
 
@@ -2468,7 +2474,12 @@ describe("normalizeAndValidateConfig()", () => {
             durable_objects: { bindings: expect.anything },
           })
         );
-        expect(diagnostics.hasWarnings()).toBe(false);
+        expect(diagnostics.hasWarnings()).toBe(true);
+        expect(diagnostics.hasErrors()).toBe(true);
+        expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+          "Processing wrangler configuration:
+            - In wrangler.toml, you have configured [durable_objects] exported by this Worker ((unnamed), (unnamed), 1666), but no [migrations] for them. This may not work as expected until you add a [migrations] section to your wrangler.toml. Refer to https://developers.cloudflare.com/workers/learning/using-durable-objects/#durable-object-migrations-in-wranglertoml for more details."
+        `);
         expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
           "Processing wrangler configuration:
 

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -675,7 +675,7 @@ describe("wrangler dev", () => {
   });
 
   describe("durable_objects", () => {
-    it("should warn if there is one or more remote Durable Object", async () => {
+    it("should warn if there are remote Durable Objects, or missing migrations for local Durable Objects", async () => {
       writeWranglerToml({
         main: "index.js",
         durable_objects: {
@@ -700,7 +700,16 @@ describe("wrangler dev", () => {
       expect((Dev as jest.Mock).mock.calls[0][0].ip).toEqual("localhost");
       expect(std.out).toMatchInlineSnapshot(`""`);
       expect(std.warn).toMatchInlineSnapshot(`
-        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mWARNING: You have Durable Object bindings that are not defined locally in the worker being developed.[0m
+        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+
+            - In wrangler.toml, you have configured [durable_objects] exported by this Worker (CLASS_1,
+          CLASS_3), but no [migrations] for them. This may not work as expected until you add a [migrations]
+          section to your wrangler.toml. Refer to
+          [4mhttps://developers.cloudflare.com/workers/learning/using-durable-objects/#durable-object-migrations-in-wranglertoml[0m
+          for more details.
+
+
+        [33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mWARNING: You have Durable Object bindings that are not defined locally in the worker being developed.[0m
 
           Be aware that changes to the data stored in these Durable Objects will be permanent and affect the
           live instances.

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -2841,7 +2841,13 @@ addEventListener('fetch', event => {});`
       `);
       expect(std.err).toMatchInlineSnapshot(`""`);
       expect(std.warn).toMatchInlineSnapshot(`
-        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mIn wrangler.toml, you have configured [durable_objects] exported by this Worker (SomeClass), but no [migrations] for them. This may not work as expected until you add a [migrations] section to your wrangler.toml. Refer to https://developers.cloudflare.com/workers/learning/using-durable-objects/#durable-object-migrations-in-wranglertoml for more details.[0m
+        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+
+            - In wrangler.toml, you have configured [durable_objects] exported by this Worker (SomeClass),
+          but no [migrations] for them. This may not work as expected until you add a [migrations] section
+          to your wrangler.toml. Refer to
+          [4mhttps://developers.cloudflare.com/workers/learning/using-durable-objects/#durable-object-migrations-in-wranglertoml[0m
+          for more details.
 
         "
       `);

--- a/packages/wrangler/src/durable.ts
+++ b/packages/wrangler/src/durable.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert";
+import { fetchResult } from "./cfetch";
+import { logger } from "./logger";
+import type { Config } from "./config";
+import type { CfWorkerInit } from "./worker";
+
+/**
+ * For a given Worker + migrations config, figure out which migrations
+ * to upload based on the current migration tag of the deployed Worker.
+ */
+export async function getMigrationsToUpload(
+  scriptName: string,
+  props: {
+    accountId: string | undefined;
+    config: Config;
+    legacyEnv: boolean | undefined;
+    env: string | undefined;
+  }
+): Promise<CfWorkerInit["migrations"]> {
+  const { config, accountId } = props;
+
+  assert(accountId, "Missing accountId");
+  // if config.migrations
+  let migrations;
+  if (config.migrations.length > 0) {
+    // get current migration tag
+    type ScriptData = { id: string; migration_tag?: string };
+    let script: ScriptData | undefined;
+    if (!props.legacyEnv) {
+      try {
+        if (props.env) {
+          const scriptData = await fetchResult<{
+            script: ScriptData;
+          }>(
+            `/accounts/${accountId}/workers/services/${scriptName}/environments/${props.env}`
+          );
+          script = scriptData.script;
+        } else {
+          const scriptData = await fetchResult<{
+            default_environment: {
+              script: ScriptData;
+            };
+          }>(`/accounts/${accountId}/workers/services/${scriptName}`);
+          script = scriptData.default_environment.script;
+        }
+      } catch (err) {
+        if (
+          ![
+            10090, // corresponds to workers.api.error.service_not_found, so the script wasn't previously published at all
+            10092, // workers.api.error.environment_not_found, so the script wasn't published to this environment yet
+          ].includes((err as { code: number }).code)
+        ) {
+          throw err;
+        }
+        // else it's a 404, no script found, and we can proceed
+      }
+    } else {
+      const scripts = await fetchResult<ScriptData[]>(
+        `/accounts/${accountId}/workers/scripts`
+      );
+      script = scripts.find(({ id }) => id === scriptName);
+    }
+
+    if (script?.migration_tag) {
+      // was already published once
+      const scriptMigrationTag = script.migration_tag;
+      const foundIndex = config.migrations.findIndex(
+        (migration) => migration.tag === scriptMigrationTag
+      );
+      if (foundIndex === -1) {
+        logger.warn(
+          `The published script ${scriptName} has a migration tag "${script.migration_tag}, which was not found in wrangler.toml. You may have already deleted it. Applying all available migrations to the script...`
+        );
+        migrations = {
+          old_tag: script.migration_tag,
+          new_tag: config.migrations[config.migrations.length - 1].tag,
+          steps: config.migrations.map(({ tag: _tag, ...rest }) => rest),
+        };
+      } else {
+        if (foundIndex !== config.migrations.length - 1) {
+          // there are new migrations to send up
+          migrations = {
+            old_tag: script.migration_tag,
+            new_tag: config.migrations[config.migrations.length - 1].tag,
+            steps: config.migrations
+              .slice(foundIndex + 1)
+              .map(({ tag: _tag, ...rest }) => rest),
+          };
+        }
+        // else, we're up to date, no migrations to send
+      }
+    } else {
+      // first time publishing durable objects to this script,
+      // so we send all the migrations
+      migrations = {
+        new_tag: config.migrations[config.migrations.length - 1].tag,
+        steps: config.migrations.map(({ tag: _tag, ...rest }) => rest),
+      };
+    }
+  }
+  return migrations;
+}

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -8,6 +8,7 @@ import { fetchResult } from "./cfetch";
 import { printBindings } from "./config";
 import { createWorkerUploadForm } from "./create-worker-upload-form";
 import { confirm } from "./dialogs";
+import { getMigrationsToUpload } from "./durable";
 import { logger } from "./logger";
 import { syncAssets } from "./sites";
 import type { Config } from "./config";
@@ -338,103 +339,19 @@ export default async function publish(props: Props): Promise<void> {
       }
     );
 
-    // Some validation of durable objects + migrations
-    if (config.durable_objects.bindings.length > 0) {
-      // intrinsic [durable_objects] implies [migrations]
-      const exportedDurableObjects = config.durable_objects.bindings.filter(
-        (binding) => !binding.script_name
-      );
-      if (exportedDurableObjects.length > 0 && config.migrations.length === 0) {
-        logger.warn(
-          `In wrangler.toml, you have configured [durable_objects] exported by this Worker (${exportedDurableObjects.map(
-            (durable) => durable.class_name
-          )}), but no [migrations] for them. This may not work as expected until you add a [migrations] section to your wrangler.toml. Refer to https://developers.cloudflare.com/workers/learning/using-durable-objects/#durable-object-migrations-in-wranglertoml for more details.`
-        );
-      }
-    }
-
     const content = readFileSync(resolvedEntryPointPath, {
       encoding: "utf-8",
     });
 
-    // if config.migrations
-    let migrations;
-    if (!props.dryRun && config.migrations.length > 0) {
-      // get current migration tag
-      type ScriptData = { id: string; migration_tag?: string };
-      let script: ScriptData | undefined;
-      if (!props.legacyEnv) {
-        try {
-          if (props.env) {
-            const scriptData = await fetchResult<{
-              script: ScriptData;
-            }>(
-              `/accounts/${accountId}/workers/services/${scriptName}/environments/${props.env}`
-            );
-            script = scriptData.script;
-          } else {
-            const scriptData = await fetchResult<{
-              default_environment: {
-                script: ScriptData;
-              };
-            }>(`/accounts/${accountId}/workers/services/${scriptName}`);
-            script = scriptData.default_environment.script;
-          }
-        } catch (err) {
-          if (
-            ![
-              10090, // corresponds to workers.api.error.service_not_found, so the script wasn't previously published at all
-              10092, // workers.api.error.environment_not_found, so the script wasn't published to this environment yet
-            ].includes((err as { code: number }).code)
-          ) {
-            throw err;
-          }
-          // else it's a 404, no script found, and we can proceed
-        }
-      } else {
-        const scripts = await fetchResult<ScriptData[]>(
-          `/accounts/${accountId}/workers/scripts`
-        );
-        script = scripts.find(({ id }) => id === scriptName);
-      }
-
-      if (script?.migration_tag) {
-        // was already published once
-        const scriptMigrationTag = script.migration_tag;
-        const foundIndex = config.migrations.findIndex(
-          (migration) => migration.tag === scriptMigrationTag
-        );
-        if (foundIndex === -1) {
-          logger.warn(
-            `The published script ${scriptName} has a migration tag "${script.migration_tag}, which was not found in wrangler.toml. You may have already deleted it. Applying all available migrations to the script...`
-          );
-          migrations = {
-            old_tag: script.migration_tag,
-            new_tag: config.migrations[config.migrations.length - 1].tag,
-            steps: config.migrations.map(({ tag: _tag, ...rest }) => rest),
-          };
-        } else {
-          if (foundIndex !== config.migrations.length - 1) {
-            // there are new migrations to send up
-            migrations = {
-              old_tag: script.migration_tag,
-              new_tag: config.migrations[config.migrations.length - 1].tag,
-              steps: config.migrations
-                .slice(foundIndex + 1)
-                .map(({ tag: _tag, ...rest }) => rest),
-            };
-          }
-          // else, we're up to date, no migrations to send
-        }
-      } else {
-        // first time publishing durable objects to this script,
-        // so we send all the migrations
-        migrations = {
-          new_tag: config.migrations[config.migrations.length - 1].tag,
-          steps: config.migrations.map(({ tag: _tag, ...rest }) => rest),
-        };
-      }
-    }
+    // durable object migrations
+    const migrations = !props.dryRun
+      ? await getMigrationsToUpload(scriptName, {
+          accountId,
+          config,
+          legacyEnv: props.legacyEnv,
+          env: props.env,
+        })
+      : undefined;
 
     const assets = await syncAssets(
       accountId,


### PR DESCRIPTION
This refactors some logic around durable objects -

- During publish, we were checking whether `[migrations]` were defined in the presence of `[durable_objects]`, and warning if not. This moves it into the config validation step, which means it'll check for all commands (but notably `dev`)
- It moves the code to determine current migration tag/migrations to upload into a helper. We'll be reusing this soon when we upload migrations to `dev`.

---

For additional context, I have a PR in flight that adds migrations to dev, blocked on some api changes, and it's been hard to rebase that over code that's been landing. This will make it easier to land that, and the additional validation is welcome. 