### PR TITLE
fix: manifest keys contains backslash (windows)

### DIFF
--- a/packages/wrangler/src/__tests__/helpers/run-wrangler.ts
+++ b/packages/wrangler/src/__tests__/helpers/run-wrangler.ts
@@ -4,12 +4,14 @@ import { normalizeSlashes, stripTimings } from "./mock-console";
 /**
  * A helper to 'run' wrangler commands for tests.
  */
-export async function runWrangler(cmd?: string) {
+export async function runWrangler(cmd?: string, _normalizeSlashes = true) {
   try {
     await main(cmd?.split(" ") ?? []);
   } catch (err) {
     if (err instanceof Error) {
-      err.message = normalizeSlashes(stripTimings(err.message));
+      err.message = _normalizeSlashes
+        ? normalizeSlashes(stripTimings(err.message))
+        : stripTimings(err.message);
     }
     throw err;
   }

--- a/packages/wrangler/src/__tests__/helpers/run-wrangler.ts
+++ b/packages/wrangler/src/__tests__/helpers/run-wrangler.ts
@@ -4,14 +4,12 @@ import { normalizeSlashes, stripTimings } from "./mock-console";
 /**
  * A helper to 'run' wrangler commands for tests.
  */
-export async function runWrangler(cmd?: string, _normalizeSlashes = true) {
+export async function runWrangler(cmd?: string) {
   try {
     await main(cmd?.split(" ") ?? []);
   } catch (err) {
     if (err instanceof Error) {
-      err.message = _normalizeSlashes
-        ? normalizeSlashes(stripTimings(err.message))
-        : stripTimings(err.message);
+      err.message = normalizeSlashes(stripTimings(err.message));
     }
     throw err;
   }

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -1327,6 +1327,56 @@ addEventListener('fetch', event => {});`
       expect(std.err).toMatchInlineSnapshot(`""`);
     });
 
+    it("should not contain backslash for assets with nested directories", async () => {
+      const assets = [
+        { filePath: "assets/subdir/file-1.txt", content: "Content of file-1" },
+        { filePath: "assets/subdir/file-2.txt", content: "Content of file-2" },
+      ];
+      const kvNamespace = {
+        title: "__test-name-workers_sites_assets",
+        id: "__test-name-workers_sites_assets-id",
+      };
+      writeWranglerToml({
+        main: "./index.js",
+        site: {
+          bucket: "assets",
+        },
+      });
+      writeWorkerSource();
+      writeAssets(assets);
+      mockUploadWorkerRequest({
+        expectedBindings: [
+          {
+            name: "__STATIC_CONTENT",
+            namespace_id: "__test-name-workers_sites_assets-id",
+            type: "kv_namespace",
+          },
+        ],
+        expectedModules: {
+          __STATIC_CONTENT_MANIFEST:
+            '{"subdir/file-1.txt":"assets/subdir/file-1.2ca234f380.txt","subdir/file-2.txt":"assets/subdir/file-2.5938485188.txt"}',
+        },
+      });
+      mockSubDomainRequest();
+      mockListKVNamespacesRequest(kvNamespace);
+      mockKeyListRequest(kvNamespace.id, []);
+      mockUploadAssetsToKVRequest(kvNamespace.id, assets);
+
+      await runWrangler("publish", false);
+
+      expect(std.out).toMatchInlineSnapshot(`
+        "Reading assets/subdir/file-1.txt...
+        Uploading as assets/subdir/file-1.2ca234f380.txt...
+        Reading assets/subdir/file-2.txt...
+        Uploading as assets/subdir/file-2.5938485188.txt...
+        ↗️  Done syncing assets
+        Uploaded test-name (TIMINGS)
+        Published test-name (TIMINGS)
+          test-name.test-sub-domain.workers.dev"
+      `);
+      expect(std.err).toMatchInlineSnapshot(`""`);
+    });
+
     it("when using a service-worker type, it should add an asset manifest as a text_blob, and bind to a namespace", async () => {
       const assets = [
         { filePath: "assets/file-1.txt", content: "Content of file-1" },

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -1362,7 +1362,7 @@ addEventListener('fetch', event => {});`
       mockKeyListRequest(kvNamespace.id, []);
       mockUploadAssetsToKVRequest(kvNamespace.id, assets);
 
-      await runWrangler("publish", false);
+      await runWrangler("publish");
 
       expect(std.out).toMatchInlineSnapshot(`
         "Reading assets/subdir/file-1.txt...

--- a/packages/wrangler/src/sites.tsx
+++ b/packages/wrangler/src/sites.tsx
@@ -177,7 +177,12 @@ export async function syncAssets(
 
     // remove the key from the set so we know what we've already uploaded
     namespaceKeys.delete(assetKey);
-    manifest[path.relative(siteAssets.assetDirectory, absAssetFile)] = assetKey;
+
+    // prevent causing different manifest keys on windows
+    const maifestKey = urlSafe(
+      path.relative(siteAssets.assetDirectory, absAssetFile)
+    );
+    manifest[maifestKey] = assetKey;
   }
 
   // keys now contains all the files we're deleting


### PR DESCRIPTION
Static assets manifest keys contain backslash on the Windows platform causing different manifests on different platforms.

This PR makes sure manifest keys are the same on Windows.