### PR TITLE
Allow setting debug level via env variable

### DIFF
--- a/.changeset/slow-bananas-protect.md
+++ b/.changeset/slow-bananas-protect.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Add environment variable WRANGLER_LOG to set log level

--- a/packages/wrangler/src/__tests__/logger.test.ts
+++ b/packages/wrangler/src/__tests__/logger.test.ts
@@ -112,4 +112,30 @@ describe("logger", () => {
       `);
     });
   });
+
+  describe("loggerLevelFromEnvVar=error", () => {
+    beforeEach(() => {
+      process.env.WRANGLER_LOG = "error";
+    });
+    afterEach(() => {
+      process.env.WRANGLER_LOG = undefined;
+    });
+
+    it("should render messages that are at or above the log level set in the env var", () => {
+      logger.loggerLevel = "error";
+      logger.debug("This is a debug message");
+      logger.log("This is a log message");
+      logger.warn("This is a warn message");
+      logger.error("This is a error message");
+
+      expect(std.debug).toMatchInlineSnapshot(`""`);
+      expect(std.out).toMatchInlineSnapshot(`""`);
+      expect(std.warn).toMatchInlineSnapshot(`""`);
+      expect(std.err).toMatchInlineSnapshot(`
+        "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mThis is a error message[0m
+
+        "
+      `);
+    });
+  });
 });

--- a/packages/wrangler/src/logger.ts
+++ b/packages/wrangler/src/logger.ts
@@ -1,5 +1,6 @@
 import { format } from "node:util";
 import { formatMessagesSync } from "esbuild";
+import { getEnvironmentVariableFactory } from "./environment-variables";
 
 const LOGGER_LEVELS = {
   error: 0,
@@ -18,9 +19,15 @@ const LOGGER_LEVEL_FORMAT_TYPE_MAP = {
   debug: undefined,
 } as const;
 
-class Logger {
-  constructor(public loggerLevel: LoggerLevel = "log") {}
+const getLogLevelFromEnv = getEnvironmentVariableFactory({
+  variableName: "WRANGLER_LOG",
+  defaultValue: "log",
+});
 
+class Logger {
+  constructor() {}
+
+  loggerLevel: LoggerLevel = (getLogLevelFromEnv() as LoggerLevel) ?? "log";
   columns = process.stdout.columns;
 
   debug = (...args: unknown[]) => this.doLog("debug", args);


### PR DESCRIPTION
As discussed in https://github.com/cloudflare/wrangler2/issues/1266

This allows the user to set the logging level via an environment variable.

$ WRANGLER_LOG=debug wrangler publish