### PR TITLE
refactor: remove use of `any`

### DIFF
--- a/.changeset/lazy-cows-press.md
+++ b/.changeset/lazy-cows-press.md
@@ -1,0 +1,10 @@
+---
+"wrangler": patch
+---
+
+refactor: remove use of `any`
+
+This "quick-win" refactors some of the code to avoid the use of `any` where possible.
+Using `any` can cause type-checking to be disabled across the code in unexpectedly wide-impact ways.
+
+There is one other use of `any` not touched here because it is fixed by #1088 separately.

--- a/packages/wrangler/src/cfetch/internal.ts
+++ b/packages/wrangler/src/cfetch/internal.ts
@@ -45,7 +45,7 @@ export async function fetchInternal<ResponseType>(
   );
   const jsonText = await response.text();
   try {
-    return parseJSON(jsonText) as ResponseType;
+    return parseJSON<ResponseType>(jsonText);
   } catch (err) {
     throw new ParseError({
       text: "Received a malformed response from the API",

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -43,6 +43,7 @@ import {
   formatMessage,
   ParseError,
   parseJSON,
+  parsePackageJSON,
   parseTOML,
   readFileSync,
 } from "./parse";
@@ -485,7 +486,7 @@ function createCLIParser(argv: string[]) {
       } else {
         // If package.json exists and wrangler isn't installed,
         // then ask to add wrangler to devDependencies
-        const packageJson = parseJSON(
+        const packageJson = parsePackageJSON(
           readFileSync(pathToPackageJson),
           pathToPackageJson
         );
@@ -539,7 +540,7 @@ function createCLIParser(argv: string[]) {
         isTypescriptProject = true;
         // If there's a tsconfig, check if @cloudflare/workers-types
         // is already installed, and offer to install it if not
-        const packageJson = parseJSON(
+        const packageJson = parsePackageJSON(
           readFileSync(pathToPackageJson),
           pathToPackageJson
         );
@@ -568,7 +569,7 @@ function createCLIParser(argv: string[]) {
         }
       }
 
-      const packageJsonContent = parseJSON(
+      const packageJsonContent = parsePackageJSON(
         readFileSync(pathToPackageJson),
         pathToPackageJson
       );

--- a/packages/wrangler/src/kv.ts
+++ b/packages/wrangler/src/kv.ts
@@ -127,25 +127,50 @@ const KeyValueKeys = new Set([
 ]);
 
 /**
+ * The object has the specified property.
+ */
+function hasProperty<T extends object>(
+  obj: object,
+  property: keyof T
+): obj is T {
+  return property in obj;
+}
+
+/**
+ * The object has a required property of the specified type.
+ */
+function hasTypedProperty<T extends object>(
+  obj: object,
+  property: keyof T,
+  type: string
+): obj is T {
+  return hasProperty(obj, property) && typeof obj[property] === type;
+}
+
+/**
+ * The object an optional property, of the specified type.
+ */
+function hasOptionalTypedProperty<T extends object>(
+  obj: object,
+  property: keyof T,
+  type: string
+): obj is Omit<T, typeof property> | T {
+  return !hasProperty(obj, property) || typeof obj[property] === type;
+}
+
+/**
  * Is the given object a valid `KeyValue` type?
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isKVKeyValue(keyValue: any): keyValue is KeyValue {
-  // (keyValue could indeed be any-thing)
+export function isKVKeyValue(keyValue: unknown): keyValue is KeyValue {
   if (
+    keyValue === null ||
     typeof keyValue !== "object" ||
-    typeof keyValue.key !== "string" ||
-    typeof keyValue.value !== "string" ||
-    !(
-      keyValue.expiration === undefined ||
-      typeof keyValue.expiration === "number"
-    ) ||
-    !(
-      keyValue.expiration_ttl === undefined ||
-      typeof keyValue.expiration_ttl === "number"
-    ) ||
-    !(keyValue.base64 === undefined || typeof keyValue.base64 === "boolean") ||
-    !(keyValue.metadata === undefined || typeof keyValue.metadata === "object")
+    !hasTypedProperty(keyValue, "key", "string") ||
+    !hasTypedProperty(keyValue, "value", "string") ||
+    !hasOptionalTypedProperty(keyValue, "expiration", "number") ||
+    !hasOptionalTypedProperty(keyValue, "expiration_ttl", "number") ||
+    !hasOptionalTypedProperty(keyValue, "base64", "boolean") ||
+    !hasOptionalTypedProperty(keyValue, "metadata", "object")
   ) {
     return false;
   }

--- a/packages/wrangler/src/parse.ts
+++ b/packages/wrangler/src/parse.ts
@@ -62,8 +62,6 @@ export class ParseError extends Error implements Message {
   }
 }
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 const TOML_ERROR_NAME = "TomlError";
 const TOML_ERROR_SUFFIX = " at row ";
 
@@ -101,9 +99,28 @@ export function parseTOML(input: string, file?: string): TOML.JsonMap | never {
 const JSON_ERROR_SUFFIX = " in JSON at position ";
 
 /**
+ * A minimal type describing a package.json file.
+ */
+export type PackageJSON = {
+  devDependencies?: Record<string, unknown>;
+  dependencies?: Record<string, unknown>;
+  scripts?: Record<string, unknown>;
+};
+
+/**
+ * A typed version of `parseJSON()`.
+ */
+export function parsePackageJSON<T extends PackageJSON = PackageJSON>(
+  input: string,
+  file?: string
+): T {
+  return parseJSON<T>(input, file);
+}
+
+/**
  * A wrapper around `JSON.parse` that throws a `ParseError`.
  */
-export function parseJSON(input: string, file?: string): any {
+export function parseJSON<T>(input: string, file?: string): T {
   try {
     return JSON.parse(input);
   } catch (err) {


### PR DESCRIPTION
This "quick-win" refactors some of the code to avoid the use of `any` where possible.
Using `any` can cause type-checking to be disabled across the code in unexpectedly wide-impact ways.

There is one other use of `any` not touched here because it is fixed by #1088 separately.