### PR TITLE
fix: differentiate between API and OAuth in whoami

### DIFF
--- a/.changeset/poor-houses-warn.md
+++ b/.changeset/poor-houses-warn.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+differentiate between API and OAuth in whoami

--- a/.changeset/poor-houses-warn.md
+++ b/.changeset/poor-houses-warn.md
@@ -2,4 +2,6 @@
 "wrangler": patch
 ---
 
-differentiate between API and OAuth in whoami
+fix: differentiate between API and OAuth in whoami
+
+Closes #1198

--- a/packages/wrangler/src/user.tsx
+++ b/packages/wrangler/src/user.tsx
@@ -233,7 +233,7 @@ import type { Response } from "undici";
 /**
  * Try to read the API token from the environment.
  */
-const getCloudflareAPITokenFromEnv = getEnvironmentVariableFactory({
+export const getCloudflareAPITokenFromEnv = getEnvironmentVariableFactory({
   variableName: "CLOUDFLARE_API_TOKEN",
   deprecatedName: "CF_API_TOKEN",
 });

--- a/packages/wrangler/src/whoami.tsx
+++ b/packages/wrangler/src/whoami.tsx
@@ -3,7 +3,7 @@ import Table from "ink-table";
 import React from "react";
 import { fetchListResult, fetchResult } from "./cfetch";
 import { logger } from "./logger";
-import { getAPIToken } from "./user";
+import { getAPIToken, getCloudflareAPITokenFromEnv } from "./user";
 
 export async function whoami() {
   logger.log("Getting User settings...");
@@ -48,10 +48,11 @@ export interface UserInfo {
 
 export async function getUserInfo(): Promise<UserInfo | undefined> {
   const apiToken = getAPIToken();
+  const apiTokenFromEnv = getCloudflareAPITokenFromEnv();
   return apiToken
     ? {
         apiToken,
-        authType: "OAuth",
+        authType: apiTokenFromEnv ? "API" : "OAuth",
         email: await getEmail(),
         accounts: await getAccounts(),
       }


### PR DESCRIPTION
Instead of:
```
rozenmd@QRVX0PWXHR ~ % wrangler logout
 ⛅️ wrangler 2.0.8
-------------------
Not logged in, exiting...
rozenmd@QRVX0PWXHR ~ % CLOUDFLARE_API_TOKEN=xxx wrangler whoami
 ⛅️ wrangler 2.0.8
-------------------
Getting User settings...
👋 You are logged in with an OAuth Token, associated with the email 'xxxxxxxx+cf@gmail.com'!
┌───────────────────────────────────┬──────────────────────────────────┐
│ Account Name                      │ Account ID                       │
├───────────────────────────────────┼──────────────────────────────────┤
│ xxxxxxxx+cf@gmail.com's Account   │ xxx                              │
└───────────────────────────────────┴──────────────────────────────────┘
```
Folks will now see:
```
rozenmd@QRVX0PWXHR ~ % CLOUDFLARE_API_TOKEN=xxx wrangler whoami
 ⛅️ wrangler 2.0.8
-------------------
Getting User settings...
👋 You are logged in with an API Token, associated with the email 'xxxxxxxx+cf@gmail.com'!
┌───────────────────────────────────┬──────────────────────────────────┐
│ Account Name                      │ Account ID                       │
├───────────────────────────────────┼──────────────────────────────────┤
│ xxxxxxxx+cf@gmail.com's Account   │ xxx                              │
└───────────────────────────────────┴──────────────────────────────────┘
```

Closes #1198

