### PR TITLE
fix: support all git versions for wrangler init

### DIFF
--- a/.changeset/eighty-bags-destroy.md
+++ b/.changeset/eighty-bags-destroy.md
@@ -1,0 +1,12 @@
+---
+"wrangler": patch
+---
+
+fix: support all git versions for `wrangler init`
+
+If `git` does not support the `--initial-branch` argument then just fallback to the default initial branch name.
+
+We tried to be more clever about this but there are two many weird corner cases with different git versions on different architectures.
+Now we do our best, with recent versions of git, to ensure that the branch is called `main` but otherwise just make sure we don't crash.
+
+Fixes #1228

--- a/packages/wrangler/src/git-client.ts
+++ b/packages/wrangler/src/git-client.ts
@@ -1,0 +1,42 @@
+import { execa } from "execa";
+import { findUp } from "find-up";
+
+/**
+ * Check whether the given current working directory is within a git repository
+ * by looking for a `.git` directory in this or an ancestor directory.
+ */
+export async function isInsideGitRepo(cwd: string) {
+  const res = await findUp(".git", { cwd, type: "directory" });
+  return res !== undefined;
+}
+
+/**
+ * Check whether git is installed by trying to run it.
+ */
+export async function isGitInstalled() {
+  try {
+    return (await execa("git", ["--version"])).exitCode === 0;
+  } catch (err) {
+    return false;
+  }
+}
+
+/**
+ * Initialize a new Worker project with a git repository.
+ *
+ * We want the branch to be called `main` but earlier versions of git do not support `--initial-branch`.
+ * If that is the case then we just fallback to the default initial branch name.
+ */
+export async function initializeGit(cwd: string) {
+  try {
+    // Try to create the repository with the HEAD branch of `main`.
+    await execa("git", ["init", "--initial-branch", "main"], {
+      cwd,
+    });
+  } catch {
+    // Unable to create the repo with a HEAD branch name, so just fall back to the default.
+    await execa("git", ["init"], {
+      cwd,
+    });
+  }
+}


### PR DESCRIPTION
If `git` does not support the `--initial-branch` argument then just fallback to the default initial branch name.

We tried to be more clever about this but there are two many weird corner cases with different git versions on different architectures.
Now we do our best, with recent versions of git, to ensure that the branch is called `main` but otherwise just make sure we don't crash.

Fixes https://github.com/cloudflare/wrangler2/issues/1228