### PR TITLE
fix: bump undici to latest 

### DIFF
--- a/.changeset/good-mugs-tease.md
+++ b/.changeset/good-mugs-tease.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: bump undici to v5.5.1 (CVE patch)

--- a/package-lock.json
+++ b/package-lock.json
@@ -20736,7 +20736,7 @@
         "timeago.js": "^4.0.2",
         "tmp-promise": "^3.0.3",
         "ts-dedent": "^2.2.0",
-        "undici": "^5.3.0",
+        "undici": "^5.5.1",
         "update-check": "^1.5.4",
         "ws": "^8.5.0",
         "yargs": "^17.4.1"
@@ -21176,6 +21176,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "packages/wrangler/node_modules/undici": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.5.1.tgz",
+      "integrity": "sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.18"
       }
     },
     "packages/wrangler/node_modules/ws": {
@@ -35601,7 +35610,7 @@
         "timeago.js": "^4.0.2",
         "tmp-promise": "^3.0.3",
         "ts-dedent": "^2.2.0",
-        "undici": "^5.3.0",
+        "undici": "^5.5.1",
         "update-check": "^1.5.4",
         "ws": "^8.5.0",
         "xxhash-wasm": "^1.0.1",
@@ -35812,6 +35821,12 @@
           "version": "9.2.2",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.2.2.tgz",
           "integrity": "sha512-XC6g/Kgux+rJXmwokjm9ECpD6k/smUoS5LKlUCcsYr4IY3rW0XyAympon2RmxGrlnZURMpg5T18gWDP9CsHXFA==",
+          "dev": true
+        },
+        "undici": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/undici/-/undici-5.5.1.tgz",
+          "integrity": "sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw==",
           "dev": true
         },
         "ws": {

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -99,7 +99,7 @@
     "timeago.js": "^4.0.2",
     "tmp-promise": "^3.0.3",
     "ts-dedent": "^2.2.0",
-    "undici": "^5.3.0",
+    "undici": "^5.5.1",
     "update-check": "^1.5.4",
     "ws": "^8.5.0",
     "yargs": "^17.4.1"


### PR DESCRIPTION
Bumping for this security release https://github.com/nodejs/undici/releases/tag/v5.5.1

Manually tested:

- [x] dev
- [x] publish
- [x] whoami
- [x] login
- [x] logout