### PR TITLE
fix: use worker name as a script ID when generating a preview session

### DIFF
--- a/.changeset/eleven-games-mate.md
+++ b/.changeset/eleven-games-mate.md
@@ -1,0 +1,10 @@
+---
+"wrangler": patch
+---
+
+fix: use worker name as a script ID when generating a preview session
+
+When generating a preview session on the edge with `wrangler dev`, for a zoned worker we were using a random id as the script ID. This would make the backend not associate the dev session with any resources that were otherwise assigned to the script (specifically for secrets, but other stuff as well) The fix is simply to use the worker name (when available) as the script ID.
+
+Fixes https://github.com/cloudflare/wrangler2/issues/1003
+Fixes https://github.com/cloudflare/wrangler2/issues/1172

--- a/packages/wrangler/src/create-worker-preview.ts
+++ b/packages/wrangler/src/create-worker-preview.ts
@@ -111,7 +111,7 @@ async function createPreviewToken(
   );
 
   const { accountId } = account;
-  const scriptId = ctx.zone ? randomId() : worker.name || host.split(".")[0];
+  const scriptId = worker.name || (ctx.zone ? randomId() : host.split(".")[0]);
   const url =
     ctx.env && !ctx.legacyEnv
       ? `/accounts/${accountId}/workers/services/${scriptId}/environments/${ctx.env}/edge-preview`


### PR DESCRIPTION
When generating a preview session on the edge with `wrangler dev`, for a zoned worker we were using a random id as the script ID. This would make the backend not associate the dev session with any resources that were otherwise assigned to the script (specifically for secrets, but other stuff as well) The fix is simply to use the worker name (when available) as the script ID.

Fixes https://github.com/cloudflare/wrangler2/issues/1003
Fixes https://github.com/cloudflare/wrangler2/issues/1172

--- 

This is a good fix, but there are some followup items we should do. Tracking here - https://github.com/cloudflare/wrangler2/issues/1191