### PR TITLE
feat: entry point is not mandatory if `--assets` is passed

### DIFF
--- a/.changeset/pretty-lemons-move.md
+++ b/.changeset/pretty-lemons-move.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+feat: entry point is not mandatory if `--assets` is passed
+
+Since we use a facade worker with `--assets`, an entry point is not strictly necessary. This makes a common usecase of "deploy a bunch of static assets" extremely easy to start, as a one liner `npx wrangler dev --assets path/to/folder` (and same with `publish`).

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -1365,6 +1365,45 @@ addEventListener('fetch', event => {});`
         "
       `);
     });
+
+    it("should not require an explicit entry point when using --assets", async () => {
+      const assets = [
+        { filePath: "file-1.txt", content: "Content of file-1" },
+        { filePath: "file-2.txt", content: "Content of file-2" },
+      ];
+      const kvNamespace = {
+        title: "__test-name-workers_sites_assets",
+        id: "__test-name-workers_sites_assets-id",
+      };
+      writeAssets(assets);
+      mockUploadWorkerRequest({ expectedMainModule: "stdin.js" });
+      mockSubDomainRequest();
+      mockListKVNamespacesRequest(kvNamespace);
+      mockKeyListRequest(kvNamespace.id, []);
+      mockUploadAssetsToKVRequest(kvNamespace.id, assets);
+
+      await runWrangler("publish --assets assets --latest --name test-name");
+
+      expect(std).toMatchInlineSnapshot(`
+        Object {
+          "debug": "",
+          "err": "",
+          "out": "Reading file-1.txt...
+        Uploading as file-1.2ca234f380.txt...
+        Reading file-2.txt...
+        Uploading as file-2.5938485188.txt...
+        ↗️  Done syncing assets
+        Uploaded test-name (TIMINGS)
+        Published test-name (TIMINGS)
+          test-name.test-sub-domain.workers.dev",
+          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mUsing the latest version of the Workers runtime. To silence this warning, please choose a specific version of the runtime with --compatibility-date, or add a compatibility_date to your wrangler.toml.[0m
+
+
+
+        ",
+        }
+      `);
+    });
   });
 
   describe("asset upload", () => {

--- a/packages/wrangler/src/entry.ts
+++ b/packages/wrangler/src/entry.ts
@@ -19,7 +19,11 @@ export type Entry = { file: string; directory: string; format: CfScriptFormat };
  * Compute the entry-point for the Worker.
  */
 export async function getEntry(
-  args: { script?: string; format?: CfScriptFormat | undefined },
+  args: {
+    script?: string;
+    format?: CfScriptFormat | undefined;
+    assets?: string | undefined;
+  },
   config: Config,
   command: "dev" | "publish"
 ): Promise<Entry> {
@@ -35,6 +39,8 @@ export async function getEntry(
         ? path.resolve(config.site?.["entry-point"])
         : // site.entry-point could be a directory
           path.resolve(config.site?.["entry-point"], "index.js");
+    } else if (args.assets) {
+      file = path.resolve(__dirname, "../templates/no-op-worker.js");
     } else {
       throw new Error(
         `Missing entry-point: The entry-point should be specified via the command line (e.g. \`wrangler ${command} path/to/script\`) or the \`main\` config field.`

--- a/packages/wrangler/templates/no-op-worker.js
+++ b/packages/wrangler/templates/no-op-worker.js
@@ -1,0 +1,10 @@
+export default {
+  fetch() {
+    return new Response("Not found", {
+      status: 404,
+      headers: {
+        "Content-Type": "text/html",
+      },
+    });
+  },
+};


### PR DESCRIPTION
Since we use a facade worker with `--assets`, an entry point is not strictly necessary. This makes a common usecase of "deploy a bunch of static assets" extremely easy to start, as a one liner `npx wrangler dev --assets path/to/folder` (and same with `publish`).