### PR TITLE
fix: print instructions even if installPackages fails

### DIFF
--- a/.changeset/beige-cobras-train.md
+++ b/.changeset/beige-cobras-train.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: print instructions even if installPackages fails to fetch npm packages

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -759,7 +759,17 @@ function createCLIParser(argv: string[]) {
         }
       }
       // install packages as the final step of init
-      await installPackages(shouldRunPackageManagerInstall, devDepsToInstall);
+      try {
+        await installPackages(shouldRunPackageManagerInstall, devDepsToInstall);
+      } catch (e) {
+        // fetching packages could fail due to loss of internet, etc
+        // we should let folks know we failed to fetch, but their
+        // workers project is still ready to go
+        logger.error(e instanceof Error ? e.message : e);
+        instructions.push(
+          "\n🚨 wrangler was unable to fetch your npm packages, but your project is ready to go"
+        );
+      }
 
       // let users know what to do now
       instructions.forEach((instruction) => logger.log(instruction));


### PR DESCRIPTION
Before:
```
 ⛅️ wrangler 0.0.0-3c7a216
---------------------------------------------------------------------
Using npm as package manager.
✨ Created quick-wins-init-1-1/wrangler.toml
Would you like to use git to manage this Worker? (y/n)
✨ Initialized git repository at quick-wins-init-1-1
No package.json found. Would you like to create one? (y/n)
✨ Created quick-wins-init-1-1/package.json
Would you like to use TypeScript? (y/n)
✨ Created quick-wins-init-1-1/tsconfig.json
Would you like to create a Worker at quick-wins-init-1-1/src/index.ts? (y/n)
✨ Created quick-wins-init-1-1/src/index.ts
npm ERR! code ETARGET
npm ERR! notarget No matching version found for wrangler@0.0.0-3c7a216.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/rozenmd/.npm/_logs/2022-05-25T15_44_20_140Z-debug-0.log

✘ [ERROR] Command failed with exit code 1: npm install @cloudflare/workers-types typescript --save-dev


If you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.
```
After:
```
 ⛅️ wrangler 0.0.0-a6430c0
---------------------------
Using npm as package manager.
✨ Created quick-wins-init5/wrangler.toml
Would you like to use git to manage this Worker? (y/n)
✨ Initialized git repository at quick-wins-init5
No package.json found. Would you like to create one? (y/n)
✨ Created quick-wins-init5/package.json
Would you like to use TypeScript? (y/n)
✨ Created quick-wins-init5/tsconfig.json
Would you like to create a Worker at quick-wins-init5/src/index.ts? (y/n)
✨ Created quick-wins-init5/src/index.ts
npm ERR! code ETARGET
npm ERR! notarget No matching version found for wrangler@0.0.0-a6430c0.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/rozenmd/.npm/_logs/2022-05-25T15_42_38_809Z-debug-0.log
✘ [ERROR] Command failed with exit code 1: npm install @cloudflare/workers-types typescript --save-dev



To start developing your Worker, run `cd quick-wins-init5 && npm start`
To publish your Worker to the Internet, run `npm run publish`

🚨 wrangler was unable to fetch your npm packages, but your project is ready to go
```

Closes #1109