### PR TITLE
Git default `main` branch

### DIFF
--- a/.changeset/giant-trees-mix.md
+++ b/.changeset/giant-trees-mix.md
@@ -1,0 +1,13 @@
+---
+"wrangler": patch
+---
+
+Git default `main` branch
+
+polish: Default branch when choosing to initialize a git repository will now be `main`.
+This is inline with current common industry ethical practices.
+See:
+
+- https://sfconservancy.org/news/2020/jun/23/gitbranchname/
+- https://github.com/github/renaming
+- https://sfconservancy.org/news/2020/jun/23/gitbranchname/

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import path from "node:path";
 import * as TOML from "@iarna/toml";
-import { execa } from "execa";
+import { execa, execaSync } from "execa";
 import { parseConfigFileTextToJson } from "typescript";
 import { version as wranglerVersion } from "../../package.json";
 import { getPackageManager } from "../package-manager";
@@ -412,10 +412,37 @@ describe("init", () => {
       `);
     });
 
+    // I... don't know how to test this lol
     it.todo(
       "should not offer to initialize a git repo if git is not installed"
     );
-    // I... don't know how to test this lol
+
+    it("should initialize git repo with `main` default branch", async () => {
+      mockConfirm(
+        {
+          text: "Would you like to use git to manage this Worker?",
+          result: true,
+        },
+        {
+          text: "No package.json found. Would you like to create one?",
+          result: false,
+        }
+      );
+      await runWrangler("init");
+      expect(std).toMatchInlineSnapshot(`
+        Object {
+          "debug": "",
+          "err": "",
+          "out": "✨ Created wrangler.toml
+        ✨ Initialized git repository",
+          "warn": "",
+        }
+      `);
+
+      expect(execaSync("git", ["symbolic-ref", "HEAD"]).stdout).toEqual(
+        "refs/heads/main"
+      );
+    });
   });
 
   describe("package.json", () => {

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -444,7 +444,9 @@ function createCLIParser(argv: string[]) {
           yesFlag ||
           (await confirm("Would you like to use git to manage this Worker?"));
         if (shouldInitGit) {
-          await execa("git", ["init"], { cwd: creationDirectory });
+          await execa("git", ["init", "--initial-branch=main"], {
+            cwd: creationDirectory,
+          });
           await writeFile(
             path.join(creationDirectory, ".gitignore"),
             readFileSync(path.join(__dirname, "../templates/gitignore"))


### PR DESCRIPTION
polish: Default branch when choosing to initialize a git repository will now be `main`.
This is inline with current common industry ethical practices.
See:
- https://sfconservancy.org/news/2020/jun/23/gitbranchname/
- https://github.com/github/renaming
- https://sfconservancy.org/news/2020/jun/23/gitbranchname/