### PR TITLE
fix: ensure wrangler init works with older versions of git

### DIFF
--- a/.changeset/tender-chefs-provide.md
+++ b/.changeset/tender-chefs-provide.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: ensure wrangler init works with older versions of git
+
+Rather than using the recently added `--initial-branch` option, we now just renamed the initial branch using `git branch -m main`.
+
+Fixes https://github.com/cloudflare/wrangler2/issues/1168

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -435,6 +435,9 @@ describe("init", () => {
       `);
       expect(fs.lstatSync(".git").isDirectory()).toBe(true);
       expect(fs.lstatSync(".gitignore").isFile()).toBe(true);
+      expect((await execa("git", ["branch", "--show-current"])).stdout).toEqual(
+        "main"
+      );
     });
 
     it("should not offer to initialize a git repo if it's already inside one", async () => {

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -444,7 +444,10 @@ function createCLIParser(argv: string[]) {
           yesFlag ||
           (await confirm("Would you like to use git to manage this Worker?"));
         if (shouldInitGit) {
-          await execa("git", ["init", "--initial-branch=main"], {
+          await execa("git", ["init"], {
+            cwd: creationDirectory,
+          });
+          await execa("git", ["branch", "-m", "main"], {
             cwd: creationDirectory,
           });
           await writeFile(


### PR DESCRIPTION
Rather than using the recently added `--initial-branch` option, we now just renamed the initial branch using `git branch -m main`.

Fixes https://github.com/cloudflare/wrangler2/issues/1168