### PR TITLE
refactor: simplify `watch_dir` validation

### DIFF
--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -175,7 +175,7 @@ interface EnvironmentInheritable {
     /** The directory in which the command is executed. */
     cwd?: string;
     /** The directory to watch for changes while using wrangler dev, defaults to the current working directory */
-    watch_dir?: string | string[] | undefined;
+    watch_dir?: string | string[];
     /**
      * Deprecated field previously used to configure the build and upload of the script.
      * @deprecated

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -227,8 +227,7 @@ function normalizeAndValidateBuild(
   rawBuild: Config["build"],
   configPath: string | undefined
 ): Config["build"] & { deprecatedUpload: DeprecatedUpload } {
-  const { command, cwd, watch_dir: _watch_dir, upload, ...rest } = rawBuild;
-  let { watch_dir } = rawBuild;
+  const { command, cwd, watch_dir = "./src", upload, ...rest } = rawBuild;
   const deprecatedUpload: DeprecatedUpload = { ...upload };
   validateAdditionalProperties(diagnostics, "build", Object.keys(rest), []);
 
@@ -284,9 +283,6 @@ function normalizeAndValidateBuild(
       true
     );
   }
-
-  // default watch_dir to './src'
-  watch_dir ||= "./src";
 
   return {
     command,


### PR DESCRIPTION
The `watch_dir` does not need to be explicitly typed with `undefined` as it has a default value of `./src`.
By initializing the default when reading from the raw config,
we can avoid the `let` and related statements.

(I was a little late to review #1231 so I thought I would just send this instead)