### PR TITLE
Sharable dev sessions PROOF OF CONCEPT

### DIFF
--- a/.changeset/chilly-bulldogs-eat.md
+++ b/.changeset/chilly-bulldogs-eat.md
@@ -1,0 +1,10 @@
+---
+"dev-tunnel": patch
+"wrangler": patch
+---
+
+Initial implementation of sharable dev sessions
+
+The `dev-tunnel` package contains a simple proxy worker that allows `wrangler` users to send HTTP requests to register their local dev sessions as a request endpoint. The `dev-tunnel` worker will then register a unique ID to that session, and forward all requests to `/<tunnel-id>/*` to that session.
+
+This implementation introduces some additional latency in the case of running a non-local (i.e. on Cloudflare's edge) dev session, as requests go to Cloudflare, then to the user's machine, then back to cloudflare. This feels acceptable to me, as the tradeoff is that it no longer matters whether the user is in local or remote mode.

--- a/.changeset/serious-kings-matter.md
+++ b/.changeset/serious-kings-matter.md
@@ -1,0 +1,7 @@
+---
+"dev-tunnel": patch
+---
+
+Initial release of dev-tunnel worker
+
+The dev-tunnel worker (currently housed under `live-share.developers.workers.dev`) allows users to share a link to their local `wrangler dev` session in a similar way to ngrok.

--- a/.changeset/serious-kings-matter.md
+++ b/.changeset/serious-kings-matter.md
@@ -1,7 +1,0 @@
----
-"dev-tunnel": patch
----
-
-Initial release of dev-tunnel worker
-
-The dev-tunnel worker (currently housed under `live-share.developers.workers.dev`) allows users to share a link to their local `wrangler dev` session in a similar way to ngrok.

--- a/.gitignore
+++ b/.gitignore
@@ -178,4 +178,5 @@ miniflare-dist
 packages/wrangler/wrangler.toml
 packages/prerelease-registry/_worker.js
 packages/wranglerjs-compat-webpack-plugin/lib
+packages/dev-tunnel/lib
 .wrangler-1-cache

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,4 @@ packages/examples/remix-pages-app/public/
 packages/prerelease-registry/_worker.js
 packages/jest-environment-wrangler/dist/
 packages/wranglerjs-compat-webpack-plugin/lib
+packages/dev-tunnel/lib

--- a/package-lock.json
+++ b/package-lock.json
@@ -1220,9 +1220,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.10.0.tgz",
-      "integrity": "sha512-gn+H5Ps9yV1VYz8FJ08bMfXLW8ubNblRF9Z+m+0ctNMyl3CdoZmUfH1pMTxYE8SMUJbLxuNvpdlZhwLDoGFXaw=="
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.11.0.tgz",
+      "integrity": "sha512-XmKgZZHrCdPsoVQkdd365R7GvwTwDVJsMyEG3Dq/Tgxz6vgrps2c8PXBqEutguwvl0zDAF0AL0e2Z8WG9Dffjw=="
     },
     "node_modules/@cnakazawa/watch": {
       "version": "1.0.4",
@@ -6430,6 +6430,10 @@
         "node": ">=8"
       }
     },
+    "node_modules/dev-tunnel": {
+      "resolved": "packages/dev-tunnel",
+      "link": true
+    },
     "node_modules/devtools-protocol": {
       "version": "0.0.955664",
       "dev": true,
@@ -10319,6 +10323,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/itty-router": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-2.6.1.tgz",
+      "integrity": "sha512-l9gxWe5TOLUESYnBn85Jxd6tIZLWdRX5YKkHIBfSgbNQ7UFPNUGuWihRV+LlEbfJJIzgLmhwAbaWRi5yWJm8kg=="
     },
     "node_modules/jest": {
       "version": "27.5.1",
@@ -20539,6 +20548,16 @@
       "version": "1.0.0",
       "license": "ISC"
     },
+    "packages/dev-tunnel": {
+      "version": "0.0.0",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "itty-router": "^2.6.1"
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^3.11.0"
+      }
+    },
     "packages/jest-environment-wrangler": {
       "version": "0.0.29",
       "license": "ISC",
@@ -21680,9 +21699,9 @@
       }
     },
     "@cloudflare/workers-types": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.10.0.tgz",
-      "integrity": "sha512-gn+H5Ps9yV1VYz8FJ08bMfXLW8ubNblRF9Z+m+0ctNMyl3CdoZmUfH1pMTxYE8SMUJbLxuNvpdlZhwLDoGFXaw=="
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.11.0.tgz",
+      "integrity": "sha512-XmKgZZHrCdPsoVQkdd365R7GvwTwDVJsMyEG3Dq/Tgxz6vgrps2c8PXBqEutguwvl0zDAF0AL0e2Z8WG9Dffjw=="
     },
     "@cnakazawa/watch": {
       "version": "1.0.4",
@@ -25541,6 +25560,13 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA=="
     },
+    "dev-tunnel": {
+      "version": "file:packages/dev-tunnel",
+      "requires": {
+        "@cloudflare/workers-types": "^3.11.0",
+        "itty-router": "^2.6.1"
+      }
+    },
     "devtools-protocol": {
       "version": "0.0.955664",
       "dev": true
@@ -28028,6 +28054,11 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
+    },
+    "itty-router": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-2.6.1.tgz",
+      "integrity": "sha512-l9gxWe5TOLUESYnBn85Jxd6tIZLWdRX5YKkHIBfSgbNQ7UFPNUGuWihRV+LlEbfJJIzgLmhwAbaWRi5yWJm8kg=="
     },
     "jest": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
       "packages/wrangler/pages/functions/template-worker.ts",
       "packages/wrangler/templates",
       "examples/remix-pages-app/public",
-      "packages/jest-environment-wrangler/dist"
+      "packages/jest-environment-wrangler/dist",
+      "packages/dev-tunnel/lib"
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "check:type": "npm run check:type --workspaces --if-present",
     "check:lint": "eslint \"packages/**/*.[tj]s?(x)\" --cache --cache-strategy content --max-warnings=0",
     "check:format": "prettier packages/** .changeset --check --ignore-unknown",
-    "build": "npm run build --workspace=wrangler --workspace=jest-environment-wrangler --workspace=pages-plugin-example --workspace=wranglerjs-compat-webpack-plugin",
+    "build": "npm run build --workspace=dev-tunnel --workspace=wrangler --workspace=jest-environment-wrangler --workspace=pages-plugin-example --workspace=wranglerjs-compat-webpack-plugin",
     "test": "npm run test --workspaces --if-present",
     "prettify": "prettier packages/** --write --ignore-unknown"
   },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "typescript": "^4.6.3"
   },
   "scripts": {
-    "check": "run-p check:* --aggregate-output --continue-on-error",
+    "check": "npm run build --workspace=dev-tunnel && run-p check:* --aggregate-output --continue-on-error",
     "check:type": "npm run check:type --workspaces --if-present",
     "check:lint": "eslint \"packages/**/*.[tj]s?(x)\" --cache --cache-strategy content --max-warnings=0",
     "check:format": "prettier packages/** .changeset --check --ignore-unknown",

--- a/packages/dev-tunnel/package.json
+++ b/packages/dev-tunnel/package.json
@@ -6,6 +6,7 @@
   "description": "Tunnel worker for sharing local `dev` sessions",
   "license": "MIT OR Apache-2.0",
   "module": "src/index.ts",
+  "main": "src/index.ts",
   "scripts": {
     "test": "jest",
     "publish": "npx wrangler publish"

--- a/packages/dev-tunnel/package.json
+++ b/packages/dev-tunnel/package.json
@@ -5,10 +5,11 @@
   "author": "wrangler@cloudflare.com",
   "description": "Tunnel worker for sharing local `dev` sessions",
   "license": "MIT OR Apache-2.0",
-  "module": "src/index.ts",
-  "main": "src/index.ts",
+  "module": "lib",
+  "main": "lib",
   "scripts": {
     "test": "jest",
+    "build": "tsc",
     "publish": "npx wrangler publish"
   },
   "bugs": {

--- a/packages/dev-tunnel/package.json
+++ b/packages/dev-tunnel/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "dev-tunnel",
+  "private": "true",
+  "version": "0.0.0",
+  "author": "wrangler@cloudflare.com",
+  "description": "Tunnel worker for sharing local `dev` sessions",
+  "license": "MIT OR Apache-2.0",
+  "module": "src/index.ts",
+  "scripts": {
+    "test": "jest",
+    "publish": "npx wrangler publish"
+  },
+  "bugs": {
+    "url": "https://github.com/cloudflare/wrangler2/issues"
+  },
+  "homepage": "https://github.com/cloudflare/wrangler2#readme",
+  "devDependencies": {
+    "@cloudflare/workers-types": "^3.11.0"
+  },
+  "dependencies": {
+    "itty-router": "^2.6.1"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.c?(t|j)sx?$": [
+        "esbuild-jest",
+        {
+          "sourcemap": true
+        }
+      ]
+    }
+  }
+}

--- a/packages/dev-tunnel/src/constants.ts
+++ b/packages/dev-tunnel/src/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * How long a tunnel will stay alive without receiving a heartbeat
+ */
+export const TUNNEL_TTL_SECONDS = 60 * 10;
+
+/**
+ * URL the tunnel worker lives at
+ */
+export const TUNNEL_WORKER_URL = "https://live-share.cass.workers.dev";

--- a/packages/dev-tunnel/src/index.spec.ts
+++ b/packages/dev-tunnel/src/index.spec.ts
@@ -1,0 +1,75 @@
+import { extractComponents } from "./index";
+
+describe("url extraction", () => {
+  type SuccessfulExtractionTestCase = {
+    url: string;
+    outcome: {
+      hostId: string;
+      path: string;
+    };
+  };
+
+  type FailedExtractionTestCase = {
+    url: string;
+    outcome: "fail";
+  };
+
+  type ExtractionTestCase =
+    | SuccessfulExtractionTestCase
+    | FailedExtractionTestCase;
+
+  const shouldSucceed = (
+    testCase: ExtractionTestCase
+  ): testCase is SuccessfulExtractionTestCase => {
+    return testCase.outcome !== "fail";
+  };
+
+  const testCases: ExtractionTestCase[] = [
+    {
+      url: "https://tunnel-url.com/some-host-id",
+      outcome: {
+        hostId: "some-host-id",
+        path: "",
+      },
+    },
+    {
+      url: "https://tunnel-url.com/some-host-id/",
+      outcome: {
+        hostId: "some-host-id",
+        path: "/",
+      },
+    },
+    { url: "https://tunnel-url.com", outcome: "fail" },
+    { url: "f", outcome: "fail" },
+    { url: "", outcome: "fail" },
+    { url: "not-a-url", outcome: "fail" },
+    { url: "http://", outcome: "fail" },
+    { url: "//h//", outcome: "fail" },
+    {
+      url: "http://a.com/some-host-id/some/nested/path?with=parameters#anchor",
+      outcome: {
+        hostId: "some-host-id",
+        path: "/some/nested/path?with=parameters#anchor",
+      },
+    },
+  ];
+
+  for (const testCase of testCases) {
+    if (shouldSucceed(testCase)) {
+      const {
+        url,
+        outcome: { hostId, path },
+      } = testCase;
+
+      it(`extracts { hostId: "${hostId}", path: "${path}" } from ${url}`, () => {
+        expect(extractComponents(url)).toStrictEqual({ hostId, path });
+      });
+    } else {
+      it(`throws on url "${testCase.url}"`, () => {
+        expect(() => {
+          extractComponents(testCase.url);
+        }).toThrow();
+      });
+    }
+  }
+});

--- a/packages/dev-tunnel/src/index.ts
+++ b/packages/dev-tunnel/src/index.ts
@@ -1,0 +1,169 @@
+import { Router } from "itty-router";
+import { TUNNEL_TTL_SECONDS } from "./constants";
+
+export type TunnelCreationRequestBody = {
+  host: string;
+};
+
+export type TunnelHeartbeatRequestBody = {
+  id: string;
+};
+
+export type TunnelShutdownRequestBody = TunnelHeartbeatRequestBody;
+
+/**
+ * Routes for interacting with the dev-tunnel worker
+ */
+// eslint has trouble with enums, it thinks we're shadowing for some reason
+// eslint-disable-next-line no-shadow
+export enum Routes {
+  /**
+   * Creates a new tunnel.
+   * Expects a `POST` request with a JSON body
+   * containing a stringified `TunnelCreationRequestBody`
+   */
+  CREATE = "/create",
+
+  /**
+   * Sends a heartbeat to keep an existing tunnel alive.
+   * Expects a `PATCH` request with a JSON body
+   * containing a stringified `TunnelHeartbeatRequestBody`
+   */
+  HEARTBEAT = "/heartbeat",
+
+  /**
+   * Shuts down a tunnel.
+   * Expects a `DELETE` request with a JSON body
+   * containing a stringified `TunnelShutdownRequestBody`
+   */
+  SHUTDOWN = "/shutdown",
+
+  /**
+   * All other requests are treated as proxy requests
+   * that should be forwarded to a dev session.
+   */
+  PROXY = "*",
+}
+
+type Env = {
+  TUNNELS: KVNamespace;
+};
+
+const router = Router();
+
+// handle tunnel creation requests
+router.post(Routes.CREATE, async (request: Request, env: Env) => {
+  try {
+    const { host } = await request.json<TunnelCreationRequestBody>();
+    const id = crypto.randomUUID();
+
+    await env.TUNNELS.put(id, host, {
+      expirationTtl: TUNNEL_TTL_SECONDS,
+    });
+
+    const { hostname } = new URL(request.url);
+
+    return new Response(
+      JSON.stringify({ id, url: `https://${hostname}/${id}` }),
+      {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+  } catch (e) {
+    return new Response("Invalid request", { status: 400 });
+  }
+});
+
+// handle tunnel heartbeat requests
+router.patch(Routes.HEARTBEAT, async (request: Request, env: Env) => {
+  try {
+    const { id } = await request.json<TunnelHeartbeatRequestBody>();
+
+    const host = await env.TUNNELS.get(id);
+    if (!host) {
+      return new Response(`No tunnel found with id ${id}`, {
+        status: 404,
+        headers: { "Content-Type": "text/plain" },
+      });
+    }
+
+    await env.TUNNELS.put(id, host, {
+      expirationTtl: TUNNEL_TTL_SECONDS,
+    });
+
+    return new Response(null, { status: 204 });
+  } catch (e) {
+    return new Response("Invalid request", {
+      status: 400,
+      headers: { "Content-Type": "text/plain" },
+    });
+  }
+});
+
+// handle tunnel shutdown requests
+router.delete(Routes.SHUTDOWN, async (request: Request, env: Env) => {
+  try {
+    const { id } = await request.json<TunnelShutdownRequestBody>();
+    await env.TUNNELS.delete(id);
+
+    return new Response(null);
+  } catch (e) {
+    return new Response("Invalid request", {
+      status: 400,
+      headers: { "Content-Type": "text/plain" },
+    });
+  }
+});
+
+// handle proxy requests
+router.all(Routes.PROXY, async (request: Request, env: Env) => {
+  try {
+    const { hostId, path } = extractComponents(request.url);
+
+    const host = await env.TUNNELS.get(hostId);
+    if (!host) {
+      return new Response(`No tunnel registered at ${hostId}`, {
+        status: 404,
+        headers: { "Content-Type": "text/plain" },
+      });
+    }
+
+    return await fetch(`${host}${path}`, request);
+  } catch (e) {
+    return new Response("Invalid request.", {
+      status: 400,
+      headers: { "Content-Type": "text/plain" },
+    });
+  }
+});
+
+export default {
+  fetch: router.handle,
+};
+
+/**
+ * Extract the host ID and "path" (not really the path in the true sense,
+ * but basically everything in the URL that comes after the host) from
+ * the URL of a request coming in to the proxy worker.
+ *
+ * Throws if it fails to extract a host ID
+ */
+export function extractComponents(url: string) {
+  const firstSlashIndex = url.indexOf("/", "https://".length);
+  if (firstSlashIndex < 0) {
+    throw new Error('Couldn\'t find "/" character');
+  }
+
+  const afterSlash = url.substring(firstSlashIndex + 1);
+  const secondSlashIndex = afterSlash.indexOf("/");
+
+  const hostId =
+    secondSlashIndex === -1
+      ? afterSlash
+      : afterSlash.substring(0, secondSlashIndex);
+
+  const path =
+    secondSlashIndex === -1 ? "" : afterSlash.substring(secondSlashIndex);
+  return { hostId, path };
+}

--- a/packages/dev-tunnel/tsconfig.json
+++ b/packages/dev-tunnel/tsconfig.json
@@ -4,7 +4,11 @@
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
-    "types": ["@cloudflare/workers-types"]
+    "types": ["@cloudflare/workers-types"],
+    "noEmit": false,
+    "declaration": true,
+    "target": "ESNext",
+    "outDir": "lib"
   },
   "include": ["src/index.ts"]
 }

--- a/packages/dev-tunnel/tsconfig.json
+++ b/packages/dev-tunnel/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src/index.ts"]
+}

--- a/packages/dev-tunnel/wrangler.toml
+++ b/packages/dev-tunnel/wrangler.toml
@@ -1,0 +1,9 @@
+name = "live-share"
+main = "src/index.ts"
+workers_dev = true
+compatibility_date = "2022-05-26"
+
+[[kv_namespaces]]
+binding    = "TUNNELS"
+id         = "096bf2fc986f4c328c93161c046a89cf"
+preview_id = "ad2ecb4a579d470eaa98939c24ac4a82"

--- a/packages/wrangler/src/dev/tunnel.ts
+++ b/packages/wrangler/src/dev/tunnel.ts
@@ -1,0 +1,130 @@
+import clipboardy from "clipboardy";
+import { Routes } from "dev-tunnel";
+import {
+  TUNNEL_TTL_SECONDS,
+  TUNNEL_WORKER_URL,
+} from "dev-tunnel/src/constants";
+import { useEffect, useState } from "react";
+import { fetch } from "undici";
+import { logger } from "../logger";
+import type {
+  TunnelShutdownRequest,
+  TunnelCreationRequest,
+  TunnelCreationResponse,
+  TunnelHeartbeatRequest,
+} from "dev-tunnel";
+
+const toUrl = (route: Routes) => `${TUNNEL_WORKER_URL}${route}`;
+
+const createTunnel = async (body: TunnelCreationRequest) => {
+  const response = await fetch(toUrl(Routes.CREATE), {
+    body: JSON.stringify(body),
+    method: "POST",
+  });
+  if (response.ok) {
+    return (await response.json()) as TunnelCreationResponse;
+  }
+
+  throw new Error(await response.text());
+};
+
+const sendHeartbeat = async (body: TunnelHeartbeatRequest) => {
+  const response = await fetch(toUrl(Routes.HEARTBEAT), {
+    body: JSON.stringify(body),
+    method: "PATCH",
+  });
+  if (response.ok) {
+    return;
+  }
+
+  throw new Error(await response.text());
+};
+
+const shutdownTunnel = async (body: TunnelShutdownRequest) => {
+  const response = await fetch(toUrl(Routes.SHUTDOWN), {
+    body: JSON.stringify(body),
+    method: "DELETE",
+  });
+
+  if (response.ok) {
+    return;
+  }
+
+  throw new Error(await response.text());
+};
+
+/**
+ * React hook for sending heartbeats to a given tunnel ID
+ *
+ * @param id the tunnel ID to send a heartbeat for
+ */
+const useHeartbeat = (id?: string) => {
+  const ms = (TUNNEL_TTL_SECONDS - 60) * 1000;
+  const [timer, setTimer] = useState<NodeJS.Timer>();
+
+  useEffect(() => {
+    if (id !== undefined) {
+      if (timer !== undefined) {
+        clearInterval(timer);
+      }
+      setTimer(setInterval(async () => await sendHeartbeat({ id }), ms));
+    } else if (timer !== undefined) {
+      clearInterval(timer);
+    }
+
+    return () => {
+      if (timer !== undefined) {
+        clearInterval(timer);
+      }
+    };
+  }, [id, ms, timer]);
+};
+
+/**
+ * React hook to generate a URL that will proxy requests to the local `dev` session
+ */
+export const useTunnel = ({
+  toggle,
+  port,
+  ip,
+  localProtocol,
+}: {
+  toggle: boolean;
+  port: number;
+  ip: string;
+  localProtocol: "http" | "https";
+}): string | undefined => {
+  const [tunnelID, setTunnelID] = useState<string>();
+  const [tunnelURL, setTunnelURL] = useState<string>();
+  useHeartbeat(tunnelID);
+
+  const sessionUrl = `${localProtocol}://${ip}:${port}`;
+
+  useEffect(() => {
+    if (toggle && tunnelID === undefined) {
+      logger.log("⎔ Sharing session...");
+      void createTunnel({
+        sessionUrl,
+      }).then(({ id, url }) => {
+        setTunnelID(id);
+        setTunnelURL(url);
+        clipboardy.writeSync(url);
+        logger.log(`⬣ Sharing at ${url}, copied to clipboard.`);
+      });
+    } else if (tunnelID !== undefined) {
+      void shutdownTunnel({ id: tunnelID }).then(() => {
+        setTunnelID(undefined);
+        setTunnelURL(undefined);
+        logger.log("⎔ Ending share session.");
+      });
+    }
+
+    return () => {
+      if (tunnelID) {
+        void shutdownTunnel({ id: tunnelID }).then(() => {});
+      }
+    };
+  }, [toggle, sessionUrl, tunnelID]);
+
+  return tunnelURL;
+};


### PR DESCRIPTION
Initial implementation of sharable dev sessions

The `dev-tunnel` package contains a simple proxy worker that allows `wrangler` users to send HTTP requests to register their local dev sessions as a request endpoint. The `dev-tunnel` worker will then register a unique ID to that session, and forward all requests to `/<tunnel-id>/*` to that session.

This implementation introduces some additional latency in the case of running a non-local (i.e. on Cloudflare's edge) dev session, as requests go to Cloudflare, then to the user's machine, then back to cloudflare. This feels acceptable to me, as the tradeoff is that it no longer matters whether the user is in local or remote mode.
