### PR TITLE
polish: Give a copy-paste config when `[migrations]` are missing

### DIFF
--- a/.changeset/rare-chicken-cross.md
+++ b/.changeset/rare-chicken-cross.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+polish: Give a copy-paste config when `[migrations]` are missing
+
+This gives a slightly better message when migrations are missing for declared durable objcts. Specifically, it gives a copy-pastable section to add to wrangler.toml, and doesn't show the warning at all for invalid class names anymore.
+
+Partially makes https://github.com/cloudflare/wrangler2/issues/1076 better.

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -678,7 +678,15 @@ describe("normalizeAndValidateConfig()", () => {
         "Processing wrangler configuration:
           - \\"unsafe\\" fields are experimental and may change or break at any time.
           - \\"services\\" fields are experimental and may change or break at any time.
-          - In wrangler.toml, you have configured [durable_objects] exported by this Worker (CLASS1), but no [migrations] for them. This may not work as expected until you add a [migrations] section to your wrangler.toml. Refer to https://developers.cloudflare.com/workers/learning/using-durable-objects/#durable-object-migrations-in-wranglertoml for more details."
+          - In wrangler.toml, you have configured [durable_objects] exported by this Worker (CLASS1), but no [migrations] for them. This may not work as expected until you add a [migrations] section to your wrangler.toml. Add this configuration to your wrangler.toml:
+
+              \`\`\`
+              [[migrations]]
+              tag = \\"v1\\" # Should be unique for each entry
+              new_classes = [\\"CLASS1\\"]
+              \`\`\`
+
+            Refer to https://developers.cloudflare.com/workers/learning/using-durable-objects/#durable-object-migrations-in-wranglertoml for more details."
       `);
     });
 
@@ -1157,12 +1165,9 @@ describe("normalizeAndValidateConfig()", () => {
             durable_objects: { bindings: expect.anything },
           })
         );
-        expect(diagnostics.hasWarnings()).toBe(true);
+        expect(diagnostics.hasWarnings()).toBe(false);
+
         expect(diagnostics.hasErrors()).toBe(true);
-        expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
-          "Processing wrangler configuration:
-            - In wrangler.toml, you have configured [durable_objects] exported by this Worker ((unnamed), (unnamed), 1666, SomeClass, 1883), but no [migrations] for them. This may not work as expected until you add a [migrations] section to your wrangler.toml. Refer to https://developers.cloudflare.com/workers/learning/using-durable-objects/#durable-object-migrations-in-wranglertoml for more details."
-        `);
         expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
           "Processing wrangler configuration:
 
@@ -2474,12 +2479,8 @@ describe("normalizeAndValidateConfig()", () => {
             durable_objects: { bindings: expect.anything },
           })
         );
-        expect(diagnostics.hasWarnings()).toBe(true);
+        expect(diagnostics.hasWarnings()).toBe(false);
         expect(diagnostics.hasErrors()).toBe(true);
-        expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
-          "Processing wrangler configuration:
-            - In wrangler.toml, you have configured [durable_objects] exported by this Worker ((unnamed), (unnamed), 1666), but no [migrations] for them. This may not work as expected until you add a [migrations] section to your wrangler.toml. Refer to https://developers.cloudflare.com/workers/learning/using-durable-objects/#durable-object-migrations-in-wranglertoml for more details."
-        `);
         expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
           "Processing wrangler configuration:
 

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -704,7 +704,15 @@ describe("wrangler dev", () => {
 
             - In wrangler.toml, you have configured [durable_objects] exported by this Worker (CLASS_1,
           CLASS_3), but no [migrations] for them. This may not work as expected until you add a [migrations]
-          section to your wrangler.toml. Refer to
+          section to your wrangler.toml. Add this configuration to your wrangler.toml:
+
+                \`\`\`
+                [[migrations]]
+                tag = \\"v1\\" # Should be unique for each entry
+                new_classes = [\\"CLASS_1\\", \\"CLASS_3\\"]
+                \`\`\`
+
+              Refer to
           [4mhttps://developers.cloudflare.com/workers/learning/using-durable-objects/#durable-object-migrations-in-wranglertoml[0m
           for more details.
 

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -2895,7 +2895,15 @@ addEventListener('fetch', event => {});`
 
             - In wrangler.toml, you have configured [durable_objects] exported by this Worker (SomeClass),
           but no [migrations] for them. This may not work as expected until you add a [migrations] section
-          to your wrangler.toml. Refer to
+          to your wrangler.toml. Add this configuration to your wrangler.toml:
+
+                \`\`\`
+                [[migrations]]
+                tag = \\"v1\\" # Should be unique for each entry
+                new_classes = [\\"SomeClass\\"]
+                \`\`\`
+
+              Refer to
           [4mhttps://developers.cloudflare.com/workers/learning/using-durable-objects/#durable-object-migrations-in-wranglertoml[0m
           for more details.
 


### PR DESCRIPTION
This gives a slightly better message when migrations are missing for declared durable objcts. Specifically, it gives a copy-pastable section to add to wrangler.toml, and doesn't show the warning at all for invalid class names anymore.

Partially makes https://github.com/cloudflare/wrangler2/issues/1076 better.