### PR TITLE
Bump minimum supported node version to v16.14.2 (Gallium)

### DIFF
--- a/.changeset/happy-fans-wave.md
+++ b/.changeset/happy-fans-wave.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Bump minimum supported node version to v16.14.2 (Gallium)

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "typescript": "^4.6.3"
       },
       "engines": {
-        "node": ">=16.7.0"
+        "node": ">=16.13.2"
       }
     },
     "examples/local-mode-tests": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "prettify": "prettier packages/** --write --ignore-unknown"
   },
   "engines": {
-    "node": ">=16.7.0"
+    "node": ">=16.13.2"
   },
   "eslintConfig": {
     "root": true,
@@ -132,6 +132,6 @@
     ]
   },
   "volta": {
-    "node": "16.7.0"
+    "node": "16.13.2"
   }
 }


### PR DESCRIPTION
The version of Node that we had been using (v16.7.0) is listed as "Current" in the [Node v16 changelog](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V16.md). We should be using LTS releases, which as of now includes v16.13-15.
