### PR TITLE
fix: ensure that the proxy server shuts down to prevent `wrangler dev` from hanging

### DIFF
--- a/.changeset/nasty-cobras-remember.md
+++ b/.changeset/nasty-cobras-remember.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+---
+
+fix: ensure that the proxy server shuts down to prevent `wrangler dev` from hanging
+
+When running `wrangler dev` we create a proxy to the actual remote Worker.
+After creating a connection to this proxy by a browser request the proxy did not shutdown.
+Now we use a `HttpTerminator` helper library to force the proxy to close open connections and shutdown correctly.
+
+Fixes #958

--- a/package-lock.json
+++ b/package-lock.json
@@ -4960,6 +4960,12 @@
       "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
       "dev": true
     },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "dev": true
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "license": "MIT",
@@ -6306,6 +6312,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delay": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
+      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/delayed-stream": {
@@ -8355,9 +8373,42 @@
       "version": "2.1.0",
       "license": "MIT"
     },
+    "node_modules/fast-json-stringify": {
+      "version": "2.7.13",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-2.7.13.tgz",
+      "integrity": "sha512-ar+hQ4+OIurUGjSJD1anvYSDcUflywhKjfxnsW4TBTD7+u0tJufv6DKRWoQk3vI6YBOWMoz0TQtfbe7dxbQmvA==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.11.0",
+        "deepmerge": "^4.2.2",
+        "rfdc": "^1.2.0",
+        "string-similarity": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "license": "MIT"
+    },
+    "node_modules/fast-printf": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/fast-printf/-/fast-printf-1.6.9.tgz",
+      "integrity": "sha512-FChq8hbz65WMj4rstcQsFB0O7Cy++nmbNfLYnD9cYv2cRn8EG6k/MGn9kO/tjO66t09DLDugj3yL+V2o6Qftrg==",
+      "dev": true,
+      "dependencies": {
+        "boolean": "^3.1.4"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -8845,6 +8896,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -9188,6 +9254,33 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/http-terminator": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/http-terminator/-/http-terminator-3.2.0.tgz",
+      "integrity": "sha512-JLjck1EzPaWjsmIf8bziM3p9fgR1Y3JoUKAkyYEbZmFrIvJM6I8vVJfBGWlEtV9IWOvzNnaTtjuwZeBY2kwB4g==",
+      "dev": true,
+      "dependencies": {
+        "delay": "^5.0.0",
+        "p-wait-for": "^3.2.0",
+        "roarr": "^7.0.4",
+        "type-fest": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/http-terminator/node_modules/type-fest": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.12.2.tgz",
+      "integrity": "sha512-qt6ylCGpLjZ7AaODxbpyBZSs9fCI9SkL3Z9q2oxMBQhs/uyY+VD8jHA8ULCGmWQJlBgqvO3EJeAngOHD8zQCrQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/http2-wrapper": {
@@ -15616,11 +15709,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dev": true,
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/p-wait-for": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-wait-for/-/p-wait-for-3.2.0.tgz",
+      "integrity": "sha512-wpgERjNkLrBiFmkMEjuZJEWKKDrNfHCKA1OhyN1wg1FrLkULbviEy6py1AyJUgZ72YWFbZ38FIpnqvVqAlDUwA==",
+      "dev": true,
+      "dependencies": {
+        "p-timeout": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pages-functions-app": {
@@ -16791,6 +16911,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+      "dev": true
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "license": "ISC",
@@ -16812,6 +16938,23 @@
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-7.11.0.tgz",
+      "integrity": "sha512-DKiMaEYHoOZ0JyD4Ohr5KRnqybQ162s3ZL/WNO9oy6EUszYvpp0eLYJErc/U4NI96HYnHsbROhFaH4LYuJPnDg==",
+      "dev": true,
+      "dependencies": {
+        "boolean": "^3.1.4",
+        "fast-json-stringify": "^2.7.10",
+        "fast-printf": "^1.6.9",
+        "fast-safe-stringify": "^2.1.1",
+        "globalthis": "^1.0.2",
+        "semver-compare": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/rollup-plugin-inject": {
@@ -17246,6 +17389,12 @@
       "bin": {
         "semver": "bin/semver"
       }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "dev": true
     },
     "node_modules/send": {
       "version": "0.18.0",
@@ -18073,6 +18222,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/string-similarity": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.4.tgz",
+      "integrity": "sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==",
+      "dev": true
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -20351,6 +20506,7 @@
         "find-up": "^6.3.0",
         "get-port": "^6.1.2",
         "glob-to-regexp": "0.4.1",
+        "http-terminator": "^3.2.0",
         "ignore": "^5.2.0",
         "ink": "^3.2.0",
         "ink-select-input": "^4.2.1",
@@ -24284,6 +24440,12 @@
       "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
       "dev": true
     },
+    "boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "requires": {
@@ -25225,6 +25387,12 @@
         "is-descriptor": "^1.0.2",
         "isobject": "^3.0.1"
       }
+    },
+    "delay": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
+      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
+      "dev": true
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -26539,8 +26707,35 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0"
     },
+    "fast-json-stringify": {
+      "version": "2.7.13",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-2.7.13.tgz",
+      "integrity": "sha512-ar+hQ4+OIurUGjSJD1anvYSDcUflywhKjfxnsW4TBTD7+u0tJufv6DKRWoQk3vI6YBOWMoz0TQtfbe7dxbQmvA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.11.0",
+        "deepmerge": "^4.2.2",
+        "rfdc": "^1.2.0",
+        "string-similarity": "^4.0.1"
+      }
+    },
     "fast-levenshtein": {
       "version": "2.0.6"
+    },
+    "fast-printf": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/fast-printf/-/fast-printf-1.6.9.tgz",
+      "integrity": "sha512-FChq8hbz65WMj4rstcQsFB0O7Cy++nmbNfLYnD9cYv2cRn8EG6k/MGn9kO/tjO66t09DLDugj3yL+V2o6Qftrg==",
+      "dev": true,
+      "requires": {
+        "boolean": "^3.1.4"
+      }
+    },
+    "fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true
     },
     "fastq": {
       "version": "1.13.0",
@@ -26879,6 +27074,15 @@
     "globals": {
       "version": "11.12.0"
     },
+    "globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3"
+      }
+    },
     "globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -27117,6 +27321,26 @@
         "@tootallnate/once": "1",
         "agent-base": "6",
         "debug": "4"
+      }
+    },
+    "http-terminator": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/http-terminator/-/http-terminator-3.2.0.tgz",
+      "integrity": "sha512-JLjck1EzPaWjsmIf8bziM3p9fgR1Y3JoUKAkyYEbZmFrIvJM6I8vVJfBGWlEtV9IWOvzNnaTtjuwZeBY2kwB4g==",
+      "dev": true,
+      "requires": {
+        "delay": "^5.0.0",
+        "p-wait-for": "^3.2.0",
+        "roarr": "^7.0.4",
+        "type-fest": "^2.3.3"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.12.2.tgz",
+          "integrity": "sha512-qt6ylCGpLjZ7AaODxbpyBZSs9fCI9SkL3Z9q2oxMBQhs/uyY+VD8jHA8ULCGmWQJlBgqvO3EJeAngOHD8zQCrQ==",
+          "dev": true
+        }
       }
     },
     "http2-wrapper": {
@@ -31487,8 +31711,26 @@
         "aggregate-error": "^3.0.0"
       }
     },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dev": true,
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
+    },
     "p-try": {
       "version": "2.2.0"
+    },
+    "p-wait-for": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-wait-for/-/p-wait-for-3.2.0.tgz",
+      "integrity": "sha512-wpgERjNkLrBiFmkMEjuZJEWKKDrNfHCKA1OhyN1wg1FrLkULbviEy6py1AyJUgZ72YWFbZ38FIpnqvVqAlDUwA==",
+      "dev": true,
+      "requires": {
+        "p-timeout": "^3.0.0"
+      }
     },
     "pages-functions-app": {
       "version": "file:examples/pages-functions-app",
@@ -32478,6 +32720,12 @@
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
     },
+    "rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+      "dev": true
+    },
     "rimraf": {
       "version": "3.0.2",
       "requires": {
@@ -32492,6 +32740,20 @@
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
+      }
+    },
+    "roarr": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-7.11.0.tgz",
+      "integrity": "sha512-DKiMaEYHoOZ0JyD4Ohr5KRnqybQ162s3ZL/WNO9oy6EUszYvpp0eLYJErc/U4NI96HYnHsbROhFaH4LYuJPnDg==",
+      "dev": true,
+      "requires": {
+        "boolean": "^3.1.4",
+        "fast-json-stringify": "^2.7.10",
+        "fast-printf": "^1.6.9",
+        "fast-safe-stringify": "^2.1.1",
+        "globalthis": "^1.0.2",
+        "semver-compare": "^1.0.0"
       }
     },
     "rollup-plugin-inject": {
@@ -32830,6 +33092,12 @@
     },
     "semver": {
       "version": "5.7.1"
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "dev": true
     },
     "send": {
       "version": "0.18.0",
@@ -33454,6 +33722,12 @@
         "char-regex": "^1.0.2",
         "strip-ansi": "^6.0.0"
       }
+    },
+    "string-similarity": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.4.tgz",
+      "integrity": "sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==",
+      "dev": true
     },
     "string-width": {
       "version": "4.2.3",
@@ -34954,6 +35228,7 @@
         "fsevents": "~2.3.2",
         "get-port": "^6.1.2",
         "glob-to-regexp": "0.4.1",
+        "http-terminator": "*",
         "ignore": "^5.2.0",
         "ink": "^3.2.0",
         "ink-select-input": "^4.2.1",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -75,6 +75,7 @@
     "find-up": "^6.3.0",
     "get-port": "^6.1.2",
     "glob-to-regexp": "0.4.1",
+    "http-terminator": "^3.2.0",
     "ignore": "^5.2.0",
     "ink": "^3.2.0",
     "ink-select-input": "^4.2.1",

--- a/packages/wrangler/src/abort.d.ts
+++ b/packages/wrangler/src/abort.d.ts
@@ -1,0 +1,3 @@
+declare interface AbortSignal {
+  addEventListener(event: "abort", handler: () => void);
+}

--- a/packages/wrangler/src/cfetch/index.ts
+++ b/packages/wrangler/src/cfetch/index.ts
@@ -27,12 +27,14 @@ export { fetchKVGetValue } from "./internal";
 export async function fetchResult<ResponseType>(
   resource: string,
   init: RequestInit = {},
-  queryParams?: URLSearchParams
+  queryParams?: URLSearchParams,
+  abortSignal?: AbortSignal
 ): Promise<ResponseType> {
   const json = await fetchInternal<FetchResult<ResponseType>>(
     resource,
     init,
-    queryParams
+    queryParams,
+    abortSignal
   );
   if (json.success) {
     return json.result;

--- a/packages/wrangler/src/cfetch/internal.ts
+++ b/packages/wrangler/src/cfetch/internal.ts
@@ -26,7 +26,8 @@ export const getCloudflareAPIBaseURL = getEnvironmentVariableFactory({
 export async function fetchInternal<ResponseType>(
   resource: string,
   init: RequestInit = {},
-  queryParams?: URLSearchParams
+  queryParams?: URLSearchParams,
+  abortSignal?: AbortSignal
 ): Promise<ResponseType> {
   await requireLoggedIn();
   const apiToken = requireApiToken();
@@ -41,6 +42,7 @@ export async function fetchInternal<ResponseType>(
       method,
       ...init,
       headers,
+      signal: abortSignal,
     }
   );
   const jsonText = await response.text();

--- a/packages/wrangler/src/create-worker-preview.ts
+++ b/packages/wrangler/src/create-worker-preview.ts
@@ -66,7 +66,12 @@ async function sessionToken(
     ? `/zones/${ctx.zone.id}/workers/edge-preview`
     : `/accounts/${accountId}/workers/subdomain/edge-preview`;
 
-  const { exchange_url } = await fetchResult<{ exchange_url: string }>(initUrl);
+  const { exchange_url } = await fetchResult<{ exchange_url: string }>(
+    initUrl,
+    undefined,
+    undefined,
+    abortSignal
+  );
   const { inspector_websocket, prewarm, token } = (await (
     await fetch(exchange_url, { signal: abortSignal })
   ).json()) as { inspector_websocket: string; token: string; prewarm: string };
@@ -119,13 +124,18 @@ async function createPreviewToken(
   const formData = createWorkerUploadForm(worker);
   formData.set("wrangler-session-config", JSON.stringify(mode));
 
-  const { preview_token } = await fetchResult<{ preview_token: string }>(url, {
-    method: "POST",
-    body: formData,
-    headers: {
-      "cf-preview-upload-config-token": value,
+  const { preview_token } = await fetchResult<{ preview_token: string }>(
+    url,
+    {
+      method: "POST",
+      body: formData,
+      headers: {
+        "cf-preview-upload-config-token": value,
+      },
     },
-  });
+    undefined,
+    abortSignal
+  );
 
   return {
     value: preview_token,

--- a/packages/wrangler/src/proxy.ts
+++ b/packages/wrangler/src/proxy.ts
@@ -404,7 +404,7 @@ export async function waitForPortToBeAvailable(
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (options.abortSignal as any).addEventListener("abort", () => {
+    options.abortSignal.addEventListener("abort", () => {
       const abortError = new Error("waitForPortToBeAvailable() aborted");
       (abortError as Error & { code: string }).code = "ABORT_ERR";
       doReject(abortError);


### PR DESCRIPTION
When running `wrangler dev` we create a proxy to the actual remote Worker.
After creating a connection to this proxy by a browser request the proxy did not shutdown.
Now we use a `HttpTerminator` helper library to force the proxy to close open connections and shutdown correctly.

Fixes https://github.com/cloudflare/wrangler2/issues/958