### PR TITLE
Support for loading wrangler configs from a js/ts module

### DIFF
--- a/packages/wrangler/src/__tests__/helpers/write-config-module.ts
+++ b/packages/wrangler/src/__tests__/helpers/write-config-module.ts
@@ -1,0 +1,76 @@
+import * as fs from "fs";
+import type { RawConfig } from "../../config";
+
+export type WriteConfigModuleFormats = "esm" | "cjs" | "ts";
+export type WriteConfigModuleOptions = {
+  hasConfig?: boolean;
+  hasOnConfig?: boolean;
+};
+
+const config = (rawConfig: RawConfig) => JSON.stringify(rawConfig);
+const onConfig = (isTs = false) => `(initialConfig${
+  isTs ? ": Record<string, unknown>" : ""
+}) => {
+  return {
+    ...initialConfig,
+    vars: {...initialConfig.vars, transformed: "yes" }
+  };
+}`;
+
+function getESMModule(
+  rawConfig: RawConfig,
+  { hasConfig, hasOnConfig }: WriteConfigModuleOptions
+): string {
+  const pieces: string[] = [];
+  if (hasConfig) pieces.push(`export const config = ${config(rawConfig)}`);
+  if (hasOnConfig) pieces.push(`export const onConfig = ${onConfig()}`);
+  return pieces.join("\n");
+}
+
+function getCJSModule(
+  rawConfig: RawConfig,
+  { hasConfig, hasOnConfig }: WriteConfigModuleOptions
+): string {
+  const pieces: string[] = ["{"];
+  if (hasConfig) pieces.push(`  config: ${config(rawConfig)},`);
+  if (hasOnConfig) pieces.push(`  onConfig: ${onConfig()},`);
+  pieces.push("}");
+  return `module.exports = ${pieces.join("\n")}`;
+}
+
+function getTSModule(
+  rawConfig: RawConfig,
+  { hasConfig, hasOnConfig }: WriteConfigModuleOptions
+): string {
+  const pieces: string[] = [];
+  if (hasConfig) pieces.push(`export const config = ${config(rawConfig)}`);
+  if (hasOnConfig) pieces.push(`export const onConfig = ${onConfig(true)}`);
+  return pieces.join("\n");
+}
+
+export default function writeConfigModule(
+  format: WriteConfigModuleFormats,
+  rawConfig: RawConfig = {},
+  options: WriteConfigModuleOptions = {}
+): string {
+  let ext = "js";
+  let content = "";
+  switch (format) {
+    case "esm":
+      ext = "mjs";
+      content = getESMModule(rawConfig, options);
+      break;
+    case "cjs":
+      ext = "js";
+      content = getCJSModule(rawConfig, options);
+      break;
+    case "ts":
+      ext = "ts";
+      content = getTSModule(rawConfig, options);
+      break;
+  }
+  const filename = `./wrangler.${ext}`;
+  // console.log({ ext, content });
+  fs.writeFileSync(filename, content, "utf-8");
+  return filename;
+}

--- a/packages/wrangler/src/config/config.ts
+++ b/packages/wrangler/src/config/config.ts
@@ -22,7 +22,15 @@ import type { Environment, RawEnvironment } from "./environment";
  */
 export type Config = ConfigFields<DevConfig> & Environment;
 
-export type RawConfig = Partial<ConfigFields<RawDevConfig>> &
+export type ImportableConfigFields = {
+  config: {
+    module: string;
+  };
+};
+
+export type RawConfig = Partial<
+  ConfigFields<RawDevConfig> & ImportableConfigFields
+> &
   RawEnvironment &
   DeprecatedConfigFields &
   EnvironmentMap;
@@ -213,6 +221,13 @@ export interface DeprecatedConfigFields {
    * @deprecated
    */
   miniflare?: unknown;
+}
+
+export type ImportableConfig = RawConfig;
+export type ImportableConfigTransform = (initialConfig: RawConfig) => RawConfig;
+export interface ImportableConfigModule {
+  config?: ImportableConfig;
+  onConfig?: ImportableConfigTransform;
 }
 
 interface EnvironmentMap {

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -228,7 +228,7 @@ export function normalizeAndValidateConfig(
     diagnostics,
     "top-level",
     Object.keys(rawConfig),
-    [...Object.keys(config), "env"]
+    [...Object.keys(config), "env", "config"]
   );
 
   return { config, diagnostics };


### PR DESCRIPTION
Adds a `config` table to `wrangler.toml`, which contains a `module` field which can point to a javascript or typescript module file. The module should export a `config` object which will be shallow-merged with the config from `wrangler.toml`. It can also export an `onConfig` function which expects the initial config (from the `wrangler.toml` config or the `config` object merge) as an input, and outputs a new config object.

To illustrate, consider the following `wrangler.toml` file for the upcoming examples:
```toml
# wrangler.toml
name = "test-worker"
main = "src/index.ts"

[config]
module = "wrangler.ts"
```

### Example 1: merge `wrangler.toml` with `wrangler.ts`:
```ts
// wrangler.ts
export const config = {
    name: 'test-worker-modified'
}
```
The resulting config will look like:
```json
{
  "name": "test-worker-modified",
  "main": "src/index.ts"
}
```

### Example 2: transform the config with a function:
```ts
// wrangler.ts
export const onConfig = (initialConfig: Record<string, unknown>) => ({
    ...initialConfig,
    name: `${initialConfig.name}-transformed`
})
```
The resulting config will look like:
```json
{
  "name": "test-worker-transformed",
  "main": "src/index.ts"
}
```

### Example 3: both merge and transform:
```ts
// wrangler.ts
export const config = {
    name: 'test-worker-modified'
}
export const onConfig = (initialConfig: Record<string, unknown>) => ({
    ...initialConfig,
    name: `${initialConfig.name}-transformed`
})
```
The resulting config will look like:
```json
{
  "name": "test-worker-modified-transformed",
  "main": "src/index.ts"
}
```

### Example 4: ES modules
```toml
# wrangler.toml
...
[config]
module = "wrangler.mjs"
```
```js
// wrangler.mjs
export const config = {
  name: 'test-worker-modified'
}
export const onConfig = (initialConfig) => ({
    ...initialConfig,
    name: `${initialConfig.name}-transformed`
})
```

### Example 5: CommonJS modules
```toml
# wrangler.toml
...
[config]
module = "wrangler.js"
```
```js
// wrangler.js
module.exports = {
  config: { name: 'in-js' },
  onConfig: (initialConfig) => ({
    ...initialConfig,
    name: `${initialConfig.name}-transformed`
  })
}
```

## Future work
- Since we can import typescript files as a config, we should expose the wrangler config types in [workers-types](https://github.com/cloudflare/workers-types), as well as a type for the `onConfig` transformer.
- We can possibly implement a similar expectation to eslint and others where we just need one file named `wrangler.{ext}` for wrangler to find rather than specifying the supplemental config file in the initial `wrangler.toml` file.
- There was some strange behavior when importing vanilla JSON modules, so we'll need to investigate that before supporting a `wrangler.json`.