### PR TITLE
Add a better message when a user doesn't have a Chromium-based browser.

### DIFF
--- a/.changeset/eleven-peaches-call.md
+++ b/.changeset/eleven-peaches-call.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Add a better message when a user doesn't have a Chromium-based browser.
+
+Certain functionality we use in wrangler depends on a Chromium-based browser. Previously, we would throw a somewhat arcane error that was hard (or impossible) to understand without knowing what we needed. While ideally all of our functionality would work across all major browsers, as a stopgap measure we can at least inform the user what the actual issue is.

--- a/packages/wrangler/src/open-in-browser.ts
+++ b/packages/wrangler/src/open-in-browser.ts
@@ -19,8 +19,22 @@ export default async function openInBrowser(
         app: [{ name: open.apps.chrome }, { name: open.apps.edge }],
       }
     : undefined;
-  const childProcess = await open(url, options);
-  childProcess.on("error", () => {
-    logger.warn(`Failed to open ${url} in a browser.`);
-  });
+
+  const errorMessage = `Failed to open ${url} in a ${
+    forceChromium ? "Chromium-based" : ""
+  } browser.${
+    forceChromium
+      ? "\nPlease install a Chromium-based browser such as Google Chrome or Microsoft Edge."
+      : ""
+  }`;
+
+  try {
+    const childProcess = await open(url, options);
+    childProcess.on("error", () => {
+      logger.warn(errorMessage);
+    });
+  } catch (e) {
+    const cause = e instanceof Error ? e : new Error(`${e}`);
+    throw new Error(errorMessage, { cause });
+  }
 }


### PR DESCRIPTION
Certain functionality we use in wrangler depends on a Chromium-based browser. Previously, we would throw a somewhat arcane error that was hard (or impossible) to understand without knowing what we needed. While ideally all of our functionality would work across all major browsers, as a stopgap measure we can at least inform the user what the actual issue is.

I'm not thrilled about how generic the message is (I think it would be nice if it said e.g. "to open devtools") but I'm not sure there's a clean way to do that without either passing in an extra optional arg describing the name of the process like

```typescript
openInBrowser(url, { forceChromium: true, processName: "devtools" });
```

or customizing the error message at the call site, which feels not very DRY.

Closes #606
