### PR TITLE
fix: Ignore .git dir during pages publish

### DIFF
--- a/.changeset/empty-news-jog.md
+++ b/.changeset/empty-news-jog.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Ignore .git when publishing a Pages project

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -1066,7 +1066,7 @@ const createDeployment: CommandModule<
       "_headers",
       ".DS_Store",
       "node_modules",
-      ".git"
+      ".git",
     ];
 
     const walk = async (

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -1066,6 +1066,7 @@ const createDeployment: CommandModule<
       "_headers",
       ".DS_Store",
       "node_modules",
+      ".git"
     ];
 
     const walk = async (


### PR DESCRIPTION
Fixes #1119 