### PR TITLE
feat: `--assets` / `config.assets` to serve a folder of static assets

### DIFF
--- a/.changeset/wise-steaks-end.md
+++ b/.changeset/wise-steaks-end.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+feat: `--assets` / `config.assets` to serve a folder of static assets
+
+This adds support for defining `assets` in `wrangler.toml`. You can configure it with a string path, or a `{bucket, include, exclude}` object (much like `[site]`). This also renames the `--experimental-public` arg as `--assets`.
+
+Via https://github.com/cloudflare/wrangler2/issues/1162

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -799,7 +799,7 @@ describe("wrangler dev", () => {
     });
   });
 
-  describe("site", () => {
+  describe("serve static assets", () => {
     it("should error if --site is used with no value", async () => {
       await expect(
         runWrangler("dev --site")
@@ -839,7 +839,7 @@ describe("wrangler dev", () => {
               --routes, --route                            Routes to upload  [array]
               --host                                       Host to forward requests to, defaults to the zone of project  [string]
               --local-protocol                             Protocol to listen to requests on, defaults to http.  [choices: \\"http\\", \\"https\\"]
-              --experimental-public                        Static assets to be served  [string]
+              --assets                                     Static assets to be served  [string]
               --site                                       Root folder of static assets for Workers Sites  [string]
               --site-include                               Array of .gitignore-style patterns that match file or directory names from the sites directory. Only matched items will be uploaded.  [array]
               --site-exclude                               Array of .gitignore-style patterns that match file or directory names from the sites directory. Matched items will not be uploaded.  [array]
@@ -857,19 +857,19 @@ describe("wrangler dev", () => {
       `);
     });
 
-    it("should error if --experimental-public and --site are used together", async () => {
+    it("should error if --assets and --site are used together", async () => {
       writeWranglerToml({
         main: "./index.js",
       });
       fs.writeFileSync("index.js", `export default {};`);
       await expect(
-        runWrangler("dev --experimental-public abc --site xyz")
+        runWrangler("dev --assets abc --site xyz")
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Cannot use --experimental-public and a Site configuration together."`
+        `"Cannot use Assets and Workers Sites in the same Worker."`
       );
     });
 
-    it("should error if --experimental-public and config.site are used together", async () => {
+    it("should error if --assets and config.site are used together", async () => {
       writeWranglerToml({
         main: "./index.js",
         site: {
@@ -878,10 +878,55 @@ describe("wrangler dev", () => {
       });
       fs.writeFileSync("index.js", `export default {};`);
       await expect(
-        runWrangler("dev --experimental-public abc")
+        runWrangler("dev --assets abc")
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Cannot use --experimental-public and a Site configuration together."`
+        `"Cannot use Assets and Workers Sites in the same Worker."`
       );
+    });
+
+    it("should error if config.assets and --site are used together", async () => {
+      writeWranglerToml({
+        main: "./index.js",
+        assets: "abc",
+      });
+      fs.writeFileSync("index.js", `export default {};`);
+      await expect(
+        runWrangler("dev --site xyz")
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Cannot use Assets and Workers Sites in the same Worker."`
+      );
+    });
+
+    it("should error if config.assets and config.site are used together", async () => {
+      writeWranglerToml({
+        main: "./index.js",
+        assets: "abc",
+        site: {
+          bucket: "xyz",
+        },
+      });
+      fs.writeFileSync("index.js", `export default {};`);
+      await expect(
+        runWrangler("dev --assets abc")
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Cannot use Assets and Workers Sites in the same Worker."`
+      );
+    });
+
+    it("should indicate whether Sites is being used", async () => {
+      writeWranglerToml({
+        main: "index.js",
+      });
+      fs.writeFileSync("index.js", `export default {};`);
+
+      await runWrangler("dev");
+      expect((Dev as jest.Mock).mock.calls[0][0].isWorkersSite).toEqual(false);
+
+      await runWrangler("dev --site abc");
+      expect((Dev as jest.Mock).mock.calls[1][0].isWorkersSite).toEqual(true);
+
+      await runWrangler("dev --assets abc");
+      expect((Dev as jest.Mock).mock.calls[2][0].isWorkersSite).toEqual(false);
     });
   });
 

--- a/packages/wrangler/src/config/config.ts
+++ b/packages/wrangler/src/config/config.ts
@@ -115,6 +115,15 @@ export interface ConfigFields<Dev extends RawDevConfig> {
     | undefined;
 
   /**
+   * Serve a folder of static assets with your Worker, without any additional code.
+   * This can either be a string, or an object with additional config fields.
+   */
+  assets:
+    | string
+    | { bucket: string; include: string[]; exclude: string[] }
+    | undefined;
+
+  /**
    * A list of wasm modules that your worker should be bound to. This is
    * the "legacy" way of binding to a wasm module. ES module workers should
    * do proper module imports.

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -186,6 +186,7 @@ export function normalizeAndValidateConfig(
       rawConfig,
       activeEnv.main
     ),
+    assets: normalizeAndValidateAssets(diagnostics, configPath, rawConfig),
     wasm_modules: normalizeAndValidateModulePaths(
       diagnostics,
       configPath,
@@ -214,6 +215,8 @@ export function normalizeAndValidateConfig(
     Object.keys(rawConfig),
     [...Object.keys(config), "env"]
   );
+
+  experimental(diagnostics, rawConfig, "assets");
 
   return { config, diagnostics };
 }
@@ -569,6 +572,35 @@ function normalizeAndValidateSite(
     };
   }
   return undefined;
+}
+
+/**
+ * Validate the `assets` configuration and return normalized values.
+ */
+function normalizeAndValidateAssets(
+  diagnostics: Diagnostics,
+  configPath: string | undefined,
+  rawConfig: RawConfig
+) {
+  if (
+    typeof rawConfig?.assets === "string" ||
+    rawConfig?.assets === undefined
+  ) {
+    return rawConfig?.assets;
+  }
+
+  const { bucket, include = [], exclude = [], ...rest } = rawConfig.assets;
+
+  validateAdditionalProperties(diagnostics, "assets", Object.keys(rest), []);
+  validateRequiredProperty(diagnostics, "assets", "bucket", bucket, "string");
+  validateTypedArray(diagnostics, "assets.include", include, "string");
+  validateTypedArray(diagnostics, "assets.exclude", exclude, "string");
+
+  return {
+    bucket,
+    include,
+    exclude,
+  };
 }
 
 /**

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -38,7 +38,7 @@ export type DevProps = {
   enableLocalPersistence: boolean;
   bindings: CfWorkerInit["bindings"];
   crons: Config["triggers"]["crons"];
-  public: string | undefined;
+  isWorkersSite: boolean;
   assetPaths: AssetPaths | undefined;
   compatibilityDate: string;
   compatibilityFlags: string[] | undefined;
@@ -53,9 +53,13 @@ export type DevProps = {
 };
 
 export function DevImplementation(props: DevProps): JSX.Element {
-  if (props.public && props.entry.format === "service-worker") {
+  if (
+    !props.isWorkersSite &&
+    props.assetPaths &&
+    props.entry.format === "service-worker"
+  ) {
     throw new Error(
-      "You cannot use the service-worker format with a `public` directory."
+      "You cannot use the service-worker format with an `assets` directory yet. For information on how to migrate to the module-worker format, see: https://developers.cloudflare.com/workers/learning/migrating-to-module-workers/"
     );
   }
 
@@ -131,12 +135,12 @@ function DevSession(props: DevSessionProps) {
   const bundle = useEsbuild({
     entry: props.entry,
     destination: directory,
-    staticRoot: props.public,
     jsxFactory: props.jsxFactory,
     rules: props.rules,
     jsxFragment: props.jsxFragment,
-    // In dev for remote mode, we serve --experimental-assets from the local proxy before we send the request to the worker.
-    serveAssetsFromWorker: !!props.public && !!props.local,
+    serveAssetsFromWorker: Boolean(
+      props.assetPaths && !props.isWorkersSite && !props.local
+    ),
     tsconfig: props.tsconfig,
     minify: props.minify,
     nodeCompat: props.nodeCompat,
@@ -152,7 +156,7 @@ function DevSession(props: DevSessionProps) {
       compatibilityFlags={props.compatibilityFlags}
       bindings={props.bindings}
       assetPaths={props.assetPaths}
-      public={props.public}
+      isWorkersSite={props.isWorkersSite}
       port={props.port}
       ip={props.ip}
       rules={props.rules}
@@ -168,7 +172,7 @@ function DevSession(props: DevSessionProps) {
       accountId={props.accountId}
       bindings={props.bindings}
       assetPaths={props.assetPaths}
-      public={props.public}
+      isWorkersSite={props.isWorkersSite}
       port={props.port}
       ip={props.ip}
       localProtocol={props.localProtocol}

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -23,7 +23,7 @@ interface LocalProps {
   bindings: CfWorkerInit["bindings"];
   localProtocol: "http" | "https";
   assetPaths: AssetPaths | undefined;
-  public: string | undefined;
+  isWorkersSite: boolean;
   port: number;
   ip: string;
   rules: Config["rules"];
@@ -50,7 +50,7 @@ function useLocalWorker({
   compatibilityFlags,
   bindings,
   assetPaths,
-  public: publicDirectory,
+  isWorkersSite,
   port,
   rules,
   enableLocalPersistence,
@@ -310,7 +310,7 @@ function useLocalWorker({
     compatibilityFlags,
     localPersistencePath,
     assetPaths,
-    publicDirectory,
+    isWorkersSite,
     rules,
     bindings.wasm_modules,
     bindings.text_blobs,

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -16,7 +16,7 @@ export function Remote(props: {
   name: string | undefined;
   bundle: EsbuildBundle | undefined;
   format: CfScriptFormat | undefined;
-  public: string | undefined;
+  isWorkersSite: boolean;
   assetPaths: AssetPaths | undefined;
   port: number;
   ip: string;
@@ -40,7 +40,7 @@ export function Remote(props: {
     accountId: props.accountId,
     bindings: props.bindings,
     assetPaths: props.assetPaths,
-    public: props.public,
+    isWorkersSite: props.isWorkersSite,
     port: props.port,
     compatibilityDate: props.compatibilityDate,
     compatibilityFlags: props.compatibilityFlags,
@@ -53,7 +53,9 @@ export function Remote(props: {
 
   usePreviewServer({
     previewToken,
-    publicRoot: props.public,
+    assetDirectory: props.isWorkersSite
+      ? undefined
+      : props.assetPaths?.assetDirectory,
     localProtocol: props.localProtocol,
     localPort: props.port,
     ip: props.ip,
@@ -75,7 +77,7 @@ export function useWorker(props: {
   accountId: string | undefined;
   bindings: CfWorkerInit["bindings"];
   assetPaths: AssetPaths | undefined;
-  public: string | undefined;
+  isWorkersSite: boolean;
   port: number;
   compatibilityDate: string | undefined;
   compatibilityFlags: string[] | undefined;
@@ -133,7 +135,7 @@ export function useWorker(props: {
         // include it in the kv namespace name regardless (since there's no
         // concept of service environments for kv namespaces yet).
         name + (!props.legacyEnv && props.env ? `-${props.env}` : ""),
-        props.public ? undefined : assetPaths,
+        props.isWorkersSite ? assetPaths : undefined,
         true,
         false
       ); // TODO: cancellable?
@@ -225,7 +227,7 @@ export function useWorker(props: {
     accountId,
     port,
     assetPaths,
-    props.public,
+    props.isWorkersSite,
     compatibilityDate,
     compatibilityFlags,
     usageModel,

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -19,7 +19,6 @@ export type EsbuildBundle = {
 export function useEsbuild({
   entry,
   destination,
-  staticRoot,
   jsxFactory,
   jsxFragment,
   rules,
@@ -30,7 +29,6 @@ export function useEsbuild({
 }: {
   entry: Entry;
   destination: string | undefined;
-  staticRoot: string | undefined;
   jsxFactory: string | undefined;
   jsxFragment: string | undefined;
   rules: Config["rules"];
@@ -101,7 +99,6 @@ export function useEsbuild({
   }, [
     entry,
     destination,
-    staticRoot,
     jsxFactory,
     jsxFragment,
     serveAssetsFromWorker,

--- a/packages/wrangler/src/proxy.ts
+++ b/packages/wrangler/src/proxy.ts
@@ -76,13 +76,13 @@ type PreviewProxy = {
 
 export function usePreviewServer({
   previewToken,
-  publicRoot,
+  assetDirectory,
   localProtocol,
   localPort: port,
   ip,
 }: {
   previewToken: CfPreviewToken | undefined;
-  publicRoot: string | undefined;
+  assetDirectory: string | undefined;
   localProtocol: "https" | "http";
   localPort: number;
   ip: string;
@@ -176,8 +176,6 @@ export function usePreviewServer({
     // We have a token. Let's proxy requests to the preview end point.
     const cleanupListeners: (() => void)[] = [];
 
-    const assetPath = typeof publicRoot === "string" ? publicRoot : null;
-
     // create a ClientHttp2Session
     const remote = connect(`https://${previewToken.host}`);
     cleanupListeners.push(() => remote.destroy());
@@ -247,8 +245,8 @@ export function usePreviewServer({
 
     // If an asset path is defined, check the file system
     // for a file first and serve if it exists.
-    const actualHandleRequest = assetPath
-      ? createHandleAssetsRequest(assetPath, handleRequest)
+    const actualHandleRequest = assetDirectory
+      ? createHandleAssetsRequest(assetDirectory, handleRequest)
       : handleRequest;
 
     proxy.server.on("request", actualHandleRequest);
@@ -293,7 +291,7 @@ export function usePreviewServer({
     };
   }, [
     previewToken,
-    publicRoot,
+    assetDirectory,
     port,
     localProtocol,
     proxy,
@@ -341,10 +339,10 @@ export function usePreviewServer({
 }
 
 function createHandleAssetsRequest(
-  assetPath: string,
+  assetDirectory: string,
   handleRequest: RequestListener
 ) {
-  const handleAsset = serveStatic(assetPath, {
+  const handleAsset = serveStatic(assetDirectory, {
     cacheControl: false,
   });
   return (request: IncomingMessage, response: ServerResponse) => {

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -40,7 +40,7 @@ type Props = {
   jsxFactory: string | undefined;
   jsxFragment: string | undefined;
   tsconfig: string | undefined;
-  experimentalPublic: boolean;
+  isWorkersSite: boolean;
   minify: boolean | undefined;
   nodeCompat: boolean | undefined;
   outDir: string | undefined;
@@ -274,7 +274,7 @@ export default async function publish(props: Props): Promise<void> {
 
   assert(
     !config.site || config.site.bucket,
-    "A [site] definition requires a `bucket` field with a path to the site's public directory."
+    "A [site] definition requires a `bucket` field with a path to the site's assets directory."
   );
 
   if (props.outDir) {
@@ -303,9 +303,13 @@ export default async function publish(props: Props): Promise<void> {
 
   const { format } = props.entry;
 
-  if (props.experimentalPublic && format === "service-worker") {
+  if (
+    !props.isWorkersSite &&
+    Boolean(props.assetPaths) &&
+    format === "service-worker"
+  ) {
     throw new Error(
-      "You cannot publish in the service-worker format with a public directory."
+      "You cannot use the service-worker format with an `assets` directory yet. For information on how to migrate to the module-worker format, see: https://developers.cloudflare.com/workers/learning/migrating-to-module-workers/"
     );
   }
 
@@ -331,7 +335,8 @@ export default async function publish(props: Props): Promise<void> {
       props.entry,
       typeof destination === "string" ? destination : destination.path,
       {
-        serveAssetsFromWorker: props.experimentalPublic,
+        serveAssetsFromWorker:
+          !props.isWorkersSite && Boolean(props.assetPaths),
         jsxFactory,
         jsxFragment,
         rules: props.rules,

--- a/packages/wrangler/src/sites.tsx
+++ b/packages/wrangler/src/sites.tsx
@@ -304,8 +304,50 @@ export interface AssetPaths {
  * Uses the args (passed from the command line) if available,
  * falling back to those defined in the config.
  *
+ * (This function corresponds to --assets/config.assets)
+ *
  */
 export function getAssetPaths(
+  config: Config,
+  assetDirectory: string | undefined
+): AssetPaths | undefined {
+  const baseDirectory = path.resolve(
+    path.dirname(config.configPath ?? "wrangler.toml")
+  );
+
+  assetDirectory ??=
+    typeof config.assets === "string"
+      ? config.assets
+      : config.assets !== undefined
+      ? config.assets.bucket
+      : undefined;
+
+  const includePatterns =
+    (typeof config.assets !== "string" && config.assets?.include) || [];
+
+  const excludePatterns =
+    (typeof config.assets !== "string" && config.assets?.exclude) || [];
+
+  return assetDirectory
+    ? {
+        baseDirectory,
+        assetDirectory,
+        includePatterns,
+        excludePatterns,
+      }
+    : undefined;
+}
+
+/**
+ * Get an object that describes what site assets to upload, if any.
+ *
+ * Uses the args (passed from the command line) if available,
+ * falling back to those defined in the config.
+ *
+ * (This function corresponds to --site/config.site)
+ *
+ */
+export function getSiteAssetPaths(
   config: Config,
   assetDirectory = config.site?.bucket,
   includePatterns = config.site?.include ?? [],


### PR DESCRIPTION
This adds support for defining `assets` in `wrangler.toml`. You can configure it with a string path, or a `{bucket, include, exclude}` object (much like `[site]`). This also renames the `--experimental-public` arg as `--assets`.

Via https://github.com/cloudflare/wrangler2/issues/1162

--- 

Followup tasks (I'll make issues for each of these later, but logging here for visibility)

- [ ] add configuration options `{cacheControl: { browserTTL: number, edgeTTL: number, bypassCache: boolean }, singlePageApp: boolean }`
- [ ] add support for `_headers`
- [ ] better defaults in the facade worker
- [ ] remove requirement for an entry point if `--assets`/`config.assets` is used 