### PR TITLE
fix: link to the issue chooser in GitHub

### DIFF
--- a/.changeset/fast-mangos-protect.md
+++ b/.changeset/fast-mangos-protect.md
@@ -1,0 +1,13 @@
+---
+"wrangler": patch
+---
+
+fix: link to the issue chooser in GitHub
+
+Previously, when an error occurs, wrangler says:
+
+> If you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.
+
+Now, it links through to the issue template chooser which is more helpful.
+
+Fixes [#1169](https://github.com/cloudflare/wrangler2/issues/1169)

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -83,7 +83,7 @@ describe("wrangler dev", () => {
 
       expect(std.out).toMatchInlineSnapshot(`
         "
-        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
+        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
       `);
       expect(std.err).toMatchInlineSnapshot(`
         "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mMissing entry-point: The entry-point should be specified via the command line (e.g. \`wrangler dev path/to/script\`) or the \`main\` config field.[0m
@@ -467,7 +467,7 @@ describe("wrangler dev", () => {
       expect(std.out).toMatchInlineSnapshot(`
         "Running custom build: node -e \\"console.log('custom build');\\"
 
-        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
+        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
       `);
       expect(std.err).toMatchInlineSnapshot(`
         "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mThe expected output file at \\"index.js\\" was not found after running custom build: node -e \\"console.log('custom build');\\".[0m

--- a/packages/wrangler/src/__tests__/kv.test.ts
+++ b/packages/wrangler/src/__tests__/kv.test.ts
@@ -663,7 +663,7 @@ describe("wrangler", () => {
 
         expect(std.out).toMatchInlineSnapshot(`
           "
-          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
+          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
         `);
         expect(std.err).toMatchInlineSnapshot(`
           "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA namespace with binding name \\"otherBinding\\" was not found in the configured \\"kv_namespaces\\".[0m
@@ -685,7 +685,7 @@ describe("wrangler", () => {
         );
         expect(std.out).toMatchInlineSnapshot(`
           "
-          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
+          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
         `);
         expect(std.err).toMatchInlineSnapshot(`
           "[31mX [41;31m[[41;97mERROR[41;31m][0m [1msomeBinding has both a namespace ID and a preview ID. Specify \\"--preview\\" or \\"--preview false\\" to avoid writing data to the wrong namespace.[0m
@@ -856,7 +856,7 @@ describe("wrangler", () => {
         `);
         expect(std.out).toMatchInlineSnapshot(`
           "
-          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
+          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
         `);
       });
     });
@@ -1044,7 +1044,7 @@ describe("wrangler", () => {
         );
         expect(std.out).toMatchInlineSnapshot(`
           "
-          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
+          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
         `);
         expect(std.err).toMatchInlineSnapshot(`
           "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA namespace with binding name \\"otherBinding\\" was not found in the configured \\"kv_namespaces\\".[0m
@@ -1226,7 +1226,7 @@ describe("wrangler", () => {
               `);
         expect(std.out).toMatchInlineSnapshot(`
           "
-          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
+          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
         `);
         expect(std.warn).toMatchInlineSnapshot(`""`);
       });
@@ -1288,7 +1288,7 @@ describe("wrangler", () => {
 
         expect(std.out).toMatchInlineSnapshot(`
           "
-          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
+          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
         `);
         expect(std.warn).toMatchInlineSnapshot(`
           "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mUnexpected key-value properties in \\"keys.json\\".[0m
@@ -1429,7 +1429,7 @@ describe("wrangler", () => {
               `);
         expect(std.out).toMatchInlineSnapshot(`
           "
-          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
+          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
         `);
         expect(std.warn).toMatchInlineSnapshot(`""`);
       });
@@ -1454,7 +1454,7 @@ describe("wrangler", () => {
               `);
         expect(std.out).toMatchInlineSnapshot(`
           "
-          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
+          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
         `);
         expect(std.warn).toMatchInlineSnapshot(`""`);
       });

--- a/packages/wrangler/src/__tests__/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages.test.ts
@@ -79,7 +79,7 @@ describe("pages", () => {
       expect(std.out).toMatchInlineSnapshot(`
         "🚧 'wrangler pages <command>' is a beta command. Please report any issues to https://github.com/cloudflare/wrangler2/issues/new/choose
 
-        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
+        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
       `);
     });
 
@@ -89,7 +89,7 @@ describe("pages", () => {
       expect(std.out).toMatchInlineSnapshot(`
         "🚧 'wrangler pages <command>' is a beta command. Please report any issues to https://github.com/cloudflare/wrangler2/issues/new/choose
 
-        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
+        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
       `);
     });
   });
@@ -374,10 +374,10 @@ describe("pages", () => {
             const body = init.body as FormData;
             const manifest = JSON.parse(body.get("manifest") as string);
             expect(manifest).toMatchInlineSnapshot(`
-            Object {
-              "/logo.png": "2082190357cfd3617ccfe04f340c6247",
-            }
-          `);
+                          Object {
+                            "/logo.png": "2082190357cfd3617ccfe04f340c6247",
+                          }
+                      `);
           });
 
           return {
@@ -445,10 +445,10 @@ describe("pages", () => {
             const body = init.body as FormData;
             const manifest = JSON.parse(body.get("manifest") as string);
             expect(manifest).toMatchInlineSnapshot(`
-            Object {
-              "/logo.txt": "1a98fb08af91aca4a7df1764a2c4ddb0",
-            }
-          `);
+                          Object {
+                            "/logo.txt": "1a98fb08af91aca4a7df1764a2c4ddb0",
+                          }
+                      `);
           });
 
           return {
@@ -533,13 +533,13 @@ describe("pages", () => {
             const body = init.body as FormData;
             const manifest = JSON.parse(body.get("manifest") as string);
             expect(manifest).toMatchInlineSnapshot(`
-            Object {
-              "/logo.html": "d96fef225537c9f5e44a3cb27fd0b492",
-              "/logo.js": "6be321bef99e758250dac034474ddbb8",
-              "/logo.png": "2082190357cfd3617ccfe04f340c6247",
-              "/logo.txt": "1a98fb08af91aca4a7df1764a2c4ddb0",
-            }
-          `);
+                          Object {
+                            "/logo.html": "d96fef225537c9f5e44a3cb27fd0b492",
+                            "/logo.js": "6be321bef99e758250dac034474ddbb8",
+                            "/logo.png": "2082190357cfd3617ccfe04f340c6247",
+                            "/logo.txt": "1a98fb08af91aca4a7df1764a2c4ddb0",
+                          }
+                      `);
           });
 
           return {

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -1121,7 +1121,7 @@ addEventListener('fetch', event => {});`
 
       expect(std.out).toMatchInlineSnapshot(`
         "
-        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
+        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
       `);
       expect(std.err).toMatchInlineSnapshot(`
         "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mProcessing wrangler.toml configuration:[0m
@@ -1279,7 +1279,7 @@ addEventListener('fetch', event => {});`
 
       expect(std.out).toMatchInlineSnapshot(`
         "
-        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
+        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
       `);
       expect(std.err).toMatchInlineSnapshot(`
         "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mMissing entry-point: The entry-point should be specified via the command line (e.g. \`wrangler publish path/to/script\`) or the \`main\` config field.[0m
@@ -1990,7 +1990,7 @@ addEventListener('fetch', event => {});`
         "Reading assets/large-file.txt...
         Uploading as assets/large-file.0ea0637a45.txt...
 
-        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
+        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
       `);
       expect(std.err).toMatchInlineSnapshot(`
         "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mFile assets/too-large-file.txt is too big, it should be under 25 MiB. See https://developers.cloudflare.com/workers/platform/limits#kv-limits[0m
@@ -2030,7 +2030,7 @@ addEventListener('fetch', event => {});`
       expect(std.out).toMatchInlineSnapshot(`
         "Reading assets/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/file.txt...
 
-        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
+        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
       `);
       expect(std.err).toMatchInlineSnapshot(`
         "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mThe asset path key \\"assets/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/folder/file.3da0d0cd12.txt\\" exceeds the maximum key size limit of 512. See https://developers.cloudflare.com/workers/platform/limits#kv-limits\\",[0m
@@ -2741,7 +2741,7 @@ addEventListener('fetch', event => {});`
       expect(std.out).toMatchInlineSnapshot(`
         "Running custom build: node -e \\"console.log('custom build');\\"
 
-        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
+        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
       `);
       expect(std.err).toMatchInlineSnapshot(`
         "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mThe expected output file at \\"index.js\\" was not found after running custom build: node -e \\"console.log('custom build');\\".[0m
@@ -2780,7 +2780,7 @@ addEventListener('fetch', event => {});`
       expect(std.out).toMatchInlineSnapshot(`
         "Running custom build: node -e \\"console.log('custom build');\\"
 
-        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
+        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
       `);
       expect(std.err).toMatchInlineSnapshot(`
         "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mThe expected output file at \\".\\" was not found after running custom build: node -e \\"console.log('custom build');\\".[0m
@@ -3589,7 +3589,7 @@ addEventListener('fetch', event => {});`
             `);
       expect(std.out).toMatchInlineSnapshot(`
         "
-        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
+        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
       `);
       expect(std.err).toMatchInlineSnapshot(`
         "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mProcessing wrangler.toml configuration:[0m
@@ -3688,7 +3688,7 @@ addEventListener('fetch', event => {});`
             `);
       expect(std.out).toMatchInlineSnapshot(`
         "
-        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
+        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
       `);
       expect(std.err).toMatchInlineSnapshot(`
         "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mProcessing wrangler.toml configuration:[0m
@@ -3822,7 +3822,7 @@ addEventListener('fetch', event => {});`
             `);
       expect(std.out).toMatchInlineSnapshot(`
         "
-        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
+        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
       `);
       expect(std.err).toMatchInlineSnapshot(`
         "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mProcessing wrangler.toml configuration:[0m
@@ -3896,7 +3896,7 @@ addEventListener('fetch', event => {});`
         );
         expect(std.out).toMatchInlineSnapshot(`
           "
-          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
+          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
         `);
         expect(std.err).toMatchInlineSnapshot(`
           "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mYou cannot configure [wasm_modules] with an ES module worker. Instead, import the .wasm module directly in your code[0m
@@ -4033,7 +4033,7 @@ addEventListener('fetch', event => {});`
         );
         expect(std.out).toMatchInlineSnapshot(`
           "
-          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
+          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
         `);
         expect(std.err).toMatchInlineSnapshot(`
           "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mYou cannot configure [text_blobs] with an ES module worker. Instead, import the file directly in your code, and optionally configure \`[rules]\` in your wrangler.toml[0m
@@ -4142,7 +4142,7 @@ addEventListener('fetch', event => {});`
         );
         expect(std.out).toMatchInlineSnapshot(`
           "
-          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
+          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
         `);
         expect(std.err).toMatchInlineSnapshot(`
           "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mYou cannot configure [data_blobs] with an ES module worker. Instead, import the file directly in your code, and optionally configure \`[rules]\` in your wrangler.toml[0m

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -148,7 +148,7 @@ describe("wrangler secret", () => {
         }
         expect(std.out).toMatchInlineSnapshot(`
           "
-          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
+          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
         `);
         expect(std.err).toMatchInlineSnapshot(`
           "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mMissing script name[0m
@@ -204,7 +204,7 @@ describe("wrangler secret", () => {
 
         expect(std.out).toMatchInlineSnapshot(`
           "
-          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
+          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
         `);
         expect(std.warn).toMatchInlineSnapshot(`""`);
       });
@@ -372,7 +372,7 @@ describe("wrangler secret", () => {
       }
       expect(std.out).toMatchInlineSnapshot(`
         "
-        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
+        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
       `);
       expect(std.err).toMatchInlineSnapshot(`
         "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mMissing script name[0m
@@ -468,7 +468,7 @@ describe("wrangler secret", () => {
       }
       expect(std.out).toMatchInlineSnapshot(`
         "
-        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.[0m"
+        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
       `);
       expect(std.err).toMatchInlineSnapshot(`
         "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mMissing script name[0m

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -2772,14 +2772,14 @@ export async function main(argv: string[]): Promise<void> {
       await createCLIParser([...argv, "--help"]).parse();
     } else if (e instanceof ParseError) {
       e.notes.push({
-        text: "\nIf you think this is a bug, please open an issue at: https://github.com/cloudflare/wrangler2/issues/new",
+        text: "\nIf you think this is a bug, please open an issue at: https://github.com/cloudflare/wrangler2/issues/new/choose",
       });
       logger.log(formatMessage(e));
     } else {
       logger.error(e instanceof Error ? e.message : e);
       logger.log(
         `${fgGreenColor}%s${resetColor}`,
-        "If you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new."
+        "If you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose"
       );
     }
     throw e;


### PR DESCRIPTION
Previously, when an error occurs, wrangler says:

> If you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new.

Now, it links through to the issue template chooser which is more helpful.

Fixes [#1169](https://github.com/cloudflare/wrangler2/issues/1169)