### PR TITLE
fix: generate site assets manifest relative to `site.bucket`

### DIFF
--- a/.changeset/odd-trains-bake.md
+++ b/.changeset/odd-trains-bake.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: generate site assets manifest relative to `site.bucket`
+
+We had a bug where we were generating asset manifest keys incorrectly if we ran wrangler from a different path to `wrangler.toml`. This fixes the generation of said keys, and adds a test for it.
+
+Fixes #1235

--- a/packages/wrangler/src/sites.tsx
+++ b/packages/wrangler/src/sites.tsx
@@ -200,9 +200,7 @@ export async function syncAssets(
     namespaceKeys.delete(assetKey);
 
     // Prevent different manifest keys on windows
-    const manifestKey = urlSafe(
-      path.relative(siteAssets.assetDirectory, absAssetFile)
-    );
+    const manifestKey = urlSafe(path.relative(assetDirectory, absAssetFile));
     manifest[manifestKey] = assetKey;
   }
 


### PR DESCRIPTION
We had a bug where we were generating asset manifest keys incorrectly if we ran wrangler from a different path to `wrangler.toml`. This fixes the generation of said keys, and adds a test for it.

Fixes https://github.com/cloudflare/wrangler2/issues/1235