### PR TITLE
Print the bindings a worker has access to during `dev` and `publish`

### DIFF
--- a/.changeset/empty-oranges-attack.md
+++ b/.changeset/empty-oranges-attack.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Print the bindings a worker has access to during `dev` and `publish`
+
+It can be helpful for a user to know exactly what resources a worker will have access to and where they can access them, so we now log the bindings available to a worker during `wrangler dev` and `wrangler publish`.

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -765,13 +765,13 @@ describe("wrangler dev", () => {
       expect(std.out).toMatchInlineSnapshot(`
         "Your worker has access to the following:
         Vars
-        	- VAR_1: original value 1
-        	- VAR_2: original value 2
-        	- VAR_3: original value 3
-        	- VAR_MULTI_LINE_1: original multi-line 1
-        	- VAR_MULTI_LINE_2: original multi-line 2
-        	- EMPTY: original empty
-        	- UNQUOTED: original unquoted
+        	- VAR_1: \\"original value 1\\"
+        	- VAR_2: \\"original value 2\\"
+        	- VAR_3: \\"original value 3\\"
+        	- VAR_MULTI_LINE_1: \\"original multi-line 1\\"
+        	- VAR_MULTI_LINE_2: \\"original multi-line 2\\"
+        	- EMPTY: \\"original empty\\"
+        	- UNQUOTED: \\"original unquoted\\"
         Using vars defined in .dev.vars"
       `);
       expect(std.warn).toMatchInlineSnapshot(`""`);
@@ -870,7 +870,7 @@ describe("wrangler dev", () => {
           "debug": "",
           "err": "",
           "out": "Your worker has access to the following:
-        Service Bindings
+        Services
         	- WorkerA: A
         	- WorkerB: B - staging",
           "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -698,7 +698,14 @@ describe("wrangler dev", () => {
       fs.writeFileSync("index.js", `export default {};`);
       await runWrangler("dev");
       expect((Dev as jest.Mock).mock.calls[0][0].ip).toEqual("localhost");
-      expect(std.out).toMatchInlineSnapshot(`""`);
+      expect(std.out).toMatchInlineSnapshot(`
+        "Your worker has access to the following:
+        Durable Objects
+        	- NAME_1: CLASS_1
+        	- NAME_2: CLASS_2 (defined in SCRIPT_A)
+        	- NAME_3: CLASS_3
+        	- NAME_4: CLASS_4 (defined in SCRIPT_B)"
+      `);
       expect(std.warn).toMatchInlineSnapshot(`
         "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mWARNING: You have Durable Object bindings that are not defined locally in the worker being developed.[0m
 
@@ -755,9 +762,18 @@ describe("wrangler dev", () => {
         EMPTY: "",
         UNQUOTED: "unquoted value", // Note that whitespace is trimmed
       });
-      expect(std.out).toMatchInlineSnapshot(
-        `"Using vars defined in .dev.vars"`
-      );
+      expect(std.out).toMatchInlineSnapshot(`
+        "Your worker has access to the following:
+        Vars
+        	- VAR_1: original value 1
+        	- VAR_2: original value 2
+        	- VAR_3: original value 3
+        	- VAR_MULTI_LINE_1: original multi-line 1
+        	- VAR_MULTI_LINE_2: original multi-line 2
+        	- EMPTY: original empty
+        	- UNQUOTED: original unquoted
+        Using vars defined in .dev.vars"
+      `);
       expect(std.warn).toMatchInlineSnapshot(`""`);
       expect(std.err).toMatchInlineSnapshot(`""`);
     });
@@ -853,7 +869,10 @@ describe("wrangler dev", () => {
         Object {
           "debug": "",
           "err": "",
-          "out": "",
+          "out": "Your worker has access to the following:
+        Service Bindings
+        	- WorkerA: A
+        	- WorkerB: B - staging",
           "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
 
             - \\"services\\" fields are experimental and may change or break at any time.

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -698,14 +698,7 @@ describe("wrangler dev", () => {
       fs.writeFileSync("index.js", `export default {};`);
       await runWrangler("dev");
       expect((Dev as jest.Mock).mock.calls[0][0].ip).toEqual("localhost");
-      expect(std.out).toMatchInlineSnapshot(`
-        "Your worker has access to the following:
-        - Durable Objects
-          - NAME_1: CLASS_1
-          - NAME_2: CLASS_2 (defined in SCRIPT_A)
-          - NAME_3: CLASS_3
-          - NAME_4: CLASS_4 (defined in SCRIPT_B)"
-      `);
+      expect(std.out).toMatchInlineSnapshot(`""`);
       expect(std.warn).toMatchInlineSnapshot(`
         "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mWARNING: You have Durable Object bindings that are not defined locally in the worker being developed.[0m
 
@@ -762,18 +755,9 @@ describe("wrangler dev", () => {
         EMPTY: "",
         UNQUOTED: "unquoted value", // Note that whitespace is trimmed
       });
-      expect(std.out).toMatchInlineSnapshot(`
-        "Your worker has access to the following:
-        - Vars
-          - VAR_1: \\"original value 1\\"
-          - VAR_2: \\"original value 2\\"
-          - VAR_3: \\"original value 3\\"
-          - VAR_MULTI_LINE_1: \\"original multi-line 1\\"
-          - VAR_MULTI_LINE_2: \\"original multi-line 2\\"
-          - EMPTY: \\"original empty\\"
-          - UNQUOTED: \\"original unquoted\\"
-        Using vars defined in .dev.vars"
-      `);
+      expect(std.out).toMatchInlineSnapshot(
+        `"Using vars defined in .dev.vars"`
+      );
       expect(std.warn).toMatchInlineSnapshot(`""`);
       expect(std.err).toMatchInlineSnapshot(`""`);
     });
@@ -869,10 +853,7 @@ describe("wrangler dev", () => {
         Object {
           "debug": "",
           "err": "",
-          "out": "Your worker has access to the following:
-        - Services
-          - WorkerA: A
-          - WorkerB: B - staging",
+          "out": "",
           "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
 
             - \\"services\\" fields are experimental and may change or break at any time.

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -700,11 +700,11 @@ describe("wrangler dev", () => {
       expect((Dev as jest.Mock).mock.calls[0][0].ip).toEqual("localhost");
       expect(std.out).toMatchInlineSnapshot(`
         "Your worker has access to the following:
-        Durable Objects
-        	- NAME_1: CLASS_1
-        	- NAME_2: CLASS_2 (defined in SCRIPT_A)
-        	- NAME_3: CLASS_3
-        	- NAME_4: CLASS_4 (defined in SCRIPT_B)"
+        - Durable Objects
+          - NAME_1: CLASS_1
+          - NAME_2: CLASS_2 (defined in SCRIPT_A)
+          - NAME_3: CLASS_3
+          - NAME_4: CLASS_4 (defined in SCRIPT_B)"
       `);
       expect(std.warn).toMatchInlineSnapshot(`
         "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mWARNING: You have Durable Object bindings that are not defined locally in the worker being developed.[0m
@@ -764,14 +764,14 @@ describe("wrangler dev", () => {
       });
       expect(std.out).toMatchInlineSnapshot(`
         "Your worker has access to the following:
-        Vars
-        	- VAR_1: \\"original value 1\\"
-        	- VAR_2: \\"original value 2\\"
-        	- VAR_3: \\"original value 3\\"
-        	- VAR_MULTI_LINE_1: \\"original multi-line 1\\"
-        	- VAR_MULTI_LINE_2: \\"original multi-line 2\\"
-        	- EMPTY: \\"original empty\\"
-        	- UNQUOTED: \\"original unquoted\\"
+        - Vars
+          - VAR_1: \\"original value 1\\"
+          - VAR_2: \\"original value 2\\"
+          - VAR_3: \\"original value 3\\"
+          - VAR_MULTI_LINE_1: \\"original multi-line 1\\"
+          - VAR_MULTI_LINE_2: \\"original multi-line 2\\"
+          - EMPTY: \\"original empty\\"
+          - UNQUOTED: \\"original unquoted\\"
         Using vars defined in .dev.vars"
       `);
       expect(std.warn).toMatchInlineSnapshot(`""`);
@@ -870,9 +870,9 @@ describe("wrangler dev", () => {
           "debug": "",
           "err": "",
           "out": "Your worker has access to the following:
-        Services
-        	- WorkerA: A
-        	- WorkerB: B - staging",
+        - Services
+          - WorkerA: A
+          - WorkerB: B - staging",
           "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
 
             - \\"services\\" fields are experimental and may change or break at any time.

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -473,7 +473,7 @@ describe("publish", () => {
     expect(std.out).toMatchInlineSnapshot(`
       "Your worker has access to the following:
       Vars
-      	- xyz: 123
+      	- xyz: \\"123\\"
       Uploaded test-name (TIMINGS)
       Published test-name (TIMINGS)
         test-name.test-sub-domain.workers.dev"
@@ -3429,8 +3429,8 @@ addEventListener('fetch', event => {});`
          \\"data\\": 1337
         }
         Vars
-        	- ENV_VAR_ONE: 123
-        	- ENV_VAR_TWO: Hello, I'm an environment variable
+        	- ENV_VAR_ONE: \\"123\\"
+        	- ENV_VAR_TWO: \\"Hello, I'm an environment variable\\"
         Wasm Modules
         	- WASM_MODULE_ONE: some_wasm.wasm
         	- WASM_MODULE_TWO: more_wasm.wasm
@@ -4177,9 +4177,9 @@ addEventListener('fetch', event => {});`
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
           Vars
-          	- text: plain ol' string
-          	- count: 1
-          	- complex: [object Object]
+          	- text: \\"plain ol' string\\"
+          	- count: \\"1\\"
+          	- complex: \\"[object Object]\\"
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
             test-name.test-sub-domain.workers.dev"
@@ -4395,7 +4395,7 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          Service Bindings
+          Services
           	- FOO: foo-service - production
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -1178,9 +1178,6 @@ addEventListener('fetch', event => {});`
         Reading assets/file-2.txt...
         Uploading as assets/file-2.5938485188.txt...
         ↗️  Done syncing assets
-        Your worker has access to the following:
-        - KV Namespaces
-          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev",
@@ -1232,9 +1229,6 @@ addEventListener('fetch', event => {});`
         Reading assets/file-2.txt...
         Uploading as assets/file-2.5938485188.txt...
         ↗️  Done syncing assets
-        Your worker has access to the following:
-        - KV Namespaces
-          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -1326,9 +1320,6 @@ addEventListener('fetch', event => {});`
         Reading assets/file-2.txt...
         Uploading as assets/file-2.5938485188.txt...
         ↗️  Done syncing assets
-        Your worker has access to the following:
-        - KV Namespaces
-          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -1385,11 +1376,6 @@ addEventListener('fetch', event => {});`
         Reading assets/file-2.txt...
         Uploading as assets/file-2.5938485188.txt...
         ↗️  Done syncing assets
-        Your worker has access to the following:
-        - KV Namespaces
-          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
-        - Text Blobs
-          - __STATIC_CONTENT_MANIFEST: __STATIC_CONTENT_MANIFEST
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -1440,9 +1426,6 @@ addEventListener('fetch', event => {});`
         Reading assets/file-2.txt...
         Uploading as assets/file-2.5938485188.txt...
         ↗️  Done syncing assets
-        Your worker has access to the following:
-        - KV Namespaces
-          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -1491,9 +1474,6 @@ addEventListener('fetch', event => {});`
         Reading assets/file-2.txt...
         Uploading as assets/file-2.5938485188.txt...
         ↗️  Done syncing assets
-        Your worker has access to the following:
-        - KV Namespaces
-          - __STATIC_CONTENT: __test-name-some-env-workers_sites_assets-id
         Uploaded test-name (some-env) (TIMINGS)
         Published test-name (some-env) (TIMINGS)
           some-env.test-name.test-sub-domain.workers.dev"
@@ -1543,9 +1523,6 @@ addEventListener('fetch', event => {});`
         Reading assets/file-2.txt...
         Uploading as assets/file-2.5938485188.txt...
         ↗️  Done syncing assets
-        Your worker has access to the following:
-        - KV Namespaces
-          - __STATIC_CONTENT: __test-name-some-env-workers_sites_assets-id
         Uploaded test-name-some-env (TIMINGS)
         Published test-name-some-env (TIMINGS)
           test-name-some-env.test-sub-domain.workers.dev"
@@ -1590,9 +1567,6 @@ addEventListener('fetch', event => {});`
         Reading assets/file-2.txt...
         Uploading as assets/file-2.5938485188.txt...
         ↗️  Done syncing assets
-        Your worker has access to the following:
-        - KV Namespaces
-          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -1632,9 +1606,6 @@ addEventListener('fetch', event => {});`
         "Reading assets/file-1.txt...
         Uploading as assets/file-1.2ca234f380.txt...
         ↗️  Done syncing assets
-        Your worker has access to the following:
-        - KV Namespaces
-          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -1674,9 +1645,6 @@ addEventListener('fetch', event => {});`
         "Reading assets/file-1.txt...
         Uploading as assets/file-1.2ca234f380.txt...
         ↗️  Done syncing assets
-        Your worker has access to the following:
-        - KV Namespaces
-          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -1717,9 +1685,6 @@ addEventListener('fetch', event => {});`
         "Reading assets/file-1.txt...
         Uploading as assets/file-1.2ca234f380.txt...
         ↗️  Done syncing assets
-        Your worker has access to the following:
-        - KV Namespaces
-          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -1760,9 +1725,6 @@ addEventListener('fetch', event => {});`
         "Reading assets/file-1.txt...
         Uploading as assets/file-1.2ca234f380.txt...
         ↗️  Done syncing assets
-        Your worker has access to the following:
-        - KV Namespaces
-          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -1803,9 +1765,6 @@ addEventListener('fetch', event => {});`
         "Reading assets/file-1.txt...
         Uploading as assets/file-1.2ca234f380.txt...
         ↗️  Done syncing assets
-        Your worker has access to the following:
-        - KV Namespaces
-          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -1846,9 +1805,6 @@ addEventListener('fetch', event => {});`
         "Reading assets/file-1.txt...
         Uploading as assets/file-1.2ca234f380.txt...
         ↗️  Done syncing assets
-        Your worker has access to the following:
-        - KV Namespaces
-          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -1891,9 +1847,6 @@ addEventListener('fetch', event => {});`
         "Reading assets/directory-1/file-1.txt...
         Uploading as assets/directory-1/file-1.2ca234f380.txt...
         ↗️  Done syncing assets
-        Your worker has access to the following:
-        - KV Namespaces
-          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -1940,9 +1893,6 @@ addEventListener('fetch', event => {});`
         "Reading assets/.well-known/file-2.txt...
         Uploading as assets/.well-known/file-2.5938485188.txt...
         ↗️  Done syncing assets
-        Your worker has access to the following:
-        - KV Namespaces
-          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -2088,9 +2038,6 @@ addEventListener('fetch', event => {});`
         Deleting assets/file-3.somehash.txt from the asset store...
         Deleting assets/file-4.anotherhash.txt from the asset store...
         ↗️  Done syncing assets
-        Your worker has access to the following:
-        - KV Namespaces
-          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -1178,6 +1178,9 @@ addEventListener('fetch', event => {});`
         Reading assets/file-2.txt...
         Uploading as assets/file-2.5938485188.txt...
         ↗️  Done syncing assets
+        Your worker has access to the following:
+        - KV Namespaces
+          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev",
@@ -1229,6 +1232,9 @@ addEventListener('fetch', event => {});`
         Reading assets/file-2.txt...
         Uploading as assets/file-2.5938485188.txt...
         ↗️  Done syncing assets
+        Your worker has access to the following:
+        - KV Namespaces
+          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -1320,6 +1326,9 @@ addEventListener('fetch', event => {});`
         Reading assets/file-2.txt...
         Uploading as assets/file-2.5938485188.txt...
         ↗️  Done syncing assets
+        Your worker has access to the following:
+        - KV Namespaces
+          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -1376,6 +1385,11 @@ addEventListener('fetch', event => {});`
         Reading assets/file-2.txt...
         Uploading as assets/file-2.5938485188.txt...
         ↗️  Done syncing assets
+        Your worker has access to the following:
+        - KV Namespaces
+          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
+        - Text Blobs
+          - __STATIC_CONTENT_MANIFEST: __STATIC_CONTENT_MANIFEST
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -1426,6 +1440,9 @@ addEventListener('fetch', event => {});`
         Reading assets/file-2.txt...
         Uploading as assets/file-2.5938485188.txt...
         ↗️  Done syncing assets
+        Your worker has access to the following:
+        - KV Namespaces
+          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -1474,6 +1491,9 @@ addEventListener('fetch', event => {});`
         Reading assets/file-2.txt...
         Uploading as assets/file-2.5938485188.txt...
         ↗️  Done syncing assets
+        Your worker has access to the following:
+        - KV Namespaces
+          - __STATIC_CONTENT: __test-name-some-env-workers_sites_assets-id
         Uploaded test-name (some-env) (TIMINGS)
         Published test-name (some-env) (TIMINGS)
           some-env.test-name.test-sub-domain.workers.dev"
@@ -1523,6 +1543,9 @@ addEventListener('fetch', event => {});`
         Reading assets/file-2.txt...
         Uploading as assets/file-2.5938485188.txt...
         ↗️  Done syncing assets
+        Your worker has access to the following:
+        - KV Namespaces
+          - __STATIC_CONTENT: __test-name-some-env-workers_sites_assets-id
         Uploaded test-name-some-env (TIMINGS)
         Published test-name-some-env (TIMINGS)
           test-name-some-env.test-sub-domain.workers.dev"
@@ -1567,6 +1590,9 @@ addEventListener('fetch', event => {});`
         Reading assets/file-2.txt...
         Uploading as assets/file-2.5938485188.txt...
         ↗️  Done syncing assets
+        Your worker has access to the following:
+        - KV Namespaces
+          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -1606,6 +1632,9 @@ addEventListener('fetch', event => {});`
         "Reading assets/file-1.txt...
         Uploading as assets/file-1.2ca234f380.txt...
         ↗️  Done syncing assets
+        Your worker has access to the following:
+        - KV Namespaces
+          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -1645,6 +1674,9 @@ addEventListener('fetch', event => {});`
         "Reading assets/file-1.txt...
         Uploading as assets/file-1.2ca234f380.txt...
         ↗️  Done syncing assets
+        Your worker has access to the following:
+        - KV Namespaces
+          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -1685,6 +1717,9 @@ addEventListener('fetch', event => {});`
         "Reading assets/file-1.txt...
         Uploading as assets/file-1.2ca234f380.txt...
         ↗️  Done syncing assets
+        Your worker has access to the following:
+        - KV Namespaces
+          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -1725,6 +1760,9 @@ addEventListener('fetch', event => {});`
         "Reading assets/file-1.txt...
         Uploading as assets/file-1.2ca234f380.txt...
         ↗️  Done syncing assets
+        Your worker has access to the following:
+        - KV Namespaces
+          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -1765,6 +1803,9 @@ addEventListener('fetch', event => {});`
         "Reading assets/file-1.txt...
         Uploading as assets/file-1.2ca234f380.txt...
         ↗️  Done syncing assets
+        Your worker has access to the following:
+        - KV Namespaces
+          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -1805,6 +1846,9 @@ addEventListener('fetch', event => {});`
         "Reading assets/file-1.txt...
         Uploading as assets/file-1.2ca234f380.txt...
         ↗️  Done syncing assets
+        Your worker has access to the following:
+        - KV Namespaces
+          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -1847,6 +1891,9 @@ addEventListener('fetch', event => {});`
         "Reading assets/directory-1/file-1.txt...
         Uploading as assets/directory-1/file-1.2ca234f380.txt...
         ↗️  Done syncing assets
+        Your worker has access to the following:
+        - KV Namespaces
+          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -1893,6 +1940,9 @@ addEventListener('fetch', event => {});`
         "Reading assets/.well-known/file-2.txt...
         Uploading as assets/.well-known/file-2.5938485188.txt...
         ↗️  Done syncing assets
+        Your worker has access to the following:
+        - KV Namespaces
+          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -2038,6 +2088,9 @@ addEventListener('fetch', event => {});`
         Deleting assets/file-3.somehash.txt from the asset store...
         Deleting assets/file-4.anotherhash.txt from the asset store...
         ↗️  Done syncing assets
+        Your worker has access to the following:
+        - KV Namespaces
+          - __STATIC_CONTENT: __test-name-workers_sites_assets-id
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -3419,10 +3472,9 @@ addEventListener('fetch', event => {});`
         - Text Blobs
           - TEXT_BLOB_ONE: my-entire-app-depends-on-this.cfg
           - TEXT_BLOB_TWO: the-entirety-of-human-knowledge.txt
-        - some unsafe thing
-          - UNSAFE_BINDING_ONE: {\\"data\\":{\\"some\\":{\\"unsafe\\":\\"thing\\"}}}
-        - another unsafe thing
-          - UNSAFE_BINDING_TWO: {\\"data\\":1337}
+        - Unsafe
+          - some unsafe thing: UNSAFE_BINDING_ONE
+          - another unsafe thing: UNSAFE_BINDING_TWO
         - Vars
           - ENV_VAR_ONE: \\"123\\"
           - ENV_VAR_TWO: \\"Hello, I'm an environment variable\\"
@@ -3832,10 +3884,7 @@ addEventListener('fetch', event => {});`
           `"You cannot configure [wasm_modules] with an ES module worker. Instead, import the .wasm module directly in your code"`
         );
         expect(std.out).toMatchInlineSnapshot(`
-          "Your worker has access to the following:
-          - Wasm Modules
-            - TESTWASMNAME: path/to/test.wasm
-
+          "
           [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
         `);
         expect(std.err).toMatchInlineSnapshot(`
@@ -3972,10 +4021,7 @@ addEventListener('fetch', event => {});`
           `"You cannot configure [text_blobs] with an ES module worker. Instead, import the file directly in your code, and optionally configure \`[rules]\` in your wrangler.toml"`
         );
         expect(std.out).toMatchInlineSnapshot(`
-          "Your worker has access to the following:
-          - Text Blobs
-            - TESTTEXTBLOBNAME: path/to/text.file
-
+          "
           [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
         `);
         expect(std.err).toMatchInlineSnapshot(`
@@ -4084,10 +4130,7 @@ addEventListener('fetch', event => {});`
           `"You cannot configure [data_blobs] with an ES module worker. Instead, import the file directly in your code, and optionally configure \`[rules]\` in your wrangler.toml"`
         );
         expect(std.out).toMatchInlineSnapshot(`
-          "Your worker has access to the following:
-          - Data Blobs
-            - TESTDATABLOBNAME: path/to/data.bin
-
+          "
           [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
         `);
         expect(std.err).toMatchInlineSnapshot(`
@@ -4435,8 +4478,8 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          - binding-type
-            - my-binding: {\\"param\\":\\"binding-param\\"}
+          - Unsafe
+            - binding-type: my-binding
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
             test-name.test-sub-domain.workers.dev"
@@ -4477,8 +4520,8 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          - plain_text
-            - my-binding: {\\"text\\":\\"text\\"}
+          - Unsafe
+            - plain_text: my-binding
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
             test-name.test-sub-domain.workers.dev"

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -471,7 +471,7 @@ describe("publish", () => {
     mockSubDomainRequest();
     await runWrangler("publish ./some-path/worker/index.js");
     expect(std.out).toMatchInlineSnapshot(`
-      "Your worker has access to the following:
+      "Your worker has access to the following bindings:
       - Vars:
         - xyz: \\"123\\"
       Uploaded test-name (TIMINGS)
@@ -2832,7 +2832,7 @@ addEventListener('fetch', event => {});`
       mockUploadWorkerRequest();
       await runWrangler("publish index.js");
       expect(std.out).toMatchInlineSnapshot(`
-        "Your worker has access to the following:
+        "Your worker has access to the following bindings:
         - Durable Objects:
           - SOMENAME: SomeClass
         Uploaded test-name (TIMINGS)
@@ -2867,7 +2867,7 @@ addEventListener('fetch', event => {});`
       mockUploadWorkerRequest();
       await runWrangler("publish index.js");
       expect(std.out).toMatchInlineSnapshot(`
-        "Your worker has access to the following:
+        "Your worker has access to the following bindings:
         - Durable Objects:
           - SOMENAME: SomeClass (defined in some-script)
         Uploaded test-name (TIMINGS)
@@ -2909,7 +2909,7 @@ addEventListener('fetch', event => {});`
 
       await runWrangler("publish index.js");
       expect(std.out).toMatchInlineSnapshot(`
-        "Your worker has access to the following:
+        "Your worker has access to the following bindings:
         - Durable Objects:
           - SOMENAME: SomeClass
           - SOMEOTHERNAME: SomeOtherClass
@@ -2959,7 +2959,7 @@ addEventListener('fetch', event => {});`
         Object {
           "debug": "",
           "err": "",
-          "out": "Your worker has access to the following:
+          "out": "Your worker has access to the following bindings:
         - Durable Objects:
           - SOMENAME: SomeClass
           - SOMEOTHERNAME: SomeOtherClass
@@ -3002,7 +3002,7 @@ addEventListener('fetch', event => {});`
         Object {
           "debug": "",
           "err": "",
-          "out": "Your worker has access to the following:
+          "out": "Your worker has access to the following bindings:
         - Durable Objects:
           - SOMENAME: SomeClass
           - SOMEOTHERNAME: SomeOtherClass
@@ -3047,7 +3047,7 @@ addEventListener('fetch', event => {});`
 
         await runWrangler("publish index.js --legacy-env false");
         expect(std.out).toMatchInlineSnapshot(`
-          "Your worker has access to the following:
+          "Your worker has access to the following bindings:
           - Durable Objects:
             - SOMENAME: SomeClass
             - SOMEOTHERNAME: SomeOtherClass
@@ -3109,7 +3109,7 @@ addEventListener('fetch', event => {});`
 
         await runWrangler("publish index.js --legacy-env false --env xyz");
         expect(std.out).toMatchInlineSnapshot(`
-          "Your worker has access to the following:
+          "Your worker has access to the following bindings:
           - Durable Objects:
             - SOMENAME: SomeClass
             - SOMEOTHERNAME: SomeOtherClass
@@ -3167,7 +3167,7 @@ addEventListener('fetch', event => {});`
           Object {
             "debug": "",
             "err": "",
-            "out": "Your worker has access to the following:
+            "out": "Your worker has access to the following bindings:
           - Durable Objects:
             - SOMENAME: SomeClass
             - SOMEOTHERNAME: SomeOtherClass
@@ -3235,7 +3235,7 @@ addEventListener('fetch', event => {});`
           Object {
             "debug": "",
             "err": "",
-            "out": "Your worker has access to the following:
+            "out": "Your worker has access to the following bindings:
           - Durable Objects:
             - SOMENAME: SomeClass
             - SOMEOTHERNAME: SomeOtherClass
@@ -3403,7 +3403,7 @@ addEventListener('fetch', event => {});`
 
       await expect(runWrangler("publish index.js")).resolves.toBeUndefined();
       expect(std.out).toMatchInlineSnapshot(`
-        "Your worker has access to the following:
+        "Your worker has access to the following bindings:
         - Data Blobs:
           - DATA_BLOB_ONE: some-data-blob.bin
           - DATA_BLOB_TWO: more-data-blob.bin
@@ -3804,7 +3804,7 @@ addEventListener('fetch', event => {});`
         mockSubDomainRequest();
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
-          "Your worker has access to the following:
+          "Your worker has access to the following bindings:
           - Wasm Modules:
             - TESTWASMNAME: path/to/test.wasm
           Uploaded test-name (TIMINGS)
@@ -3873,7 +3873,7 @@ addEventListener('fetch', event => {});`
         mockSubDomainRequest();
         await runWrangler("publish index.js --config ./path/to/wrangler.toml");
         expect(std.out).toMatchInlineSnapshot(`
-          "Your worker has access to the following:
+          "Your worker has access to the following bindings:
           - Wasm Modules:
             - TESTWASMNAME: path/to/and/the/path/to/test.wasm
           Uploaded test-name (TIMINGS)
@@ -3941,7 +3941,7 @@ addEventListener('fetch', event => {});`
         mockSubDomainRequest();
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
-          "Your worker has access to the following:
+          "Your worker has access to the following bindings:
           - Text Blobs:
             - TESTTEXTBLOBNAME: path/to/text.file
           Uploaded test-name (TIMINGS)
@@ -4014,7 +4014,7 @@ addEventListener('fetch', event => {});`
         mockSubDomainRequest();
         await runWrangler("publish index.js --config ./path/to/wrangler.toml");
         expect(std.out).toMatchInlineSnapshot(`
-          "Your worker has access to the following:
+          "Your worker has access to the following bindings:
           - Text Blobs:
             - TESTTEXTBLOBNAME: path/to/and/the/path/to/text.file
           Uploaded test-name (TIMINGS)
@@ -4050,7 +4050,7 @@ addEventListener('fetch', event => {});`
         mockSubDomainRequest();
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
-          "Your worker has access to the following:
+          "Your worker has access to the following bindings:
           - Data Blobs:
             - TESTDATABLOBNAME: path/to/data.bin
           Uploaded test-name (TIMINGS)
@@ -4123,7 +4123,7 @@ addEventListener('fetch', event => {});`
         mockSubDomainRequest();
         await runWrangler("publish index.js --config ./path/to/wrangler.toml");
         expect(std.out).toMatchInlineSnapshot(`
-          "Your worker has access to the following:
+          "Your worker has access to the following bindings:
           - Data Blobs:
             - TESTDATABLOBNAME: path/to/and/the/path/to/data.bin
           Uploaded test-name (TIMINGS)
@@ -4160,7 +4160,7 @@ addEventListener('fetch', event => {});`
 
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
-          "Your worker has access to the following:
+          "Your worker has access to the following bindings:
           - Vars:
             - text: \\"plain ol' string\\"
             - count: \\"1\\"
@@ -4189,7 +4189,7 @@ addEventListener('fetch', event => {});`
 
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
-          "Your worker has access to the following:
+          "Your worker has access to the following bindings:
           - R2 Buckets:
             - FOO: foo-bucket
           Uploaded test-name (TIMINGS)
@@ -4234,7 +4234,7 @@ addEventListener('fetch', event => {});`
 
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
-          "Your worker has access to the following:
+          "Your worker has access to the following bindings:
           - Durable Objects:
             - EXAMPLE_DO_BINDING: ExampleDurableObject
           Uploaded test-name (TIMINGS)
@@ -4273,7 +4273,7 @@ addEventListener('fetch', event => {});`
 
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
-          "Your worker has access to the following:
+          "Your worker has access to the following bindings:
           - Durable Objects:
             - EXAMPLE_DO_BINDING: ExampleDurableObject (defined in example-do-binding-worker)
           Uploaded test-name (TIMINGS)
@@ -4317,7 +4317,7 @@ addEventListener('fetch', event => {});`
 
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
-          "Your worker has access to the following:
+          "Your worker has access to the following bindings:
           - Durable Objects:
             - EXAMPLE_DO_BINDING: ExampleDurableObject
           Uploaded test-name (TIMINGS)
@@ -4379,7 +4379,7 @@ addEventListener('fetch', event => {});`
 
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
-          "Your worker has access to the following:
+          "Your worker has access to the following bindings:
           - Services:
             - FOO: foo-service - production
           Uploaded test-name (TIMINGS)
@@ -4424,7 +4424,7 @@ addEventListener('fetch', event => {});`
 
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
-          "Your worker has access to the following:
+          "Your worker has access to the following bindings:
           - Unsafe:
             - binding-type: my-binding
           Uploaded test-name (TIMINGS)
@@ -4466,7 +4466,7 @@ addEventListener('fetch', event => {});`
 
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
-          "Your worker has access to the following:
+          "Your worker has access to the following bindings:
           - Unsafe:
             - plain_text: my-binding
           Uploaded test-name (TIMINGS)
@@ -4920,7 +4920,7 @@ addEventListener('fetch', event => {});`
         Object {
           "debug": "",
           "err": "",
-          "out": "Your worker has access to the following:
+          "out": "Your worker has access to the following bindings:
         - Durable Objects:
           - NAME: SomeClass
         --dry-run: exiting now.",

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -3420,14 +3420,9 @@ addEventListener('fetch', event => {});`
           - TEXT_BLOB_ONE: my-entire-app-depends-on-this.cfg
           - TEXT_BLOB_TWO: the-entirety-of-human-knowledge.txt
         - some unsafe thing
-          - UNSAFE_BINDING_ONE: {
-         \\"data\\": {
-          \\"some\\": {
-           \\"unsafe\\":...
+          - UNSAFE_BINDING_ONE: {\\"data\\":{\\"some\\":{\\"unsafe\\":\\"thing\\"}}}
         - another unsafe thing
-          - UNSAFE_BINDING_TWO: {
-         \\"data\\": 1337
-        }
+          - UNSAFE_BINDING_TWO: {\\"data\\":1337}
         - Vars
           - ENV_VAR_ONE: \\"123\\"
           - ENV_VAR_TWO: \\"Hello, I'm an environment variable\\"
@@ -4441,9 +4436,7 @@ addEventListener('fetch', event => {});`
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
           - binding-type
-            - my-binding: {
-           \\"param\\": \\"binding-param\\"
-          }
+            - my-binding: {\\"param\\":\\"binding-param\\"}
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
             test-name.test-sub-domain.workers.dev"
@@ -4485,9 +4478,7 @@ addEventListener('fetch', event => {});`
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
           - plain_text
-            - my-binding: {
-           \\"text\\": \\"text\\"
-          }
+            - my-binding: {\\"text\\":\\"text\\"}
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
             test-name.test-sub-domain.workers.dev"

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -472,7 +472,7 @@ describe("publish", () => {
     await runWrangler("publish ./some-path/worker/index.js");
     expect(std.out).toMatchInlineSnapshot(`
       "Your worker has access to the following:
-      - Vars
+      - Vars:
         - xyz: \\"123\\"
       Uploaded test-name (TIMINGS)
       Published test-name (TIMINGS)
@@ -2833,7 +2833,7 @@ addEventListener('fetch', event => {});`
       await runWrangler("publish index.js");
       expect(std.out).toMatchInlineSnapshot(`
         "Your worker has access to the following:
-        - Durable Objects
+        - Durable Objects:
           - SOMENAME: SomeClass
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
@@ -2868,7 +2868,7 @@ addEventListener('fetch', event => {});`
       await runWrangler("publish index.js");
       expect(std.out).toMatchInlineSnapshot(`
         "Your worker has access to the following:
-        - Durable Objects
+        - Durable Objects:
           - SOMENAME: SomeClass (defined in some-script)
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
@@ -2910,7 +2910,7 @@ addEventListener('fetch', event => {});`
       await runWrangler("publish index.js");
       expect(std.out).toMatchInlineSnapshot(`
         "Your worker has access to the following:
-        - Durable Objects
+        - Durable Objects:
           - SOMENAME: SomeClass
           - SOMEOTHERNAME: SomeOtherClass
         Uploaded test-name (TIMINGS)
@@ -2960,7 +2960,7 @@ addEventListener('fetch', event => {});`
           "debug": "",
           "err": "",
           "out": "Your worker has access to the following:
-        - Durable Objects
+        - Durable Objects:
           - SOMENAME: SomeClass
           - SOMEOTHERNAME: SomeOtherClass
         Uploaded test-name (TIMINGS)
@@ -3003,7 +3003,7 @@ addEventListener('fetch', event => {});`
           "debug": "",
           "err": "",
           "out": "Your worker has access to the following:
-        - Durable Objects
+        - Durable Objects:
           - SOMENAME: SomeClass
           - SOMEOTHERNAME: SomeOtherClass
         Uploaded test-name (TIMINGS)
@@ -3048,7 +3048,7 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js --legacy-env false");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          - Durable Objects
+          - Durable Objects:
             - SOMENAME: SomeClass
             - SOMEOTHERNAME: SomeOtherClass
           Uploaded test-name (TIMINGS)
@@ -3110,7 +3110,7 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js --legacy-env false --env xyz");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          - Durable Objects
+          - Durable Objects:
             - SOMENAME: SomeClass
             - SOMEOTHERNAME: SomeOtherClass
           Uploaded test-name (xyz) (TIMINGS)
@@ -3168,7 +3168,7 @@ addEventListener('fetch', event => {});`
             "debug": "",
             "err": "",
             "out": "Your worker has access to the following:
-          - Durable Objects
+          - Durable Objects:
             - SOMENAME: SomeClass
             - SOMEOTHERNAME: SomeOtherClass
           Uploaded test-name (TIMINGS)
@@ -3236,7 +3236,7 @@ addEventListener('fetch', event => {});`
             "debug": "",
             "err": "",
             "out": "Your worker has access to the following:
-          - Durable Objects
+          - Durable Objects:
             - SOMENAME: SomeClass
             - SOMEOTHERNAME: SomeOtherClass
           Uploaded test-name (xyz) (TIMINGS)
@@ -3404,28 +3404,28 @@ addEventListener('fetch', event => {});`
       await expect(runWrangler("publish index.js")).resolves.toBeUndefined();
       expect(std.out).toMatchInlineSnapshot(`
         "Your worker has access to the following:
-        - Data Blobs
+        - Data Blobs:
           - DATA_BLOB_ONE: some-data-blob.bin
           - DATA_BLOB_TWO: more-data-blob.bin
-        - Durable Objects
+        - Durable Objects:
           - DURABLE_OBJECT_ONE: SomeDurableObject (defined in some-durable-object-worker)
           - DURABLE_OBJECT_TWO: AnotherDurableObject (defined in another-durable-object-worker) - staging
-        - KV Namespaces
+        - KV Namespaces:
           - KV_NAMESPACE_ONE: kv-ns-one-id
           - KV_NAMESPACE_TWO: kv-ns-two-id
-        - R2 Buckets
+        - R2 Buckets:
           - R2_BUCKET_ONE: r2-bucket-one-name
           - R2_BUCKET_TWO: r2-bucket-two-name
-        - Text Blobs
+        - Text Blobs:
           - TEXT_BLOB_ONE: my-entire-app-depends-on-this.cfg
           - TEXT_BLOB_TWO: the-entirety-of-human-knowledge.txt
-        - Unsafe
+        - Unsafe:
           - some unsafe thing: UNSAFE_BINDING_ONE
           - another unsafe thing: UNSAFE_BINDING_TWO
-        - Vars
+        - Vars:
           - ENV_VAR_ONE: \\"123\\"
           - ENV_VAR_TWO: \\"Hello, I'm an environment variable\\"
-        - Wasm Modules
+        - Wasm Modules:
           - WASM_MODULE_ONE: some_wasm.wasm
           - WASM_MODULE_TWO: more_wasm.wasm
         Uploaded test-name (TIMINGS)
@@ -3805,7 +3805,7 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          - Wasm Modules
+          - Wasm Modules:
             - TESTWASMNAME: path/to/test.wasm
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
@@ -3874,7 +3874,7 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js --config ./path/to/wrangler.toml");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          - Wasm Modules
+          - Wasm Modules:
             - TESTWASMNAME: path/to/and/the/path/to/test.wasm
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
@@ -3942,7 +3942,7 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          - Text Blobs
+          - Text Blobs:
             - TESTTEXTBLOBNAME: path/to/text.file
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
@@ -4015,7 +4015,7 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js --config ./path/to/wrangler.toml");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          - Text Blobs
+          - Text Blobs:
             - TESTTEXTBLOBNAME: path/to/and/the/path/to/text.file
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
@@ -4051,7 +4051,7 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          - Data Blobs
+          - Data Blobs:
             - TESTDATABLOBNAME: path/to/data.bin
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
@@ -4124,7 +4124,7 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js --config ./path/to/wrangler.toml");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          - Data Blobs
+          - Data Blobs:
             - TESTDATABLOBNAME: path/to/and/the/path/to/data.bin
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
@@ -4161,7 +4161,7 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          - Vars
+          - Vars:
             - text: \\"plain ol' string\\"
             - count: \\"1\\"
             - complex: \\"[object Object]\\"
@@ -4190,7 +4190,7 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          - R2 Buckets
+          - R2 Buckets:
             - FOO: foo-bucket
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
@@ -4235,7 +4235,7 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          - Durable Objects
+          - Durable Objects:
             - EXAMPLE_DO_BINDING: ExampleDurableObject
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
@@ -4274,7 +4274,7 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          - Durable Objects
+          - Durable Objects:
             - EXAMPLE_DO_BINDING: ExampleDurableObject (defined in example-do-binding-worker)
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
@@ -4318,7 +4318,7 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          - Durable Objects
+          - Durable Objects:
             - EXAMPLE_DO_BINDING: ExampleDurableObject
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
@@ -4380,7 +4380,7 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          - Services
+          - Services:
             - FOO: foo-service - production
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
@@ -4425,7 +4425,7 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          - Unsafe
+          - Unsafe:
             - binding-type: my-binding
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
@@ -4467,7 +4467,7 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          - Unsafe
+          - Unsafe:
             - plain_text: my-binding
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
@@ -4921,7 +4921,7 @@ addEventListener('fetch', event => {});`
           "debug": "",
           "err": "",
           "out": "Your worker has access to the following:
-        - Durable Objects
+        - Durable Objects:
           - NAME: SomeClass
         --dry-run: exiting now.",
           "warn": "",

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -472,8 +472,8 @@ describe("publish", () => {
     await runWrangler("publish ./some-path/worker/index.js");
     expect(std.out).toMatchInlineSnapshot(`
       "Your worker has access to the following:
-      Vars
-      	- xyz: \\"123\\"
+      - Vars
+        - xyz: \\"123\\"
       Uploaded test-name (TIMINGS)
       Published test-name (TIMINGS)
         test-name.test-sub-domain.workers.dev"
@@ -2833,8 +2833,8 @@ addEventListener('fetch', event => {});`
       await runWrangler("publish index.js");
       expect(std.out).toMatchInlineSnapshot(`
         "Your worker has access to the following:
-        Durable Objects
-        	- SOMENAME: SomeClass
+        - Durable Objects
+          - SOMENAME: SomeClass
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -2868,8 +2868,8 @@ addEventListener('fetch', event => {});`
       await runWrangler("publish index.js");
       expect(std.out).toMatchInlineSnapshot(`
         "Your worker has access to the following:
-        Durable Objects
-        	- SOMENAME: SomeClass (defined in some-script)
+        - Durable Objects
+          - SOMENAME: SomeClass (defined in some-script)
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -2910,9 +2910,9 @@ addEventListener('fetch', event => {});`
       await runWrangler("publish index.js");
       expect(std.out).toMatchInlineSnapshot(`
         "Your worker has access to the following:
-        Durable Objects
-        	- SOMENAME: SomeClass
-        	- SOMEOTHERNAME: SomeOtherClass
+        - Durable Objects
+          - SOMENAME: SomeClass
+          - SOMEOTHERNAME: SomeOtherClass
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -2960,9 +2960,9 @@ addEventListener('fetch', event => {});`
           "debug": "",
           "err": "",
           "out": "Your worker has access to the following:
-        Durable Objects
-        	- SOMENAME: SomeClass
-        	- SOMEOTHERNAME: SomeOtherClass
+        - Durable Objects
+          - SOMENAME: SomeClass
+          - SOMEOTHERNAME: SomeOtherClass
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev",
@@ -3003,9 +3003,9 @@ addEventListener('fetch', event => {});`
           "debug": "",
           "err": "",
           "out": "Your worker has access to the following:
-        Durable Objects
-        	- SOMENAME: SomeClass
-        	- SOMEOTHERNAME: SomeOtherClass
+        - Durable Objects
+          - SOMENAME: SomeClass
+          - SOMEOTHERNAME: SomeOtherClass
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev",
@@ -3048,9 +3048,9 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js --legacy-env false");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          Durable Objects
-          	- SOMENAME: SomeClass
-          	- SOMEOTHERNAME: SomeOtherClass
+          - Durable Objects
+            - SOMENAME: SomeClass
+            - SOMEOTHERNAME: SomeOtherClass
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
             test-name.test-sub-domain.workers.dev"
@@ -3110,9 +3110,9 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js --legacy-env false --env xyz");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          Durable Objects
-          	- SOMENAME: SomeClass
-          	- SOMEOTHERNAME: SomeOtherClass
+          - Durable Objects
+            - SOMENAME: SomeClass
+            - SOMEOTHERNAME: SomeOtherClass
           Uploaded test-name (xyz) (TIMINGS)
           Published test-name (xyz) (TIMINGS)
             xyz.test-name.test-sub-domain.workers.dev"
@@ -3168,9 +3168,9 @@ addEventListener('fetch', event => {});`
             "debug": "",
             "err": "",
             "out": "Your worker has access to the following:
-          Durable Objects
-          	- SOMENAME: SomeClass
-          	- SOMEOTHERNAME: SomeOtherClass
+          - Durable Objects
+            - SOMENAME: SomeClass
+            - SOMEOTHERNAME: SomeOtherClass
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
             test-name.test-sub-domain.workers.dev",
@@ -3236,9 +3236,9 @@ addEventListener('fetch', event => {});`
             "debug": "",
             "err": "",
             "out": "Your worker has access to the following:
-          Durable Objects
-          	- SOMENAME: SomeClass
-          	- SOMEOTHERNAME: SomeOtherClass
+          - Durable Objects
+            - SOMENAME: SomeClass
+            - SOMEOTHERNAME: SomeOtherClass
           Uploaded test-name (xyz) (TIMINGS)
           Published test-name (xyz) (TIMINGS)
             xyz.test-name.test-sub-domain.workers.dev",
@@ -3404,36 +3404,36 @@ addEventListener('fetch', event => {});`
       await expect(runWrangler("publish index.js")).resolves.toBeUndefined();
       expect(std.out).toMatchInlineSnapshot(`
         "Your worker has access to the following:
-        Data Blobs
-        	- DATA_BLOB_ONE: some-data-blob.bin
-        	- DATA_BLOB_TWO: more-data-blob.bin
-        Durable Objects
-        	- DURABLE_OBJECT_ONE: SomeDurableObject (defined in some-durable-object-worker)
-        	- DURABLE_OBJECT_TWO: AnotherDurableObject (defined in another-durable-object-worker) - staging
-        KV Namespaces
-        	- KV_NAMESPACE_ONE: kv-ns-one-id
-        	- KV_NAMESPACE_TWO: kv-ns-two-id
-        R2 Buckets
-        	- R2_BUCKET_ONE: r2-bucket-one-name
-        	- R2_BUCKET_TWO: r2-bucket-two-name
-        Text Blobs
-        	- TEXT_BLOB_ONE: my-entire-app-depends-on-this.cfg
-        	- TEXT_BLOB_TWO: the-entirety-of-human-knowledge.txt
-        some unsafe thing
-        	- UNSAFE_BINDING_ONE: {
+        - Data Blobs
+          - DATA_BLOB_ONE: some-data-blob.bin
+          - DATA_BLOB_TWO: more-data-blob.bin
+        - Durable Objects
+          - DURABLE_OBJECT_ONE: SomeDurableObject (defined in some-durable-object-worker)
+          - DURABLE_OBJECT_TWO: AnotherDurableObject (defined in another-durable-object-worker) - staging
+        - KV Namespaces
+          - KV_NAMESPACE_ONE: kv-ns-one-id
+          - KV_NAMESPACE_TWO: kv-ns-two-id
+        - R2 Buckets
+          - R2_BUCKET_ONE: r2-bucket-one-name
+          - R2_BUCKET_TWO: r2-bucket-two-name
+        - Text Blobs
+          - TEXT_BLOB_ONE: my-entire-app-depends-on-this.cfg
+          - TEXT_BLOB_TWO: the-entirety-of-human-knowledge.txt
+        - some unsafe thing
+          - UNSAFE_BINDING_ONE: {
          \\"data\\": {
           \\"some\\": {
            \\"unsafe\\":...
-        another unsafe thing
-        	- UNSAFE_BINDING_TWO: {
+        - another unsafe thing
+          - UNSAFE_BINDING_TWO: {
          \\"data\\": 1337
         }
-        Vars
-        	- ENV_VAR_ONE: \\"123\\"
-        	- ENV_VAR_TWO: \\"Hello, I'm an environment variable\\"
-        Wasm Modules
-        	- WASM_MODULE_ONE: some_wasm.wasm
-        	- WASM_MODULE_TWO: more_wasm.wasm
+        - Vars
+          - ENV_VAR_ONE: \\"123\\"
+          - ENV_VAR_TWO: \\"Hello, I'm an environment variable\\"
+        - Wasm Modules
+          - WASM_MODULE_ONE: some_wasm.wasm
+          - WASM_MODULE_TWO: more_wasm.wasm
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
@@ -3811,8 +3811,8 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          Wasm Modules
-          	- TESTWASMNAME: path/to/test.wasm
+          - Wasm Modules
+            - TESTWASMNAME: path/to/test.wasm
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
             test-name.test-sub-domain.workers.dev"
@@ -3838,8 +3838,8 @@ addEventListener('fetch', event => {});`
         );
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          Wasm Modules
-          	- TESTWASMNAME: path/to/test.wasm
+          - Wasm Modules
+            - TESTWASMNAME: path/to/test.wasm
 
           [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
         `);
@@ -3883,8 +3883,8 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js --config ./path/to/wrangler.toml");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          Wasm Modules
-          	- TESTWASMNAME: path/to/and/the/path/to/test.wasm
+          - Wasm Modules
+            - TESTWASMNAME: path/to/and/the/path/to/test.wasm
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
             test-name.test-sub-domain.workers.dev"
@@ -3951,8 +3951,8 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          Text Blobs
-          	- TESTTEXTBLOBNAME: path/to/text.file
+          - Text Blobs
+            - TESTTEXTBLOBNAME: path/to/text.file
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
             test-name.test-sub-domain.workers.dev"
@@ -3978,8 +3978,8 @@ addEventListener('fetch', event => {});`
         );
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          Text Blobs
-          	- TESTTEXTBLOBNAME: path/to/text.file
+          - Text Blobs
+            - TESTTEXTBLOBNAME: path/to/text.file
 
           [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
         `);
@@ -4027,8 +4027,8 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js --config ./path/to/wrangler.toml");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          Text Blobs
-          	- TESTTEXTBLOBNAME: path/to/and/the/path/to/text.file
+          - Text Blobs
+            - TESTTEXTBLOBNAME: path/to/and/the/path/to/text.file
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
             test-name.test-sub-domain.workers.dev"
@@ -4063,8 +4063,8 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          Data Blobs
-          	- TESTDATABLOBNAME: path/to/data.bin
+          - Data Blobs
+            - TESTDATABLOBNAME: path/to/data.bin
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
             test-name.test-sub-domain.workers.dev"
@@ -4090,8 +4090,8 @@ addEventListener('fetch', event => {});`
         );
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          Data Blobs
-          	- TESTDATABLOBNAME: path/to/data.bin
+          - Data Blobs
+            - TESTDATABLOBNAME: path/to/data.bin
 
           [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
         `);
@@ -4139,8 +4139,8 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js --config ./path/to/wrangler.toml");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          Data Blobs
-          	- TESTDATABLOBNAME: path/to/and/the/path/to/data.bin
+          - Data Blobs
+            - TESTDATABLOBNAME: path/to/and/the/path/to/data.bin
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
             test-name.test-sub-domain.workers.dev"
@@ -4176,10 +4176,10 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          Vars
-          	- text: \\"plain ol' string\\"
-          	- count: \\"1\\"
-          	- complex: \\"[object Object]\\"
+          - Vars
+            - text: \\"plain ol' string\\"
+            - count: \\"1\\"
+            - complex: \\"[object Object]\\"
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
             test-name.test-sub-domain.workers.dev"
@@ -4205,8 +4205,8 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          R2 Buckets
-          	- FOO: foo-bucket
+          - R2 Buckets
+            - FOO: foo-bucket
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
             test-name.test-sub-domain.workers.dev"
@@ -4250,8 +4250,8 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          Durable Objects
-          	- EXAMPLE_DO_BINDING: ExampleDurableObject
+          - Durable Objects
+            - EXAMPLE_DO_BINDING: ExampleDurableObject
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
             test-name.test-sub-domain.workers.dev"
@@ -4289,8 +4289,8 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          Durable Objects
-          	- EXAMPLE_DO_BINDING: ExampleDurableObject (defined in example-do-binding-worker)
+          - Durable Objects
+            - EXAMPLE_DO_BINDING: ExampleDurableObject (defined in example-do-binding-worker)
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
             test-name.test-sub-domain.workers.dev"
@@ -4333,8 +4333,8 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          Durable Objects
-          	- EXAMPLE_DO_BINDING: ExampleDurableObject
+          - Durable Objects
+            - EXAMPLE_DO_BINDING: ExampleDurableObject
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
             test-name.test-sub-domain.workers.dev"
@@ -4395,8 +4395,8 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          Services
-          	- FOO: foo-service - production
+          - Services
+            - FOO: foo-service - production
           Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
             test-name.test-sub-domain.workers.dev"
@@ -4440,8 +4440,8 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          binding-type
-          	- my-binding: {
+          - binding-type
+            - my-binding: {
            \\"param\\": \\"binding-param\\"
           }
           Uploaded test-name (TIMINGS)
@@ -4484,8 +4484,8 @@ addEventListener('fetch', event => {});`
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
           "Your worker has access to the following:
-          plain_text
-          	- my-binding: {
+          - plain_text
+            - my-binding: {
            \\"text\\": \\"text\\"
           }
           Uploaded test-name (TIMINGS)
@@ -4940,8 +4940,8 @@ addEventListener('fetch', event => {});`
           "debug": "",
           "err": "",
           "out": "Your worker has access to the following:
-        Durable Objects
-        	- NAME: SomeClass
+        - Durable Objects
+          - NAME: SomeClass
         --dry-run: exiting now.",
           "warn": "",
         }

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -471,7 +471,10 @@ describe("publish", () => {
     mockSubDomainRequest();
     await runWrangler("publish ./some-path/worker/index.js");
     expect(std.out).toMatchInlineSnapshot(`
-      "Uploaded test-name (TIMINGS)
+      "Your worker has access to the following:
+      Vars
+      	- xyz: 123
+      Uploaded test-name (TIMINGS)
       Published test-name (TIMINGS)
         test-name.test-sub-domain.workers.dev"
     `);
@@ -2829,7 +2832,10 @@ addEventListener('fetch', event => {});`
       mockUploadWorkerRequest();
       await runWrangler("publish index.js");
       expect(std.out).toMatchInlineSnapshot(`
-        "Uploaded test-name (TIMINGS)
+        "Your worker has access to the following:
+        Durable Objects
+        	- SOMENAME: SomeClass
+        Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
       `);
@@ -2861,7 +2867,10 @@ addEventListener('fetch', event => {});`
       mockUploadWorkerRequest();
       await runWrangler("publish index.js");
       expect(std.out).toMatchInlineSnapshot(`
-        "Uploaded test-name (TIMINGS)
+        "Your worker has access to the following:
+        Durable Objects
+        	- SOMENAME: SomeClass (defined in some-script)
+        Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
       `);
@@ -2900,7 +2909,11 @@ addEventListener('fetch', event => {});`
 
       await runWrangler("publish index.js");
       expect(std.out).toMatchInlineSnapshot(`
-        "Uploaded test-name (TIMINGS)
+        "Your worker has access to the following:
+        Durable Objects
+        	- SOMENAME: SomeClass
+        	- SOMEOTHERNAME: SomeOtherClass
+        Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
       `);
@@ -2946,7 +2959,11 @@ addEventListener('fetch', event => {});`
         Object {
           "debug": "",
           "err": "",
-          "out": "Uploaded test-name (TIMINGS)
+          "out": "Your worker has access to the following:
+        Durable Objects
+        	- SOMENAME: SomeClass
+        	- SOMEOTHERNAME: SomeOtherClass
+        Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev",
           "warn": "",
@@ -2985,7 +3002,11 @@ addEventListener('fetch', event => {});`
         Object {
           "debug": "",
           "err": "",
-          "out": "Uploaded test-name (TIMINGS)
+          "out": "Your worker has access to the following:
+        Durable Objects
+        	- SOMENAME: SomeClass
+        	- SOMEOTHERNAME: SomeOtherClass
+        Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev",
           "warn": "",
@@ -3026,7 +3047,11 @@ addEventListener('fetch', event => {});`
 
         await runWrangler("publish index.js --legacy-env false");
         expect(std.out).toMatchInlineSnapshot(`
-          "Uploaded test-name (TIMINGS)
+          "Your worker has access to the following:
+          Durable Objects
+          	- SOMENAME: SomeClass
+          	- SOMEOTHERNAME: SomeOtherClass
+          Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
             test-name.test-sub-domain.workers.dev"
         `);
@@ -3084,7 +3109,11 @@ addEventListener('fetch', event => {});`
 
         await runWrangler("publish index.js --legacy-env false --env xyz");
         expect(std.out).toMatchInlineSnapshot(`
-          "Uploaded test-name (xyz) (TIMINGS)
+          "Your worker has access to the following:
+          Durable Objects
+          	- SOMENAME: SomeClass
+          	- SOMEOTHERNAME: SomeOtherClass
+          Uploaded test-name (xyz) (TIMINGS)
           Published test-name (xyz) (TIMINGS)
             xyz.test-name.test-sub-domain.workers.dev"
         `);
@@ -3138,7 +3167,11 @@ addEventListener('fetch', event => {});`
           Object {
             "debug": "",
             "err": "",
-            "out": "Uploaded test-name (TIMINGS)
+            "out": "Your worker has access to the following:
+          Durable Objects
+          	- SOMENAME: SomeClass
+          	- SOMEOTHERNAME: SomeOtherClass
+          Uploaded test-name (TIMINGS)
           Published test-name (TIMINGS)
             test-name.test-sub-domain.workers.dev",
             "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
@@ -3202,7 +3235,11 @@ addEventListener('fetch', event => {});`
           Object {
             "debug": "",
             "err": "",
-            "out": "Uploaded test-name (xyz) (TIMINGS)
+            "out": "Your worker has access to the following:
+          Durable Objects
+          	- SOMENAME: SomeClass
+          	- SOMEOTHERNAME: SomeOtherClass
+          Uploaded test-name (xyz) (TIMINGS)
           Published test-name (xyz) (TIMINGS)
             xyz.test-name.test-sub-domain.workers.dev",
             "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
@@ -3366,7 +3403,38 @@ addEventListener('fetch', event => {});`
 
       await expect(runWrangler("publish index.js")).resolves.toBeUndefined();
       expect(std.out).toMatchInlineSnapshot(`
-        "Uploaded test-name (TIMINGS)
+        "Your worker has access to the following:
+        Data Blobs
+        	- DATA_BLOB_ONE: some-data-blob.bin
+        	- DATA_BLOB_TWO: more-data-blob.bin
+        Durable Objects
+        	- DURABLE_OBJECT_ONE: SomeDurableObject (defined in some-durable-object-worker)
+        	- DURABLE_OBJECT_TWO: AnotherDurableObject (defined in another-durable-object-worker) - staging
+        KV Namespaces
+        	- KV_NAMESPACE_ONE: kv-ns-one-id
+        	- KV_NAMESPACE_TWO: kv-ns-two-id
+        R2 Buckets
+        	- R2_BUCKET_ONE: r2-bucket-one-name
+        	- R2_BUCKET_TWO: r2-bucket-two-name
+        Text Blobs
+        	- TEXT_BLOB_ONE: my-entire-app-depends-on-this.cfg
+        	- TEXT_BLOB_TWO: the-entirety-of-human-knowledge.txt
+        some unsafe thing
+        	- UNSAFE_BINDING_ONE: {
+         \\"data\\": {
+          \\"some\\": {
+           \\"unsafe\\":...
+        another unsafe thing
+        	- UNSAFE_BINDING_TWO: {
+         \\"data\\": 1337
+        }
+        Vars
+        	- ENV_VAR_ONE: 123
+        	- ENV_VAR_TWO: Hello, I'm an environment variable
+        Wasm Modules
+        	- WASM_MODULE_ONE: some_wasm.wasm
+        	- WASM_MODULE_TWO: more_wasm.wasm
+        Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev"
       `);
@@ -3742,10 +3810,13 @@ addEventListener('fetch', event => {});`
         mockSubDomainRequest();
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
-                  "Uploaded test-name (TIMINGS)
-                  Published test-name (TIMINGS)
-                    test-name.test-sub-domain.workers.dev"
-              `);
+          "Your worker has access to the following:
+          Wasm Modules
+          	- TESTWASMNAME: path/to/test.wasm
+          Uploaded test-name (TIMINGS)
+          Published test-name (TIMINGS)
+            test-name.test-sub-domain.workers.dev"
+        `);
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.warn).toMatchInlineSnapshot(`""`);
       });
@@ -3766,7 +3837,10 @@ addEventListener('fetch', event => {});`
           `"You cannot configure [wasm_modules] with an ES module worker. Instead, import the .wasm module directly in your code"`
         );
         expect(std.out).toMatchInlineSnapshot(`
-          "
+          "Your worker has access to the following:
+          Wasm Modules
+          	- TESTWASMNAME: path/to/test.wasm
+
           [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
         `);
         expect(std.err).toMatchInlineSnapshot(`
@@ -3808,10 +3882,13 @@ addEventListener('fetch', event => {});`
         mockSubDomainRequest();
         await runWrangler("publish index.js --config ./path/to/wrangler.toml");
         expect(std.out).toMatchInlineSnapshot(`
-                  "Uploaded test-name (TIMINGS)
-                  Published test-name (TIMINGS)
-                    test-name.test-sub-domain.workers.dev"
-              `);
+          "Your worker has access to the following:
+          Wasm Modules
+          	- TESTWASMNAME: path/to/and/the/path/to/test.wasm
+          Uploaded test-name (TIMINGS)
+          Published test-name (TIMINGS)
+            test-name.test-sub-domain.workers.dev"
+        `);
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.warn).toMatchInlineSnapshot(`""`);
       });
@@ -3873,10 +3950,13 @@ addEventListener('fetch', event => {});`
         mockSubDomainRequest();
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
-                  "Uploaded test-name (TIMINGS)
-                  Published test-name (TIMINGS)
-                    test-name.test-sub-domain.workers.dev"
-              `);
+          "Your worker has access to the following:
+          Text Blobs
+          	- TESTTEXTBLOBNAME: path/to/text.file
+          Uploaded test-name (TIMINGS)
+          Published test-name (TIMINGS)
+            test-name.test-sub-domain.workers.dev"
+        `);
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.warn).toMatchInlineSnapshot(`""`);
       });
@@ -3897,7 +3977,10 @@ addEventListener('fetch', event => {});`
           `"You cannot configure [text_blobs] with an ES module worker. Instead, import the file directly in your code, and optionally configure \`[rules]\` in your wrangler.toml"`
         );
         expect(std.out).toMatchInlineSnapshot(`
-          "
+          "Your worker has access to the following:
+          Text Blobs
+          	- TESTTEXTBLOBNAME: path/to/text.file
+
           [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
         `);
         expect(std.err).toMatchInlineSnapshot(`
@@ -3943,10 +4026,13 @@ addEventListener('fetch', event => {});`
         mockSubDomainRequest();
         await runWrangler("publish index.js --config ./path/to/wrangler.toml");
         expect(std.out).toMatchInlineSnapshot(`
-                  "Uploaded test-name (TIMINGS)
-                  Published test-name (TIMINGS)
-                    test-name.test-sub-domain.workers.dev"
-              `);
+          "Your worker has access to the following:
+          Text Blobs
+          	- TESTTEXTBLOBNAME: path/to/and/the/path/to/text.file
+          Uploaded test-name (TIMINGS)
+          Published test-name (TIMINGS)
+            test-name.test-sub-domain.workers.dev"
+        `);
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.warn).toMatchInlineSnapshot(`""`);
       });
@@ -3976,10 +4062,13 @@ addEventListener('fetch', event => {});`
         mockSubDomainRequest();
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
-                  "Uploaded test-name (TIMINGS)
-                  Published test-name (TIMINGS)
-                    test-name.test-sub-domain.workers.dev"
-              `);
+          "Your worker has access to the following:
+          Data Blobs
+          	- TESTDATABLOBNAME: path/to/data.bin
+          Uploaded test-name (TIMINGS)
+          Published test-name (TIMINGS)
+            test-name.test-sub-domain.workers.dev"
+        `);
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.warn).toMatchInlineSnapshot(`""`);
       });
@@ -4000,7 +4089,10 @@ addEventListener('fetch', event => {});`
           `"You cannot configure [data_blobs] with an ES module worker. Instead, import the file directly in your code, and optionally configure \`[rules]\` in your wrangler.toml"`
         );
         expect(std.out).toMatchInlineSnapshot(`
-          "
+          "Your worker has access to the following:
+          Data Blobs
+          	- TESTDATABLOBNAME: path/to/data.bin
+
           [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
         `);
         expect(std.err).toMatchInlineSnapshot(`
@@ -4046,10 +4138,13 @@ addEventListener('fetch', event => {});`
         mockSubDomainRequest();
         await runWrangler("publish index.js --config ./path/to/wrangler.toml");
         expect(std.out).toMatchInlineSnapshot(`
-                  "Uploaded test-name (TIMINGS)
-                  Published test-name (TIMINGS)
-                    test-name.test-sub-domain.workers.dev"
-              `);
+          "Your worker has access to the following:
+          Data Blobs
+          	- TESTDATABLOBNAME: path/to/and/the/path/to/data.bin
+          Uploaded test-name (TIMINGS)
+          Published test-name (TIMINGS)
+            test-name.test-sub-domain.workers.dev"
+        `);
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.warn).toMatchInlineSnapshot(`""`);
       });
@@ -4080,10 +4175,15 @@ addEventListener('fetch', event => {});`
 
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
-                  "Uploaded test-name (TIMINGS)
-                  Published test-name (TIMINGS)
-                    test-name.test-sub-domain.workers.dev"
-              `);
+          "Your worker has access to the following:
+          Vars
+          	- text: plain ol' string
+          	- count: 1
+          	- complex: [object Object]
+          Uploaded test-name (TIMINGS)
+          Published test-name (TIMINGS)
+            test-name.test-sub-domain.workers.dev"
+        `);
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.warn).toMatchInlineSnapshot(`""`);
       });
@@ -4104,10 +4204,13 @@ addEventListener('fetch', event => {});`
 
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
-                  "Uploaded test-name (TIMINGS)
-                  Published test-name (TIMINGS)
-                    test-name.test-sub-domain.workers.dev"
-              `);
+          "Your worker has access to the following:
+          R2 Buckets
+          	- FOO: foo-bucket
+          Uploaded test-name (TIMINGS)
+          Published test-name (TIMINGS)
+            test-name.test-sub-domain.workers.dev"
+        `);
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.warn).toMatchInlineSnapshot(`""`);
       });
@@ -4146,10 +4249,13 @@ addEventListener('fetch', event => {});`
 
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
-                  "Uploaded test-name (TIMINGS)
-                  Published test-name (TIMINGS)
-                    test-name.test-sub-domain.workers.dev"
-              `);
+          "Your worker has access to the following:
+          Durable Objects
+          	- EXAMPLE_DO_BINDING: ExampleDurableObject
+          Uploaded test-name (TIMINGS)
+          Published test-name (TIMINGS)
+            test-name.test-sub-domain.workers.dev"
+        `);
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.warn).toMatchInlineSnapshot(`""`);
       });
@@ -4182,10 +4288,13 @@ addEventListener('fetch', event => {});`
 
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
-                  "Uploaded test-name (TIMINGS)
-                  Published test-name (TIMINGS)
-                    test-name.test-sub-domain.workers.dev"
-              `);
+          "Your worker has access to the following:
+          Durable Objects
+          	- EXAMPLE_DO_BINDING: ExampleDurableObject (defined in example-do-binding-worker)
+          Uploaded test-name (TIMINGS)
+          Published test-name (TIMINGS)
+            test-name.test-sub-domain.workers.dev"
+        `);
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.warn).toMatchInlineSnapshot(`""`);
       });
@@ -4223,10 +4332,13 @@ addEventListener('fetch', event => {});`
 
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
-                  "Uploaded test-name (TIMINGS)
-                  Published test-name (TIMINGS)
-                    test-name.test-sub-domain.workers.dev"
-              `);
+          "Your worker has access to the following:
+          Durable Objects
+          	- EXAMPLE_DO_BINDING: ExampleDurableObject
+          Uploaded test-name (TIMINGS)
+          Published test-name (TIMINGS)
+            test-name.test-sub-domain.workers.dev"
+        `);
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.warn).toMatchInlineSnapshot(`""`);
       });
@@ -4282,10 +4394,13 @@ addEventListener('fetch', event => {});`
 
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
-                  "Uploaded test-name (TIMINGS)
-                  Published test-name (TIMINGS)
-                    test-name.test-sub-domain.workers.dev"
-              `);
+          "Your worker has access to the following:
+          Service Bindings
+          	- FOO: foo-service - production
+          Uploaded test-name (TIMINGS)
+          Published test-name (TIMINGS)
+            test-name.test-sub-domain.workers.dev"
+        `);
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.warn).toMatchInlineSnapshot(`
           "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
@@ -4324,10 +4439,15 @@ addEventListener('fetch', event => {});`
 
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
-                  "Uploaded test-name (TIMINGS)
-                  Published test-name (TIMINGS)
-                    test-name.test-sub-domain.workers.dev"
-              `);
+          "Your worker has access to the following:
+          binding-type
+          	- my-binding: {
+           \\"param\\": \\"binding-param\\"
+          }
+          Uploaded test-name (TIMINGS)
+          Published test-name (TIMINGS)
+            test-name.test-sub-domain.workers.dev"
+        `);
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.warn).toMatchInlineSnapshot(`
           "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
@@ -4363,10 +4483,15 @@ addEventListener('fetch', event => {});`
 
         await runWrangler("publish index.js");
         expect(std.out).toMatchInlineSnapshot(`
-                  "Uploaded test-name (TIMINGS)
-                  Published test-name (TIMINGS)
-                    test-name.test-sub-domain.workers.dev"
-              `);
+          "Your worker has access to the following:
+          plain_text
+          	- my-binding: {
+           \\"text\\": \\"text\\"
+          }
+          Uploaded test-name (TIMINGS)
+          Published test-name (TIMINGS)
+            test-name.test-sub-domain.workers.dev"
+        `);
         expect(std.err).toMatchInlineSnapshot(`""`);
         expect(std.warn).toMatchInlineSnapshot(`
           "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
@@ -4814,7 +4939,10 @@ addEventListener('fetch', event => {});`
         Object {
           "debug": "",
           "err": "",
-          "out": "--dry-run: exiting now.",
+          "out": "Your worker has access to the following:
+        Durable Objects
+        	- NAME: SomeClass
+        --dry-run: exiting now.",
           "warn": "",
         }
       `);

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -214,7 +214,7 @@ export function printBindings(bindings: CfWorkerInit["bindings"]) {
     ...output
       .map((bindingGroup) => {
         return [
-          `- ${bindingGroup.type}`,
+          `- ${bindingGroup.type}:`,
           bindingGroup.entries.map(({ key, value }) => `  - ${key}: ${value}`),
         ];
       })

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -210,7 +210,7 @@ export function printBindings(bindings: CfWorkerInit["bindings"]) {
   }
 
   const message = [
-    `Your worker has access to the following:`,
+    `Your worker has access to the following bindings:`,
     ...output
       .map((bindingGroup) => {
         return [

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -223,7 +223,7 @@ export function printBindings({
       type: "Vars",
       entries: Object.entries(vars).map(([key, value]) => ({
         key,
-        value: truncate(`${value}`),
+        value: `"${truncate(`${value}`)}"`,
       })),
     });
   }

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -247,8 +247,8 @@ export function printBindings({
     ...output
       .map((bindingGroup) => {
         return [
-          bindingGroup.type,
-          bindingGroup.entries.map(({ key, value }) => `\t- ${key}: ${value}`),
+          `- ${bindingGroup.type}`,
+          bindingGroup.entries.map(({ key, value }) => `  - ${key}: ${value}`),
         ];
       })
       .flat(2),

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -61,3 +61,198 @@ export function findWranglerToml(
   const configPath = findUpSync("wrangler.toml", { cwd: referencePath });
   return configPath;
 }
+
+/**
+ * Print all the bindings a worker using a given config would have access to
+ */
+export function printBindings({
+  config,
+  dev,
+}: {
+  /**
+   * The configuration to get bindings from
+   */
+  config: Config;
+
+  /**
+   * `true` if running in dev mode. Uses `preview_id`s when possible.
+   */
+  dev: boolean;
+}) {
+  const truncate = (item: string | Record<string, unknown>) => {
+    const s = typeof item === "string" ? item : JSON.stringify(item, null, " ");
+    const maxLength = 40;
+    if (s.length < maxLength) {
+      return s;
+    }
+
+    return `${s.substring(0, maxLength - 3)}...`;
+  };
+
+  const output: { type: string; entries: { key: string; value: string }[] }[] =
+    [];
+
+  const {
+    data_blobs,
+    durable_objects,
+    kv_namespaces,
+    r2_buckets,
+    services,
+    text_blobs,
+    unsafe,
+    vars,
+    wasm_modules,
+  } = config;
+
+  if (data_blobs !== undefined && Object.keys(data_blobs).length > 0) {
+    output.push({
+      type: "Data Blobs",
+      entries: Object.entries(data_blobs).map(([key, value]) => ({
+        key,
+        value: truncate(value),
+      })),
+    });
+  }
+
+  if (durable_objects.bindings.length > 0) {
+    output.push({
+      type: "Durable Objects",
+      entries: durable_objects.bindings.map(
+        ({ name, class_name, script_name, environment }) => {
+          let value = class_name;
+          if (script_name) {
+            value += ` (defined in ${script_name})`;
+          }
+          if (environment) {
+            value += ` - ${environment}`;
+          }
+
+          return {
+            key: name,
+            value,
+          };
+        }
+      ),
+    });
+  }
+
+  if (kv_namespaces.length > 0) {
+    output.push({
+      type: "KV Namespaces",
+      entries: kv_namespaces.map(({ binding, id, preview_id }) => {
+        return {
+          key: binding,
+          value: dev ? preview_id ?? id : id,
+        };
+      }),
+    });
+  }
+
+  if (r2_buckets.length > 0) {
+    output.push({
+      type: "R2 Buckets",
+      entries: r2_buckets.map(
+        ({ binding, bucket_name, preview_bucket_name }) => {
+          return {
+            key: binding,
+            value: dev ? preview_bucket_name ?? bucket_name : bucket_name,
+          };
+        }
+      ),
+    });
+  }
+
+  if (services.length > 0) {
+    output.push({
+      type: "Services",
+      entries: services.map(({ binding, service, environment }) => {
+        let value = service;
+        if (environment) {
+          value += ` - ${environment}`;
+        }
+
+        return {
+          key: binding,
+          value,
+        };
+      }),
+    });
+  }
+
+  if (text_blobs !== undefined && Object.keys(text_blobs).length > 0) {
+    output.push({
+      type: "Text Blobs",
+      entries: Object.entries(text_blobs).map(([key, value]) => ({
+        key,
+        value: truncate(value),
+      })),
+    });
+  }
+
+  if (unsafe.bindings.length > 0) {
+    const groupedBindings = unsafe.bindings.reduce(
+      (grouped, { type, name, ...binding }) => {
+        const i = grouped.findIndex((group) => group.type === type);
+        if (i < 0) {
+          grouped.push({
+            type,
+            entries: [
+              {
+                key: name,
+                value: truncate(binding),
+              },
+            ],
+          });
+        } else {
+          grouped[i].entries.push({
+            key: name,
+            value: truncate(binding),
+          });
+        }
+
+        return grouped;
+      },
+      [] as typeof output
+    );
+
+    output.push(...groupedBindings);
+  }
+
+  if (vars !== undefined && Object.keys(vars).length > 0) {
+    output.push({
+      type: "Vars",
+      entries: Object.entries(vars).map(([key, value]) => ({
+        key,
+        value: truncate(`${value}`),
+      })),
+    });
+  }
+
+  if (wasm_modules !== undefined && Object.keys(wasm_modules).length > 0) {
+    output.push({
+      type: "Wasm Modules",
+      entries: Object.entries(wasm_modules).map(([key, value]) => ({
+        key,
+        value: truncate(value),
+      })),
+    });
+  }
+
+  if (output.length === 0) {
+    return;
+  }
+
+  const message = [
+    `Your worker has access to the following:`,
+    ...output
+      .map((bindingGroup) => {
+        return [
+          bindingGroup.type,
+          bindingGroup.entries.map(({ key, value }) => `\t- ${key}: ${value}`),
+        ];
+      })
+      .flat(2),
+  ].join("\n");
+
+  logger.log(message);
+}

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -80,7 +80,7 @@ export function printBindings({
   dev: boolean;
 }) {
   const truncate = (item: string | Record<string, unknown>) => {
-    const s = typeof item === "string" ? item : JSON.stringify(item, null, " ");
+    const s = typeof item === "string" ? item : JSON.stringify(item);
     const maxLength = 40;
     if (s.length < maxLength) {
       return s;

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -102,7 +102,7 @@ export function printBindings(bindings: CfWorkerInit["bindings"]) {
     });
   }
 
-  if (durable_objects && durable_objects.bindings.length > 0) {
+  if (durable_objects !== undefined && durable_objects.bindings.length > 0) {
     output.push({
       type: "Durable Objects",
       entries: durable_objects.bindings.map(
@@ -124,7 +124,7 @@ export function printBindings(bindings: CfWorkerInit["bindings"]) {
     });
   }
 
-  if (kv_namespaces && kv_namespaces.length > 0) {
+  if (kv_namespaces !== undefined && kv_namespaces.length > 0) {
     output.push({
       type: "KV Namespaces",
       entries: kv_namespaces.map(({ binding, id }) => {
@@ -136,7 +136,7 @@ export function printBindings(bindings: CfWorkerInit["bindings"]) {
     });
   }
 
-  if (r2_buckets && r2_buckets.length > 0) {
+  if (r2_buckets !== undefined && r2_buckets.length > 0) {
     output.push({
       type: "R2 Buckets",
       entries: r2_buckets.map(({ binding, bucket_name }) => {
@@ -148,7 +148,7 @@ export function printBindings(bindings: CfWorkerInit["bindings"]) {
     });
   }
 
-  if (services && services.length > 0) {
+  if (services !== undefined && services.length > 0) {
     output.push({
       type: "Services",
       entries: services.map(({ binding, service, environment }) => {
@@ -175,7 +175,7 @@ export function printBindings(bindings: CfWorkerInit["bindings"]) {
     });
   }
 
-  if (unsafe && unsafe.length > 0) {
+  if (unsafe !== undefined && unsafe.length > 0) {
     output.push({
       type: "Unsafe",
       entries: unsafe.map(({ name, type }) => ({

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -9,6 +9,7 @@ import { withErrorBoundary, useErrorHandler } from "react-error-boundary";
 import onExit from "signal-exit";
 import tmp from "tmp-promise";
 import { fetch } from "undici";
+import { printBindings } from "../config";
 import { runCustomBuild } from "../entry";
 import { openInspector } from "../inspect";
 import { logger } from "../logger";
@@ -104,6 +105,8 @@ export function DevImplementation(props: DevProps): JSX.Element {
     minify: props.minify,
     nodeCompat: props.nodeCompat,
   });
+
+  printBindings(props.bindings);
 
   // only load the UI if we're running in a supported environment
   const { isRawModeSupported } = useStdin();

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -14,7 +14,7 @@ import supportsColor from "supports-color";
 import makeCLI from "yargs";
 import { version as wranglerVersion } from "../package.json";
 import { fetchResult } from "./cfetch";
-import { findWranglerToml, readConfig } from "./config";
+import { findWranglerToml, printBindings, readConfig } from "./config";
 import { createWorkerUploadForm } from "./create-worker-upload-form";
 import Dev from "./dev/dev";
 import { getVarsForDev } from "./dev/dev-vars";
@@ -1036,6 +1036,8 @@ function createCLIParser(argv: string[]) {
         );
       }
 
+      printBindings({ config, dev: true });
+
       const { waitUntilExit } = render(
         <Dev
           name={getScriptName(args, config)}
@@ -1286,6 +1288,9 @@ function createCLIParser(argv: string[]) {
         args.siteInclude,
         args.siteExclude
       );
+
+      printBindings({ config, dev: false });
+
       await publish({
         config,
         accountId,

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -14,7 +14,7 @@ import supportsColor from "supports-color";
 import makeCLI from "yargs";
 import { version as wranglerVersion } from "../package.json";
 import { fetchResult } from "./cfetch";
-import { findWranglerToml, printBindings, readConfig } from "./config";
+import { findWranglerToml, readConfig } from "./config";
 import { createWorkerUploadForm } from "./create-worker-upload-form";
 import Dev from "./dev/dev";
 import { getVarsForDev } from "./dev/dev-vars";
@@ -1036,8 +1036,6 @@ function createCLIParser(argv: string[]) {
         );
       }
 
-      printBindings({ config, dev: true });
-
       const { waitUntilExit } = render(
         <Dev
           name={getScriptName(args, config)}
@@ -1288,8 +1286,6 @@ function createCLIParser(argv: string[]) {
         args.siteInclude,
         args.siteExclude
       );
-
-      printBindings({ config, dev: false });
 
       await publish({
         config,

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -494,7 +494,12 @@ export default async function publish(props: Props): Promise<void> {
       usage_model: config.usage_model,
     };
 
-    printBindings(bindings);
+    const withoutStaticAssets = {
+      ...bindings,
+      kv_namespaces: config.kv_namespaces,
+      text_blobs: config.text_blobs,
+    };
+    printBindings(withoutStaticAssets);
 
     if (!props.dryRun) {
       // Upload the script so it has time to propagate.

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -5,6 +5,7 @@ import { URLSearchParams } from "node:url";
 import tmp from "tmp-promise";
 import { bundleWorker } from "./bundle";
 import { fetchResult } from "./cfetch";
+import { printBindings } from "./config";
 import { createWorkerUploadForm } from "./create-worker-upload-form";
 import { confirm } from "./dialogs";
 import { logger } from "./logger";
@@ -492,6 +493,8 @@ export default async function publish(props: Props): Promise<void> {
         props.compatibilityFlags ?? config.compatibility_flags,
       usage_model: config.usage_model,
     };
+
+    printBindings(bindings);
 
     if (!props.dryRun) {
       // Upload the script so it has time to propagate.


### PR DESCRIPTION
It can be helpful for a user to know exactly what resources a worker will have access to and where they can access them, so we now log the bindings available to a worker during `wrangler dev` and `wrangler publish`.

Will rendering the `<Dev />` component interfere with the logged output during `wrangler dev`?

Closes #509
