### PR TITLE
Delegate to local installs of wrangler when possible

### DIFF
--- a/.changeset/lovely-toys-happen.md
+++ b/.changeset/lovely-toys-happen.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Delegate to a local install of `wrangler` if one exists.
+
+Users will frequently install `wrangler` globally to run commands like `wrangler init`, but we also recommend pinning a specific version of `wrangler` in a project's `package.json`. Now, when a user invokes a global install of `wrangler`, we'll check to see if they also have a local installation. If they do, we'll delegate to that version.
+
+This requires that we define a `main` (maybe `module` would work too?) field in `package.json` so that `require.resolve` can find `"wrangler"`, but it's something of an implementation detail.

--- a/.changeset/lovely-toys-happen.md
+++ b/.changeset/lovely-toys-happen.md
@@ -5,5 +5,3 @@
 Delegate to a local install of `wrangler` if one exists.
 
 Users will frequently install `wrangler` globally to run commands like `wrangler init`, but we also recommend pinning a specific version of `wrangler` in a project's `package.json`. Now, when a user invokes a global install of `wrangler`, we'll check to see if they also have a local installation. If they do, we'll delegate to that version.
-
-This requires that we define a `main` (maybe `module` would work too?) field in `package.json` so that `require.resolve` can find `"wrangler"`, but it's something of an implementation detail.

--- a/packages/wrangler/bin/wrangler.js
+++ b/packages/wrangler/bin/wrangler.js
@@ -76,7 +76,7 @@ function runDelegatedWrangler() {
   // of the other work.
   return spawn(
     process.execPath,
-    [path.resolve(packageJsonPath, binaryPath), ...process.argv],
+    [path.resolve(packageJsonPath, "..", binaryPath), ...process.argv.slice(2)],
     {
       stdio: "inherit",
     }

--- a/packages/wrangler/bin/wrangler.js
+++ b/packages/wrangler/bin/wrangler.js
@@ -71,7 +71,7 @@ function runDelegatedWrangler() {
   const packageJsonPath = require.resolve("wrangler/package.json", {
     paths: [process.cwd()],
   });
-  const binaryPath = JSON.parse(packageJsonPath).bin.wrangler;
+  const binaryPath = JSON.parse(fs.readFileSync(packageJsonPath)).bin.wrangler;
   // this call to `spawn` is simpler because the delegated version will do all
   // of the other work.
   return spawn(

--- a/packages/wrangler/bin/wrangler.js
+++ b/packages/wrangler/bin/wrangler.js
@@ -9,19 +9,11 @@ const MIN_NODE_VERSION = "16.7.0";
 
 let wranglerProcess;
 
-async function main() {
-  if (semiver(process.versions.node, MIN_NODE_VERSION) < 0) {
-    // Note Volta and nvm are also recommended in the official docs:
-    // https://developers.cloudflare.com/workers/get-started/guide#2-install-the-workers-cli
-    console.error(
-      `Wrangler requires at least Node.js v${MIN_NODE_VERSION}. You are using v${process.versions.node}.
-You should use the latest Node.js version if possible, as Cloudflare Workers use a very up-to-date version of V8.
-Consider using a Node.js version manager such as https://volta.sh/ or https://github.com/nvm-sh/nvm.`
-    );
-    process.exitCode = 1;
-    return;
-  }
-
+/**
+ * Executes ../wrangler-dist/cli.js
+ * @returns {ChildProcess} the wrangler process
+ */
+function runWrangler() {
   let pathToCACerts = process.env.NODE_EXTRA_CA_CERTS;
   if (pathToCACerts) {
     // TODO:
@@ -46,17 +38,7 @@ Consider using a Node.js version manager such as https://volta.sh/ or https://gi
     pathToCACerts = certPath;
   }
 
-  let pathToWranglerCli;
-  try {
-    // try to use a local version of wrangler, if there is one.
-    // `require.resolve` throws if it can't find anything.
-    pathToWranglerCli = require.resolve("wrangler", { paths: [process.cwd()] });
-  } catch (e) {
-    // we couldn't find a local install, so just use this (presumably global) version instead.
-    pathToWranglerCli = path.join(__dirname, "../wrangler-dist/cli.js");
-  }
-
-  wranglerProcess = spawn(
+  return spawn(
     process.execPath,
     [
       ...(semiver(process.versions.node, "18.0.0") >= 0
@@ -78,6 +60,72 @@ Consider using a Node.js version manager such as https://volta.sh/ or https://gi
   ).on("exit", (code) =>
     process.exit(code === undefined || code === null ? 0 : code)
   );
+}
+
+/**
+ * Runs a locally-installed version of wrangler, delegating from this version.
+ * @throws {MODULE_NOT_FOUND} if there isn't a locally installed version of wrangler.
+ * @returns {ChildProcess} the delegated wrangler process
+ */
+function runDelegatedWrangler() {
+  const packageJsonPath = require.resolve("wrangler/package.json", {
+    paths: [process.cwd()],
+  });
+  const binaryPath = JSON.parse(packageJsonPath).bin.wrangler;
+  // this call to `spawn` is simpler because the delegated version will do all
+  // of the other work.
+  return spawn(
+    process.execPath,
+    [path.resolve(packageJsonPath, binaryPath), ...process.argv],
+    {
+      stdio: "inherit",
+    }
+  ).on("exit", (code) =>
+    process.exit(code === undefined || code === null ? 0 : code)
+  );
+}
+
+/**
+ * Indicates if this invocation of `wrangler` should delegate
+ * to a locally-installed version.
+ */
+const shouldDelegate = (function () {
+  // IIFE because we need to catch a MODULE_NOT_FOUND error thrown
+  // by `require.resolve`
+  try {
+    // `require.resolve` will throw if it can't find
+    // a locally-installed version of `wrangler`
+    const delegatedPackageJson = require.resolve("wrangler/package.json", {
+      paths: [process.cwd()],
+    });
+    const thisPackageJson = path.resolve(__dirname, "..", "package.json");
+    // if it's the same path, then we're already a local install -- no need to delegate
+    return thisPackageJson !== delegatedPackageJson;
+  } catch (e) {
+    // there's no local version to delegate to -- `require.resolve` threw
+    return false;
+  }
+})();
+
+async function main() {
+  if (shouldDelegate) {
+    wranglerProcess = runDelegatedWrangler();
+    return;
+  }
+
+  if (semiver(process.versions.node, MIN_NODE_VERSION) < 0) {
+    // Note Volta and nvm are also recommended in the official docs:
+    // https://developers.cloudflare.com/workers/get-started/guide#2-install-the-workers-cli
+    console.error(
+      `Wrangler requires at least Node.js v${MIN_NODE_VERSION}. You are using v${process.versions.node}.
+You should use the latest Node.js version if possible, as Cloudflare Workers use a very up-to-date version of V8.
+Consider using a Node.js version manager such as https://volta.sh/ or https://github.com/nvm-sh/nvm.`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  wranglerProcess = runWrangler();
 }
 
 process.on("SIGINT", () => {

--- a/packages/wrangler/bin/wrangler.js
+++ b/packages/wrangler/bin/wrangler.js
@@ -46,6 +46,16 @@ Consider using a Node.js version manager such as https://volta.sh/ or https://gi
     pathToCACerts = certPath;
   }
 
+  let pathToWranglerCli;
+  try {
+    // try to use a local version of wrangler, if there is one.
+    // `require.resolve` throws if it can't find anything.
+    pathToWranglerCli = require.resolve("wrangler", { paths: [process.cwd()] });
+  } catch (e) {
+    // we couldn't find a local install, so just use this (presumably global) version instead.
+    pathToWranglerCli = path.join(__dirname, "../wrangler-dist/cli.js");
+  }
+
   wranglerProcess = spawn(
     process.execPath,
     [

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -7,6 +7,7 @@
     "wrangler": "./bin/wrangler.js",
     "wrangler2": "./bin/wrangler.js"
   },
+  "main": "wrangler-dist/cli.js",
   "license": "MIT OR Apache-2.0",
   "bugs": {
     "url": "https://github.com/cloudflare/wrangler2/issues"

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -7,7 +7,6 @@
     "wrangler": "./bin/wrangler.js",
     "wrangler2": "./bin/wrangler.js"
   },
-  "main": "wrangler-dist/cli.js",
   "license": "MIT OR Apache-2.0",
   "bugs": {
     "url": "https://github.com/cloudflare/wrangler2/issues"


### PR DESCRIPTION
Delegate to a local install of `wrangler` if one exists.

Users will frequently install `wrangler` globally to run commands like `wrangler init`, but we also recommend pinning a specific version of `wrangler` in a project's `package.json`. Now, when a user invokes a global install of `wrangler`, we'll check to see if they also have a local installation. If they do, we'll delegate to that version.

Closes #955

Here's a recording of this in action, with a couple `console.log`s indicating if a global or local installation is running:

[![asciicast](https://asciinema.org/a/qfw9PNGP2BHGiYd0UVjandH9p.svg)](https://asciinema.org/a/qfw9PNGP2BHGiYd0UVjandH9p)