### PR TITLE
fix: pass env and ctx to request handler when using `--experimental-public`

### DIFF
--- a/.changeset/tender-tables-fetch.md
+++ b/.changeset/tender-tables-fetch.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: pass env and ctx to request handler when using `--experimental-public`

--- a/packages/wrangler/templates/static-asset-facade.js
+++ b/packages/wrangler/templates/static-asset-facade.js
@@ -35,7 +35,7 @@ export default {
     } catch (e) {
       console.error(e);
       // if an error is thrown then serve from actual worker
-      return worker.fetch(request);
+      return worker.fetch(request, env, ctx);
       // TODO: throw here if worker is not available
       // (which implies it may be a service-worker)
     }


### PR DESCRIPTION
(as reported on discord)