### PR TITLE
fix: do not crash when not logged in and switching to remote dev mode

### DIFF
--- a/.changeset/funny-crabs-add.md
+++ b/.changeset/funny-crabs-add.md
@@ -1,0 +1,18 @@
+---
+"wrangler": patch
+---
+
+fix: do not crash when not logged in and switching to remote dev mode
+
+Previously, if you are not logged in when running `wrangler dev` it will only try to log you in
+if you start in "remote" mode. In "local" mode there is no need to be logged in, so it doesn't
+bother to try to login, and then will crash if you switch to "remote" mode interactively.
+
+The problem was that we were only attempting to login once before creating the `<Remote>` component.
+Now this logic has been moved into a `useEffect()` inside `<Remote>` so that it will be run whether
+starting in "remote" or transitioning to "remote" from "local".
+
+The fact that the check is no longer done before creating the components is proven by removing the
+`mockAccountId()` and `mockApiToken()` calls from the `dev.test.ts` files.
+
+Fixes [#18](https://github.com/cloudflare/wrangler2/issues/18)

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -3,7 +3,6 @@ import getPort from "get-port";
 import patchConsole from "patch-console";
 import dedent from "ts-dedent";
 import Dev from "../dev/dev";
-import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { setMockResponse, unsetAllMocks } from "./helpers/mock-cfetch";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { runInTempDir } from "./helpers/run-in-tmp";
@@ -11,8 +10,6 @@ import { runWrangler } from "./helpers/run-wrangler";
 import writeWranglerToml from "./helpers/write-wrangler-toml";
 
 describe("wrangler dev", () => {
-  mockAccountId();
-  mockApiToken();
   runInTempDir();
   const std = mockConsoleMethods();
   afterEach(() => {

--- a/packages/wrangler/src/cfetch/internal.ts
+++ b/packages/wrangler/src/cfetch/internal.ts
@@ -3,7 +3,7 @@ import { fetch, Headers } from "undici";
 import { version as wranglerVersion } from "../../package.json";
 import { getEnvironmentVariableFactory } from "../environment-variables";
 import { ParseError, parseJSON } from "../parse";
-import { getAPIToken, loginOrRefreshIfRequired } from "../user";
+import { loginOrRefreshIfRequired, requireApiToken } from "../user";
 import type { URLSearchParams } from "node:url";
 import type { RequestInit, HeadersInit } from "undici";
 
@@ -93,14 +93,6 @@ async function requireLoggedIn(): Promise<void> {
   if (!loggedIn) {
     throw new Error("Not logged in.");
   }
-}
-
-function requireApiToken(): string {
-  const authToken = getAPIToken();
-  if (!authToken) {
-    throw new Error("No API token found.");
-  }
-  return authToken;
 }
 
 function addAuthorizationHeaderIfUnspecified(

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -13,7 +13,6 @@ import { runCustomBuild } from "../entry";
 import { openInspector } from "../inspect";
 import { logger } from "../logger";
 import openInBrowser from "../open-in-browser";
-import { getAPIToken } from "../user";
 import { Local } from "./local";
 import { Remote } from "./remote";
 import { useEsbuild } from "./use-esbuild";
@@ -59,7 +58,6 @@ export type DevProps = {
 };
 
 export function DevImplementation(props: DevProps): JSX.Element {
-  const apiToken = props.initialMode === "remote" ? getAPIToken() : undefined;
   const directory = useTmpDir();
 
   useCustomBuild(props.entry, props.build);
@@ -104,19 +102,17 @@ export function DevImplementation(props: DevProps): JSX.Element {
   // only load the UI if we're running in a supported environment
   const { isRawModeSupported } = useStdin();
   return isRawModeSupported ? (
-    <InteractiveDevSession {...props} bundle={bundle} apiToken={apiToken} />
+    <InteractiveDevSession {...props} bundle={bundle} />
   ) : (
     <DevSession
       {...props}
       bundle={bundle}
-      apiToken={apiToken}
       local={props.initialMode === "local"}
     />
   );
 }
 
 type InteractiveDevSessionProps = DevProps & {
-  apiToken: string | undefined;
   bundle: EsbuildBundle | undefined;
 };
 
@@ -179,7 +175,6 @@ function DevSession(props: DevSessionProps) {
       bundle={props.bundle}
       format={props.entry.format}
       accountId={props.accountId}
-      apiToken={props.apiToken}
       bindings={props.bindings}
       assetPaths={props.assetPaths}
       public={props.public}

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -1083,8 +1083,6 @@ function createCLIParser(argv: string[]) {
         );
       }
 
-      const accountId = !args.local ? await requireAuth(config) : undefined;
-
       // TODO: if worker_dev = false and no routes, then error (only for dev)
 
       // Compute zone info from the `host` and `route` args and config;
@@ -1198,7 +1196,7 @@ function createCLIParser(argv: string[]) {
           enableLocalPersistence={
             args["experimental-enable-local-persistence"] || false
           }
-          accountId={accountId}
+          accountId={config.account_id}
           assetPaths={getAssetPaths(
             config,
             args.site,

--- a/packages/wrangler/src/user.tsx
+++ b/packages/wrangler/src/user.tsx
@@ -1201,3 +1201,14 @@ export async function requireAuth(config: {
 
   return accountId;
 }
+
+/**
+ * Throw an error if there is no API token available.
+ */
+export function requireApiToken(): string {
+  const authToken = getAPIToken();
+  if (!authToken) {
+    throw new Error("No API token found.");
+  }
+  return authToken;
+}


### PR DESCRIPTION
Previously, if you are not logged in when running `wrangler dev` it will only try to log you in
if you start in "remote" mode. In "local" mode there is no need to be logged in, so it doesn't
bother to try to login, and then will crash if you switch to "remote" mode interactively.

The problem was that we were only attempting to login once before creating the `<Remote>` component.
Now this logic has been moved into a `useEffect()` inside `<Remote>` so that it will be run whether
starting in "remote" or transitioning to "remote" from "local".

The fact that the check is no longer done before creating the components is proven by removing the
`mockAccountId()` and `mockApiToken()` calls from the `dev.test.ts` files.

Fixes [#18](https://github.com/cloudflare/wrangler2/issues/18)