### PR TITLE
fix: warn on unexpected fields on `config.triggers`

### DIFF
--- a/.changeset/late-carrots-push.md
+++ b/.changeset/late-carrots-push.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: warn on unexpected fields on `config.triggers`
+
+This adds a warning when we find unexpected fields on the `triggers` config (and any future fields that use the `isObjectWith()` validation helper)

--- a/packages/wrangler/src/config/validation-helpers.ts
+++ b/packages/wrangler/src/config/validation-helpers.ts
@@ -277,12 +277,21 @@ export const isObjectWith =
         !properties.every((prop) => prop in value))
     ) {
       diagnostics.errors.push(
-        `Expected "${field}" to be of type object, containing properties ${properties}, but got ${JSON.stringify(
+        `Expected "${field}" to be of type object, containing only properties ${properties}, but got ${JSON.stringify(
           value
         )}.`
       );
       return false;
     }
+    // it's an object with the field as desired,
+    // but let's also check for unexpected fields
+    if (value !== undefined) {
+      const restFields = Object.keys(value).filter(
+        (key) => !properties.includes(key)
+      );
+      validateAdditionalProperties(diagnostics, field, restFields, []);
+    }
+
     return true;
   };
 


### PR DESCRIPTION
This adds a warning when we find unexpected fields on the `triggers` config (and any future fields that use the `isObjectWith()` validation helper)