### PR TITLE
fix: improve error message when CF API responds with an error

### DIFF
--- a/.changeset/pink-plums-turn.md
+++ b/.changeset/pink-plums-turn.md
@@ -1,0 +1,15 @@
+---
+"wrangler": patch
+---
+
+fix: display chained errors from the CF API
+
+For example if you have an invalid CF_API_TOKEN and try running `wrangler whoami`
+you now get the additional `6111` error information:
+
+```
+✘ [ERROR] A request to the Cloudflare API (/user) failed.
+
+  Invalid request headers [code: 6003]
+  - Invalid format for Authorization header [code: 6111]
+```

--- a/.changeset/wise-panthers-glow.md
+++ b/.changeset/wise-panthers-glow.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: improve error message when CF API responds with an error

--- a/packages/wrangler/src/cfetch/index.ts
+++ b/packages/wrangler/src/cfetch/index.ts
@@ -85,7 +85,7 @@ function throwFetchError(
   response: FetchResult<unknown>
 ): never {
   const error = new ParseError({
-    text: "Received a bad response from the API",
+    text: `A request to the Cloudflare API (${resource}) failed.`,
     notes: response.errors.map((err) => ({
       text: err.code ? `${err.message} [code: ${err.code}]` : err.message,
     })),

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -2754,7 +2754,7 @@ export async function main(argv: string[]): Promise<void> {
       e.notes.push({
         text: "\nIf you think this is a bug, please open an issue at: https://github.com/cloudflare/wrangler2/issues/new",
       });
-      logger.error(formatMessage(e));
+      logger.log(formatMessage(e));
     } else {
       logger.error(e instanceof Error ? e.message : e);
       logger.log(


### PR DESCRIPTION
I find the current message confusing. The response is not bad it is a valid response saying that the request failed.