### PR TITLE
fix: instruct api to exclude script content on worker upload

### DIFF
--- a/.changeset/curvy-donuts-knock.md
+++ b/.changeset/curvy-donuts-knock.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: instruct api to exclude script content on worker upload
+
+When we upload a script bundle, we get the actual content of the script back in the response. Sometimes that script can be large (depending on whether the upload was large), and currently it may even be a badly escaped string. We can pass a queryparam `excludeScript` that, as it implies, exclude the script content in the response. This fix does that.
+
+Fixes https://github.com/cloudflare/wrangler2/issues/1222

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -5294,6 +5294,7 @@ function mockUploadWorkerRequest(
         expect(envName).toEqual(env);
       }
       expect(queryParams.get("include_subdomain_availability")).toEqual("true");
+      expect(queryParams.get("excludeScript")).toEqual("true");
       const formBody = body as FormData;
       if (expectedEntry !== undefined) {
         expect(await (formBody.get("index.js") as File).text()).toMatch(

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -430,7 +430,12 @@ export default async function publish(props: Props): Promise<void> {
             method: "PUT",
             body: createWorkerUploadForm(worker),
           },
-          new URLSearchParams({ include_subdomain_availability: "true" })
+          new URLSearchParams({
+            include_subdomain_availability: "true",
+            // pass excludeScript so the whole body of the
+            // script doesn't get included in the response
+            excludeScript: "true",
+          })
         )
       ).available_on_subdomain;
     }


### PR DESCRIPTION
When we upload a script bundle, we get the actual content of the script back in the response. Sometimes that script can be large (depending on whether the upload was large), and currently it may even be a badly escaped string. We can pass a queryparam `excludeScript` that, as it implies, exclude the script content in the response. This fix does that.

Will eventually fix https://github.com/cloudflare/wrangler2/issues/1222

--- 

This fix working is dependent on the internal api rolling out support for this query param, which is imminent. 