### PR TITLE
fix: ensure all line endings are normalized before parsing as TOML

### DIFF
--- a/.changeset/forty-dolphins-heal.md
+++ b/.changeset/forty-dolphins-heal.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: ensure all line endings are normalized before parsing as TOML
+
+Only the last line-ending was being normalized not all of them.
+
+Fixes https://github.com/cloudflare/wrangler2/issues/1094

--- a/packages/wrangler/src/__tests__/parse.test.ts
+++ b/packages/wrangler/src/__tests__/parse.test.ts
@@ -167,7 +167,11 @@ describe("parseTOML", () => {
   });
 
   it("should cope with Windows line-endings", () => {
-    expect(parseTOML("# A comment with a Windows line-ending\r\n")).toEqual({});
+    expect(
+      parseTOML(
+        "# A comment with a Windows line-ending\r\n# Another comment with a Windows line-ending\r\n"
+      )
+    ).toEqual({});
   });
 });
 

--- a/packages/wrangler/src/parse.ts
+++ b/packages/wrangler/src/parse.ts
@@ -76,7 +76,7 @@ type TomlError = Error & {
 export function parseTOML(input: string, file?: string): TOML.JsonMap | never {
   try {
     // Normalize CRLF to LF to avoid hitting https://github.com/iarna/iarna-toml/issues/33.
-    const normalizedInput = input.replace(/\r\n$/g, "\n");
+    const normalizedInput = input.replace(/\r\n/g, "\n");
     return TOML.parse(normalizedInput);
   } catch (err) {
     const { name, message, line, col } = err as TomlError;


### PR DESCRIPTION
Only the last line-ending was being normalized not all of them.

Fixes https://github.com/cloudflare/wrangler2/issues/1094