### PR TITLE
fix: serve `--assets` in dev + local mode

### DIFF
--- a/.changeset/tasty-ravens-double.md
+++ b/.changeset/tasty-ravens-double.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: serve `--assets` in dev + local mode
+
+A quick bugfix to make sure --assets/config.assets gets served correctly in `dev --local`.

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -139,7 +139,7 @@ function DevSession(props: DevSessionProps) {
     rules: props.rules,
     jsxFragment: props.jsxFragment,
     serveAssetsFromWorker: Boolean(
-      props.assetPaths && !props.isWorkersSite && !props.local
+      props.assetPaths && !props.isWorkersSite && props.local
     ),
     tsconfig: props.tsconfig,
     minify: props.minify,


### PR DESCRIPTION
A quick bugfix to make sure --assets/config.assets gets served correctly in `dev --local`.