### PR TITLE
chore: upgrade `miniflare` to `2.5.0`

### DIFF
--- a/.changeset/ten-countries-kiss.md
+++ b/.changeset/ten-countries-kiss.md
@@ -1,0 +1,6 @@
+---
+"jest-environment-wrangler": patch
+"wrangler": patch
+---
+
+Upgrade `miniflare` to [`2.5.0`](https://github.com/cloudflare/miniflare/releases/tag/v2.5.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2847,6 +2847,253 @@
         "node": ">=6 <7 || >=8"
       }
     },
+    "node_modules/@miniflare/cache": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.5.0.tgz",
+      "integrity": "sha512-tJuDbWwzYsk4pJvPPJzdlfdGFqNnn1IN3JVrGDCq8UwOXm0K8hFiSwq2nMjjT+Z/9X2FfimgaXOx81zjPL+FjQ==",
+      "dependencies": {
+        "@miniflare/core": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "http-cache-semantics": "^4.1.0",
+        "undici": "5.3.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "node_modules/@miniflare/cli-parser": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.5.0.tgz",
+      "integrity": "sha512-aY/wQ4Rwy8x0Awtb8TzhKFYp4g1Y8xBhtKFfHOZpYCEFCVfKtgdk0pHPKctf/ClK0qJdT3siJKeXxsH2GRAMXg==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.0",
+        "kleur": "^4.1.4"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "node_modules/@miniflare/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-BtMRi17DiimcpmDjQiIU6mIYSo/h21lVGC082n5G3JTF7AcGFAs7N2Fz2YLiYuc3zYc6qJx/NIjDoOqL2gfp3A==",
+      "dependencies": {
+        "@iarna/toml": "^2.2.5",
+        "@miniflare/shared": "2.5.0",
+        "@miniflare/watcher": "2.5.0",
+        "busboy": "^1.6.0",
+        "dotenv": "^10.0.0",
+        "kleur": "^4.1.4",
+        "set-cookie-parser": "^2.4.8",
+        "undici": "5.3.0",
+        "urlpattern-polyfill": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "node_modules/@miniflare/core/node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@miniflare/durable-objects": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.5.0.tgz",
+      "integrity": "sha512-HJuP5Lsm/CCaSx3dePZiywAniGqTpU1ocCEqV6kE4zX1C0uGplfjPPXo5xsVc2NXkD+0ZL65rJzcj2tfrwKZlg==",
+      "dependencies": {
+        "@miniflare/core": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "@miniflare/storage-memory": "2.5.0",
+        "undici": "5.3.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "node_modules/@miniflare/html-rewriter": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.5.0.tgz",
+      "integrity": "sha512-bV2lQ/2clPeBmDth+cMnCBFYk8xtGs83S6PhfwmNNd24rzHvOEch1h/VCtEUy8k+rtgDSpc9pVkd31k0tMsyxQ==",
+      "dependencies": {
+        "@miniflare/core": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "html-rewriter-wasm": "^0.4.1",
+        "undici": "5.3.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "node_modules/@miniflare/http-server": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.5.0.tgz",
+      "integrity": "sha512-+sRPgNq0Q4Q6t1k94ncYzgcf/UNIv0Bz4ubUu6InJy4kMaJKeJPOLlU55lTXJSYfBZM/L4NvAui2i5vA9g2BrA==",
+      "dependencies": {
+        "@miniflare/core": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "@miniflare/web-sockets": "2.5.0",
+        "kleur": "^4.1.4",
+        "selfsigned": "^2.0.0",
+        "undici": "5.3.0",
+        "ws": "^8.2.2",
+        "youch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "node_modules/@miniflare/http-server/node_modules/ws": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
+      "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@miniflare/kv": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.5.0.tgz",
+      "integrity": "sha512-5dzcUMMOKl8u75FXbpy2BHp38uafjzo3RW2HEm6EY8QoM/vHw6RChFzJ9YEPJDbvcHR8gdMpgC65LYPTjifc3g==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "node_modules/@miniflare/runner-vm": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.5.0.tgz",
+      "integrity": "sha512-0n85cOBq91D7roqsIqJESDnj0oRi+xNVjDfd5uDIT1dW1qo5asA5Mwx6ntzCJB1BcB4khNatUIwpO3ZT+kT/YQ==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "node_modules/@miniflare/scheduler": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.5.0.tgz",
+      "integrity": "sha512-+a/I2QLp3UaZpKVobzFH3eHsi5ubhBp8q/AH/sCDwcZmatbCp2+oDrjMgTqhF6Fm8ryR4BYkHQOgkGZ5l7gQjw==",
+      "dependencies": {
+        "@miniflare/core": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "cron-schedule": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "node_modules/@miniflare/shared": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.5.0.tgz",
+      "integrity": "sha512-2oPxhnCGg8DNoo0NzUdc2BylGGeHQQvFJ6mDODjxbSXybeQC0+Ul5Ujv/FyU9W/eTbUEWNqKBycINyuXqSnJ/w==",
+      "dependencies": {
+        "ignore": "^5.1.8",
+        "kleur": "^4.1.4"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "node_modules/@miniflare/sites": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.5.0.tgz",
+      "integrity": "sha512-AwYZb6ppP00YLkVNJnCe0lzJJemCDwibFjJywECY+aXFFNRo80sLpePPOXytplaUpen1uxnxUc8vdKBFVoB5cQ==",
+      "dependencies": {
+        "@miniflare/kv": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "@miniflare/storage-file": "2.5.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "node_modules/@miniflare/storage-file": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.5.0.tgz",
+      "integrity": "sha512-ytwWZEIn3eMBnI2FdqvM5+mJVuI2aIBeZNjhZFuF5/AW3v1uslqY55Qd5Fnfn+2C7z6ivVaUv/TlEwot9ZDUnw==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.0",
+        "@miniflare/storage-memory": "2.5.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "node_modules/@miniflare/storage-memory": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.5.0.tgz",
+      "integrity": "sha512-cydVKLY0cZe2Sah0jV3s9MK3gmYLrQQcpCdMHMBEUz+nRfjfnuzs4WXzzUXCWwNT+WFC0V2WvDp2sMt+lVsmsA==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "node_modules/@miniflare/watcher": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.5.0.tgz",
+      "integrity": "sha512-6ECE7po8NBxLmr2M00f7TWLEp1dMaAm3swf4D3ZU2xy3IqSBZE3QbOBuczYEYUIk7F+kXgaREISQg4e5QdECXQ==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "node_modules/@miniflare/web-sockets": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.5.0.tgz",
+      "integrity": "sha512-nnLBtbHdmgGUNTxP0IeAz1B4UGCO/6W+4edzjogtz3JJumKQE+ink5+SIrmL0C1Pitrc2+kO2WYsQzWh3a2Amg==",
+      "dependencies": {
+        "@miniflare/core": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "undici": "5.3.0",
+        "ws": "^8.2.2"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "node_modules/@miniflare/web-sockets/node_modules/ws": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
+      "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4962,6 +5209,17 @@
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/cacache": {
       "version": "15.3.0",
@@ -11177,6 +11435,131 @@
         "node": ">=8"
       }
     },
+    "node_modules/jest-environment-miniflare": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-miniflare/-/jest-environment-miniflare-2.5.0.tgz",
+      "integrity": "sha512-3OirfOB+kBxVBN5kOsXXQMgGHDUoO0+toulyoqGEWfZRa2kfL48CFCF10jB8A1K63cB5JMblN+uqyWUeZb/SBw==",
+      "dependencies": {
+        "@jest/environment": ">=27",
+        "@jest/fake-timers": ">=27",
+        "@jest/types": ">=27",
+        "@miniflare/cache": "2.5.0",
+        "@miniflare/core": "2.5.0",
+        "@miniflare/durable-objects": "2.5.0",
+        "@miniflare/html-rewriter": "2.5.0",
+        "@miniflare/kv": "2.5.0",
+        "@miniflare/runner-vm": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "@miniflare/sites": "2.5.0",
+        "@miniflare/storage-memory": "2.5.0",
+        "@miniflare/web-sockets": "2.5.0",
+        "jest-mock": ">=27",
+        "jest-util": ">=27",
+        "miniflare": "2.5.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      },
+      "peerDependencies": {
+        "jest": ">=27"
+      }
+    },
+    "node_modules/jest-environment-miniflare/node_modules/@jest/types": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.0.tgz",
+      "integrity": "sha512-xmEggMPr317MIOjjDoZ4ejCSr9Lpbt/u34+dvc99t7DS8YirW5rwZEhzKPC2BMUFkUhI48qs6qLUSGw5FuL0GA==",
+      "dependencies": {
+        "@jest/schemas": "^28.0.2",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/jest-environment-miniflare/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-environment-miniflare/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-environment-miniflare/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-environment-miniflare/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/jest-environment-miniflare/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-environment-miniflare/node_modules/jest-util": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.0.tgz",
+      "integrity": "sha512-qYdCKD77k4Hwkose2YBEqQk7PzUf/NSE+rutzceduFveQREeH6b+89Dc9+wjX9dAwHcgdx4yedGA3FQlU/qCTA==",
+      "dependencies": {
+        "@jest/types": "^28.1.0",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/jest-environment-miniflare/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jest-environment-node": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.5.1.tgz",
@@ -14564,6 +14947,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.5.0.tgz",
+      "integrity": "sha512-3IR+n/kLBA7zQ20HDjnA0HufQlr197krD8jPsaYO5wTrkIUCTvrilbI0sCo0X9CP/I3BCIl8fiZc1Jf7+MX7jQ==",
+      "dependencies": {
+        "@miniflare/cache": "2.5.0",
+        "@miniflare/cli-parser": "2.5.0",
+        "@miniflare/core": "2.5.0",
+        "@miniflare/durable-objects": "2.5.0",
+        "@miniflare/html-rewriter": "2.5.0",
+        "@miniflare/http-server": "2.5.0",
+        "@miniflare/kv": "2.5.0",
+        "@miniflare/runner-vm": "2.5.0",
+        "@miniflare/scheduler": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "@miniflare/sites": "2.5.0",
+        "@miniflare/storage-file": "2.5.0",
+        "@miniflare/storage-memory": "2.5.0",
+        "@miniflare/web-sockets": "2.5.0",
+        "kleur": "^4.1.4",
+        "semiver": "^1.1.0",
+        "source-map-support": "^0.5.20",
+        "undici": "5.3.0"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=16.7"
+      },
+      "peerDependencies": {
+        "@miniflare/storage-redis": "2.5.0",
+        "cron-schedule": "^3.0.4",
+        "ioredis": "^4.27.9"
+      },
+      "peerDependenciesMeta": {
+        "@miniflare/storage-redis": {
+          "optional": true
+        },
+        "cron-schedule": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        }
       }
     },
     "node_modules/minimalistic-assert": {
@@ -17954,6 +18384,14 @@
         "mixme": "^0.5.1"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "license": "MIT",
@@ -18831,6 +19269,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.3.0.tgz",
+      "integrity": "sha512-8LxC/xmR2GCE4q1heE1sJxVnnf5S6yQ2dObvMFBBWkB8aQlaqNuWovgRFWRMB7KUdLPGZfOTTmUeeLEJYX56iQ==",
+      "engines": {
+        "node": ">=12.18"
       }
     },
     "node_modules/unified": {
@@ -20208,433 +20654,7 @@
       "version": "0.0.29",
       "license": "ISC",
       "dependencies": {
-        "jest-environment-miniflare": "2.5.0"
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/@jest/types": {
-      "version": "28.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.0.tgz",
-      "integrity": "sha512-xmEggMPr317MIOjjDoZ4ejCSr9Lpbt/u34+dvc99t7DS8YirW5rwZEhzKPC2BMUFkUhI48qs6qLUSGw5FuL0GA==",
-      "dependencies": {
-        "@jest/schemas": "^28.0.2",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/@miniflare/cache": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.5.0.tgz",
-      "integrity": "sha512-tJuDbWwzYsk4pJvPPJzdlfdGFqNnn1IN3JVrGDCq8UwOXm0K8hFiSwq2nMjjT+Z/9X2FfimgaXOx81zjPL+FjQ==",
-      "dependencies": {
-        "@miniflare/core": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "http-cache-semantics": "^4.1.0",
-        "undici": "5.3.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/@miniflare/cli-parser": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.5.0.tgz",
-      "integrity": "sha512-aY/wQ4Rwy8x0Awtb8TzhKFYp4g1Y8xBhtKFfHOZpYCEFCVfKtgdk0pHPKctf/ClK0qJdT3siJKeXxsH2GRAMXg==",
-      "dependencies": {
-        "@miniflare/shared": "2.5.0",
-        "kleur": "^4.1.4"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/@miniflare/core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.5.0.tgz",
-      "integrity": "sha512-BtMRi17DiimcpmDjQiIU6mIYSo/h21lVGC082n5G3JTF7AcGFAs7N2Fz2YLiYuc3zYc6qJx/NIjDoOqL2gfp3A==",
-      "dependencies": {
-        "@iarna/toml": "^2.2.5",
-        "@miniflare/shared": "2.5.0",
-        "@miniflare/watcher": "2.5.0",
-        "busboy": "^1.6.0",
-        "dotenv": "^10.0.0",
-        "kleur": "^4.1.4",
-        "set-cookie-parser": "^2.4.8",
-        "undici": "5.3.0",
-        "urlpattern-polyfill": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/@miniflare/durable-objects": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.5.0.tgz",
-      "integrity": "sha512-HJuP5Lsm/CCaSx3dePZiywAniGqTpU1ocCEqV6kE4zX1C0uGplfjPPXo5xsVc2NXkD+0ZL65rJzcj2tfrwKZlg==",
-      "dependencies": {
-        "@miniflare/core": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "@miniflare/storage-memory": "2.5.0",
-        "undici": "5.3.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/@miniflare/html-rewriter": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.5.0.tgz",
-      "integrity": "sha512-bV2lQ/2clPeBmDth+cMnCBFYk8xtGs83S6PhfwmNNd24rzHvOEch1h/VCtEUy8k+rtgDSpc9pVkd31k0tMsyxQ==",
-      "dependencies": {
-        "@miniflare/core": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "html-rewriter-wasm": "^0.4.1",
-        "undici": "5.3.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/@miniflare/http-server": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.5.0.tgz",
-      "integrity": "sha512-+sRPgNq0Q4Q6t1k94ncYzgcf/UNIv0Bz4ubUu6InJy4kMaJKeJPOLlU55lTXJSYfBZM/L4NvAui2i5vA9g2BrA==",
-      "dependencies": {
-        "@miniflare/core": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "@miniflare/web-sockets": "2.5.0",
-        "kleur": "^4.1.4",
-        "selfsigned": "^2.0.0",
-        "undici": "5.3.0",
-        "ws": "^8.2.2",
-        "youch": "^2.2.2"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/@miniflare/kv": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.5.0.tgz",
-      "integrity": "sha512-5dzcUMMOKl8u75FXbpy2BHp38uafjzo3RW2HEm6EY8QoM/vHw6RChFzJ9YEPJDbvcHR8gdMpgC65LYPTjifc3g==",
-      "dependencies": {
-        "@miniflare/shared": "2.5.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/@miniflare/runner-vm": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.5.0.tgz",
-      "integrity": "sha512-0n85cOBq91D7roqsIqJESDnj0oRi+xNVjDfd5uDIT1dW1qo5asA5Mwx6ntzCJB1BcB4khNatUIwpO3ZT+kT/YQ==",
-      "dependencies": {
-        "@miniflare/shared": "2.5.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/@miniflare/scheduler": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.5.0.tgz",
-      "integrity": "sha512-+a/I2QLp3UaZpKVobzFH3eHsi5ubhBp8q/AH/sCDwcZmatbCp2+oDrjMgTqhF6Fm8ryR4BYkHQOgkGZ5l7gQjw==",
-      "dependencies": {
-        "@miniflare/core": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "cron-schedule": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/@miniflare/shared": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.5.0.tgz",
-      "integrity": "sha512-2oPxhnCGg8DNoo0NzUdc2BylGGeHQQvFJ6mDODjxbSXybeQC0+Ul5Ujv/FyU9W/eTbUEWNqKBycINyuXqSnJ/w==",
-      "dependencies": {
-        "ignore": "^5.1.8",
-        "kleur": "^4.1.4"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/@miniflare/sites": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.5.0.tgz",
-      "integrity": "sha512-AwYZb6ppP00YLkVNJnCe0lzJJemCDwibFjJywECY+aXFFNRo80sLpePPOXytplaUpen1uxnxUc8vdKBFVoB5cQ==",
-      "dependencies": {
-        "@miniflare/kv": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "@miniflare/storage-file": "2.5.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/@miniflare/storage-file": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.5.0.tgz",
-      "integrity": "sha512-ytwWZEIn3eMBnI2FdqvM5+mJVuI2aIBeZNjhZFuF5/AW3v1uslqY55Qd5Fnfn+2C7z6ivVaUv/TlEwot9ZDUnw==",
-      "dependencies": {
-        "@miniflare/shared": "2.5.0",
-        "@miniflare/storage-memory": "2.5.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/@miniflare/storage-memory": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.5.0.tgz",
-      "integrity": "sha512-cydVKLY0cZe2Sah0jV3s9MK3gmYLrQQcpCdMHMBEUz+nRfjfnuzs4WXzzUXCWwNT+WFC0V2WvDp2sMt+lVsmsA==",
-      "dependencies": {
-        "@miniflare/shared": "2.5.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/@miniflare/watcher": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.5.0.tgz",
-      "integrity": "sha512-6ECE7po8NBxLmr2M00f7TWLEp1dMaAm3swf4D3ZU2xy3IqSBZE3QbOBuczYEYUIk7F+kXgaREISQg4e5QdECXQ==",
-      "dependencies": {
-        "@miniflare/shared": "2.5.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/@miniflare/web-sockets": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.5.0.tgz",
-      "integrity": "sha512-nnLBtbHdmgGUNTxP0IeAz1B4UGCO/6W+4edzjogtz3JJumKQE+ink5+SIrmL0C1Pitrc2+kO2WYsQzWh3a2Amg==",
-      "dependencies": {
-        "@miniflare/core": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "undici": "5.3.0",
-        "ws": "^8.2.2"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "packages/jest-environment-wrangler/node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/jest-environment-miniflare": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-miniflare/-/jest-environment-miniflare-2.5.0.tgz",
-      "integrity": "sha512-3OirfOB+kBxVBN5kOsXXQMgGHDUoO0+toulyoqGEWfZRa2kfL48CFCF10jB8A1K63cB5JMblN+uqyWUeZb/SBw==",
-      "dependencies": {
-        "@jest/environment": ">=27",
-        "@jest/fake-timers": ">=27",
-        "@jest/types": ">=27",
-        "@miniflare/cache": "2.5.0",
-        "@miniflare/core": "2.5.0",
-        "@miniflare/durable-objects": "2.5.0",
-        "@miniflare/html-rewriter": "2.5.0",
-        "@miniflare/kv": "2.5.0",
-        "@miniflare/runner-vm": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "@miniflare/sites": "2.5.0",
-        "@miniflare/storage-memory": "2.5.0",
-        "@miniflare/web-sockets": "2.5.0",
-        "jest-mock": ">=27",
-        "jest-util": ">=27",
-        "miniflare": "2.5.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      },
-      "peerDependencies": {
-        "jest": ">=27"
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/jest-util": {
-      "version": "28.1.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.0.tgz",
-      "integrity": "sha512-qYdCKD77k4Hwkose2YBEqQk7PzUf/NSE+rutzceduFveQREeH6b+89Dc9+wjX9dAwHcgdx4yedGA3FQlU/qCTA==",
-      "dependencies": {
-        "@jest/types": "^28.1.0",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/miniflare": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.5.0.tgz",
-      "integrity": "sha512-3IR+n/kLBA7zQ20HDjnA0HufQlr197krD8jPsaYO5wTrkIUCTvrilbI0sCo0X9CP/I3BCIl8fiZc1Jf7+MX7jQ==",
-      "dependencies": {
-        "@miniflare/cache": "2.5.0",
-        "@miniflare/cli-parser": "2.5.0",
-        "@miniflare/core": "2.5.0",
-        "@miniflare/durable-objects": "2.5.0",
-        "@miniflare/html-rewriter": "2.5.0",
-        "@miniflare/http-server": "2.5.0",
-        "@miniflare/kv": "2.5.0",
-        "@miniflare/runner-vm": "2.5.0",
-        "@miniflare/scheduler": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "@miniflare/sites": "2.5.0",
-        "@miniflare/storage-file": "2.5.0",
-        "@miniflare/storage-memory": "2.5.0",
-        "@miniflare/web-sockets": "2.5.0",
-        "kleur": "^4.1.4",
-        "semiver": "^1.1.0",
-        "source-map-support": "^0.5.20",
-        "undici": "5.3.0"
-      },
-      "bin": {
-        "miniflare": "bootstrap.js"
-      },
-      "engines": {
-        "node": ">=16.7"
-      },
-      "peerDependencies": {
-        "@miniflare/storage-redis": "2.5.0",
-        "cron-schedule": "^3.0.4",
-        "ioredis": "^4.27.9"
-      },
-      "peerDependenciesMeta": {
-        "@miniflare/storage-redis": {
-          "optional": true
-        },
-        "cron-schedule": {
-          "optional": true
-        },
-        "ioredis": {
-          "optional": true
-        }
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/undici": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.3.0.tgz",
-      "integrity": "sha512-8LxC/xmR2GCE4q1heE1sJxVnnf5S6yQ2dObvMFBBWkB8aQlaqNuWovgRFWRMB7KUdLPGZfOTTmUeeLEJYX56iQ==",
-      "engines": {
-        "node": ">=12.18"
-      }
-    },
-    "packages/jest-environment-wrangler/node_modules/ws": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
-      "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
+        "jest-environment-miniflare": "^2.5.0"
       }
     },
     "packages/prerelease-registry": {
@@ -20655,7 +20675,7 @@
         "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
         "blake3-wasm": "^2.1.5",
         "esbuild": "0.14.34",
-        "miniflare": "2.5.0",
+        "miniflare": "^2.5.0",
         "nanoid": "^3.3.3",
         "path-to-regexp": "^6.2.0",
         "selfsigned": "^2.0.1",
@@ -20731,229 +20751,6 @@
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-3.0.0.tgz",
       "integrity": "sha512-td6ZUkz2oS3VeleBcN+m//Q6HlCFCPrnI0FZhrt/h4XqLEdOyYp2u21nd8MdsR+WJy5r9PTDaHTDDfhf4H4l6Q==",
       "dev": true
-    },
-    "packages/wrangler/node_modules/@miniflare/cache": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.5.0.tgz",
-      "integrity": "sha512-tJuDbWwzYsk4pJvPPJzdlfdGFqNnn1IN3JVrGDCq8UwOXm0K8hFiSwq2nMjjT+Z/9X2FfimgaXOx81zjPL+FjQ==",
-      "dependencies": {
-        "@miniflare/core": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "http-cache-semantics": "^4.1.0",
-        "undici": "5.3.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/wrangler/node_modules/@miniflare/cli-parser": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.5.0.tgz",
-      "integrity": "sha512-aY/wQ4Rwy8x0Awtb8TzhKFYp4g1Y8xBhtKFfHOZpYCEFCVfKtgdk0pHPKctf/ClK0qJdT3siJKeXxsH2GRAMXg==",
-      "dependencies": {
-        "@miniflare/shared": "2.5.0",
-        "kleur": "^4.1.4"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/wrangler/node_modules/@miniflare/core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.5.0.tgz",
-      "integrity": "sha512-BtMRi17DiimcpmDjQiIU6mIYSo/h21lVGC082n5G3JTF7AcGFAs7N2Fz2YLiYuc3zYc6qJx/NIjDoOqL2gfp3A==",
-      "dependencies": {
-        "@iarna/toml": "^2.2.5",
-        "@miniflare/shared": "2.5.0",
-        "@miniflare/watcher": "2.5.0",
-        "busboy": "^1.6.0",
-        "dotenv": "^10.0.0",
-        "kleur": "^4.1.4",
-        "set-cookie-parser": "^2.4.8",
-        "undici": "5.3.0",
-        "urlpattern-polyfill": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/wrangler/node_modules/@miniflare/core/node_modules/@iarna/toml": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
-      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
-    },
-    "packages/wrangler/node_modules/@miniflare/core/node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/wrangler/node_modules/@miniflare/durable-objects": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.5.0.tgz",
-      "integrity": "sha512-HJuP5Lsm/CCaSx3dePZiywAniGqTpU1ocCEqV6kE4zX1C0uGplfjPPXo5xsVc2NXkD+0ZL65rJzcj2tfrwKZlg==",
-      "dependencies": {
-        "@miniflare/core": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "@miniflare/storage-memory": "2.5.0",
-        "undici": "5.3.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/wrangler/node_modules/@miniflare/html-rewriter": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.5.0.tgz",
-      "integrity": "sha512-bV2lQ/2clPeBmDth+cMnCBFYk8xtGs83S6PhfwmNNd24rzHvOEch1h/VCtEUy8k+rtgDSpc9pVkd31k0tMsyxQ==",
-      "dependencies": {
-        "@miniflare/core": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "html-rewriter-wasm": "^0.4.1",
-        "undici": "5.3.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/wrangler/node_modules/@miniflare/http-server": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.5.0.tgz",
-      "integrity": "sha512-+sRPgNq0Q4Q6t1k94ncYzgcf/UNIv0Bz4ubUu6InJy4kMaJKeJPOLlU55lTXJSYfBZM/L4NvAui2i5vA9g2BrA==",
-      "dependencies": {
-        "@miniflare/core": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "@miniflare/web-sockets": "2.5.0",
-        "kleur": "^4.1.4",
-        "selfsigned": "^2.0.0",
-        "undici": "5.3.0",
-        "ws": "^8.2.2",
-        "youch": "^2.2.2"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/wrangler/node_modules/@miniflare/kv": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.5.0.tgz",
-      "integrity": "sha512-5dzcUMMOKl8u75FXbpy2BHp38uafjzo3RW2HEm6EY8QoM/vHw6RChFzJ9YEPJDbvcHR8gdMpgC65LYPTjifc3g==",
-      "dependencies": {
-        "@miniflare/shared": "2.5.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/wrangler/node_modules/@miniflare/runner-vm": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.5.0.tgz",
-      "integrity": "sha512-0n85cOBq91D7roqsIqJESDnj0oRi+xNVjDfd5uDIT1dW1qo5asA5Mwx6ntzCJB1BcB4khNatUIwpO3ZT+kT/YQ==",
-      "dependencies": {
-        "@miniflare/shared": "2.5.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/wrangler/node_modules/@miniflare/scheduler": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.5.0.tgz",
-      "integrity": "sha512-+a/I2QLp3UaZpKVobzFH3eHsi5ubhBp8q/AH/sCDwcZmatbCp2+oDrjMgTqhF6Fm8ryR4BYkHQOgkGZ5l7gQjw==",
-      "dependencies": {
-        "@miniflare/core": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "cron-schedule": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/wrangler/node_modules/@miniflare/shared": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.5.0.tgz",
-      "integrity": "sha512-2oPxhnCGg8DNoo0NzUdc2BylGGeHQQvFJ6mDODjxbSXybeQC0+Ul5Ujv/FyU9W/eTbUEWNqKBycINyuXqSnJ/w==",
-      "dependencies": {
-        "ignore": "^5.1.8",
-        "kleur": "^4.1.4"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/wrangler/node_modules/@miniflare/sites": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.5.0.tgz",
-      "integrity": "sha512-AwYZb6ppP00YLkVNJnCe0lzJJemCDwibFjJywECY+aXFFNRo80sLpePPOXytplaUpen1uxnxUc8vdKBFVoB5cQ==",
-      "dependencies": {
-        "@miniflare/kv": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "@miniflare/storage-file": "2.5.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/wrangler/node_modules/@miniflare/storage-file": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.5.0.tgz",
-      "integrity": "sha512-ytwWZEIn3eMBnI2FdqvM5+mJVuI2aIBeZNjhZFuF5/AW3v1uslqY55Qd5Fnfn+2C7z6ivVaUv/TlEwot9ZDUnw==",
-      "dependencies": {
-        "@miniflare/shared": "2.5.0",
-        "@miniflare/storage-memory": "2.5.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/wrangler/node_modules/@miniflare/storage-memory": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.5.0.tgz",
-      "integrity": "sha512-cydVKLY0cZe2Sah0jV3s9MK3gmYLrQQcpCdMHMBEUz+nRfjfnuzs4WXzzUXCWwNT+WFC0V2WvDp2sMt+lVsmsA==",
-      "dependencies": {
-        "@miniflare/shared": "2.5.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/wrangler/node_modules/@miniflare/watcher": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.5.0.tgz",
-      "integrity": "sha512-6ECE7po8NBxLmr2M00f7TWLEp1dMaAm3swf4D3ZU2xy3IqSBZE3QbOBuczYEYUIk7F+kXgaREISQg4e5QdECXQ==",
-      "dependencies": {
-        "@miniflare/shared": "2.5.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/wrangler/node_modules/@miniflare/web-sockets": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.5.0.tgz",
-      "integrity": "sha512-nnLBtbHdmgGUNTxP0IeAz1B4UGCO/6W+4edzjogtz3JJumKQE+ink5+SIrmL0C1Pitrc2+kO2WYsQzWh3a2Amg==",
-      "dependencies": {
-        "@miniflare/core": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "undici": "5.3.0",
-        "ws": "^8.2.2"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "packages/wrangler/node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
-      }
     },
     "packages/wrangler/node_modules/dotenv": {
       "version": "16.0.0",
@@ -21329,53 +21126,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "packages/wrangler/node_modules/miniflare": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.5.0.tgz",
-      "integrity": "sha512-3IR+n/kLBA7zQ20HDjnA0HufQlr197krD8jPsaYO5wTrkIUCTvrilbI0sCo0X9CP/I3BCIl8fiZc1Jf7+MX7jQ==",
-      "dependencies": {
-        "@miniflare/cache": "2.5.0",
-        "@miniflare/cli-parser": "2.5.0",
-        "@miniflare/core": "2.5.0",
-        "@miniflare/durable-objects": "2.5.0",
-        "@miniflare/html-rewriter": "2.5.0",
-        "@miniflare/http-server": "2.5.0",
-        "@miniflare/kv": "2.5.0",
-        "@miniflare/runner-vm": "2.5.0",
-        "@miniflare/scheduler": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "@miniflare/sites": "2.5.0",
-        "@miniflare/storage-file": "2.5.0",
-        "@miniflare/storage-memory": "2.5.0",
-        "@miniflare/web-sockets": "2.5.0",
-        "kleur": "^4.1.4",
-        "semiver": "^1.1.0",
-        "source-map-support": "^0.5.20",
-        "undici": "5.3.0"
-      },
-      "bin": {
-        "miniflare": "bootstrap.js"
-      },
-      "engines": {
-        "node": ">=16.7"
-      },
-      "peerDependencies": {
-        "@miniflare/storage-redis": "2.5.0",
-        "cron-schedule": "^3.0.4",
-        "ioredis": "^4.27.9"
-      },
-      "peerDependenciesMeta": {
-        "@miniflare/storage-redis": {
-          "optional": true
-        },
-        "cron-schedule": {
-          "optional": true
-        },
-        "ioredis": {
-          "optional": true
-        }
-      }
-    },
     "packages/wrangler/node_modules/p-limit": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
@@ -21414,14 +21164,6 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
-    "packages/wrangler/node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "packages/wrangler/node_modules/supports-color": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.2.2.tgz",
@@ -21434,18 +21176,11 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "packages/wrangler/node_modules/undici": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.3.0.tgz",
-      "integrity": "sha512-8LxC/xmR2GCE4q1heE1sJxVnnf5S6yQ2dObvMFBBWkB8aQlaqNuWovgRFWRMB7KUdLPGZfOTTmUeeLEJYX56iQ==",
-      "engines": {
-        "node": ">=12.18"
-      }
-    },
     "packages/wrangler/node_modules/ws": {
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
       "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -21497,15 +21232,6 @@
         "typescript": "^4.6.3",
         "undici": "^5.0.0",
         "webpack": "^4.46.0"
-      }
-    },
-    "packages/wranglerjs-compat-webpack-plugin/node_modules/undici": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.0.0.tgz",
-      "integrity": "sha512-VhUpiZ3No1DOPPQVQnsDZyfcbTTcHdcgWej1PdFnSvOeJmOVDgiOHkunJmBLfmjt4CqgPQddPVjSWW0dsTs5Yg==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.18"
       }
     }
   },
@@ -23287,6 +23013,183 @@
         }
       }
     },
+    "@miniflare/cache": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.5.0.tgz",
+      "integrity": "sha512-tJuDbWwzYsk4pJvPPJzdlfdGFqNnn1IN3JVrGDCq8UwOXm0K8hFiSwq2nMjjT+Z/9X2FfimgaXOx81zjPL+FjQ==",
+      "requires": {
+        "@miniflare/core": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "http-cache-semantics": "^4.1.0",
+        "undici": "5.3.0"
+      }
+    },
+    "@miniflare/cli-parser": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.5.0.tgz",
+      "integrity": "sha512-aY/wQ4Rwy8x0Awtb8TzhKFYp4g1Y8xBhtKFfHOZpYCEFCVfKtgdk0pHPKctf/ClK0qJdT3siJKeXxsH2GRAMXg==",
+      "requires": {
+        "@miniflare/shared": "2.5.0",
+        "kleur": "^4.1.4"
+      }
+    },
+    "@miniflare/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-BtMRi17DiimcpmDjQiIU6mIYSo/h21lVGC082n5G3JTF7AcGFAs7N2Fz2YLiYuc3zYc6qJx/NIjDoOqL2gfp3A==",
+      "requires": {
+        "@iarna/toml": "^2.2.5",
+        "@miniflare/shared": "2.5.0",
+        "@miniflare/watcher": "2.5.0",
+        "busboy": "^1.6.0",
+        "dotenv": "^10.0.0",
+        "kleur": "^4.1.4",
+        "set-cookie-parser": "^2.4.8",
+        "undici": "5.3.0",
+        "urlpattern-polyfill": "^4.0.3"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+        }
+      }
+    },
+    "@miniflare/durable-objects": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.5.0.tgz",
+      "integrity": "sha512-HJuP5Lsm/CCaSx3dePZiywAniGqTpU1ocCEqV6kE4zX1C0uGplfjPPXo5xsVc2NXkD+0ZL65rJzcj2tfrwKZlg==",
+      "requires": {
+        "@miniflare/core": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "@miniflare/storage-memory": "2.5.0",
+        "undici": "5.3.0"
+      }
+    },
+    "@miniflare/html-rewriter": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.5.0.tgz",
+      "integrity": "sha512-bV2lQ/2clPeBmDth+cMnCBFYk8xtGs83S6PhfwmNNd24rzHvOEch1h/VCtEUy8k+rtgDSpc9pVkd31k0tMsyxQ==",
+      "requires": {
+        "@miniflare/core": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "html-rewriter-wasm": "^0.4.1",
+        "undici": "5.3.0"
+      }
+    },
+    "@miniflare/http-server": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.5.0.tgz",
+      "integrity": "sha512-+sRPgNq0Q4Q6t1k94ncYzgcf/UNIv0Bz4ubUu6InJy4kMaJKeJPOLlU55lTXJSYfBZM/L4NvAui2i5vA9g2BrA==",
+      "requires": {
+        "@miniflare/core": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "@miniflare/web-sockets": "2.5.0",
+        "kleur": "^4.1.4",
+        "selfsigned": "^2.0.0",
+        "undici": "5.3.0",
+        "ws": "^8.2.2",
+        "youch": "^2.2.2"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
+          "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
+          "requires": {}
+        }
+      }
+    },
+    "@miniflare/kv": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.5.0.tgz",
+      "integrity": "sha512-5dzcUMMOKl8u75FXbpy2BHp38uafjzo3RW2HEm6EY8QoM/vHw6RChFzJ9YEPJDbvcHR8gdMpgC65LYPTjifc3g==",
+      "requires": {
+        "@miniflare/shared": "2.5.0"
+      }
+    },
+    "@miniflare/runner-vm": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.5.0.tgz",
+      "integrity": "sha512-0n85cOBq91D7roqsIqJESDnj0oRi+xNVjDfd5uDIT1dW1qo5asA5Mwx6ntzCJB1BcB4khNatUIwpO3ZT+kT/YQ==",
+      "requires": {
+        "@miniflare/shared": "2.5.0"
+      }
+    },
+    "@miniflare/scheduler": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.5.0.tgz",
+      "integrity": "sha512-+a/I2QLp3UaZpKVobzFH3eHsi5ubhBp8q/AH/sCDwcZmatbCp2+oDrjMgTqhF6Fm8ryR4BYkHQOgkGZ5l7gQjw==",
+      "requires": {
+        "@miniflare/core": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "cron-schedule": "^3.0.4"
+      }
+    },
+    "@miniflare/shared": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.5.0.tgz",
+      "integrity": "sha512-2oPxhnCGg8DNoo0NzUdc2BylGGeHQQvFJ6mDODjxbSXybeQC0+Ul5Ujv/FyU9W/eTbUEWNqKBycINyuXqSnJ/w==",
+      "requires": {
+        "ignore": "^5.1.8",
+        "kleur": "^4.1.4"
+      }
+    },
+    "@miniflare/sites": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.5.0.tgz",
+      "integrity": "sha512-AwYZb6ppP00YLkVNJnCe0lzJJemCDwibFjJywECY+aXFFNRo80sLpePPOXytplaUpen1uxnxUc8vdKBFVoB5cQ==",
+      "requires": {
+        "@miniflare/kv": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "@miniflare/storage-file": "2.5.0"
+      }
+    },
+    "@miniflare/storage-file": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.5.0.tgz",
+      "integrity": "sha512-ytwWZEIn3eMBnI2FdqvM5+mJVuI2aIBeZNjhZFuF5/AW3v1uslqY55Qd5Fnfn+2C7z6ivVaUv/TlEwot9ZDUnw==",
+      "requires": {
+        "@miniflare/shared": "2.5.0",
+        "@miniflare/storage-memory": "2.5.0"
+      }
+    },
+    "@miniflare/storage-memory": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.5.0.tgz",
+      "integrity": "sha512-cydVKLY0cZe2Sah0jV3s9MK3gmYLrQQcpCdMHMBEUz+nRfjfnuzs4WXzzUXCWwNT+WFC0V2WvDp2sMt+lVsmsA==",
+      "requires": {
+        "@miniflare/shared": "2.5.0"
+      }
+    },
+    "@miniflare/watcher": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.5.0.tgz",
+      "integrity": "sha512-6ECE7po8NBxLmr2M00f7TWLEp1dMaAm3swf4D3ZU2xy3IqSBZE3QbOBuczYEYUIk7F+kXgaREISQg4e5QdECXQ==",
+      "requires": {
+        "@miniflare/shared": "2.5.0"
+      }
+    },
+    "@miniflare/web-sockets": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.5.0.tgz",
+      "integrity": "sha512-nnLBtbHdmgGUNTxP0IeAz1B4UGCO/6W+4edzjogtz3JJumKQE+ink5+SIrmL0C1Pitrc2+kO2WYsQzWh3a2Amg==",
+      "requires": {
+        "@miniflare/core": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "undici": "5.3.0",
+        "ws": "^8.2.2"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
+          "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
+          "requires": {}
+        }
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -24909,6 +24812,14 @@
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
+    },
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "requires": {
+        "streamsearch": "^1.1.0"
+      }
     },
     "cacache": {
       "version": "15.3.0",
@@ -29023,6 +28934,100 @@
         }
       }
     },
+    "jest-environment-miniflare": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-miniflare/-/jest-environment-miniflare-2.5.0.tgz",
+      "integrity": "sha512-3OirfOB+kBxVBN5kOsXXQMgGHDUoO0+toulyoqGEWfZRa2kfL48CFCF10jB8A1K63cB5JMblN+uqyWUeZb/SBw==",
+      "requires": {
+        "@jest/environment": ">=27",
+        "@jest/fake-timers": ">=27",
+        "@jest/types": ">=27",
+        "@miniflare/cache": "2.5.0",
+        "@miniflare/core": "2.5.0",
+        "@miniflare/durable-objects": "2.5.0",
+        "@miniflare/html-rewriter": "2.5.0",
+        "@miniflare/kv": "2.5.0",
+        "@miniflare/runner-vm": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "@miniflare/sites": "2.5.0",
+        "@miniflare/storage-memory": "2.5.0",
+        "@miniflare/web-sockets": "2.5.0",
+        "jest-mock": ">=27",
+        "jest-util": ">=27",
+        "miniflare": "2.5.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "28.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.0.tgz",
+          "integrity": "sha512-xmEggMPr317MIOjjDoZ4ejCSr9Lpbt/u34+dvc99t7DS8YirW5rwZEhzKPC2BMUFkUhI48qs6qLUSGw5FuL0GA==",
+          "requires": {
+            "@jest/schemas": "^28.0.2",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^17.0.8",
+            "chalk": "^4.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "jest-util": {
+          "version": "28.1.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.0.tgz",
+          "integrity": "sha512-qYdCKD77k4Hwkose2YBEqQk7PzUf/NSE+rutzceduFveQREeH6b+89Dc9+wjX9dAwHcgdx4yedGA3FQlU/qCTA==",
+          "requires": {
+            "@jest/types": "^28.1.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.9",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "jest-environment-node": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.5.1.tgz",
@@ -29117,309 +29122,7 @@
     "jest-environment-wrangler": {
       "version": "file:packages/jest-environment-wrangler",
       "requires": {
-        "jest-environment-miniflare": "2.5.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "28.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.0.tgz",
-          "integrity": "sha512-xmEggMPr317MIOjjDoZ4ejCSr9Lpbt/u34+dvc99t7DS8YirW5rwZEhzKPC2BMUFkUhI48qs6qLUSGw5FuL0GA==",
-          "requires": {
-            "@jest/schemas": "^28.0.2",
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^17.0.8",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@miniflare/cache": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.5.0.tgz",
-          "integrity": "sha512-tJuDbWwzYsk4pJvPPJzdlfdGFqNnn1IN3JVrGDCq8UwOXm0K8hFiSwq2nMjjT+Z/9X2FfimgaXOx81zjPL+FjQ==",
-          "requires": {
-            "@miniflare/core": "2.5.0",
-            "@miniflare/shared": "2.5.0",
-            "http-cache-semantics": "^4.1.0",
-            "undici": "5.3.0"
-          }
-        },
-        "@miniflare/cli-parser": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.5.0.tgz",
-          "integrity": "sha512-aY/wQ4Rwy8x0Awtb8TzhKFYp4g1Y8xBhtKFfHOZpYCEFCVfKtgdk0pHPKctf/ClK0qJdT3siJKeXxsH2GRAMXg==",
-          "requires": {
-            "@miniflare/shared": "2.5.0",
-            "kleur": "^4.1.4"
-          }
-        },
-        "@miniflare/core": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.5.0.tgz",
-          "integrity": "sha512-BtMRi17DiimcpmDjQiIU6mIYSo/h21lVGC082n5G3JTF7AcGFAs7N2Fz2YLiYuc3zYc6qJx/NIjDoOqL2gfp3A==",
-          "requires": {
-            "@iarna/toml": "^2.2.5",
-            "@miniflare/shared": "2.5.0",
-            "@miniflare/watcher": "2.5.0",
-            "busboy": "^1.6.0",
-            "dotenv": "^10.0.0",
-            "kleur": "^4.1.4",
-            "set-cookie-parser": "^2.4.8",
-            "undici": "5.3.0",
-            "urlpattern-polyfill": "^4.0.3"
-          }
-        },
-        "@miniflare/durable-objects": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.5.0.tgz",
-          "integrity": "sha512-HJuP5Lsm/CCaSx3dePZiywAniGqTpU1ocCEqV6kE4zX1C0uGplfjPPXo5xsVc2NXkD+0ZL65rJzcj2tfrwKZlg==",
-          "requires": {
-            "@miniflare/core": "2.5.0",
-            "@miniflare/shared": "2.5.0",
-            "@miniflare/storage-memory": "2.5.0",
-            "undici": "5.3.0"
-          }
-        },
-        "@miniflare/html-rewriter": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.5.0.tgz",
-          "integrity": "sha512-bV2lQ/2clPeBmDth+cMnCBFYk8xtGs83S6PhfwmNNd24rzHvOEch1h/VCtEUy8k+rtgDSpc9pVkd31k0tMsyxQ==",
-          "requires": {
-            "@miniflare/core": "2.5.0",
-            "@miniflare/shared": "2.5.0",
-            "html-rewriter-wasm": "^0.4.1",
-            "undici": "5.3.0"
-          }
-        },
-        "@miniflare/http-server": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.5.0.tgz",
-          "integrity": "sha512-+sRPgNq0Q4Q6t1k94ncYzgcf/UNIv0Bz4ubUu6InJy4kMaJKeJPOLlU55lTXJSYfBZM/L4NvAui2i5vA9g2BrA==",
-          "requires": {
-            "@miniflare/core": "2.5.0",
-            "@miniflare/shared": "2.5.0",
-            "@miniflare/web-sockets": "2.5.0",
-            "kleur": "^4.1.4",
-            "selfsigned": "^2.0.0",
-            "undici": "5.3.0",
-            "ws": "^8.2.2",
-            "youch": "^2.2.2"
-          }
-        },
-        "@miniflare/kv": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.5.0.tgz",
-          "integrity": "sha512-5dzcUMMOKl8u75FXbpy2BHp38uafjzo3RW2HEm6EY8QoM/vHw6RChFzJ9YEPJDbvcHR8gdMpgC65LYPTjifc3g==",
-          "requires": {
-            "@miniflare/shared": "2.5.0"
-          }
-        },
-        "@miniflare/runner-vm": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.5.0.tgz",
-          "integrity": "sha512-0n85cOBq91D7roqsIqJESDnj0oRi+xNVjDfd5uDIT1dW1qo5asA5Mwx6ntzCJB1BcB4khNatUIwpO3ZT+kT/YQ==",
-          "requires": {
-            "@miniflare/shared": "2.5.0"
-          }
-        },
-        "@miniflare/scheduler": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.5.0.tgz",
-          "integrity": "sha512-+a/I2QLp3UaZpKVobzFH3eHsi5ubhBp8q/AH/sCDwcZmatbCp2+oDrjMgTqhF6Fm8ryR4BYkHQOgkGZ5l7gQjw==",
-          "requires": {
-            "@miniflare/core": "2.5.0",
-            "@miniflare/shared": "2.5.0",
-            "cron-schedule": "^3.0.4"
-          }
-        },
-        "@miniflare/shared": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.5.0.tgz",
-          "integrity": "sha512-2oPxhnCGg8DNoo0NzUdc2BylGGeHQQvFJ6mDODjxbSXybeQC0+Ul5Ujv/FyU9W/eTbUEWNqKBycINyuXqSnJ/w==",
-          "requires": {
-            "ignore": "^5.1.8",
-            "kleur": "^4.1.4"
-          }
-        },
-        "@miniflare/sites": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.5.0.tgz",
-          "integrity": "sha512-AwYZb6ppP00YLkVNJnCe0lzJJemCDwibFjJywECY+aXFFNRo80sLpePPOXytplaUpen1uxnxUc8vdKBFVoB5cQ==",
-          "requires": {
-            "@miniflare/kv": "2.5.0",
-            "@miniflare/shared": "2.5.0",
-            "@miniflare/storage-file": "2.5.0"
-          }
-        },
-        "@miniflare/storage-file": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.5.0.tgz",
-          "integrity": "sha512-ytwWZEIn3eMBnI2FdqvM5+mJVuI2aIBeZNjhZFuF5/AW3v1uslqY55Qd5Fnfn+2C7z6ivVaUv/TlEwot9ZDUnw==",
-          "requires": {
-            "@miniflare/shared": "2.5.0",
-            "@miniflare/storage-memory": "2.5.0"
-          }
-        },
-        "@miniflare/storage-memory": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.5.0.tgz",
-          "integrity": "sha512-cydVKLY0cZe2Sah0jV3s9MK3gmYLrQQcpCdMHMBEUz+nRfjfnuzs4WXzzUXCWwNT+WFC0V2WvDp2sMt+lVsmsA==",
-          "requires": {
-            "@miniflare/shared": "2.5.0"
-          }
-        },
-        "@miniflare/watcher": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.5.0.tgz",
-          "integrity": "sha512-6ECE7po8NBxLmr2M00f7TWLEp1dMaAm3swf4D3ZU2xy3IqSBZE3QbOBuczYEYUIk7F+kXgaREISQg4e5QdECXQ==",
-          "requires": {
-            "@miniflare/shared": "2.5.0"
-          }
-        },
-        "@miniflare/web-sockets": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.5.0.tgz",
-          "integrity": "sha512-nnLBtbHdmgGUNTxP0IeAz1B4UGCO/6W+4edzjogtz3JJumKQE+ink5+SIrmL0C1Pitrc2+kO2WYsQzWh3a2Amg==",
-          "requires": {
-            "@miniflare/core": "2.5.0",
-            "@miniflare/shared": "2.5.0",
-            "undici": "5.3.0",
-            "ws": "^8.2.2"
-          }
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "busboy": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-          "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-          "requires": {
-            "streamsearch": "^1.1.0"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "dotenv": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "jest-environment-miniflare": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/jest-environment-miniflare/-/jest-environment-miniflare-2.5.0.tgz",
-          "integrity": "sha512-3OirfOB+kBxVBN5kOsXXQMgGHDUoO0+toulyoqGEWfZRa2kfL48CFCF10jB8A1K63cB5JMblN+uqyWUeZb/SBw==",
-          "requires": {
-            "@jest/environment": ">=27",
-            "@jest/fake-timers": ">=27",
-            "@jest/types": ">=27",
-            "@miniflare/cache": "2.5.0",
-            "@miniflare/core": "2.5.0",
-            "@miniflare/durable-objects": "2.5.0",
-            "@miniflare/html-rewriter": "2.5.0",
-            "@miniflare/kv": "2.5.0",
-            "@miniflare/runner-vm": "2.5.0",
-            "@miniflare/shared": "2.5.0",
-            "@miniflare/sites": "2.5.0",
-            "@miniflare/storage-memory": "2.5.0",
-            "@miniflare/web-sockets": "2.5.0",
-            "jest-mock": ">=27",
-            "jest-util": ">=27",
-            "miniflare": "2.5.0"
-          }
-        },
-        "jest-util": {
-          "version": "28.1.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.0.tgz",
-          "integrity": "sha512-qYdCKD77k4Hwkose2YBEqQk7PzUf/NSE+rutzceduFveQREeH6b+89Dc9+wjX9dAwHcgdx4yedGA3FQlU/qCTA==",
-          "requires": {
-            "@jest/types": "^28.1.0",
-            "@types/node": "*",
-            "chalk": "^4.0.0",
-            "ci-info": "^3.2.0",
-            "graceful-fs": "^4.2.9",
-            "picomatch": "^2.2.3"
-          }
-        },
-        "miniflare": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.5.0.tgz",
-          "integrity": "sha512-3IR+n/kLBA7zQ20HDjnA0HufQlr197krD8jPsaYO5wTrkIUCTvrilbI0sCo0X9CP/I3BCIl8fiZc1Jf7+MX7jQ==",
-          "requires": {
-            "@miniflare/cache": "2.5.0",
-            "@miniflare/cli-parser": "2.5.0",
-            "@miniflare/core": "2.5.0",
-            "@miniflare/durable-objects": "2.5.0",
-            "@miniflare/html-rewriter": "2.5.0",
-            "@miniflare/http-server": "2.5.0",
-            "@miniflare/kv": "2.5.0",
-            "@miniflare/runner-vm": "2.5.0",
-            "@miniflare/scheduler": "2.5.0",
-            "@miniflare/shared": "2.5.0",
-            "@miniflare/sites": "2.5.0",
-            "@miniflare/storage-file": "2.5.0",
-            "@miniflare/storage-memory": "2.5.0",
-            "@miniflare/web-sockets": "2.5.0",
-            "kleur": "^4.1.4",
-            "semiver": "^1.1.0",
-            "source-map-support": "^0.5.20",
-            "undici": "5.3.0"
-          }
-        },
-        "streamsearch": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-          "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "undici": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/undici/-/undici-5.3.0.tgz",
-          "integrity": "sha512-8LxC/xmR2GCE4q1heE1sJxVnnf5S6yQ2dObvMFBBWkB8aQlaqNuWovgRFWRMB7KUdLPGZfOTTmUeeLEJYX56iQ=="
-        },
-        "ws": {
-          "version": "8.7.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
-          "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
-          "requires": {}
-        }
+        "jest-environment-miniflare": "^2.5.0"
       }
     },
     "jest-fetch-mock": {
@@ -31679,6 +31382,31 @@
     },
     "min-indent": {
       "version": "1.0.1"
+    },
+    "miniflare": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.5.0.tgz",
+      "integrity": "sha512-3IR+n/kLBA7zQ20HDjnA0HufQlr197krD8jPsaYO5wTrkIUCTvrilbI0sCo0X9CP/I3BCIl8fiZc1Jf7+MX7jQ==",
+      "requires": {
+        "@miniflare/cache": "2.5.0",
+        "@miniflare/cli-parser": "2.5.0",
+        "@miniflare/core": "2.5.0",
+        "@miniflare/durable-objects": "2.5.0",
+        "@miniflare/html-rewriter": "2.5.0",
+        "@miniflare/http-server": "2.5.0",
+        "@miniflare/kv": "2.5.0",
+        "@miniflare/runner-vm": "2.5.0",
+        "@miniflare/scheduler": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "@miniflare/sites": "2.5.0",
+        "@miniflare/storage-file": "2.5.0",
+        "@miniflare/storage-memory": "2.5.0",
+        "@miniflare/web-sockets": "2.5.0",
+        "kleur": "^4.1.4",
+        "semiver": "^1.1.0",
+        "source-map-support": "^0.5.20",
+        "undici": "5.3.0"
+      }
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -34301,6 +34029,11 @@
         "mixme": "^0.5.1"
       }
     },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
+    },
     "string_decoder": {
       "version": "1.1.1",
       "requires": {
@@ -34923,6 +34656,11 @@
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.3.0.tgz",
+      "integrity": "sha512-8LxC/xmR2GCE4q1heE1sJxVnnf5S6yQ2dObvMFBBWkB8aQlaqNuWovgRFWRMB7KUdLPGZfOTTmUeeLEJYX56iQ=="
     },
     "unified": {
       "version": "10.1.1",
@@ -35871,180 +35609,6 @@
           "integrity": "sha512-td6ZUkz2oS3VeleBcN+m//Q6HlCFCPrnI0FZhrt/h4XqLEdOyYp2u21nd8MdsR+WJy5r9PTDaHTDDfhf4H4l6Q==",
           "dev": true
         },
-        "@miniflare/cache": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.5.0.tgz",
-          "integrity": "sha512-tJuDbWwzYsk4pJvPPJzdlfdGFqNnn1IN3JVrGDCq8UwOXm0K8hFiSwq2nMjjT+Z/9X2FfimgaXOx81zjPL+FjQ==",
-          "requires": {
-            "@miniflare/core": "2.5.0",
-            "@miniflare/shared": "2.5.0",
-            "http-cache-semantics": "^4.1.0",
-            "undici": "5.3.0"
-          }
-        },
-        "@miniflare/cli-parser": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.5.0.tgz",
-          "integrity": "sha512-aY/wQ4Rwy8x0Awtb8TzhKFYp4g1Y8xBhtKFfHOZpYCEFCVfKtgdk0pHPKctf/ClK0qJdT3siJKeXxsH2GRAMXg==",
-          "requires": {
-            "@miniflare/shared": "2.5.0",
-            "kleur": "^4.1.4"
-          }
-        },
-        "@miniflare/core": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.5.0.tgz",
-          "integrity": "sha512-BtMRi17DiimcpmDjQiIU6mIYSo/h21lVGC082n5G3JTF7AcGFAs7N2Fz2YLiYuc3zYc6qJx/NIjDoOqL2gfp3A==",
-          "requires": {
-            "@iarna/toml": "^2.2.5",
-            "@miniflare/shared": "2.5.0",
-            "@miniflare/watcher": "2.5.0",
-            "busboy": "^1.6.0",
-            "dotenv": "^10.0.0",
-            "kleur": "^4.1.4",
-            "set-cookie-parser": "^2.4.8",
-            "undici": "5.3.0",
-            "urlpattern-polyfill": "^4.0.3"
-          },
-          "dependencies": {
-            "@iarna/toml": {
-              "version": "2.2.5",
-              "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
-              "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
-            },
-            "dotenv": {
-              "version": "10.0.0",
-              "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-              "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
-            }
-          }
-        },
-        "@miniflare/durable-objects": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.5.0.tgz",
-          "integrity": "sha512-HJuP5Lsm/CCaSx3dePZiywAniGqTpU1ocCEqV6kE4zX1C0uGplfjPPXo5xsVc2NXkD+0ZL65rJzcj2tfrwKZlg==",
-          "requires": {
-            "@miniflare/core": "2.5.0",
-            "@miniflare/shared": "2.5.0",
-            "@miniflare/storage-memory": "2.5.0",
-            "undici": "5.3.0"
-          }
-        },
-        "@miniflare/html-rewriter": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.5.0.tgz",
-          "integrity": "sha512-bV2lQ/2clPeBmDth+cMnCBFYk8xtGs83S6PhfwmNNd24rzHvOEch1h/VCtEUy8k+rtgDSpc9pVkd31k0tMsyxQ==",
-          "requires": {
-            "@miniflare/core": "2.5.0",
-            "@miniflare/shared": "2.5.0",
-            "html-rewriter-wasm": "^0.4.1",
-            "undici": "5.3.0"
-          }
-        },
-        "@miniflare/http-server": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.5.0.tgz",
-          "integrity": "sha512-+sRPgNq0Q4Q6t1k94ncYzgcf/UNIv0Bz4ubUu6InJy4kMaJKeJPOLlU55lTXJSYfBZM/L4NvAui2i5vA9g2BrA==",
-          "requires": {
-            "@miniflare/core": "2.5.0",
-            "@miniflare/shared": "2.5.0",
-            "@miniflare/web-sockets": "2.5.0",
-            "kleur": "^4.1.4",
-            "selfsigned": "^2.0.0",
-            "undici": "5.3.0",
-            "ws": "^8.2.2",
-            "youch": "^2.2.2"
-          }
-        },
-        "@miniflare/kv": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.5.0.tgz",
-          "integrity": "sha512-5dzcUMMOKl8u75FXbpy2BHp38uafjzo3RW2HEm6EY8QoM/vHw6RChFzJ9YEPJDbvcHR8gdMpgC65LYPTjifc3g==",
-          "requires": {
-            "@miniflare/shared": "2.5.0"
-          }
-        },
-        "@miniflare/runner-vm": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.5.0.tgz",
-          "integrity": "sha512-0n85cOBq91D7roqsIqJESDnj0oRi+xNVjDfd5uDIT1dW1qo5asA5Mwx6ntzCJB1BcB4khNatUIwpO3ZT+kT/YQ==",
-          "requires": {
-            "@miniflare/shared": "2.5.0"
-          }
-        },
-        "@miniflare/scheduler": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.5.0.tgz",
-          "integrity": "sha512-+a/I2QLp3UaZpKVobzFH3eHsi5ubhBp8q/AH/sCDwcZmatbCp2+oDrjMgTqhF6Fm8ryR4BYkHQOgkGZ5l7gQjw==",
-          "requires": {
-            "@miniflare/core": "2.5.0",
-            "@miniflare/shared": "2.5.0",
-            "cron-schedule": "^3.0.4"
-          }
-        },
-        "@miniflare/shared": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.5.0.tgz",
-          "integrity": "sha512-2oPxhnCGg8DNoo0NzUdc2BylGGeHQQvFJ6mDODjxbSXybeQC0+Ul5Ujv/FyU9W/eTbUEWNqKBycINyuXqSnJ/w==",
-          "requires": {
-            "ignore": "^5.1.8",
-            "kleur": "^4.1.4"
-          }
-        },
-        "@miniflare/sites": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.5.0.tgz",
-          "integrity": "sha512-AwYZb6ppP00YLkVNJnCe0lzJJemCDwibFjJywECY+aXFFNRo80sLpePPOXytplaUpen1uxnxUc8vdKBFVoB5cQ==",
-          "requires": {
-            "@miniflare/kv": "2.5.0",
-            "@miniflare/shared": "2.5.0",
-            "@miniflare/storage-file": "2.5.0"
-          }
-        },
-        "@miniflare/storage-file": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.5.0.tgz",
-          "integrity": "sha512-ytwWZEIn3eMBnI2FdqvM5+mJVuI2aIBeZNjhZFuF5/AW3v1uslqY55Qd5Fnfn+2C7z6ivVaUv/TlEwot9ZDUnw==",
-          "requires": {
-            "@miniflare/shared": "2.5.0",
-            "@miniflare/storage-memory": "2.5.0"
-          }
-        },
-        "@miniflare/storage-memory": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.5.0.tgz",
-          "integrity": "sha512-cydVKLY0cZe2Sah0jV3s9MK3gmYLrQQcpCdMHMBEUz+nRfjfnuzs4WXzzUXCWwNT+WFC0V2WvDp2sMt+lVsmsA==",
-          "requires": {
-            "@miniflare/shared": "2.5.0"
-          }
-        },
-        "@miniflare/watcher": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.5.0.tgz",
-          "integrity": "sha512-6ECE7po8NBxLmr2M00f7TWLEp1dMaAm3swf4D3ZU2xy3IqSBZE3QbOBuczYEYUIk7F+kXgaREISQg4e5QdECXQ==",
-          "requires": {
-            "@miniflare/shared": "2.5.0"
-          }
-        },
-        "@miniflare/web-sockets": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.5.0.tgz",
-          "integrity": "sha512-nnLBtbHdmgGUNTxP0IeAz1B4UGCO/6W+4edzjogtz3JJumKQE+ink5+SIrmL0C1Pitrc2+kO2WYsQzWh3a2Amg==",
-          "requires": {
-            "@miniflare/core": "2.5.0",
-            "@miniflare/shared": "2.5.0",
-            "undici": "5.3.0",
-            "ws": "^8.2.2"
-          }
-        },
-        "busboy": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-          "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-          "requires": {
-            "streamsearch": "^1.1.0"
-          }
-        },
         "dotenv": {
           "version": "16.0.0",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
@@ -36217,31 +35781,6 @@
             "p-locate": "^6.0.0"
           }
         },
-        "miniflare": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.5.0.tgz",
-          "integrity": "sha512-3IR+n/kLBA7zQ20HDjnA0HufQlr197krD8jPsaYO5wTrkIUCTvrilbI0sCo0X9CP/I3BCIl8fiZc1Jf7+MX7jQ==",
-          "requires": {
-            "@miniflare/cache": "2.5.0",
-            "@miniflare/cli-parser": "2.5.0",
-            "@miniflare/core": "2.5.0",
-            "@miniflare/durable-objects": "2.5.0",
-            "@miniflare/html-rewriter": "2.5.0",
-            "@miniflare/http-server": "2.5.0",
-            "@miniflare/kv": "2.5.0",
-            "@miniflare/runner-vm": "2.5.0",
-            "@miniflare/scheduler": "2.5.0",
-            "@miniflare/shared": "2.5.0",
-            "@miniflare/sites": "2.5.0",
-            "@miniflare/storage-file": "2.5.0",
-            "@miniflare/storage-memory": "2.5.0",
-            "@miniflare/web-sockets": "2.5.0",
-            "kleur": "^4.1.4",
-            "semiver": "^1.1.0",
-            "source-map-support": "^0.5.20",
-            "undici": "5.3.0"
-          }
-        },
         "p-limit": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
@@ -36264,26 +35803,17 @@
           "version": "5.0.0",
           "dev": true
         },
-        "streamsearch": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-          "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
-        },
         "supports-color": {
           "version": "9.2.2",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.2.2.tgz",
           "integrity": "sha512-XC6g/Kgux+rJXmwokjm9ECpD6k/smUoS5LKlUCcsYr4IY3rW0XyAympon2RmxGrlnZURMpg5T18gWDP9CsHXFA==",
           "dev": true
         },
-        "undici": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/undici/-/undici-5.3.0.tgz",
-          "integrity": "sha512-8LxC/xmR2GCE4q1heE1sJxVnnf5S6yQ2dObvMFBBWkB8aQlaqNuWovgRFWRMB7KUdLPGZfOTTmUeeLEJYX56iQ=="
-        },
         "ws": {
           "version": "8.5.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
           "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+          "dev": true,
           "requires": {}
         },
         "yocto-queue": {
@@ -36314,14 +35844,6 @@
         "typescript": "^4.6.3",
         "undici": "^5.0.0",
         "webpack": "^4.46.0"
-      },
-      "dependencies": {
-        "undici": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/undici/-/undici-5.0.0.tgz",
-          "integrity": "sha512-VhUpiZ3No1DOPPQVQnsDZyfcbTTcHdcgWej1PdFnSvOeJmOVDgiOHkunJmBLfmjt4CqgPQddPVjSWW0dsTs5Yg==",
-          "dev": true
-        }
       }
     },
     "wrap-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2268,6 +2268,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jest/schemas": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.0.2.tgz",
+      "integrity": "sha512-YVDJZjd4izeTDkij00vHHAymNXQ6WWsdChFRK86qck6Jpr3DCL5W3Is3vslviRlP+bLuMYRLbdp98amMvqudhA==",
+      "dependencies": {
+        "@sinclair/typebox": "^0.23.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
     "node_modules/@jest/source-map": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-27.5.1.tgz",
@@ -2836,252 +2847,6 @@
         "node": ">=6 <7 || >=8"
       }
     },
-    "node_modules/@miniflare/cache": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.4.0.tgz",
-      "integrity": "sha512-tMDXlUVlThgFubJmlxZoKmLK8kBxDmuMbVMt7csHpXegzkuo2TmIsDqBE/C3CRiJ5xeCQgpD6iZtKBu5Zn5fRA==",
-      "dependencies": {
-        "@miniflare/core": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "http-cache-semantics": "^4.1.0",
-        "undici": "4.13.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/cli-parser": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.4.0.tgz",
-      "integrity": "sha512-Xr5lO8f+oIr9r/b2dfo0on1p0MNN+pkwRHWoY5ACSnp9FaGnwm/g71DM7AajIQPIk0TpRsSVNDx8Ygj1LPT+sQ==",
-      "dependencies": {
-        "@miniflare/shared": "2.4.0",
-        "kleur": "^4.1.4"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.4.0.tgz",
-      "integrity": "sha512-vYl8xaWTFzxtkbzx3IkT4Py0OAFdfmFnVo627O1HKHWVGlkjVr8UKtxBpIR+f5pq/HCMzzqA1HM9FXO0dQfy3A==",
-      "dependencies": {
-        "@iarna/toml": "^2.2.5",
-        "@miniflare/shared": "2.4.0",
-        "@miniflare/watcher": "2.4.0",
-        "busboy": "^0.3.1",
-        "dotenv": "^10.0.0",
-        "kleur": "^4.1.4",
-        "set-cookie-parser": "^2.4.8",
-        "undici": "4.13.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/core/node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@miniflare/durable-objects": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.4.0.tgz",
-      "integrity": "sha512-VVLaUXXcAQcYE/3YmDLTacZf5OzR8bib6q1T9NqVb0uK5sLMQqyHvQdsG5rMqs7iyxfJxyZ0bL2OW9XGALOkoQ==",
-      "dependencies": {
-        "@miniflare/core": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "@miniflare/storage-memory": "2.4.0",
-        "undici": "4.13.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/html-rewriter": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.4.0.tgz",
-      "integrity": "sha512-ZG8819N7LelDD+8+Ss5FZpVyQQq/V2igod0qE68JK4he/w4/yn57Rk6Efb49y15HoHAXl2RpCCsnCyIow/Xjug==",
-      "dependencies": {
-        "@miniflare/core": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "html-rewriter-wasm": "^0.4.1",
-        "undici": "4.13.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/http-server": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.4.0.tgz",
-      "integrity": "sha512-r6Z/nqxE0oa1z63L95yvnG0PUeLRxZOeGS7ADxZMFKan4WD5lvYtSKDuDEm0lkbQshCOHQ3uXFr0cotOm8JoMQ==",
-      "dependencies": {
-        "@miniflare/core": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "@miniflare/web-sockets": "2.4.0",
-        "kleur": "^4.1.4",
-        "selfsigned": "^2.0.0",
-        "undici": "4.13.0",
-        "ws": "^8.2.2",
-        "youch": "^2.2.2"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/http-server/node_modules/ws": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@miniflare/kv": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.4.0.tgz",
-      "integrity": "sha512-1UW7f1386xR6EDEXNZOR1TpFwQfRRSxUPqD6m/U0WprlsbM0cIYGz+AUeaVbkFf8lfE2MeXCUrjbWsLOvsnw3g==",
-      "dependencies": {
-        "@miniflare/shared": "2.4.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/runner-vm": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.4.0.tgz",
-      "integrity": "sha512-7sdwBYzXQTwYeR3tTvQ+vJfzc7BXwqR8AUPK9l5gvCtg+Geq9sMslr5SikIJpgcvbYqKDjvC9DQEPJ3sqr9cSQ==",
-      "dependencies": {
-        "@miniflare/shared": "2.4.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/scheduler": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.4.0.tgz",
-      "integrity": "sha512-dfMCXoAS8Y+3xABNxYju62I2xIBS54Op7ohCHoatvAM5RvualJUPICEMPZzX6/z29q5xPIeSLhLDhl/asAQ19w==",
-      "dependencies": {
-        "@miniflare/core": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "cron-schedule": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/shared": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.4.0.tgz",
-      "integrity": "sha512-lPQFzBUVGNQ93gQ/dliToWnO0OqAgsD3/902Pd/IixVSRwRj3BTnYv2dHMUKZcODBPrhnbqZeqcPWdBLzEx8uw==",
-      "dependencies": {
-        "ignore": "^5.1.8",
-        "kleur": "^4.1.4"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/sites": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.4.0.tgz",
-      "integrity": "sha512-YZy/TujnR1lkBvCncDDQ8tsWsXRE4JJ4x9a0bKN/XnZh7r6OhDM0sw4BFcBQhT6Ukdtttam1O3FlJxnMitrDGg==",
-      "dependencies": {
-        "@miniflare/kv": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "@miniflare/storage-file": "2.4.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/storage-file": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.4.0.tgz",
-      "integrity": "sha512-f1AUMz8xps/4VhNJMb8JeCevZFeU4pg2lIWmC11gG4xeq2nibTPBi6Qtx594Le7ZKij/tF6rRsoNfGau2Q5gdw==",
-      "dependencies": {
-        "@miniflare/shared": "2.4.0",
-        "@miniflare/storage-memory": "2.4.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/storage-memory": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.4.0.tgz",
-      "integrity": "sha512-mhWwgHhDNtEa7y1bYbdVucV0lqUmzagYXUSppAdSGS5JPyJMyw3HseqRNTk6gC/vKlvEYlFf3ugWcREGCedr9A==",
-      "dependencies": {
-        "@miniflare/shared": "2.4.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/watcher": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.4.0.tgz",
-      "integrity": "sha512-gDQRUxwOjmctvowyd4Hcdy3fjxz3ERKzirp6TvA3AWUohKZk3IhwGlaA8aCwbdP+ELYQlG5wK44AfLSGi956fg==",
-      "dependencies": {
-        "@miniflare/shared": "2.4.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/web-sockets": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.4.0.tgz",
-      "integrity": "sha512-cz/cN0GoQOXRLh80UmlcEJODPIw2ijKBK3PLRzvfTzqQ5avK6wp2M8Fj8C/5JIT6g7siwvBANyKXD3U3RpKGHQ==",
-      "dependencies": {
-        "@miniflare/core": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "undici": "4.13.0",
-        "ws": "^8.2.2"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/web-sockets/node_modules/ws": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3446,6 +3211,11 @@
       "resolved": "https://registry.npmjs.org/@schemastore/package/-/package-0.0.6.tgz",
       "integrity": "sha512-uNloNHoyHttSSdeuEkkSC+mdxJXMKlcUPOMb//qhQbIQijXg8x54VmAw3jm6GJZQ5DBtIqGBd66zEQCDCChQVA==",
       "dev": true
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.23.5.tgz",
+      "integrity": "sha512-AFBVi/iT4g20DHoujvMH1aEDn8fGJh4xsRGCP6d8RpLPMqsNPvW01Jcn0QysXTsg++/xj25NmJsGyH9xug/wKg=="
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.4.0",
@@ -3905,7 +3675,6 @@
       "version": "17.0.10",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.10.tgz",
       "integrity": "sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==",
-      "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -5194,17 +4963,6 @@
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
-    "node_modules/busboy": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
-      "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
-      "dependencies": {
-        "dicer": "0.3.0"
-      },
-      "engines": {
-        "node": ">=4.5.0"
-      }
-    },
     "node_modules/cacache": {
       "version": "15.3.0",
       "dev": true,
@@ -6434,17 +6192,6 @@
       "version": "0.0.955664",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/dicer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
-      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
-      "dependencies": {
-        "streamsearch": "0.1.2"
-      },
-      "engines": {
-        "node": ">=4.5.0"
-      }
     },
     "node_modules/diff": {
       "version": "5.0.0",
@@ -11430,30 +11177,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-environment-miniflare": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-miniflare/-/jest-environment-miniflare-2.4.0.tgz",
-      "integrity": "sha512-WTsUBXrjyX1yNWCnKyzTSNFfBNm3QxT+f4AXaaSBrZEHCjE4/zl08/BE0fSmVQah6Vp/N3pgrM2efYQD6xiaHw==",
-      "dependencies": {
-        "@miniflare/cache": "2.4.0",
-        "@miniflare/core": "2.4.0",
-        "@miniflare/durable-objects": "2.4.0",
-        "@miniflare/html-rewriter": "2.4.0",
-        "@miniflare/kv": "2.4.0",
-        "@miniflare/runner-vm": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "@miniflare/sites": "2.4.0",
-        "@miniflare/storage-memory": "2.4.0",
-        "@miniflare/web-sockets": "2.4.0",
-        "miniflare": "2.4.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      },
-      "peerDependencies": {
-        "jest": ">=27"
-      }
-    },
     "node_modules/jest-environment-node": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.5.1.tgz",
@@ -14841,53 +14564,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/miniflare": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.4.0.tgz",
-      "integrity": "sha512-xOBL/dQsUL95rxIYO+KrrVPPpm2TAf6TKl4AvhcjSfUeVkzDWd/y9f7hXCt8x6srDoK0Z2LpYouatvSfSUzGOw==",
-      "dependencies": {
-        "@miniflare/cache": "2.4.0",
-        "@miniflare/cli-parser": "2.4.0",
-        "@miniflare/core": "2.4.0",
-        "@miniflare/durable-objects": "2.4.0",
-        "@miniflare/html-rewriter": "2.4.0",
-        "@miniflare/http-server": "2.4.0",
-        "@miniflare/kv": "2.4.0",
-        "@miniflare/runner-vm": "2.4.0",
-        "@miniflare/scheduler": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "@miniflare/sites": "2.4.0",
-        "@miniflare/storage-file": "2.4.0",
-        "@miniflare/storage-memory": "2.4.0",
-        "@miniflare/web-sockets": "2.4.0",
-        "kleur": "^4.1.4",
-        "semiver": "^1.1.0",
-        "source-map-support": "^0.5.20",
-        "undici": "4.13.0"
-      },
-      "bin": {
-        "miniflare": "bootstrap.js"
-      },
-      "engines": {
-        "node": ">=16.7"
-      },
-      "peerDependencies": {
-        "@miniflare/storage-redis": "2.4.0",
-        "cron-schedule": "^3.0.4",
-        "ioredis": "^4.27.9"
-      },
-      "peerDependenciesMeta": {
-        "@miniflare/storage-redis": {
-          "optional": true
-        },
-        "cron-schedule": {
-          "optional": true
-        },
-        "ioredis": {
-          "optional": true
-        }
       }
     },
     "node_modules/minimalistic-assert": {
@@ -18278,14 +17954,6 @@
         "mixme": "^0.5.1"
       }
     },
-    "node_modules/streamsearch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "license": "MIT",
@@ -19165,14 +18833,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/undici": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-4.13.0.tgz",
-      "integrity": "sha512-8lk8S/f2V0VUNGf2scU2b+KI2JSzEQLdCyRNRF3XmHu+5jectlSDaPSBCXAHFaUlt1rzngzOBVDgJS9/Gue/KA==",
-      "engines": {
-        "node": ">=12.18"
-      }
-    },
     "node_modules/unified": {
       "version": "10.1.1",
       "dev": true,
@@ -19450,6 +19110,11 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
       "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
       "dev": true
+    },
+    "node_modules/urlpattern-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-4.0.3.tgz",
+      "integrity": "sha512-DOE84vZT2fEcl9gqCUTcnAw5ZY5Id55ikUcziSUntuEFL3pRvavg5kwDmTEUJkeCHInTlV/HexFomgYnzO5kdQ=="
     },
     "node_modules/use": {
       "version": "3.1.1",
@@ -20543,7 +20208,433 @@
       "version": "0.0.29",
       "license": "ISC",
       "dependencies": {
-        "jest-environment-miniflare": "2.4.0"
+        "jest-environment-miniflare": "2.5.0"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@jest/types": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.0.tgz",
+      "integrity": "sha512-xmEggMPr317MIOjjDoZ4ejCSr9Lpbt/u34+dvc99t7DS8YirW5rwZEhzKPC2BMUFkUhI48qs6qLUSGw5FuL0GA==",
+      "dependencies": {
+        "@jest/schemas": "^28.0.2",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/cache": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.5.0.tgz",
+      "integrity": "sha512-tJuDbWwzYsk4pJvPPJzdlfdGFqNnn1IN3JVrGDCq8UwOXm0K8hFiSwq2nMjjT+Z/9X2FfimgaXOx81zjPL+FjQ==",
+      "dependencies": {
+        "@miniflare/core": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "http-cache-semantics": "^4.1.0",
+        "undici": "5.3.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/cli-parser": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.5.0.tgz",
+      "integrity": "sha512-aY/wQ4Rwy8x0Awtb8TzhKFYp4g1Y8xBhtKFfHOZpYCEFCVfKtgdk0pHPKctf/ClK0qJdT3siJKeXxsH2GRAMXg==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.0",
+        "kleur": "^4.1.4"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-BtMRi17DiimcpmDjQiIU6mIYSo/h21lVGC082n5G3JTF7AcGFAs7N2Fz2YLiYuc3zYc6qJx/NIjDoOqL2gfp3A==",
+      "dependencies": {
+        "@iarna/toml": "^2.2.5",
+        "@miniflare/shared": "2.5.0",
+        "@miniflare/watcher": "2.5.0",
+        "busboy": "^1.6.0",
+        "dotenv": "^10.0.0",
+        "kleur": "^4.1.4",
+        "set-cookie-parser": "^2.4.8",
+        "undici": "5.3.0",
+        "urlpattern-polyfill": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/durable-objects": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.5.0.tgz",
+      "integrity": "sha512-HJuP5Lsm/CCaSx3dePZiywAniGqTpU1ocCEqV6kE4zX1C0uGplfjPPXo5xsVc2NXkD+0ZL65rJzcj2tfrwKZlg==",
+      "dependencies": {
+        "@miniflare/core": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "@miniflare/storage-memory": "2.5.0",
+        "undici": "5.3.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/html-rewriter": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.5.0.tgz",
+      "integrity": "sha512-bV2lQ/2clPeBmDth+cMnCBFYk8xtGs83S6PhfwmNNd24rzHvOEch1h/VCtEUy8k+rtgDSpc9pVkd31k0tMsyxQ==",
+      "dependencies": {
+        "@miniflare/core": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "html-rewriter-wasm": "^0.4.1",
+        "undici": "5.3.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/http-server": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.5.0.tgz",
+      "integrity": "sha512-+sRPgNq0Q4Q6t1k94ncYzgcf/UNIv0Bz4ubUu6InJy4kMaJKeJPOLlU55lTXJSYfBZM/L4NvAui2i5vA9g2BrA==",
+      "dependencies": {
+        "@miniflare/core": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "@miniflare/web-sockets": "2.5.0",
+        "kleur": "^4.1.4",
+        "selfsigned": "^2.0.0",
+        "undici": "5.3.0",
+        "ws": "^8.2.2",
+        "youch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/kv": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.5.0.tgz",
+      "integrity": "sha512-5dzcUMMOKl8u75FXbpy2BHp38uafjzo3RW2HEm6EY8QoM/vHw6RChFzJ9YEPJDbvcHR8gdMpgC65LYPTjifc3g==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/runner-vm": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.5.0.tgz",
+      "integrity": "sha512-0n85cOBq91D7roqsIqJESDnj0oRi+xNVjDfd5uDIT1dW1qo5asA5Mwx6ntzCJB1BcB4khNatUIwpO3ZT+kT/YQ==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/scheduler": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.5.0.tgz",
+      "integrity": "sha512-+a/I2QLp3UaZpKVobzFH3eHsi5ubhBp8q/AH/sCDwcZmatbCp2+oDrjMgTqhF6Fm8ryR4BYkHQOgkGZ5l7gQjw==",
+      "dependencies": {
+        "@miniflare/core": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "cron-schedule": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/shared": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.5.0.tgz",
+      "integrity": "sha512-2oPxhnCGg8DNoo0NzUdc2BylGGeHQQvFJ6mDODjxbSXybeQC0+Ul5Ujv/FyU9W/eTbUEWNqKBycINyuXqSnJ/w==",
+      "dependencies": {
+        "ignore": "^5.1.8",
+        "kleur": "^4.1.4"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/sites": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.5.0.tgz",
+      "integrity": "sha512-AwYZb6ppP00YLkVNJnCe0lzJJemCDwibFjJywECY+aXFFNRo80sLpePPOXytplaUpen1uxnxUc8vdKBFVoB5cQ==",
+      "dependencies": {
+        "@miniflare/kv": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "@miniflare/storage-file": "2.5.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/storage-file": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.5.0.tgz",
+      "integrity": "sha512-ytwWZEIn3eMBnI2FdqvM5+mJVuI2aIBeZNjhZFuF5/AW3v1uslqY55Qd5Fnfn+2C7z6ivVaUv/TlEwot9ZDUnw==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.0",
+        "@miniflare/storage-memory": "2.5.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/storage-memory": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.5.0.tgz",
+      "integrity": "sha512-cydVKLY0cZe2Sah0jV3s9MK3gmYLrQQcpCdMHMBEUz+nRfjfnuzs4WXzzUXCWwNT+WFC0V2WvDp2sMt+lVsmsA==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/watcher": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.5.0.tgz",
+      "integrity": "sha512-6ECE7po8NBxLmr2M00f7TWLEp1dMaAm3swf4D3ZU2xy3IqSBZE3QbOBuczYEYUIk7F+kXgaREISQg4e5QdECXQ==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/web-sockets": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.5.0.tgz",
+      "integrity": "sha512-nnLBtbHdmgGUNTxP0IeAz1B4UGCO/6W+4edzjogtz3JJumKQE+ink5+SIrmL0C1Pitrc2+kO2WYsQzWh3a2Amg==",
+      "dependencies": {
+        "@miniflare/core": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "undici": "5.3.0",
+        "ws": "^8.2.2"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "packages/jest-environment-wrangler/node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/jest-environment-miniflare": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-miniflare/-/jest-environment-miniflare-2.5.0.tgz",
+      "integrity": "sha512-3OirfOB+kBxVBN5kOsXXQMgGHDUoO0+toulyoqGEWfZRa2kfL48CFCF10jB8A1K63cB5JMblN+uqyWUeZb/SBw==",
+      "dependencies": {
+        "@jest/environment": ">=27",
+        "@jest/fake-timers": ">=27",
+        "@jest/types": ">=27",
+        "@miniflare/cache": "2.5.0",
+        "@miniflare/core": "2.5.0",
+        "@miniflare/durable-objects": "2.5.0",
+        "@miniflare/html-rewriter": "2.5.0",
+        "@miniflare/kv": "2.5.0",
+        "@miniflare/runner-vm": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "@miniflare/sites": "2.5.0",
+        "@miniflare/storage-memory": "2.5.0",
+        "@miniflare/web-sockets": "2.5.0",
+        "jest-mock": ">=27",
+        "jest-util": ">=27",
+        "miniflare": "2.5.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      },
+      "peerDependencies": {
+        "jest": ">=27"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/jest-util": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.0.tgz",
+      "integrity": "sha512-qYdCKD77k4Hwkose2YBEqQk7PzUf/NSE+rutzceduFveQREeH6b+89Dc9+wjX9dAwHcgdx4yedGA3FQlU/qCTA==",
+      "dependencies": {
+        "@jest/types": "^28.1.0",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/miniflare": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.5.0.tgz",
+      "integrity": "sha512-3IR+n/kLBA7zQ20HDjnA0HufQlr197krD8jPsaYO5wTrkIUCTvrilbI0sCo0X9CP/I3BCIl8fiZc1Jf7+MX7jQ==",
+      "dependencies": {
+        "@miniflare/cache": "2.5.0",
+        "@miniflare/cli-parser": "2.5.0",
+        "@miniflare/core": "2.5.0",
+        "@miniflare/durable-objects": "2.5.0",
+        "@miniflare/html-rewriter": "2.5.0",
+        "@miniflare/http-server": "2.5.0",
+        "@miniflare/kv": "2.5.0",
+        "@miniflare/runner-vm": "2.5.0",
+        "@miniflare/scheduler": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "@miniflare/sites": "2.5.0",
+        "@miniflare/storage-file": "2.5.0",
+        "@miniflare/storage-memory": "2.5.0",
+        "@miniflare/web-sockets": "2.5.0",
+        "kleur": "^4.1.4",
+        "semiver": "^1.1.0",
+        "source-map-support": "^0.5.20",
+        "undici": "5.3.0"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=16.7"
+      },
+      "peerDependencies": {
+        "@miniflare/storage-redis": "2.5.0",
+        "cron-schedule": "^3.0.4",
+        "ioredis": "^4.27.9"
+      },
+      "peerDependenciesMeta": {
+        "@miniflare/storage-redis": {
+          "optional": true
+        },
+        "cron-schedule": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        }
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/undici": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.3.0.tgz",
+      "integrity": "sha512-8LxC/xmR2GCE4q1heE1sJxVnnf5S6yQ2dObvMFBBWkB8aQlaqNuWovgRFWRMB7KUdLPGZfOTTmUeeLEJYX56iQ==",
+      "engines": {
+        "node": ">=12.18"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/ws": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
+      "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "packages/prerelease-registry": {
@@ -20564,7 +20655,7 @@
         "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
         "blake3-wasm": "^2.1.5",
         "esbuild": "0.14.34",
-        "miniflare": "2.4.0",
+        "miniflare": "2.5.0",
         "nanoid": "^3.3.3",
         "path-to-regexp": "^6.2.0",
         "selfsigned": "^2.0.1",
@@ -20640,6 +20731,229 @@
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-3.0.0.tgz",
       "integrity": "sha512-td6ZUkz2oS3VeleBcN+m//Q6HlCFCPrnI0FZhrt/h4XqLEdOyYp2u21nd8MdsR+WJy5r9PTDaHTDDfhf4H4l6Q==",
       "dev": true
+    },
+    "packages/wrangler/node_modules/@miniflare/cache": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.5.0.tgz",
+      "integrity": "sha512-tJuDbWwzYsk4pJvPPJzdlfdGFqNnn1IN3JVrGDCq8UwOXm0K8hFiSwq2nMjjT+Z/9X2FfimgaXOx81zjPL+FjQ==",
+      "dependencies": {
+        "@miniflare/core": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "http-cache-semantics": "^4.1.0",
+        "undici": "5.3.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/cli-parser": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.5.0.tgz",
+      "integrity": "sha512-aY/wQ4Rwy8x0Awtb8TzhKFYp4g1Y8xBhtKFfHOZpYCEFCVfKtgdk0pHPKctf/ClK0qJdT3siJKeXxsH2GRAMXg==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.0",
+        "kleur": "^4.1.4"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-BtMRi17DiimcpmDjQiIU6mIYSo/h21lVGC082n5G3JTF7AcGFAs7N2Fz2YLiYuc3zYc6qJx/NIjDoOqL2gfp3A==",
+      "dependencies": {
+        "@iarna/toml": "^2.2.5",
+        "@miniflare/shared": "2.5.0",
+        "@miniflare/watcher": "2.5.0",
+        "busboy": "^1.6.0",
+        "dotenv": "^10.0.0",
+        "kleur": "^4.1.4",
+        "set-cookie-parser": "^2.4.8",
+        "undici": "5.3.0",
+        "urlpattern-polyfill": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/core/node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
+    },
+    "packages/wrangler/node_modules/@miniflare/core/node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/durable-objects": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.5.0.tgz",
+      "integrity": "sha512-HJuP5Lsm/CCaSx3dePZiywAniGqTpU1ocCEqV6kE4zX1C0uGplfjPPXo5xsVc2NXkD+0ZL65rJzcj2tfrwKZlg==",
+      "dependencies": {
+        "@miniflare/core": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "@miniflare/storage-memory": "2.5.0",
+        "undici": "5.3.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/html-rewriter": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.5.0.tgz",
+      "integrity": "sha512-bV2lQ/2clPeBmDth+cMnCBFYk8xtGs83S6PhfwmNNd24rzHvOEch1h/VCtEUy8k+rtgDSpc9pVkd31k0tMsyxQ==",
+      "dependencies": {
+        "@miniflare/core": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "html-rewriter-wasm": "^0.4.1",
+        "undici": "5.3.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/http-server": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.5.0.tgz",
+      "integrity": "sha512-+sRPgNq0Q4Q6t1k94ncYzgcf/UNIv0Bz4ubUu6InJy4kMaJKeJPOLlU55lTXJSYfBZM/L4NvAui2i5vA9g2BrA==",
+      "dependencies": {
+        "@miniflare/core": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "@miniflare/web-sockets": "2.5.0",
+        "kleur": "^4.1.4",
+        "selfsigned": "^2.0.0",
+        "undici": "5.3.0",
+        "ws": "^8.2.2",
+        "youch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/kv": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.5.0.tgz",
+      "integrity": "sha512-5dzcUMMOKl8u75FXbpy2BHp38uafjzo3RW2HEm6EY8QoM/vHw6RChFzJ9YEPJDbvcHR8gdMpgC65LYPTjifc3g==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/runner-vm": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.5.0.tgz",
+      "integrity": "sha512-0n85cOBq91D7roqsIqJESDnj0oRi+xNVjDfd5uDIT1dW1qo5asA5Mwx6ntzCJB1BcB4khNatUIwpO3ZT+kT/YQ==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/scheduler": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.5.0.tgz",
+      "integrity": "sha512-+a/I2QLp3UaZpKVobzFH3eHsi5ubhBp8q/AH/sCDwcZmatbCp2+oDrjMgTqhF6Fm8ryR4BYkHQOgkGZ5l7gQjw==",
+      "dependencies": {
+        "@miniflare/core": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "cron-schedule": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/shared": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.5.0.tgz",
+      "integrity": "sha512-2oPxhnCGg8DNoo0NzUdc2BylGGeHQQvFJ6mDODjxbSXybeQC0+Ul5Ujv/FyU9W/eTbUEWNqKBycINyuXqSnJ/w==",
+      "dependencies": {
+        "ignore": "^5.1.8",
+        "kleur": "^4.1.4"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/sites": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.5.0.tgz",
+      "integrity": "sha512-AwYZb6ppP00YLkVNJnCe0lzJJemCDwibFjJywECY+aXFFNRo80sLpePPOXytplaUpen1uxnxUc8vdKBFVoB5cQ==",
+      "dependencies": {
+        "@miniflare/kv": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "@miniflare/storage-file": "2.5.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/storage-file": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.5.0.tgz",
+      "integrity": "sha512-ytwWZEIn3eMBnI2FdqvM5+mJVuI2aIBeZNjhZFuF5/AW3v1uslqY55Qd5Fnfn+2C7z6ivVaUv/TlEwot9ZDUnw==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.0",
+        "@miniflare/storage-memory": "2.5.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/storage-memory": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.5.0.tgz",
+      "integrity": "sha512-cydVKLY0cZe2Sah0jV3s9MK3gmYLrQQcpCdMHMBEUz+nRfjfnuzs4WXzzUXCWwNT+WFC0V2WvDp2sMt+lVsmsA==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/watcher": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.5.0.tgz",
+      "integrity": "sha512-6ECE7po8NBxLmr2M00f7TWLEp1dMaAm3swf4D3ZU2xy3IqSBZE3QbOBuczYEYUIk7F+kXgaREISQg4e5QdECXQ==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/web-sockets": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.5.0.tgz",
+      "integrity": "sha512-nnLBtbHdmgGUNTxP0IeAz1B4UGCO/6W+4edzjogtz3JJumKQE+ink5+SIrmL0C1Pitrc2+kO2WYsQzWh3a2Amg==",
+      "dependencies": {
+        "@miniflare/core": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "undici": "5.3.0",
+        "ws": "^8.2.2"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "packages/wrangler/node_modules/dotenv": {
       "version": "16.0.0",
@@ -21015,6 +21329,53 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "packages/wrangler/node_modules/miniflare": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.5.0.tgz",
+      "integrity": "sha512-3IR+n/kLBA7zQ20HDjnA0HufQlr197krD8jPsaYO5wTrkIUCTvrilbI0sCo0X9CP/I3BCIl8fiZc1Jf7+MX7jQ==",
+      "dependencies": {
+        "@miniflare/cache": "2.5.0",
+        "@miniflare/cli-parser": "2.5.0",
+        "@miniflare/core": "2.5.0",
+        "@miniflare/durable-objects": "2.5.0",
+        "@miniflare/html-rewriter": "2.5.0",
+        "@miniflare/http-server": "2.5.0",
+        "@miniflare/kv": "2.5.0",
+        "@miniflare/runner-vm": "2.5.0",
+        "@miniflare/scheduler": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "@miniflare/sites": "2.5.0",
+        "@miniflare/storage-file": "2.5.0",
+        "@miniflare/storage-memory": "2.5.0",
+        "@miniflare/web-sockets": "2.5.0",
+        "kleur": "^4.1.4",
+        "semiver": "^1.1.0",
+        "source-map-support": "^0.5.20",
+        "undici": "5.3.0"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=16.7"
+      },
+      "peerDependencies": {
+        "@miniflare/storage-redis": "2.5.0",
+        "cron-schedule": "^3.0.4",
+        "ioredis": "^4.27.9"
+      },
+      "peerDependenciesMeta": {
+        "@miniflare/storage-redis": {
+          "optional": true
+        },
+        "cron-schedule": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        }
+      }
+    },
     "packages/wrangler/node_modules/p-limit": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
@@ -21053,6 +21414,14 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "packages/wrangler/node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "packages/wrangler/node_modules/supports-color": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.2.2.tgz",
@@ -21069,7 +21438,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.3.0.tgz",
       "integrity": "sha512-8LxC/xmR2GCE4q1heE1sJxVnnf5S6yQ2dObvMFBBWkB8aQlaqNuWovgRFWRMB7KUdLPGZfOTTmUeeLEJYX56iQ==",
-      "dev": true,
       "engines": {
         "node": ">=12.18"
       }
@@ -21078,7 +21446,6 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
       "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -22472,6 +22839,14 @@
         }
       }
     },
+    "@jest/schemas": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.0.2.tgz",
+      "integrity": "sha512-YVDJZjd4izeTDkij00vHHAymNXQ6WWsdChFRK86qck6Jpr3DCL5W3Is3vslviRlP+bLuMYRLbdp98amMvqudhA==",
+      "requires": {
+        "@sinclair/typebox": "^0.23.3"
+      }
+    },
     "@jest/source-map": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-27.5.1.tgz",
@@ -22912,182 +23287,6 @@
         }
       }
     },
-    "@miniflare/cache": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.4.0.tgz",
-      "integrity": "sha512-tMDXlUVlThgFubJmlxZoKmLK8kBxDmuMbVMt7csHpXegzkuo2TmIsDqBE/C3CRiJ5xeCQgpD6iZtKBu5Zn5fRA==",
-      "requires": {
-        "@miniflare/core": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "http-cache-semantics": "^4.1.0",
-        "undici": "4.13.0"
-      }
-    },
-    "@miniflare/cli-parser": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.4.0.tgz",
-      "integrity": "sha512-Xr5lO8f+oIr9r/b2dfo0on1p0MNN+pkwRHWoY5ACSnp9FaGnwm/g71DM7AajIQPIk0TpRsSVNDx8Ygj1LPT+sQ==",
-      "requires": {
-        "@miniflare/shared": "2.4.0",
-        "kleur": "^4.1.4"
-      }
-    },
-    "@miniflare/core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.4.0.tgz",
-      "integrity": "sha512-vYl8xaWTFzxtkbzx3IkT4Py0OAFdfmFnVo627O1HKHWVGlkjVr8UKtxBpIR+f5pq/HCMzzqA1HM9FXO0dQfy3A==",
-      "requires": {
-        "@iarna/toml": "^2.2.5",
-        "@miniflare/shared": "2.4.0",
-        "@miniflare/watcher": "2.4.0",
-        "busboy": "^0.3.1",
-        "dotenv": "^10.0.0",
-        "kleur": "^4.1.4",
-        "set-cookie-parser": "^2.4.8",
-        "undici": "4.13.0"
-      },
-      "dependencies": {
-        "dotenv": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
-        }
-      }
-    },
-    "@miniflare/durable-objects": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.4.0.tgz",
-      "integrity": "sha512-VVLaUXXcAQcYE/3YmDLTacZf5OzR8bib6q1T9NqVb0uK5sLMQqyHvQdsG5rMqs7iyxfJxyZ0bL2OW9XGALOkoQ==",
-      "requires": {
-        "@miniflare/core": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "@miniflare/storage-memory": "2.4.0",
-        "undici": "4.13.0"
-      }
-    },
-    "@miniflare/html-rewriter": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.4.0.tgz",
-      "integrity": "sha512-ZG8819N7LelDD+8+Ss5FZpVyQQq/V2igod0qE68JK4he/w4/yn57Rk6Efb49y15HoHAXl2RpCCsnCyIow/Xjug==",
-      "requires": {
-        "@miniflare/core": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "html-rewriter-wasm": "^0.4.1",
-        "undici": "4.13.0"
-      }
-    },
-    "@miniflare/http-server": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.4.0.tgz",
-      "integrity": "sha512-r6Z/nqxE0oa1z63L95yvnG0PUeLRxZOeGS7ADxZMFKan4WD5lvYtSKDuDEm0lkbQshCOHQ3uXFr0cotOm8JoMQ==",
-      "requires": {
-        "@miniflare/core": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "@miniflare/web-sockets": "2.4.0",
-        "kleur": "^4.1.4",
-        "selfsigned": "^2.0.0",
-        "undici": "4.13.0",
-        "ws": "^8.2.2",
-        "youch": "^2.2.2"
-      },
-      "dependencies": {
-        "ws": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-          "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-          "requires": {}
-        }
-      }
-    },
-    "@miniflare/kv": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.4.0.tgz",
-      "integrity": "sha512-1UW7f1386xR6EDEXNZOR1TpFwQfRRSxUPqD6m/U0WprlsbM0cIYGz+AUeaVbkFf8lfE2MeXCUrjbWsLOvsnw3g==",
-      "requires": {
-        "@miniflare/shared": "2.4.0"
-      }
-    },
-    "@miniflare/runner-vm": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.4.0.tgz",
-      "integrity": "sha512-7sdwBYzXQTwYeR3tTvQ+vJfzc7BXwqR8AUPK9l5gvCtg+Geq9sMslr5SikIJpgcvbYqKDjvC9DQEPJ3sqr9cSQ==",
-      "requires": {
-        "@miniflare/shared": "2.4.0"
-      }
-    },
-    "@miniflare/scheduler": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.4.0.tgz",
-      "integrity": "sha512-dfMCXoAS8Y+3xABNxYju62I2xIBS54Op7ohCHoatvAM5RvualJUPICEMPZzX6/z29q5xPIeSLhLDhl/asAQ19w==",
-      "requires": {
-        "@miniflare/core": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "cron-schedule": "^3.0.4"
-      }
-    },
-    "@miniflare/shared": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.4.0.tgz",
-      "integrity": "sha512-lPQFzBUVGNQ93gQ/dliToWnO0OqAgsD3/902Pd/IixVSRwRj3BTnYv2dHMUKZcODBPrhnbqZeqcPWdBLzEx8uw==",
-      "requires": {
-        "ignore": "^5.1.8",
-        "kleur": "^4.1.4"
-      }
-    },
-    "@miniflare/sites": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.4.0.tgz",
-      "integrity": "sha512-YZy/TujnR1lkBvCncDDQ8tsWsXRE4JJ4x9a0bKN/XnZh7r6OhDM0sw4BFcBQhT6Ukdtttam1O3FlJxnMitrDGg==",
-      "requires": {
-        "@miniflare/kv": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "@miniflare/storage-file": "2.4.0"
-      }
-    },
-    "@miniflare/storage-file": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.4.0.tgz",
-      "integrity": "sha512-f1AUMz8xps/4VhNJMb8JeCevZFeU4pg2lIWmC11gG4xeq2nibTPBi6Qtx594Le7ZKij/tF6rRsoNfGau2Q5gdw==",
-      "requires": {
-        "@miniflare/shared": "2.4.0",
-        "@miniflare/storage-memory": "2.4.0"
-      }
-    },
-    "@miniflare/storage-memory": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.4.0.tgz",
-      "integrity": "sha512-mhWwgHhDNtEa7y1bYbdVucV0lqUmzagYXUSppAdSGS5JPyJMyw3HseqRNTk6gC/vKlvEYlFf3ugWcREGCedr9A==",
-      "requires": {
-        "@miniflare/shared": "2.4.0"
-      }
-    },
-    "@miniflare/watcher": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.4.0.tgz",
-      "integrity": "sha512-gDQRUxwOjmctvowyd4Hcdy3fjxz3ERKzirp6TvA3AWUohKZk3IhwGlaA8aCwbdP+ELYQlG5wK44AfLSGi956fg==",
-      "requires": {
-        "@miniflare/shared": "2.4.0"
-      }
-    },
-    "@miniflare/web-sockets": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.4.0.tgz",
-      "integrity": "sha512-cz/cN0GoQOXRLh80UmlcEJODPIw2ijKBK3PLRzvfTzqQ5avK6wp2M8Fj8C/5JIT6g7siwvBANyKXD3U3RpKGHQ==",
-      "requires": {
-        "@miniflare/core": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "undici": "4.13.0",
-        "ws": "^8.2.2"
-      },
-      "dependencies": {
-        "ws": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-          "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-          "requires": {}
-        }
-      }
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -23372,6 +23571,11 @@
       "resolved": "https://registry.npmjs.org/@schemastore/package/-/package-0.0.6.tgz",
       "integrity": "sha512-uNloNHoyHttSSdeuEkkSC+mdxJXMKlcUPOMb//qhQbIQijXg8x54VmAw3jm6GJZQ5DBtIqGBd66zEQCDCChQVA==",
       "dev": true
+    },
+    "@sinclair/typebox": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.23.5.tgz",
+      "integrity": "sha512-AFBVi/iT4g20DHoujvMH1aEDn8fGJh4xsRGCP6d8RpLPMqsNPvW01Jcn0QysXTsg++/xj25NmJsGyH9xug/wKg=="
     },
     "@sindresorhus/is": {
       "version": "4.4.0",
@@ -23782,7 +23986,6 @@
       "version": "17.0.10",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.10.tgz",
       "integrity": "sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==",
-      "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
       }
@@ -24707,14 +24910,6 @@
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
-    "busboy": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
-      "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
-      "requires": {
-        "dicer": "0.3.0"
-      }
-    },
     "cacache": {
       "version": "15.3.0",
       "dev": true,
@@ -25544,14 +25739,6 @@
     "devtools-protocol": {
       "version": "0.0.955664",
       "dev": true
-    },
-    "dicer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
-      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
-      "requires": {
-        "streamsearch": "0.1.2"
-      }
     },
     "diff": {
       "version": "5.0.0",
@@ -28836,24 +29023,6 @@
         }
       }
     },
-    "jest-environment-miniflare": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-miniflare/-/jest-environment-miniflare-2.4.0.tgz",
-      "integrity": "sha512-WTsUBXrjyX1yNWCnKyzTSNFfBNm3QxT+f4AXaaSBrZEHCjE4/zl08/BE0fSmVQah6Vp/N3pgrM2efYQD6xiaHw==",
-      "requires": {
-        "@miniflare/cache": "2.4.0",
-        "@miniflare/core": "2.4.0",
-        "@miniflare/durable-objects": "2.4.0",
-        "@miniflare/html-rewriter": "2.4.0",
-        "@miniflare/kv": "2.4.0",
-        "@miniflare/runner-vm": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "@miniflare/sites": "2.4.0",
-        "@miniflare/storage-memory": "2.4.0",
-        "@miniflare/web-sockets": "2.4.0",
-        "miniflare": "2.4.0"
-      }
-    },
     "jest-environment-node": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.5.1.tgz",
@@ -28948,7 +29117,309 @@
     "jest-environment-wrangler": {
       "version": "file:packages/jest-environment-wrangler",
       "requires": {
-        "jest-environment-miniflare": "2.4.0"
+        "jest-environment-miniflare": "2.5.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "28.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.0.tgz",
+          "integrity": "sha512-xmEggMPr317MIOjjDoZ4ejCSr9Lpbt/u34+dvc99t7DS8YirW5rwZEhzKPC2BMUFkUhI48qs6qLUSGw5FuL0GA==",
+          "requires": {
+            "@jest/schemas": "^28.0.2",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^17.0.8",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@miniflare/cache": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.5.0.tgz",
+          "integrity": "sha512-tJuDbWwzYsk4pJvPPJzdlfdGFqNnn1IN3JVrGDCq8UwOXm0K8hFiSwq2nMjjT+Z/9X2FfimgaXOx81zjPL+FjQ==",
+          "requires": {
+            "@miniflare/core": "2.5.0",
+            "@miniflare/shared": "2.5.0",
+            "http-cache-semantics": "^4.1.0",
+            "undici": "5.3.0"
+          }
+        },
+        "@miniflare/cli-parser": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.5.0.tgz",
+          "integrity": "sha512-aY/wQ4Rwy8x0Awtb8TzhKFYp4g1Y8xBhtKFfHOZpYCEFCVfKtgdk0pHPKctf/ClK0qJdT3siJKeXxsH2GRAMXg==",
+          "requires": {
+            "@miniflare/shared": "2.5.0",
+            "kleur": "^4.1.4"
+          }
+        },
+        "@miniflare/core": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.5.0.tgz",
+          "integrity": "sha512-BtMRi17DiimcpmDjQiIU6mIYSo/h21lVGC082n5G3JTF7AcGFAs7N2Fz2YLiYuc3zYc6qJx/NIjDoOqL2gfp3A==",
+          "requires": {
+            "@iarna/toml": "^2.2.5",
+            "@miniflare/shared": "2.5.0",
+            "@miniflare/watcher": "2.5.0",
+            "busboy": "^1.6.0",
+            "dotenv": "^10.0.0",
+            "kleur": "^4.1.4",
+            "set-cookie-parser": "^2.4.8",
+            "undici": "5.3.0",
+            "urlpattern-polyfill": "^4.0.3"
+          }
+        },
+        "@miniflare/durable-objects": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.5.0.tgz",
+          "integrity": "sha512-HJuP5Lsm/CCaSx3dePZiywAniGqTpU1ocCEqV6kE4zX1C0uGplfjPPXo5xsVc2NXkD+0ZL65rJzcj2tfrwKZlg==",
+          "requires": {
+            "@miniflare/core": "2.5.0",
+            "@miniflare/shared": "2.5.0",
+            "@miniflare/storage-memory": "2.5.0",
+            "undici": "5.3.0"
+          }
+        },
+        "@miniflare/html-rewriter": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.5.0.tgz",
+          "integrity": "sha512-bV2lQ/2clPeBmDth+cMnCBFYk8xtGs83S6PhfwmNNd24rzHvOEch1h/VCtEUy8k+rtgDSpc9pVkd31k0tMsyxQ==",
+          "requires": {
+            "@miniflare/core": "2.5.0",
+            "@miniflare/shared": "2.5.0",
+            "html-rewriter-wasm": "^0.4.1",
+            "undici": "5.3.0"
+          }
+        },
+        "@miniflare/http-server": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.5.0.tgz",
+          "integrity": "sha512-+sRPgNq0Q4Q6t1k94ncYzgcf/UNIv0Bz4ubUu6InJy4kMaJKeJPOLlU55lTXJSYfBZM/L4NvAui2i5vA9g2BrA==",
+          "requires": {
+            "@miniflare/core": "2.5.0",
+            "@miniflare/shared": "2.5.0",
+            "@miniflare/web-sockets": "2.5.0",
+            "kleur": "^4.1.4",
+            "selfsigned": "^2.0.0",
+            "undici": "5.3.0",
+            "ws": "^8.2.2",
+            "youch": "^2.2.2"
+          }
+        },
+        "@miniflare/kv": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.5.0.tgz",
+          "integrity": "sha512-5dzcUMMOKl8u75FXbpy2BHp38uafjzo3RW2HEm6EY8QoM/vHw6RChFzJ9YEPJDbvcHR8gdMpgC65LYPTjifc3g==",
+          "requires": {
+            "@miniflare/shared": "2.5.0"
+          }
+        },
+        "@miniflare/runner-vm": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.5.0.tgz",
+          "integrity": "sha512-0n85cOBq91D7roqsIqJESDnj0oRi+xNVjDfd5uDIT1dW1qo5asA5Mwx6ntzCJB1BcB4khNatUIwpO3ZT+kT/YQ==",
+          "requires": {
+            "@miniflare/shared": "2.5.0"
+          }
+        },
+        "@miniflare/scheduler": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.5.0.tgz",
+          "integrity": "sha512-+a/I2QLp3UaZpKVobzFH3eHsi5ubhBp8q/AH/sCDwcZmatbCp2+oDrjMgTqhF6Fm8ryR4BYkHQOgkGZ5l7gQjw==",
+          "requires": {
+            "@miniflare/core": "2.5.0",
+            "@miniflare/shared": "2.5.0",
+            "cron-schedule": "^3.0.4"
+          }
+        },
+        "@miniflare/shared": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.5.0.tgz",
+          "integrity": "sha512-2oPxhnCGg8DNoo0NzUdc2BylGGeHQQvFJ6mDODjxbSXybeQC0+Ul5Ujv/FyU9W/eTbUEWNqKBycINyuXqSnJ/w==",
+          "requires": {
+            "ignore": "^5.1.8",
+            "kleur": "^4.1.4"
+          }
+        },
+        "@miniflare/sites": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.5.0.tgz",
+          "integrity": "sha512-AwYZb6ppP00YLkVNJnCe0lzJJemCDwibFjJywECY+aXFFNRo80sLpePPOXytplaUpen1uxnxUc8vdKBFVoB5cQ==",
+          "requires": {
+            "@miniflare/kv": "2.5.0",
+            "@miniflare/shared": "2.5.0",
+            "@miniflare/storage-file": "2.5.0"
+          }
+        },
+        "@miniflare/storage-file": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.5.0.tgz",
+          "integrity": "sha512-ytwWZEIn3eMBnI2FdqvM5+mJVuI2aIBeZNjhZFuF5/AW3v1uslqY55Qd5Fnfn+2C7z6ivVaUv/TlEwot9ZDUnw==",
+          "requires": {
+            "@miniflare/shared": "2.5.0",
+            "@miniflare/storage-memory": "2.5.0"
+          }
+        },
+        "@miniflare/storage-memory": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.5.0.tgz",
+          "integrity": "sha512-cydVKLY0cZe2Sah0jV3s9MK3gmYLrQQcpCdMHMBEUz+nRfjfnuzs4WXzzUXCWwNT+WFC0V2WvDp2sMt+lVsmsA==",
+          "requires": {
+            "@miniflare/shared": "2.5.0"
+          }
+        },
+        "@miniflare/watcher": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.5.0.tgz",
+          "integrity": "sha512-6ECE7po8NBxLmr2M00f7TWLEp1dMaAm3swf4D3ZU2xy3IqSBZE3QbOBuczYEYUIk7F+kXgaREISQg4e5QdECXQ==",
+          "requires": {
+            "@miniflare/shared": "2.5.0"
+          }
+        },
+        "@miniflare/web-sockets": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.5.0.tgz",
+          "integrity": "sha512-nnLBtbHdmgGUNTxP0IeAz1B4UGCO/6W+4edzjogtz3JJumKQE+ink5+SIrmL0C1Pitrc2+kO2WYsQzWh3a2Amg==",
+          "requires": {
+            "@miniflare/core": "2.5.0",
+            "@miniflare/shared": "2.5.0",
+            "undici": "5.3.0",
+            "ws": "^8.2.2"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "busboy": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+          "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+          "requires": {
+            "streamsearch": "^1.1.0"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "dotenv": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "jest-environment-miniflare": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/jest-environment-miniflare/-/jest-environment-miniflare-2.5.0.tgz",
+          "integrity": "sha512-3OirfOB+kBxVBN5kOsXXQMgGHDUoO0+toulyoqGEWfZRa2kfL48CFCF10jB8A1K63cB5JMblN+uqyWUeZb/SBw==",
+          "requires": {
+            "@jest/environment": ">=27",
+            "@jest/fake-timers": ">=27",
+            "@jest/types": ">=27",
+            "@miniflare/cache": "2.5.0",
+            "@miniflare/core": "2.5.0",
+            "@miniflare/durable-objects": "2.5.0",
+            "@miniflare/html-rewriter": "2.5.0",
+            "@miniflare/kv": "2.5.0",
+            "@miniflare/runner-vm": "2.5.0",
+            "@miniflare/shared": "2.5.0",
+            "@miniflare/sites": "2.5.0",
+            "@miniflare/storage-memory": "2.5.0",
+            "@miniflare/web-sockets": "2.5.0",
+            "jest-mock": ">=27",
+            "jest-util": ">=27",
+            "miniflare": "2.5.0"
+          }
+        },
+        "jest-util": {
+          "version": "28.1.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.0.tgz",
+          "integrity": "sha512-qYdCKD77k4Hwkose2YBEqQk7PzUf/NSE+rutzceduFveQREeH6b+89Dc9+wjX9dAwHcgdx4yedGA3FQlU/qCTA==",
+          "requires": {
+            "@jest/types": "^28.1.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.9",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "miniflare": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.5.0.tgz",
+          "integrity": "sha512-3IR+n/kLBA7zQ20HDjnA0HufQlr197krD8jPsaYO5wTrkIUCTvrilbI0sCo0X9CP/I3BCIl8fiZc1Jf7+MX7jQ==",
+          "requires": {
+            "@miniflare/cache": "2.5.0",
+            "@miniflare/cli-parser": "2.5.0",
+            "@miniflare/core": "2.5.0",
+            "@miniflare/durable-objects": "2.5.0",
+            "@miniflare/html-rewriter": "2.5.0",
+            "@miniflare/http-server": "2.5.0",
+            "@miniflare/kv": "2.5.0",
+            "@miniflare/runner-vm": "2.5.0",
+            "@miniflare/scheduler": "2.5.0",
+            "@miniflare/shared": "2.5.0",
+            "@miniflare/sites": "2.5.0",
+            "@miniflare/storage-file": "2.5.0",
+            "@miniflare/storage-memory": "2.5.0",
+            "@miniflare/web-sockets": "2.5.0",
+            "kleur": "^4.1.4",
+            "semiver": "^1.1.0",
+            "source-map-support": "^0.5.20",
+            "undici": "5.3.0"
+          }
+        },
+        "streamsearch": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+          "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "undici": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/undici/-/undici-5.3.0.tgz",
+          "integrity": "sha512-8LxC/xmR2GCE4q1heE1sJxVnnf5S6yQ2dObvMFBBWkB8aQlaqNuWovgRFWRMB7KUdLPGZfOTTmUeeLEJYX56iQ=="
+        },
+        "ws": {
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
+          "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
+          "requires": {}
+        }
       }
     },
     "jest-fetch-mock": {
@@ -31208,31 +31679,6 @@
     },
     "min-indent": {
       "version": "1.0.1"
-    },
-    "miniflare": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.4.0.tgz",
-      "integrity": "sha512-xOBL/dQsUL95rxIYO+KrrVPPpm2TAf6TKl4AvhcjSfUeVkzDWd/y9f7hXCt8x6srDoK0Z2LpYouatvSfSUzGOw==",
-      "requires": {
-        "@miniflare/cache": "2.4.0",
-        "@miniflare/cli-parser": "2.4.0",
-        "@miniflare/core": "2.4.0",
-        "@miniflare/durable-objects": "2.4.0",
-        "@miniflare/html-rewriter": "2.4.0",
-        "@miniflare/http-server": "2.4.0",
-        "@miniflare/kv": "2.4.0",
-        "@miniflare/runner-vm": "2.4.0",
-        "@miniflare/scheduler": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "@miniflare/sites": "2.4.0",
-        "@miniflare/storage-file": "2.4.0",
-        "@miniflare/storage-memory": "2.4.0",
-        "@miniflare/web-sockets": "2.4.0",
-        "kleur": "^4.1.4",
-        "semiver": "^1.1.0",
-        "source-map-support": "^0.5.20",
-        "undici": "4.13.0"
-      }
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -33855,11 +34301,6 @@
         "mixme": "^0.5.1"
       }
     },
-    "streamsearch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
-    },
     "string_decoder": {
       "version": "1.1.1",
       "requires": {
@@ -34483,11 +34924,6 @@
         "which-boxed-primitive": "^1.0.2"
       }
     },
-    "undici": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-4.13.0.tgz",
-      "integrity": "sha512-8lk8S/f2V0VUNGf2scU2b+KI2JSzEQLdCyRNRF3XmHu+5jectlSDaPSBCXAHFaUlt1rzngzOBVDgJS9/Gue/KA=="
-    },
     "unified": {
       "version": "10.1.1",
       "dev": true,
@@ -34679,6 +35115,11 @@
           "dev": true
         }
       }
+    },
+    "urlpattern-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-4.0.3.tgz",
+      "integrity": "sha512-DOE84vZT2fEcl9gqCUTcnAw5ZY5Id55ikUcziSUntuEFL3pRvavg5kwDmTEUJkeCHInTlV/HexFomgYnzO5kdQ=="
     },
     "use": {
       "version": "3.1.1"
@@ -35400,7 +35841,7 @@
         "jest-fetch-mock": "^3.0.3",
         "jest-websocket-mock": "^2.3.0",
         "mime": "^3.0.0",
-        "miniflare": "2.4.0",
+        "miniflare": "2.5.0",
         "nanoid": "^3.3.3",
         "open": "^8.4.0",
         "p-queue": "^7.2.0",
@@ -35429,6 +35870,180 @@
           "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-3.0.0.tgz",
           "integrity": "sha512-td6ZUkz2oS3VeleBcN+m//Q6HlCFCPrnI0FZhrt/h4XqLEdOyYp2u21nd8MdsR+WJy5r9PTDaHTDDfhf4H4l6Q==",
           "dev": true
+        },
+        "@miniflare/cache": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.5.0.tgz",
+          "integrity": "sha512-tJuDbWwzYsk4pJvPPJzdlfdGFqNnn1IN3JVrGDCq8UwOXm0K8hFiSwq2nMjjT+Z/9X2FfimgaXOx81zjPL+FjQ==",
+          "requires": {
+            "@miniflare/core": "2.5.0",
+            "@miniflare/shared": "2.5.0",
+            "http-cache-semantics": "^4.1.0",
+            "undici": "5.3.0"
+          }
+        },
+        "@miniflare/cli-parser": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.5.0.tgz",
+          "integrity": "sha512-aY/wQ4Rwy8x0Awtb8TzhKFYp4g1Y8xBhtKFfHOZpYCEFCVfKtgdk0pHPKctf/ClK0qJdT3siJKeXxsH2GRAMXg==",
+          "requires": {
+            "@miniflare/shared": "2.5.0",
+            "kleur": "^4.1.4"
+          }
+        },
+        "@miniflare/core": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.5.0.tgz",
+          "integrity": "sha512-BtMRi17DiimcpmDjQiIU6mIYSo/h21lVGC082n5G3JTF7AcGFAs7N2Fz2YLiYuc3zYc6qJx/NIjDoOqL2gfp3A==",
+          "requires": {
+            "@iarna/toml": "^2.2.5",
+            "@miniflare/shared": "2.5.0",
+            "@miniflare/watcher": "2.5.0",
+            "busboy": "^1.6.0",
+            "dotenv": "^10.0.0",
+            "kleur": "^4.1.4",
+            "set-cookie-parser": "^2.4.8",
+            "undici": "5.3.0",
+            "urlpattern-polyfill": "^4.0.3"
+          },
+          "dependencies": {
+            "@iarna/toml": {
+              "version": "2.2.5",
+              "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+              "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
+            },
+            "dotenv": {
+              "version": "10.0.0",
+              "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+              "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+            }
+          }
+        },
+        "@miniflare/durable-objects": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.5.0.tgz",
+          "integrity": "sha512-HJuP5Lsm/CCaSx3dePZiywAniGqTpU1ocCEqV6kE4zX1C0uGplfjPPXo5xsVc2NXkD+0ZL65rJzcj2tfrwKZlg==",
+          "requires": {
+            "@miniflare/core": "2.5.0",
+            "@miniflare/shared": "2.5.0",
+            "@miniflare/storage-memory": "2.5.0",
+            "undici": "5.3.0"
+          }
+        },
+        "@miniflare/html-rewriter": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.5.0.tgz",
+          "integrity": "sha512-bV2lQ/2clPeBmDth+cMnCBFYk8xtGs83S6PhfwmNNd24rzHvOEch1h/VCtEUy8k+rtgDSpc9pVkd31k0tMsyxQ==",
+          "requires": {
+            "@miniflare/core": "2.5.0",
+            "@miniflare/shared": "2.5.0",
+            "html-rewriter-wasm": "^0.4.1",
+            "undici": "5.3.0"
+          }
+        },
+        "@miniflare/http-server": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.5.0.tgz",
+          "integrity": "sha512-+sRPgNq0Q4Q6t1k94ncYzgcf/UNIv0Bz4ubUu6InJy4kMaJKeJPOLlU55lTXJSYfBZM/L4NvAui2i5vA9g2BrA==",
+          "requires": {
+            "@miniflare/core": "2.5.0",
+            "@miniflare/shared": "2.5.0",
+            "@miniflare/web-sockets": "2.5.0",
+            "kleur": "^4.1.4",
+            "selfsigned": "^2.0.0",
+            "undici": "5.3.0",
+            "ws": "^8.2.2",
+            "youch": "^2.2.2"
+          }
+        },
+        "@miniflare/kv": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.5.0.tgz",
+          "integrity": "sha512-5dzcUMMOKl8u75FXbpy2BHp38uafjzo3RW2HEm6EY8QoM/vHw6RChFzJ9YEPJDbvcHR8gdMpgC65LYPTjifc3g==",
+          "requires": {
+            "@miniflare/shared": "2.5.0"
+          }
+        },
+        "@miniflare/runner-vm": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.5.0.tgz",
+          "integrity": "sha512-0n85cOBq91D7roqsIqJESDnj0oRi+xNVjDfd5uDIT1dW1qo5asA5Mwx6ntzCJB1BcB4khNatUIwpO3ZT+kT/YQ==",
+          "requires": {
+            "@miniflare/shared": "2.5.0"
+          }
+        },
+        "@miniflare/scheduler": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.5.0.tgz",
+          "integrity": "sha512-+a/I2QLp3UaZpKVobzFH3eHsi5ubhBp8q/AH/sCDwcZmatbCp2+oDrjMgTqhF6Fm8ryR4BYkHQOgkGZ5l7gQjw==",
+          "requires": {
+            "@miniflare/core": "2.5.0",
+            "@miniflare/shared": "2.5.0",
+            "cron-schedule": "^3.0.4"
+          }
+        },
+        "@miniflare/shared": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.5.0.tgz",
+          "integrity": "sha512-2oPxhnCGg8DNoo0NzUdc2BylGGeHQQvFJ6mDODjxbSXybeQC0+Ul5Ujv/FyU9W/eTbUEWNqKBycINyuXqSnJ/w==",
+          "requires": {
+            "ignore": "^5.1.8",
+            "kleur": "^4.1.4"
+          }
+        },
+        "@miniflare/sites": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.5.0.tgz",
+          "integrity": "sha512-AwYZb6ppP00YLkVNJnCe0lzJJemCDwibFjJywECY+aXFFNRo80sLpePPOXytplaUpen1uxnxUc8vdKBFVoB5cQ==",
+          "requires": {
+            "@miniflare/kv": "2.5.0",
+            "@miniflare/shared": "2.5.0",
+            "@miniflare/storage-file": "2.5.0"
+          }
+        },
+        "@miniflare/storage-file": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.5.0.tgz",
+          "integrity": "sha512-ytwWZEIn3eMBnI2FdqvM5+mJVuI2aIBeZNjhZFuF5/AW3v1uslqY55Qd5Fnfn+2C7z6ivVaUv/TlEwot9ZDUnw==",
+          "requires": {
+            "@miniflare/shared": "2.5.0",
+            "@miniflare/storage-memory": "2.5.0"
+          }
+        },
+        "@miniflare/storage-memory": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.5.0.tgz",
+          "integrity": "sha512-cydVKLY0cZe2Sah0jV3s9MK3gmYLrQQcpCdMHMBEUz+nRfjfnuzs4WXzzUXCWwNT+WFC0V2WvDp2sMt+lVsmsA==",
+          "requires": {
+            "@miniflare/shared": "2.5.0"
+          }
+        },
+        "@miniflare/watcher": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.5.0.tgz",
+          "integrity": "sha512-6ECE7po8NBxLmr2M00f7TWLEp1dMaAm3swf4D3ZU2xy3IqSBZE3QbOBuczYEYUIk7F+kXgaREISQg4e5QdECXQ==",
+          "requires": {
+            "@miniflare/shared": "2.5.0"
+          }
+        },
+        "@miniflare/web-sockets": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.5.0.tgz",
+          "integrity": "sha512-nnLBtbHdmgGUNTxP0IeAz1B4UGCO/6W+4edzjogtz3JJumKQE+ink5+SIrmL0C1Pitrc2+kO2WYsQzWh3a2Amg==",
+          "requires": {
+            "@miniflare/core": "2.5.0",
+            "@miniflare/shared": "2.5.0",
+            "undici": "5.3.0",
+            "ws": "^8.2.2"
+          }
+        },
+        "busboy": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+          "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+          "requires": {
+            "streamsearch": "^1.1.0"
+          }
         },
         "dotenv": {
           "version": "16.0.0",
@@ -35602,6 +36217,31 @@
             "p-locate": "^6.0.0"
           }
         },
+        "miniflare": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.5.0.tgz",
+          "integrity": "sha512-3IR+n/kLBA7zQ20HDjnA0HufQlr197krD8jPsaYO5wTrkIUCTvrilbI0sCo0X9CP/I3BCIl8fiZc1Jf7+MX7jQ==",
+          "requires": {
+            "@miniflare/cache": "2.5.0",
+            "@miniflare/cli-parser": "2.5.0",
+            "@miniflare/core": "2.5.0",
+            "@miniflare/durable-objects": "2.5.0",
+            "@miniflare/html-rewriter": "2.5.0",
+            "@miniflare/http-server": "2.5.0",
+            "@miniflare/kv": "2.5.0",
+            "@miniflare/runner-vm": "2.5.0",
+            "@miniflare/scheduler": "2.5.0",
+            "@miniflare/shared": "2.5.0",
+            "@miniflare/sites": "2.5.0",
+            "@miniflare/storage-file": "2.5.0",
+            "@miniflare/storage-memory": "2.5.0",
+            "@miniflare/web-sockets": "2.5.0",
+            "kleur": "^4.1.4",
+            "semiver": "^1.1.0",
+            "source-map-support": "^0.5.20",
+            "undici": "5.3.0"
+          }
+        },
         "p-limit": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
@@ -35624,6 +36264,11 @@
           "version": "5.0.0",
           "dev": true
         },
+        "streamsearch": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+          "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
+        },
         "supports-color": {
           "version": "9.2.2",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.2.2.tgz",
@@ -35633,14 +36278,12 @@
         "undici": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/undici/-/undici-5.3.0.tgz",
-          "integrity": "sha512-8LxC/xmR2GCE4q1heE1sJxVnnf5S6yQ2dObvMFBBWkB8aQlaqNuWovgRFWRMB7KUdLPGZfOTTmUeeLEJYX56iQ==",
-          "dev": true
+          "integrity": "sha512-8LxC/xmR2GCE4q1heE1sJxVnnf5S6yQ2dObvMFBBWkB8aQlaqNuWovgRFWRMB7KUdLPGZfOTTmUeeLEJYX56iQ=="
         },
         "ws": {
           "version": "8.5.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
           "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-          "dev": true,
           "requires": {}
         },
         "yocto-queue": {

--- a/packages/jest-environment-wrangler/package.json
+++ b/packages/jest-environment-wrangler/package.json
@@ -17,6 +17,6 @@
   "author": "wrangler@cloudflare.com",
   "license": "ISC",
   "dependencies": {
-    "jest-environment-miniflare": "2.5.0"
+    "jest-environment-miniflare": "^2.5.0"
   }
 }

--- a/packages/jest-environment-wrangler/package.json
+++ b/packages/jest-environment-wrangler/package.json
@@ -17,6 +17,6 @@
   "author": "wrangler@cloudflare.com",
   "license": "ISC",
   "dependencies": {
-    "jest-environment-miniflare": "2.4.0"
+    "jest-environment-miniflare": "2.5.0"
   }
 }

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -40,7 +40,7 @@
     "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
     "blake3-wasm": "^2.1.5",
     "esbuild": "0.14.34",
-    "miniflare": "2.4.0",
+    "miniflare": "2.5.0",
     "nanoid": "^3.3.3",
     "path-to-regexp": "^6.2.0",
     "selfsigned": "^2.0.1",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -40,7 +40,7 @@
     "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
     "blake3-wasm": "^2.1.5",
     "esbuild": "0.14.34",
-    "miniflare": "2.5.0",
+    "miniflare": "^2.5.0",
     "nanoid": "^3.3.3",
     "path-to-regexp": "^6.2.0",
     "selfsigned": "^2.0.1",


### PR DESCRIPTION
Hey! 👋 This PR upgrades `miniflare` to version `2.5.0`. See the [full changelog here](https://github.com/cloudflare/miniflare/releases/tag/v2.5.0).