### PR TITLE
WIP feat: support `--assets` for service-worker Workers

### DIFF
--- a/.changeset/brown-moose-do.md
+++ b/.changeset/brown-moose-do.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+feat: support `--assets` for service-worker Workers
+
+This adds support for `--assets` for service-worker Workers. We do this similarly to how we implement support for module workers (using a facade), but here's the difference - we have to to hijack `addEventListener()` to capture fetch event handlers, so we can call them after checking whether we need to serve a static asset request first. Conveniently, we can use esbuild's `define`+`inject` to hijack the event listener and redirect to our implementation (see `sw-asset-facade-addEventListener.js`).

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -1484,30 +1484,6 @@ addEventListener('fetch', event => {});`
       `);
     });
 
-    it("should error when trying to use --assets with a service-worker Worker", async () => {
-      writeWranglerToml({
-        main: "./index.js",
-      });
-      writeWorkerSource({ type: "sw" });
-      await expect(
-        runWrangler("publish --assets abc")
-      ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"You cannot use the service-worker format with an \`assets\` directory yet. For information on how to migrate to the module-worker format, see: https://developers.cloudflare.com/workers/learning/migrating-to-module-workers/"`
-      );
-
-      expect(std).toMatchInlineSnapshot(`
-        Object {
-          "debug": "",
-          "err": "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mYou cannot use the service-worker format with an \`assets\` directory yet. For information on how to migrate to the module-worker format, see: https://developers.cloudflare.com/workers/learning/migrating-to-module-workers/[0m
-
-        ",
-          "out": "
-        [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m",
-          "warn": "",
-        }
-      `);
-    });
-
     it("should error if --assets and --site are used together", async () => {
       writeWranglerToml({
         main: "./index.js",

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -53,16 +53,6 @@ export type DevProps = {
 };
 
 export function DevImplementation(props: DevProps): JSX.Element {
-  if (
-    !props.isWorkersSite &&
-    props.assetPaths &&
-    props.entry.format === "service-worker"
-  ) {
-    throw new Error(
-      "You cannot use the service-worker format with an `assets` directory yet. For information on how to migrate to the module-worker format, see: https://developers.cloudflare.com/workers/learning/migrating-to-module-workers/"
-    );
-  }
-
   if (props.bindings.wasm_modules && props.entry.format === "modules") {
     throw new Error(
       "You cannot configure [wasm_modules] with an ES module worker. Instead, import the .wasm module directly in your code"
@@ -139,7 +129,7 @@ function DevSession(props: DevSessionProps) {
     rules: props.rules,
     jsxFragment: props.jsxFragment,
     serveAssetsFromWorker: Boolean(
-      props.assetPaths && !props.isWorkersSite && !props.local
+      props.assetPaths && !props.isWorkersSite && props.local
     ),
     tsconfig: props.tsconfig,
     minify: props.minify,

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -303,16 +303,6 @@ export default async function publish(props: Props): Promise<void> {
 
   const { format } = props.entry;
 
-  if (
-    !props.isWorkersSite &&
-    Boolean(props.assetPaths) &&
-    format === "service-worker"
-  ) {
-    throw new Error(
-      "You cannot use the service-worker format with an `assets` directory yet. For information on how to migrate to the module-worker format, see: https://developers.cloudflare.com/workers/learning/migrating-to-module-workers/"
-    );
-  }
-
   if (config.wasm_modules && format === "modules") {
     throw new Error(
       "You cannot configure [wasm_modules] with an ES module worker. Instead, import the .wasm module directly in your code"

--- a/packages/wrangler/templates/module-asset-facade.js
+++ b/packages/wrangler/templates/module-asset-facade.js
@@ -1,6 +1,6 @@
 // DO NOT IMPORT THIS DIRECTLY
 import worker from "__ENTRY_POINT__";
-import { getAssetFromKV } from "__KV_ASSET_HANDLER__";
+import { getAssetFromKV, NotFoundError } from "__KV_ASSET_HANDLER__";
 import manifest from "__STATIC_CONTENT_MANIFEST";
 const ASSET_MANIFEST = JSON.parse(manifest);
 
@@ -33,11 +33,12 @@ export default {
 
       return response;
     } catch (e) {
-      console.error(e);
-      // if an error is thrown then serve from actual worker
-      return worker.fetch(request, env, ctx);
-      // TODO: throw here if worker is not available
-      // (which implies it may be a service-worker)
+      if (e instanceof NotFoundError) {
+        // if an error is thrown then serve from actual worker
+        return worker.fetch(request, env, ctx);
+      } else {
+        throw e;
+      }
     }
   },
 };

--- a/packages/wrangler/templates/sw-asset-facade-addEventListener.js
+++ b/packages/wrangler/templates/sw-asset-facade-addEventListener.js
@@ -1,0 +1,8 @@
+globalThis.__inner_sw_fetch_listeners__ = [];
+export function swAssetHandlerAddEventListener(event, listener) {
+  if (event === "fetch") {
+    globalThis.__inner_sw_fetch_listeners__.push(listener);
+  } else {
+    globalThis.addEventListener(event, listener);
+  }
+}

--- a/packages/wrangler/templates/sw-asset-facade.js
+++ b/packages/wrangler/templates/sw-asset-facade.js
@@ -1,0 +1,39 @@
+// DO NOT IMPORT THIS DIRECTLY
+import "__ENTRY_POINT__"; // inside this worker, our user will call addEventListener/swAssetHandlerAddEventListener and register theur fetch listeneers
+import { getAssetFromKV, NotFoundError } from "__KV_ASSET_HANDLER__";
+
+globalThis.addEventListener("fetch", handleFetchEvent);
+
+function handleFetchEvent(event) {
+  event.respondWith(
+    (async () => {
+      try {
+        const page = await getAssetFromKV(event);
+
+        // allow headers to be altered
+        const response = new Response(page.body, page);
+
+        response.headers.set("X-XSS-Protection", "1; mode=block");
+        response.headers.set("X-Content-Type-Options", "nosniff");
+        response.headers.set("X-Frame-Options", "DENY");
+        response.headers.set("Referrer-Policy", "unsafe-url");
+        response.headers.set("Feature-Policy", "none");
+        return response;
+      } catch (err) {
+        if (err instanceof NotFoundError) {
+          return new Promise((resolve, reject) => {
+            const evt = {
+              ...event,
+              respondWith(response) {
+                resolve(response);
+              },
+            };
+            for (const listener of globalThis.__inner_sw_fetch_listeners__) {
+              listener(evt);
+            }
+          });
+        } else throw err;
+      }
+    })()
+  );
+}


### PR DESCRIPTION
**DO NOT LAND**
---

This adds support for `--assets` for service-worker Workers. We do this similarly to how we implement support for module workers (using a facade), but here's the difference - we have to to hijack `addEventListener()` to capture fetch event handlers, so we can call them after checking whether we need to serve a static asset request first. Conveniently, we can use esbuild's `define`+`inject` to hijack the event listener and redirect to our implementation (see `sw-asset-facade-addEventListener.js`).

--- 

This requires some more work before we can land it, specifically it's getting hairy, so it needs a bunch of docs. It also deserves tests, which I've avoided so far but probably shouldn't anymore. I'm putting this up here to get an initial round of feedback on implementation, and to test out the preview builds. 
