### PR TITLE
fix: only log available bindings once in `dev`

### DIFF
--- a/.changeset/cyan-guests-grin.md
+++ b/.changeset/cyan-guests-grin.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: only log available bindings once in `dev`
+
+Because we were calling `printBindings` during the render phase of `<Dev/>`, we were logging the bindings multiple times (render can be called multiple times, and the interaction of Ink's stdout output intermingled with console is a bit weird). We could have put it into an effect, but I think a better solution here is to simply log it before we even start rendering `<Dev/>` (so we could see the bindings even if Dev fails to load, for example).
+
+This also adds a fix that masks any overriden values so that we don't accidentally log potential secrets into the terminal.

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -9,7 +9,6 @@ import { withErrorBoundary, useErrorHandler } from "react-error-boundary";
 import onExit from "signal-exit";
 import tmp from "tmp-promise";
 import { fetch } from "undici";
-import { printBindings } from "../config";
 import { runCustomBuild } from "../entry";
 import { openInspector } from "../inspect";
 import { logger } from "../logger";
@@ -105,8 +104,6 @@ export function DevImplementation(props: DevProps): JSX.Element {
     minify: props.minify,
     nodeCompat: props.nodeCompat,
   });
-
-  printBindings(props.bindings);
 
   // only load the UI if we're running in a supported environment
   const { isRawModeSupported } = useStdin();


### PR DESCRIPTION
Because we were calling `printBindings` during the render phase of `<Dev/>`, we were logging the bindings multiple times (render can be called multiple times, and the interaction of Ink's stdout output intermingled with console is a bit weird). We could have put it into an effect, but I think a better solution here is to simply log it before we even start rendering `<Dev/>` (so we could see the bindings even if Dev fails to load, for example).

This also adds a fix that masks any overriden values so that we don't accidentally log potential secrets into the terminal.