### PR TITLE
New worker improvements

### DIFF
--- a/.changeset/tough-flies-dream.md
+++ b/.changeset/tough-flies-dream.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+chore: updated new worker ts template with env/ctx parameters and added Env interface

--- a/packages/wrangler/templates/new-worker.ts
+++ b/packages/wrangler/templates/new-worker.ts
@@ -8,8 +8,23 @@
  * Learn more at https://developers.cloudflare.com/workers/
  */
 
+export interface Env {
+  // Example binding to KV. Learn more at https://developers.cloudflare.com/workers/runtime-apis/kv/
+  // MY_KV_NAMESPACE: KVNamespace;
+  //
+  // Example binding to Durable Object. Learn more at https://developers.cloudflare.com/workers/runtime-apis/durable-objects/
+  // MY_DURABLE_OBJECT: DurableObjectNamespace;
+  //
+  // Example binding to R2. Learn more at https://developers.cloudflare.com/workers/runtime-apis/r2/
+  // MY_BUCKET: R2Bucket;
+}
+
 export default {
-  async fetch(request: Request): Promise<Response> {
+  async fetch(
+    request: Request,
+    env: Env,
+    ctx: ExecutionContext
+  ): Promise<Response> {
     return new Response("Hello World!");
   },
 };


### PR DESCRIPTION
closes #1112 

The current prettier `printWidth` setting forces the function parameters onto multiple lines.  If that's an issue, bumping `printWidth` from 80 to 90 fixes it.