### PR TITLE
fix: delegate `wrangler build` to `wrangler publish`

### DIFF
--- a/.changeset/neat-frogs-smash.md
+++ b/.changeset/neat-frogs-smash.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: delegate `wrangler build` to `wrangler publish`
+
+Since `wrangler publish --dry-run --outdir=dist` is basically the same result
+as what Wrangler 1 did with `wrangler build` let's run that for the user if
+they try to run `wrangler build`.

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -724,13 +724,34 @@ function createCLIParser(argv: string[]) {
     (yargs) => {
       return yargs.option("env", {
         describe: "Perform on a specific environment",
+        type: "string",
       });
     },
-    () => {
+    async (buildArgs) => {
       // "[DEPRECATED] 🦀 Build your project (if applicable)",
-      throw new DeprecationError(
-        "`wrangler build` has been deprecated, please refer to https://developers.cloudflare.com/workers/wrangler/migration/deprecations/#build for alternatives"
+
+      const envFlag = buildArgs.env ? ` --env=${buildArgs.env}` : "";
+      logger.log(
+        formatMessage({
+          kind: "warning",
+          text: "Deprecation: `wrangler build` has been deprecated.",
+          notes: [
+            {
+              text: "Please refer to https://developers.cloudflare.com/workers/wrangler/migration/deprecations/#build for more information.",
+            },
+            {
+              text: `Attempting to run \`wrangler publish --dry-run --outdir=dist${envFlag}\` for you instead:`,
+            },
+          ],
+        })
       );
+
+      await createCLIParser([
+        "publish",
+        "--dry-run",
+        "--outdir=dist",
+        ...(buildArgs.env ? ["--env", buildArgs.env] : []),
+      ]).parse();
     }
   );
 


### PR DESCRIPTION
Since `wrangler publish --dry-run --outdir=dist` is basically the same result
as what Wrangler 1 did with `wrangler build` let's run that for the user if
they try to run `wrangler build`.