### PR TITLE
Adds Pages team as codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,5 @@
 # Global owners
 * @threepointone @petebacondarwin
-/packages/wrangler/pages/ @GregBrimble
+/packages/wrangler/pages/ @cloudflare/pages
+/packages/wrangler/src/pages/ @cloudflare/pages
+/packages/wrangler/src/pages.* @cloudflare/pages


### PR DESCRIPTION
We've just created the @cloudflare/pages team so everyone can stay on top of our open-sourced work.

Adds the team as codeowners for Pages stuff. We don't yet have a `src/pages/` folder, but I figure it's probably inevitable when we refactor the `src/pages.tsx` a bit.