### PR TITLE
fix: Skip cfFetch if there are no functions during pages dev

### DIFF
--- a/.changeset/perfect-numbers-decide.md
+++ b/.changeset/perfect-numbers-decide.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Skip cfFetch if there are no functions during pages dev

--- a/packages/wrangler/src/pages.tsx
+++ b/packages/wrangler/src/pages.tsx
@@ -1522,6 +1522,9 @@ export const pages: BuilderCallback<unknown, unknown> = (yargs) => {
           } else {
             logger.log("No functions. Shimming...");
             miniflareArgs = {
+              // cfFetch sets the `cf` object that a function could expect
+              // If there are no functions, there's no reason to set this up (and not make that network call)
+              cfFetch: false,
               // TODO: The fact that these request/response hacks are necessary is ridiculous.
               // We need to eliminate them from env.ASSETS.fetch (not sure if just local or prod as well)
               script: `


### PR DESCRIPTION
Fixes #1115 