### PR TITLE
chore: upgrade `miniflare` to `2.5.1`

### DIFF
--- a/.changeset/afraid-fishes-retire.md
+++ b/.changeset/afraid-fishes-retire.md
@@ -1,0 +1,6 @@
+---
+"jest-environment-wrangler": patch
+"wrangler": patch
+---
+
+Upgrade `miniflare` to [`2.5.1`](https://github.com/cloudflare/miniflare/releases/tag/v2.5.1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2848,253 +2848,6 @@
         "node": ">=6 <7 || >=8"
       }
     },
-    "node_modules/@miniflare/cache": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.5.0.tgz",
-      "integrity": "sha512-tJuDbWwzYsk4pJvPPJzdlfdGFqNnn1IN3JVrGDCq8UwOXm0K8hFiSwq2nMjjT+Z/9X2FfimgaXOx81zjPL+FjQ==",
-      "dependencies": {
-        "@miniflare/core": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "http-cache-semantics": "^4.1.0",
-        "undici": "5.3.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/cli-parser": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.5.0.tgz",
-      "integrity": "sha512-aY/wQ4Rwy8x0Awtb8TzhKFYp4g1Y8xBhtKFfHOZpYCEFCVfKtgdk0pHPKctf/ClK0qJdT3siJKeXxsH2GRAMXg==",
-      "dependencies": {
-        "@miniflare/shared": "2.5.0",
-        "kleur": "^4.1.4"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.5.0.tgz",
-      "integrity": "sha512-BtMRi17DiimcpmDjQiIU6mIYSo/h21lVGC082n5G3JTF7AcGFAs7N2Fz2YLiYuc3zYc6qJx/NIjDoOqL2gfp3A==",
-      "dependencies": {
-        "@iarna/toml": "^2.2.5",
-        "@miniflare/shared": "2.5.0",
-        "@miniflare/watcher": "2.5.0",
-        "busboy": "^1.6.0",
-        "dotenv": "^10.0.0",
-        "kleur": "^4.1.4",
-        "set-cookie-parser": "^2.4.8",
-        "undici": "5.3.0",
-        "urlpattern-polyfill": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/core/node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@miniflare/durable-objects": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.5.0.tgz",
-      "integrity": "sha512-HJuP5Lsm/CCaSx3dePZiywAniGqTpU1ocCEqV6kE4zX1C0uGplfjPPXo5xsVc2NXkD+0ZL65rJzcj2tfrwKZlg==",
-      "dependencies": {
-        "@miniflare/core": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "@miniflare/storage-memory": "2.5.0",
-        "undici": "5.3.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/html-rewriter": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.5.0.tgz",
-      "integrity": "sha512-bV2lQ/2clPeBmDth+cMnCBFYk8xtGs83S6PhfwmNNd24rzHvOEch1h/VCtEUy8k+rtgDSpc9pVkd31k0tMsyxQ==",
-      "dependencies": {
-        "@miniflare/core": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "html-rewriter-wasm": "^0.4.1",
-        "undici": "5.3.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/http-server": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.5.0.tgz",
-      "integrity": "sha512-+sRPgNq0Q4Q6t1k94ncYzgcf/UNIv0Bz4ubUu6InJy4kMaJKeJPOLlU55lTXJSYfBZM/L4NvAui2i5vA9g2BrA==",
-      "dependencies": {
-        "@miniflare/core": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "@miniflare/web-sockets": "2.5.0",
-        "kleur": "^4.1.4",
-        "selfsigned": "^2.0.0",
-        "undici": "5.3.0",
-        "ws": "^8.2.2",
-        "youch": "^2.2.2"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/http-server/node_modules/ws": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
-      "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@miniflare/kv": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.5.0.tgz",
-      "integrity": "sha512-5dzcUMMOKl8u75FXbpy2BHp38uafjzo3RW2HEm6EY8QoM/vHw6RChFzJ9YEPJDbvcHR8gdMpgC65LYPTjifc3g==",
-      "dependencies": {
-        "@miniflare/shared": "2.5.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/runner-vm": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.5.0.tgz",
-      "integrity": "sha512-0n85cOBq91D7roqsIqJESDnj0oRi+xNVjDfd5uDIT1dW1qo5asA5Mwx6ntzCJB1BcB4khNatUIwpO3ZT+kT/YQ==",
-      "dependencies": {
-        "@miniflare/shared": "2.5.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/scheduler": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.5.0.tgz",
-      "integrity": "sha512-+a/I2QLp3UaZpKVobzFH3eHsi5ubhBp8q/AH/sCDwcZmatbCp2+oDrjMgTqhF6Fm8ryR4BYkHQOgkGZ5l7gQjw==",
-      "dependencies": {
-        "@miniflare/core": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "cron-schedule": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/shared": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.5.0.tgz",
-      "integrity": "sha512-2oPxhnCGg8DNoo0NzUdc2BylGGeHQQvFJ6mDODjxbSXybeQC0+Ul5Ujv/FyU9W/eTbUEWNqKBycINyuXqSnJ/w==",
-      "dependencies": {
-        "ignore": "^5.1.8",
-        "kleur": "^4.1.4"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/sites": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.5.0.tgz",
-      "integrity": "sha512-AwYZb6ppP00YLkVNJnCe0lzJJemCDwibFjJywECY+aXFFNRo80sLpePPOXytplaUpen1uxnxUc8vdKBFVoB5cQ==",
-      "dependencies": {
-        "@miniflare/kv": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "@miniflare/storage-file": "2.5.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/storage-file": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.5.0.tgz",
-      "integrity": "sha512-ytwWZEIn3eMBnI2FdqvM5+mJVuI2aIBeZNjhZFuF5/AW3v1uslqY55Qd5Fnfn+2C7z6ivVaUv/TlEwot9ZDUnw==",
-      "dependencies": {
-        "@miniflare/shared": "2.5.0",
-        "@miniflare/storage-memory": "2.5.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/storage-memory": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.5.0.tgz",
-      "integrity": "sha512-cydVKLY0cZe2Sah0jV3s9MK3gmYLrQQcpCdMHMBEUz+nRfjfnuzs4WXzzUXCWwNT+WFC0V2WvDp2sMt+lVsmsA==",
-      "dependencies": {
-        "@miniflare/shared": "2.5.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/watcher": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.5.0.tgz",
-      "integrity": "sha512-6ECE7po8NBxLmr2M00f7TWLEp1dMaAm3swf4D3ZU2xy3IqSBZE3QbOBuczYEYUIk7F+kXgaREISQg4e5QdECXQ==",
-      "dependencies": {
-        "@miniflare/shared": "2.5.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/web-sockets": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.5.0.tgz",
-      "integrity": "sha512-nnLBtbHdmgGUNTxP0IeAz1B4UGCO/6W+4edzjogtz3JJumKQE+ink5+SIrmL0C1Pitrc2+kO2WYsQzWh3a2Amg==",
-      "dependencies": {
-        "@miniflare/core": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "undici": "5.3.0",
-        "ws": "^8.2.2"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@miniflare/web-sockets/node_modules/ws": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
-      "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -11557,131 +11310,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-environment-miniflare": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-miniflare/-/jest-environment-miniflare-2.5.0.tgz",
-      "integrity": "sha512-3OirfOB+kBxVBN5kOsXXQMgGHDUoO0+toulyoqGEWfZRa2kfL48CFCF10jB8A1K63cB5JMblN+uqyWUeZb/SBw==",
-      "dependencies": {
-        "@jest/environment": ">=27",
-        "@jest/fake-timers": ">=27",
-        "@jest/types": ">=27",
-        "@miniflare/cache": "2.5.0",
-        "@miniflare/core": "2.5.0",
-        "@miniflare/durable-objects": "2.5.0",
-        "@miniflare/html-rewriter": "2.5.0",
-        "@miniflare/kv": "2.5.0",
-        "@miniflare/runner-vm": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "@miniflare/sites": "2.5.0",
-        "@miniflare/storage-memory": "2.5.0",
-        "@miniflare/web-sockets": "2.5.0",
-        "jest-mock": ">=27",
-        "jest-util": ">=27",
-        "miniflare": "2.5.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      },
-      "peerDependencies": {
-        "jest": ">=27"
-      }
-    },
-    "node_modules/jest-environment-miniflare/node_modules/@jest/types": {
-      "version": "28.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.0.tgz",
-      "integrity": "sha512-xmEggMPr317MIOjjDoZ4ejCSr9Lpbt/u34+dvc99t7DS8YirW5rwZEhzKPC2BMUFkUhI48qs6qLUSGw5FuL0GA==",
-      "dependencies": {
-        "@jest/schemas": "^28.0.2",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/jest-environment-miniflare/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-environment-miniflare/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-environment-miniflare/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/jest-environment-miniflare/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/jest-environment-miniflare/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-environment-miniflare/node_modules/jest-util": {
-      "version": "28.1.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.0.tgz",
-      "integrity": "sha512-qYdCKD77k4Hwkose2YBEqQk7PzUf/NSE+rutzceduFveQREeH6b+89Dc9+wjX9dAwHcgdx4yedGA3FQlU/qCTA==",
-      "dependencies": {
-        "@jest/types": "^28.1.0",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/jest-environment-miniflare/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-environment-node": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.5.1.tgz",
@@ -15069,53 +14697,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/miniflare": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.5.0.tgz",
-      "integrity": "sha512-3IR+n/kLBA7zQ20HDjnA0HufQlr197krD8jPsaYO5wTrkIUCTvrilbI0sCo0X9CP/I3BCIl8fiZc1Jf7+MX7jQ==",
-      "dependencies": {
-        "@miniflare/cache": "2.5.0",
-        "@miniflare/cli-parser": "2.5.0",
-        "@miniflare/core": "2.5.0",
-        "@miniflare/durable-objects": "2.5.0",
-        "@miniflare/html-rewriter": "2.5.0",
-        "@miniflare/http-server": "2.5.0",
-        "@miniflare/kv": "2.5.0",
-        "@miniflare/runner-vm": "2.5.0",
-        "@miniflare/scheduler": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "@miniflare/sites": "2.5.0",
-        "@miniflare/storage-file": "2.5.0",
-        "@miniflare/storage-memory": "2.5.0",
-        "@miniflare/web-sockets": "2.5.0",
-        "kleur": "^4.1.4",
-        "semiver": "^1.1.0",
-        "source-map-support": "^0.5.20",
-        "undici": "5.3.0"
-      },
-      "bin": {
-        "miniflare": "bootstrap.js"
-      },
-      "engines": {
-        "node": ">=16.7"
-      },
-      "peerDependencies": {
-        "@miniflare/storage-redis": "2.5.0",
-        "cron-schedule": "^3.0.4",
-        "ioredis": "^4.27.9"
-      },
-      "peerDependenciesMeta": {
-        "@miniflare/storage-redis": {
-          "optional": true
-        },
-        "cron-schedule": {
-          "optional": true
-        },
-        "ioredis": {
-          "optional": true
-        }
       }
     },
     "node_modules/minimalistic-assert": {
@@ -19427,6 +19008,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.3.0.tgz",
       "integrity": "sha512-8LxC/xmR2GCE4q1heE1sJxVnnf5S6yQ2dObvMFBBWkB8aQlaqNuWovgRFWRMB7KUdLPGZfOTTmUeeLEJYX56iQ==",
+      "dev": true,
       "engines": {
         "node": ">=12.18"
       }
@@ -20806,7 +20388,414 @@
       "version": "0.0.30",
       "license": "ISC",
       "dependencies": {
-        "jest-environment-miniflare": "^2.5.0"
+        "jest-environment-miniflare": "^2.5.1"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@jest/types": {
+      "version": "28.1.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.1.tgz",
+      "integrity": "sha512-vRXVqSg1VhDnB8bWcmvLzmg0Bt9CRKVgHPXqYwvWMX3TvAjeO+nRuK6+VdTKCtWOvYlmkF/HqNAL/z+N3B53Kw==",
+      "dependencies": {
+        "@jest/schemas": "^28.0.2",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/cache": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.5.1.tgz",
+      "integrity": "sha512-qH5PC4zb7mHdQHlcaOuP0KUXuRbNSuB/HU7gpoeplV8J6CgNJGceVmQCZVZLycgDKZtAlhyGE1gkpJmeW7GCyw==",
+      "dependencies": {
+        "@miniflare/core": "2.5.1",
+        "@miniflare/shared": "2.5.1",
+        "http-cache-semantics": "^4.1.0",
+        "undici": "5.5.1"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/cli-parser": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.5.1.tgz",
+      "integrity": "sha512-itlMDe9jwO806mkNkg3G70QYoG9YQHW6V10AF9L5b8J4LYt/V78uCEJSwNnCpL7zfKrScRPtDfXZxhrFzMXiUw==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.1",
+        "kleur": "^4.1.4"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/core": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.5.1.tgz",
+      "integrity": "sha512-0oEBLV5AM3xxs6TS+7/fn4MSGNBfhUFVv41R8uc72H1a89+kBfRoz+xYI2RnJ3Yo+we66UgU3fXdG+R2KyESlQ==",
+      "dependencies": {
+        "@iarna/toml": "^2.2.5",
+        "@miniflare/shared": "2.5.1",
+        "@miniflare/watcher": "2.5.1",
+        "busboy": "^1.6.0",
+        "dotenv": "^10.0.0",
+        "kleur": "^4.1.4",
+        "set-cookie-parser": "^2.4.8",
+        "undici": "5.5.1",
+        "urlpattern-polyfill": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/durable-objects": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.5.1.tgz",
+      "integrity": "sha512-AZEGSA9LMA6vBzwADAzr81RBSWYlMfa/cDHnHaFL31w4mQwMUcqXOvemoqe6sTSq1KI0TTtvYbxPt0Lui8tEPw==",
+      "dependencies": {
+        "@miniflare/core": "2.5.1",
+        "@miniflare/shared": "2.5.1",
+        "@miniflare/storage-memory": "2.5.1",
+        "undici": "5.5.1"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/html-rewriter": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.5.1.tgz",
+      "integrity": "sha512-fdO1qme8ukucejRz5yXJN/F4B9qEDRbBLPOEG94zwx8bHGGIo5VX15+J6oHubhjifLwzNuvOcg16Bu5dyR1KxQ==",
+      "dependencies": {
+        "@miniflare/core": "2.5.1",
+        "@miniflare/shared": "2.5.1",
+        "html-rewriter-wasm": "^0.4.1",
+        "undici": "5.5.1"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/http-server": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.5.1.tgz",
+      "integrity": "sha512-K+VoBU0LN8/oku/JWLEyX8wrp9fiaTC8/dosbY/6VWizyIrgQze16uD21GnK5+NBtbCAtLRryS5dZ3PnhiTR1w==",
+      "dependencies": {
+        "@miniflare/core": "2.5.1",
+        "@miniflare/shared": "2.5.1",
+        "@miniflare/web-sockets": "2.5.1",
+        "kleur": "^4.1.4",
+        "selfsigned": "^2.0.0",
+        "undici": "5.5.1",
+        "ws": "^8.2.2",
+        "youch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/kv": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.5.1.tgz",
+      "integrity": "sha512-ODTUqI7on3egHluBpFHifO0a9QFQUZscciASWKxGOt8VDp1vp0vIfU9ykQZrdZYFVeSKNVlUNqNQx+NMYZ6gIg==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.1"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/runner-vm": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.5.1.tgz",
+      "integrity": "sha512-7U7BPgzaikwWkAMonlmyy4lDpW1H7mqHFr7NdK9kA6BbXZ2GY6uro69QsGw0c4Y/vyKBodKiqXAq53iGdM3Kug==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.1"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/scheduler": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.5.1.tgz",
+      "integrity": "sha512-ybho5Kg3Cfl4E0JleKAbiv/RTA+/PVqH6Y/PuCH2oowSM7qeAvFkrwiRvxtN7BuAl+5lsGyVxFe4gL+weXohEw==",
+      "dependencies": {
+        "@miniflare/core": "2.5.1",
+        "@miniflare/shared": "2.5.1",
+        "cron-schedule": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/shared": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.5.1.tgz",
+      "integrity": "sha512-DObgqbFml3qetIBtZa8fNqkBqUH9XtI6rdrWtTYVrx0rzKsd5PDf6gdMoxy7v1rr9zBAipKJxrcBqlEgjPl53Q==",
+      "dependencies": {
+        "ignore": "^5.1.8",
+        "kleur": "^4.1.4"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/sites": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.5.1.tgz",
+      "integrity": "sha512-7V/fAzR50LYgMcOfoCaoppqBCjagBpGWFbZgMyJi/Hj4oVlSIzxo+424hzdjitNzikCpv+AryF9tXfy9j6qiOg==",
+      "dependencies": {
+        "@miniflare/kv": "2.5.1",
+        "@miniflare/shared": "2.5.1",
+        "@miniflare/storage-file": "2.5.1"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/storage-file": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.5.1.tgz",
+      "integrity": "sha512-o12KFXgc1M0nHD98mrA/IqwBsJ6KYLWH9NaTwqLhxhpGz/KSo5kWb7z/vrz2I/Rk2XR/gHSYQm2XR9XE6IJCdA==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.1",
+        "@miniflare/storage-memory": "2.5.1"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/storage-memory": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.5.1.tgz",
+      "integrity": "sha512-LIdBEFcwY7yLCeowO34p5bajRsvU1XuQjXIqcgfiCVt1+qa3D0seELTpW1NSFEJzxulVtu/KsScEug9GipEt7A==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.1"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/watcher": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.5.1.tgz",
+      "integrity": "sha512-8oOdgWA7CZ7uIAwbjqSrhDnuQXRJqd9e3yDHsMa91E/jkC/GDmlt5SJh6VEMlNDtBGWd661IpVErZf7injI52w==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.1"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/@miniflare/web-sockets": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.5.1.tgz",
+      "integrity": "sha512-GyXHoDAI5LDF87rmD+d0cSoN7Xs2pCYjSyUR6Vf6exkS4CN6F/Rtr8vIM5+om9kRkS6qxAyOYjWeEqBOjLm/og==",
+      "dependencies": {
+        "@miniflare/core": "2.5.1",
+        "@miniflare/shared": "2.5.1",
+        "undici": "5.5.1",
+        "ws": "^8.2.2"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "packages/jest-environment-wrangler/node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/jest-environment-miniflare": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-miniflare/-/jest-environment-miniflare-2.5.1.tgz",
+      "integrity": "sha512-BQZNE393imnQcHjPXhXpgAYYrb2RAyCTtkveMVeygrpzsrVLZ2uG/qxyrG05HFvWJ4Ca2EyI5AOCrNDGqMgD5g==",
+      "dependencies": {
+        "@jest/environment": ">=27",
+        "@jest/fake-timers": ">=27",
+        "@jest/types": ">=27",
+        "@miniflare/cache": "2.5.1",
+        "@miniflare/core": "2.5.1",
+        "@miniflare/durable-objects": "2.5.1",
+        "@miniflare/html-rewriter": "2.5.1",
+        "@miniflare/kv": "2.5.1",
+        "@miniflare/runner-vm": "2.5.1",
+        "@miniflare/shared": "2.5.1",
+        "@miniflare/sites": "2.5.1",
+        "@miniflare/storage-memory": "2.5.1",
+        "@miniflare/web-sockets": "2.5.1",
+        "jest-mock": ">=27",
+        "jest-util": ">=27",
+        "miniflare": "2.5.1"
+      },
+      "engines": {
+        "node": ">=16.7"
+      },
+      "peerDependencies": {
+        "jest": ">=27"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/jest-util": {
+      "version": "28.1.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.1.tgz",
+      "integrity": "sha512-FktOu7ca1DZSyhPAxgxB6hfh2+9zMoJ7aEQA759Z6p45NuO8mWcqujH+UdHlCm/V6JTWwDztM2ITCzU1ijJAfw==",
+      "dependencies": {
+        "@jest/types": "^28.1.1",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/miniflare": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.5.1.tgz",
+      "integrity": "sha512-PT56C/j7U6n7WDxnIUHu0d8EY/gedPRsta2b+LsrIHGZPSkxAcPzf2DgbbPU7obv0C4hT9H0GL1fWpWtr2SbDQ==",
+      "dependencies": {
+        "@miniflare/cache": "2.5.1",
+        "@miniflare/cli-parser": "2.5.1",
+        "@miniflare/core": "2.5.1",
+        "@miniflare/durable-objects": "2.5.1",
+        "@miniflare/html-rewriter": "2.5.1",
+        "@miniflare/http-server": "2.5.1",
+        "@miniflare/kv": "2.5.1",
+        "@miniflare/runner-vm": "2.5.1",
+        "@miniflare/scheduler": "2.5.1",
+        "@miniflare/shared": "2.5.1",
+        "@miniflare/sites": "2.5.1",
+        "@miniflare/storage-file": "2.5.1",
+        "@miniflare/storage-memory": "2.5.1",
+        "@miniflare/web-sockets": "2.5.1",
+        "kleur": "^4.1.4",
+        "semiver": "^1.1.0",
+        "source-map-support": "^0.5.20",
+        "undici": "5.5.1"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=16.7"
+      },
+      "peerDependencies": {
+        "@miniflare/storage-redis": "2.5.1",
+        "cron-schedule": "^3.0.4",
+        "ioredis": "^4.27.9"
+      },
+      "peerDependenciesMeta": {
+        "@miniflare/storage-redis": {
+          "optional": true
+        },
+        "cron-schedule": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        }
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/undici": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.5.1.tgz",
+      "integrity": "sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw==",
+      "engines": {
+        "node": ">=12.18"
+      }
+    },
+    "packages/jest-environment-wrangler/node_modules/ws": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
+      "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "packages/prerelease-registry": {
@@ -20828,7 +20817,7 @@
         "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
         "blake3-wasm": "^2.1.5",
         "esbuild": "0.14.34",
-        "miniflare": "^2.5.0",
+        "miniflare": "^2.5.1",
         "nanoid": "^3.3.3",
         "path-to-regexp": "^6.2.0",
         "selfsigned": "^2.0.1",
@@ -20905,6 +20894,218 @@
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-3.0.0.tgz",
       "integrity": "sha512-td6ZUkz2oS3VeleBcN+m//Q6HlCFCPrnI0FZhrt/h4XqLEdOyYp2u21nd8MdsR+WJy5r9PTDaHTDDfhf4H4l6Q==",
       "dev": true
+    },
+    "packages/wrangler/node_modules/@miniflare/cache": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.5.1.tgz",
+      "integrity": "sha512-qH5PC4zb7mHdQHlcaOuP0KUXuRbNSuB/HU7gpoeplV8J6CgNJGceVmQCZVZLycgDKZtAlhyGE1gkpJmeW7GCyw==",
+      "dependencies": {
+        "@miniflare/core": "2.5.1",
+        "@miniflare/shared": "2.5.1",
+        "http-cache-semantics": "^4.1.0",
+        "undici": "5.5.1"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/cli-parser": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.5.1.tgz",
+      "integrity": "sha512-itlMDe9jwO806mkNkg3G70QYoG9YQHW6V10AF9L5b8J4LYt/V78uCEJSwNnCpL7zfKrScRPtDfXZxhrFzMXiUw==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.1",
+        "kleur": "^4.1.4"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/core": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.5.1.tgz",
+      "integrity": "sha512-0oEBLV5AM3xxs6TS+7/fn4MSGNBfhUFVv41R8uc72H1a89+kBfRoz+xYI2RnJ3Yo+we66UgU3fXdG+R2KyESlQ==",
+      "dependencies": {
+        "@iarna/toml": "^2.2.5",
+        "@miniflare/shared": "2.5.1",
+        "@miniflare/watcher": "2.5.1",
+        "busboy": "^1.6.0",
+        "dotenv": "^10.0.0",
+        "kleur": "^4.1.4",
+        "set-cookie-parser": "^2.4.8",
+        "undici": "5.5.1",
+        "urlpattern-polyfill": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/core/node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
+    },
+    "packages/wrangler/node_modules/@miniflare/core/node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/durable-objects": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.5.1.tgz",
+      "integrity": "sha512-AZEGSA9LMA6vBzwADAzr81RBSWYlMfa/cDHnHaFL31w4mQwMUcqXOvemoqe6sTSq1KI0TTtvYbxPt0Lui8tEPw==",
+      "dependencies": {
+        "@miniflare/core": "2.5.1",
+        "@miniflare/shared": "2.5.1",
+        "@miniflare/storage-memory": "2.5.1",
+        "undici": "5.5.1"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/html-rewriter": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.5.1.tgz",
+      "integrity": "sha512-fdO1qme8ukucejRz5yXJN/F4B9qEDRbBLPOEG94zwx8bHGGIo5VX15+J6oHubhjifLwzNuvOcg16Bu5dyR1KxQ==",
+      "dependencies": {
+        "@miniflare/core": "2.5.1",
+        "@miniflare/shared": "2.5.1",
+        "html-rewriter-wasm": "^0.4.1",
+        "undici": "5.5.1"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/http-server": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.5.1.tgz",
+      "integrity": "sha512-K+VoBU0LN8/oku/JWLEyX8wrp9fiaTC8/dosbY/6VWizyIrgQze16uD21GnK5+NBtbCAtLRryS5dZ3PnhiTR1w==",
+      "dependencies": {
+        "@miniflare/core": "2.5.1",
+        "@miniflare/shared": "2.5.1",
+        "@miniflare/web-sockets": "2.5.1",
+        "kleur": "^4.1.4",
+        "selfsigned": "^2.0.0",
+        "undici": "5.5.1",
+        "ws": "^8.2.2",
+        "youch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/kv": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.5.1.tgz",
+      "integrity": "sha512-ODTUqI7on3egHluBpFHifO0a9QFQUZscciASWKxGOt8VDp1vp0vIfU9ykQZrdZYFVeSKNVlUNqNQx+NMYZ6gIg==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.1"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/runner-vm": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.5.1.tgz",
+      "integrity": "sha512-7U7BPgzaikwWkAMonlmyy4lDpW1H7mqHFr7NdK9kA6BbXZ2GY6uro69QsGw0c4Y/vyKBodKiqXAq53iGdM3Kug==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.1"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/scheduler": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.5.1.tgz",
+      "integrity": "sha512-ybho5Kg3Cfl4E0JleKAbiv/RTA+/PVqH6Y/PuCH2oowSM7qeAvFkrwiRvxtN7BuAl+5lsGyVxFe4gL+weXohEw==",
+      "dependencies": {
+        "@miniflare/core": "2.5.1",
+        "@miniflare/shared": "2.5.1",
+        "cron-schedule": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/shared": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.5.1.tgz",
+      "integrity": "sha512-DObgqbFml3qetIBtZa8fNqkBqUH9XtI6rdrWtTYVrx0rzKsd5PDf6gdMoxy7v1rr9zBAipKJxrcBqlEgjPl53Q==",
+      "dependencies": {
+        "ignore": "^5.1.8",
+        "kleur": "^4.1.4"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/sites": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.5.1.tgz",
+      "integrity": "sha512-7V/fAzR50LYgMcOfoCaoppqBCjagBpGWFbZgMyJi/Hj4oVlSIzxo+424hzdjitNzikCpv+AryF9tXfy9j6qiOg==",
+      "dependencies": {
+        "@miniflare/kv": "2.5.1",
+        "@miniflare/shared": "2.5.1",
+        "@miniflare/storage-file": "2.5.1"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/storage-file": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.5.1.tgz",
+      "integrity": "sha512-o12KFXgc1M0nHD98mrA/IqwBsJ6KYLWH9NaTwqLhxhpGz/KSo5kWb7z/vrz2I/Rk2XR/gHSYQm2XR9XE6IJCdA==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.1",
+        "@miniflare/storage-memory": "2.5.1"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/storage-memory": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.5.1.tgz",
+      "integrity": "sha512-LIdBEFcwY7yLCeowO34p5bajRsvU1XuQjXIqcgfiCVt1+qa3D0seELTpW1NSFEJzxulVtu/KsScEug9GipEt7A==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.1"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/watcher": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.5.1.tgz",
+      "integrity": "sha512-8oOdgWA7CZ7uIAwbjqSrhDnuQXRJqd9e3yDHsMa91E/jkC/GDmlt5SJh6VEMlNDtBGWd661IpVErZf7injI52w==",
+      "dependencies": {
+        "@miniflare/shared": "2.5.1"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "packages/wrangler/node_modules/@miniflare/web-sockets": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.5.1.tgz",
+      "integrity": "sha512-GyXHoDAI5LDF87rmD+d0cSoN7Xs2pCYjSyUR6Vf6exkS4CN6F/Rtr8vIM5+om9kRkS6qxAyOYjWeEqBOjLm/og==",
+      "dependencies": {
+        "@miniflare/core": "2.5.1",
+        "@miniflare/shared": "2.5.1",
+        "undici": "5.5.1",
+        "ws": "^8.2.2"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
     },
     "packages/wrangler/node_modules/dotenv": {
       "version": "16.0.0",
@@ -21280,6 +21481,53 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "packages/wrangler/node_modules/miniflare": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.5.1.tgz",
+      "integrity": "sha512-PT56C/j7U6n7WDxnIUHu0d8EY/gedPRsta2b+LsrIHGZPSkxAcPzf2DgbbPU7obv0C4hT9H0GL1fWpWtr2SbDQ==",
+      "dependencies": {
+        "@miniflare/cache": "2.5.1",
+        "@miniflare/cli-parser": "2.5.1",
+        "@miniflare/core": "2.5.1",
+        "@miniflare/durable-objects": "2.5.1",
+        "@miniflare/html-rewriter": "2.5.1",
+        "@miniflare/http-server": "2.5.1",
+        "@miniflare/kv": "2.5.1",
+        "@miniflare/runner-vm": "2.5.1",
+        "@miniflare/scheduler": "2.5.1",
+        "@miniflare/shared": "2.5.1",
+        "@miniflare/sites": "2.5.1",
+        "@miniflare/storage-file": "2.5.1",
+        "@miniflare/storage-memory": "2.5.1",
+        "@miniflare/web-sockets": "2.5.1",
+        "kleur": "^4.1.4",
+        "semiver": "^1.1.0",
+        "source-map-support": "^0.5.20",
+        "undici": "5.5.1"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=16.7"
+      },
+      "peerDependencies": {
+        "@miniflare/storage-redis": "2.5.1",
+        "cron-schedule": "^3.0.4",
+        "ioredis": "^4.27.9"
+      },
+      "peerDependenciesMeta": {
+        "@miniflare/storage-redis": {
+          "optional": true
+        },
+        "cron-schedule": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        }
+      }
+    },
     "packages/wrangler/node_modules/p-limit": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
@@ -21334,7 +21582,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.5.1.tgz",
       "integrity": "sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw==",
-      "dev": true,
       "engines": {
         "node": ">=12.18"
       }
@@ -21343,7 +21590,6 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
       "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -23175,183 +23421,6 @@
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
           }
-        }
-      }
-    },
-    "@miniflare/cache": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.5.0.tgz",
-      "integrity": "sha512-tJuDbWwzYsk4pJvPPJzdlfdGFqNnn1IN3JVrGDCq8UwOXm0K8hFiSwq2nMjjT+Z/9X2FfimgaXOx81zjPL+FjQ==",
-      "requires": {
-        "@miniflare/core": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "http-cache-semantics": "^4.1.0",
-        "undici": "5.3.0"
-      }
-    },
-    "@miniflare/cli-parser": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.5.0.tgz",
-      "integrity": "sha512-aY/wQ4Rwy8x0Awtb8TzhKFYp4g1Y8xBhtKFfHOZpYCEFCVfKtgdk0pHPKctf/ClK0qJdT3siJKeXxsH2GRAMXg==",
-      "requires": {
-        "@miniflare/shared": "2.5.0",
-        "kleur": "^4.1.4"
-      }
-    },
-    "@miniflare/core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.5.0.tgz",
-      "integrity": "sha512-BtMRi17DiimcpmDjQiIU6mIYSo/h21lVGC082n5G3JTF7AcGFAs7N2Fz2YLiYuc3zYc6qJx/NIjDoOqL2gfp3A==",
-      "requires": {
-        "@iarna/toml": "^2.2.5",
-        "@miniflare/shared": "2.5.0",
-        "@miniflare/watcher": "2.5.0",
-        "busboy": "^1.6.0",
-        "dotenv": "^10.0.0",
-        "kleur": "^4.1.4",
-        "set-cookie-parser": "^2.4.8",
-        "undici": "5.3.0",
-        "urlpattern-polyfill": "^4.0.3"
-      },
-      "dependencies": {
-        "dotenv": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
-        }
-      }
-    },
-    "@miniflare/durable-objects": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.5.0.tgz",
-      "integrity": "sha512-HJuP5Lsm/CCaSx3dePZiywAniGqTpU1ocCEqV6kE4zX1C0uGplfjPPXo5xsVc2NXkD+0ZL65rJzcj2tfrwKZlg==",
-      "requires": {
-        "@miniflare/core": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "@miniflare/storage-memory": "2.5.0",
-        "undici": "5.3.0"
-      }
-    },
-    "@miniflare/html-rewriter": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.5.0.tgz",
-      "integrity": "sha512-bV2lQ/2clPeBmDth+cMnCBFYk8xtGs83S6PhfwmNNd24rzHvOEch1h/VCtEUy8k+rtgDSpc9pVkd31k0tMsyxQ==",
-      "requires": {
-        "@miniflare/core": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "html-rewriter-wasm": "^0.4.1",
-        "undici": "5.3.0"
-      }
-    },
-    "@miniflare/http-server": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.5.0.tgz",
-      "integrity": "sha512-+sRPgNq0Q4Q6t1k94ncYzgcf/UNIv0Bz4ubUu6InJy4kMaJKeJPOLlU55lTXJSYfBZM/L4NvAui2i5vA9g2BrA==",
-      "requires": {
-        "@miniflare/core": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "@miniflare/web-sockets": "2.5.0",
-        "kleur": "^4.1.4",
-        "selfsigned": "^2.0.0",
-        "undici": "5.3.0",
-        "ws": "^8.2.2",
-        "youch": "^2.2.2"
-      },
-      "dependencies": {
-        "ws": {
-          "version": "8.7.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
-          "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
-          "requires": {}
-        }
-      }
-    },
-    "@miniflare/kv": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.5.0.tgz",
-      "integrity": "sha512-5dzcUMMOKl8u75FXbpy2BHp38uafjzo3RW2HEm6EY8QoM/vHw6RChFzJ9YEPJDbvcHR8gdMpgC65LYPTjifc3g==",
-      "requires": {
-        "@miniflare/shared": "2.5.0"
-      }
-    },
-    "@miniflare/runner-vm": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.5.0.tgz",
-      "integrity": "sha512-0n85cOBq91D7roqsIqJESDnj0oRi+xNVjDfd5uDIT1dW1qo5asA5Mwx6ntzCJB1BcB4khNatUIwpO3ZT+kT/YQ==",
-      "requires": {
-        "@miniflare/shared": "2.5.0"
-      }
-    },
-    "@miniflare/scheduler": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.5.0.tgz",
-      "integrity": "sha512-+a/I2QLp3UaZpKVobzFH3eHsi5ubhBp8q/AH/sCDwcZmatbCp2+oDrjMgTqhF6Fm8ryR4BYkHQOgkGZ5l7gQjw==",
-      "requires": {
-        "@miniflare/core": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "cron-schedule": "^3.0.4"
-      }
-    },
-    "@miniflare/shared": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.5.0.tgz",
-      "integrity": "sha512-2oPxhnCGg8DNoo0NzUdc2BylGGeHQQvFJ6mDODjxbSXybeQC0+Ul5Ujv/FyU9W/eTbUEWNqKBycINyuXqSnJ/w==",
-      "requires": {
-        "ignore": "^5.1.8",
-        "kleur": "^4.1.4"
-      }
-    },
-    "@miniflare/sites": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.5.0.tgz",
-      "integrity": "sha512-AwYZb6ppP00YLkVNJnCe0lzJJemCDwibFjJywECY+aXFFNRo80sLpePPOXytplaUpen1uxnxUc8vdKBFVoB5cQ==",
-      "requires": {
-        "@miniflare/kv": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "@miniflare/storage-file": "2.5.0"
-      }
-    },
-    "@miniflare/storage-file": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.5.0.tgz",
-      "integrity": "sha512-ytwWZEIn3eMBnI2FdqvM5+mJVuI2aIBeZNjhZFuF5/AW3v1uslqY55Qd5Fnfn+2C7z6ivVaUv/TlEwot9ZDUnw==",
-      "requires": {
-        "@miniflare/shared": "2.5.0",
-        "@miniflare/storage-memory": "2.5.0"
-      }
-    },
-    "@miniflare/storage-memory": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.5.0.tgz",
-      "integrity": "sha512-cydVKLY0cZe2Sah0jV3s9MK3gmYLrQQcpCdMHMBEUz+nRfjfnuzs4WXzzUXCWwNT+WFC0V2WvDp2sMt+lVsmsA==",
-      "requires": {
-        "@miniflare/shared": "2.5.0"
-      }
-    },
-    "@miniflare/watcher": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.5.0.tgz",
-      "integrity": "sha512-6ECE7po8NBxLmr2M00f7TWLEp1dMaAm3swf4D3ZU2xy3IqSBZE3QbOBuczYEYUIk7F+kXgaREISQg4e5QdECXQ==",
-      "requires": {
-        "@miniflare/shared": "2.5.0"
-      }
-    },
-    "@miniflare/web-sockets": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.5.0.tgz",
-      "integrity": "sha512-nnLBtbHdmgGUNTxP0IeAz1B4UGCO/6W+4edzjogtz3JJumKQE+ink5+SIrmL0C1Pitrc2+kO2WYsQzWh3a2Amg==",
-      "requires": {
-        "@miniflare/core": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "undici": "5.3.0",
-        "ws": "^8.2.2"
-      },
-      "dependencies": {
-        "ws": {
-          "version": "8.7.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
-          "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
-          "requires": {}
         }
       }
     },
@@ -29184,100 +29253,6 @@
         }
       }
     },
-    "jest-environment-miniflare": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-miniflare/-/jest-environment-miniflare-2.5.0.tgz",
-      "integrity": "sha512-3OirfOB+kBxVBN5kOsXXQMgGHDUoO0+toulyoqGEWfZRa2kfL48CFCF10jB8A1K63cB5JMblN+uqyWUeZb/SBw==",
-      "requires": {
-        "@jest/environment": ">=27",
-        "@jest/fake-timers": ">=27",
-        "@jest/types": ">=27",
-        "@miniflare/cache": "2.5.0",
-        "@miniflare/core": "2.5.0",
-        "@miniflare/durable-objects": "2.5.0",
-        "@miniflare/html-rewriter": "2.5.0",
-        "@miniflare/kv": "2.5.0",
-        "@miniflare/runner-vm": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "@miniflare/sites": "2.5.0",
-        "@miniflare/storage-memory": "2.5.0",
-        "@miniflare/web-sockets": "2.5.0",
-        "jest-mock": ">=27",
-        "jest-util": ">=27",
-        "miniflare": "2.5.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "28.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.0.tgz",
-          "integrity": "sha512-xmEggMPr317MIOjjDoZ4ejCSr9Lpbt/u34+dvc99t7DS8YirW5rwZEhzKPC2BMUFkUhI48qs6qLUSGw5FuL0GA==",
-          "requires": {
-            "@jest/schemas": "^28.0.2",
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^17.0.8",
-            "chalk": "^4.0.0"
-          }
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "jest-util": {
-          "version": "28.1.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.0.tgz",
-          "integrity": "sha512-qYdCKD77k4Hwkose2YBEqQk7PzUf/NSE+rutzceduFveQREeH6b+89Dc9+wjX9dAwHcgdx4yedGA3FQlU/qCTA==",
-          "requires": {
-            "@jest/types": "^28.1.0",
-            "@types/node": "*",
-            "chalk": "^4.0.0",
-            "ci-info": "^3.2.0",
-            "graceful-fs": "^4.2.9",
-            "picomatch": "^2.2.3"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "jest-environment-node": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.5.1.tgz",
@@ -29372,7 +29347,296 @@
     "jest-environment-wrangler": {
       "version": "file:packages/jest-environment-wrangler",
       "requires": {
-        "jest-environment-miniflare": "^2.5.0"
+        "jest-environment-miniflare": "^2.5.1"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "28.1.1",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.1.tgz",
+          "integrity": "sha512-vRXVqSg1VhDnB8bWcmvLzmg0Bt9CRKVgHPXqYwvWMX3TvAjeO+nRuK6+VdTKCtWOvYlmkF/HqNAL/z+N3B53Kw==",
+          "requires": {
+            "@jest/schemas": "^28.0.2",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^17.0.8",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@miniflare/cache": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.5.1.tgz",
+          "integrity": "sha512-qH5PC4zb7mHdQHlcaOuP0KUXuRbNSuB/HU7gpoeplV8J6CgNJGceVmQCZVZLycgDKZtAlhyGE1gkpJmeW7GCyw==",
+          "requires": {
+            "@miniflare/core": "2.5.1",
+            "@miniflare/shared": "2.5.1",
+            "http-cache-semantics": "^4.1.0",
+            "undici": "5.5.1"
+          }
+        },
+        "@miniflare/cli-parser": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.5.1.tgz",
+          "integrity": "sha512-itlMDe9jwO806mkNkg3G70QYoG9YQHW6V10AF9L5b8J4LYt/V78uCEJSwNnCpL7zfKrScRPtDfXZxhrFzMXiUw==",
+          "requires": {
+            "@miniflare/shared": "2.5.1",
+            "kleur": "^4.1.4"
+          }
+        },
+        "@miniflare/core": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.5.1.tgz",
+          "integrity": "sha512-0oEBLV5AM3xxs6TS+7/fn4MSGNBfhUFVv41R8uc72H1a89+kBfRoz+xYI2RnJ3Yo+we66UgU3fXdG+R2KyESlQ==",
+          "requires": {
+            "@iarna/toml": "^2.2.5",
+            "@miniflare/shared": "2.5.1",
+            "@miniflare/watcher": "2.5.1",
+            "busboy": "^1.6.0",
+            "dotenv": "^10.0.0",
+            "kleur": "^4.1.4",
+            "set-cookie-parser": "^2.4.8",
+            "undici": "5.5.1",
+            "urlpattern-polyfill": "^4.0.3"
+          }
+        },
+        "@miniflare/durable-objects": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.5.1.tgz",
+          "integrity": "sha512-AZEGSA9LMA6vBzwADAzr81RBSWYlMfa/cDHnHaFL31w4mQwMUcqXOvemoqe6sTSq1KI0TTtvYbxPt0Lui8tEPw==",
+          "requires": {
+            "@miniflare/core": "2.5.1",
+            "@miniflare/shared": "2.5.1",
+            "@miniflare/storage-memory": "2.5.1",
+            "undici": "5.5.1"
+          }
+        },
+        "@miniflare/html-rewriter": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.5.1.tgz",
+          "integrity": "sha512-fdO1qme8ukucejRz5yXJN/F4B9qEDRbBLPOEG94zwx8bHGGIo5VX15+J6oHubhjifLwzNuvOcg16Bu5dyR1KxQ==",
+          "requires": {
+            "@miniflare/core": "2.5.1",
+            "@miniflare/shared": "2.5.1",
+            "html-rewriter-wasm": "^0.4.1",
+            "undici": "5.5.1"
+          }
+        },
+        "@miniflare/http-server": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.5.1.tgz",
+          "integrity": "sha512-K+VoBU0LN8/oku/JWLEyX8wrp9fiaTC8/dosbY/6VWizyIrgQze16uD21GnK5+NBtbCAtLRryS5dZ3PnhiTR1w==",
+          "requires": {
+            "@miniflare/core": "2.5.1",
+            "@miniflare/shared": "2.5.1",
+            "@miniflare/web-sockets": "2.5.1",
+            "kleur": "^4.1.4",
+            "selfsigned": "^2.0.0",
+            "undici": "5.5.1",
+            "ws": "^8.2.2",
+            "youch": "^2.2.2"
+          }
+        },
+        "@miniflare/kv": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.5.1.tgz",
+          "integrity": "sha512-ODTUqI7on3egHluBpFHifO0a9QFQUZscciASWKxGOt8VDp1vp0vIfU9ykQZrdZYFVeSKNVlUNqNQx+NMYZ6gIg==",
+          "requires": {
+            "@miniflare/shared": "2.5.1"
+          }
+        },
+        "@miniflare/runner-vm": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.5.1.tgz",
+          "integrity": "sha512-7U7BPgzaikwWkAMonlmyy4lDpW1H7mqHFr7NdK9kA6BbXZ2GY6uro69QsGw0c4Y/vyKBodKiqXAq53iGdM3Kug==",
+          "requires": {
+            "@miniflare/shared": "2.5.1"
+          }
+        },
+        "@miniflare/scheduler": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.5.1.tgz",
+          "integrity": "sha512-ybho5Kg3Cfl4E0JleKAbiv/RTA+/PVqH6Y/PuCH2oowSM7qeAvFkrwiRvxtN7BuAl+5lsGyVxFe4gL+weXohEw==",
+          "requires": {
+            "@miniflare/core": "2.5.1",
+            "@miniflare/shared": "2.5.1",
+            "cron-schedule": "^3.0.4"
+          }
+        },
+        "@miniflare/shared": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.5.1.tgz",
+          "integrity": "sha512-DObgqbFml3qetIBtZa8fNqkBqUH9XtI6rdrWtTYVrx0rzKsd5PDf6gdMoxy7v1rr9zBAipKJxrcBqlEgjPl53Q==",
+          "requires": {
+            "ignore": "^5.1.8",
+            "kleur": "^4.1.4"
+          }
+        },
+        "@miniflare/sites": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.5.1.tgz",
+          "integrity": "sha512-7V/fAzR50LYgMcOfoCaoppqBCjagBpGWFbZgMyJi/Hj4oVlSIzxo+424hzdjitNzikCpv+AryF9tXfy9j6qiOg==",
+          "requires": {
+            "@miniflare/kv": "2.5.1",
+            "@miniflare/shared": "2.5.1",
+            "@miniflare/storage-file": "2.5.1"
+          }
+        },
+        "@miniflare/storage-file": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.5.1.tgz",
+          "integrity": "sha512-o12KFXgc1M0nHD98mrA/IqwBsJ6KYLWH9NaTwqLhxhpGz/KSo5kWb7z/vrz2I/Rk2XR/gHSYQm2XR9XE6IJCdA==",
+          "requires": {
+            "@miniflare/shared": "2.5.1",
+            "@miniflare/storage-memory": "2.5.1"
+          }
+        },
+        "@miniflare/storage-memory": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.5.1.tgz",
+          "integrity": "sha512-LIdBEFcwY7yLCeowO34p5bajRsvU1XuQjXIqcgfiCVt1+qa3D0seELTpW1NSFEJzxulVtu/KsScEug9GipEt7A==",
+          "requires": {
+            "@miniflare/shared": "2.5.1"
+          }
+        },
+        "@miniflare/watcher": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.5.1.tgz",
+          "integrity": "sha512-8oOdgWA7CZ7uIAwbjqSrhDnuQXRJqd9e3yDHsMa91E/jkC/GDmlt5SJh6VEMlNDtBGWd661IpVErZf7injI52w==",
+          "requires": {
+            "@miniflare/shared": "2.5.1"
+          }
+        },
+        "@miniflare/web-sockets": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.5.1.tgz",
+          "integrity": "sha512-GyXHoDAI5LDF87rmD+d0cSoN7Xs2pCYjSyUR6Vf6exkS4CN6F/Rtr8vIM5+om9kRkS6qxAyOYjWeEqBOjLm/og==",
+          "requires": {
+            "@miniflare/core": "2.5.1",
+            "@miniflare/shared": "2.5.1",
+            "undici": "5.5.1",
+            "ws": "^8.2.2"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "dotenv": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "jest-environment-miniflare": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/jest-environment-miniflare/-/jest-environment-miniflare-2.5.1.tgz",
+          "integrity": "sha512-BQZNE393imnQcHjPXhXpgAYYrb2RAyCTtkveMVeygrpzsrVLZ2uG/qxyrG05HFvWJ4Ca2EyI5AOCrNDGqMgD5g==",
+          "requires": {
+            "@jest/environment": ">=27",
+            "@jest/fake-timers": ">=27",
+            "@jest/types": ">=27",
+            "@miniflare/cache": "2.5.1",
+            "@miniflare/core": "2.5.1",
+            "@miniflare/durable-objects": "2.5.1",
+            "@miniflare/html-rewriter": "2.5.1",
+            "@miniflare/kv": "2.5.1",
+            "@miniflare/runner-vm": "2.5.1",
+            "@miniflare/shared": "2.5.1",
+            "@miniflare/sites": "2.5.1",
+            "@miniflare/storage-memory": "2.5.1",
+            "@miniflare/web-sockets": "2.5.1",
+            "jest-mock": ">=27",
+            "jest-util": ">=27",
+            "miniflare": "2.5.1"
+          }
+        },
+        "jest-util": {
+          "version": "28.1.1",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.1.tgz",
+          "integrity": "sha512-FktOu7ca1DZSyhPAxgxB6hfh2+9zMoJ7aEQA759Z6p45NuO8mWcqujH+UdHlCm/V6JTWwDztM2ITCzU1ijJAfw==",
+          "requires": {
+            "@jest/types": "^28.1.1",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.9",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "miniflare": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.5.1.tgz",
+          "integrity": "sha512-PT56C/j7U6n7WDxnIUHu0d8EY/gedPRsta2b+LsrIHGZPSkxAcPzf2DgbbPU7obv0C4hT9H0GL1fWpWtr2SbDQ==",
+          "requires": {
+            "@miniflare/cache": "2.5.1",
+            "@miniflare/cli-parser": "2.5.1",
+            "@miniflare/core": "2.5.1",
+            "@miniflare/durable-objects": "2.5.1",
+            "@miniflare/html-rewriter": "2.5.1",
+            "@miniflare/http-server": "2.5.1",
+            "@miniflare/kv": "2.5.1",
+            "@miniflare/runner-vm": "2.5.1",
+            "@miniflare/scheduler": "2.5.1",
+            "@miniflare/shared": "2.5.1",
+            "@miniflare/sites": "2.5.1",
+            "@miniflare/storage-file": "2.5.1",
+            "@miniflare/storage-memory": "2.5.1",
+            "@miniflare/web-sockets": "2.5.1",
+            "kleur": "^4.1.4",
+            "semiver": "^1.1.0",
+            "source-map-support": "^0.5.20",
+            "undici": "5.5.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "undici": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/undici/-/undici-5.5.1.tgz",
+          "integrity": "sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw=="
+        },
+        "ws": {
+          "version": "8.8.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
+          "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
+          "requires": {}
+        }
       }
     },
     "jest-fetch-mock": {
@@ -31632,31 +31896,6 @@
     },
     "min-indent": {
       "version": "1.0.1"
-    },
-    "miniflare": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.5.0.tgz",
-      "integrity": "sha512-3IR+n/kLBA7zQ20HDjnA0HufQlr197krD8jPsaYO5wTrkIUCTvrilbI0sCo0X9CP/I3BCIl8fiZc1Jf7+MX7jQ==",
-      "requires": {
-        "@miniflare/cache": "2.5.0",
-        "@miniflare/cli-parser": "2.5.0",
-        "@miniflare/core": "2.5.0",
-        "@miniflare/durable-objects": "2.5.0",
-        "@miniflare/html-rewriter": "2.5.0",
-        "@miniflare/http-server": "2.5.0",
-        "@miniflare/kv": "2.5.0",
-        "@miniflare/runner-vm": "2.5.0",
-        "@miniflare/scheduler": "2.5.0",
-        "@miniflare/shared": "2.5.0",
-        "@miniflare/sites": "2.5.0",
-        "@miniflare/storage-file": "2.5.0",
-        "@miniflare/storage-memory": "2.5.0",
-        "@miniflare/web-sockets": "2.5.0",
-        "kleur": "^4.1.4",
-        "semiver": "^1.1.0",
-        "source-map-support": "^0.5.20",
-        "undici": "5.3.0"
-      }
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -34939,7 +35178,8 @@
     "undici": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.3.0.tgz",
-      "integrity": "sha512-8LxC/xmR2GCE4q1heE1sJxVnnf5S6yQ2dObvMFBBWkB8aQlaqNuWovgRFWRMB7KUdLPGZfOTTmUeeLEJYX56iQ=="
+      "integrity": "sha512-8LxC/xmR2GCE4q1heE1sJxVnnf5S6yQ2dObvMFBBWkB8aQlaqNuWovgRFWRMB7KUdLPGZfOTTmUeeLEJYX56iQ==",
+      "dev": true
     },
     "unified": {
       "version": "10.1.1",
@@ -35860,7 +36100,7 @@
         "jest-fetch-mock": "^3.0.3",
         "jest-websocket-mock": "^2.3.0",
         "mime": "^3.0.0",
-        "miniflare": "^2.5.0",
+        "miniflare": "^2.5.1",
         "nanoid": "^3.3.3",
         "open": "^8.4.0",
         "p-queue": "^7.2.0",
@@ -35889,6 +36129,172 @@
           "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-3.0.0.tgz",
           "integrity": "sha512-td6ZUkz2oS3VeleBcN+m//Q6HlCFCPrnI0FZhrt/h4XqLEdOyYp2u21nd8MdsR+WJy5r9PTDaHTDDfhf4H4l6Q==",
           "dev": true
+        },
+        "@miniflare/cache": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.5.1.tgz",
+          "integrity": "sha512-qH5PC4zb7mHdQHlcaOuP0KUXuRbNSuB/HU7gpoeplV8J6CgNJGceVmQCZVZLycgDKZtAlhyGE1gkpJmeW7GCyw==",
+          "requires": {
+            "@miniflare/core": "2.5.1",
+            "@miniflare/shared": "2.5.1",
+            "http-cache-semantics": "^4.1.0",
+            "undici": "5.5.1"
+          }
+        },
+        "@miniflare/cli-parser": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.5.1.tgz",
+          "integrity": "sha512-itlMDe9jwO806mkNkg3G70QYoG9YQHW6V10AF9L5b8J4LYt/V78uCEJSwNnCpL7zfKrScRPtDfXZxhrFzMXiUw==",
+          "requires": {
+            "@miniflare/shared": "2.5.1",
+            "kleur": "^4.1.4"
+          }
+        },
+        "@miniflare/core": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.5.1.tgz",
+          "integrity": "sha512-0oEBLV5AM3xxs6TS+7/fn4MSGNBfhUFVv41R8uc72H1a89+kBfRoz+xYI2RnJ3Yo+we66UgU3fXdG+R2KyESlQ==",
+          "requires": {
+            "@iarna/toml": "^2.2.5",
+            "@miniflare/shared": "2.5.1",
+            "@miniflare/watcher": "2.5.1",
+            "busboy": "^1.6.0",
+            "dotenv": "^10.0.0",
+            "kleur": "^4.1.4",
+            "set-cookie-parser": "^2.4.8",
+            "undici": "5.5.1",
+            "urlpattern-polyfill": "^4.0.3"
+          },
+          "dependencies": {
+            "@iarna/toml": {
+              "version": "2.2.5",
+              "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+              "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
+            },
+            "dotenv": {
+              "version": "10.0.0",
+              "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+              "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+            }
+          }
+        },
+        "@miniflare/durable-objects": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.5.1.tgz",
+          "integrity": "sha512-AZEGSA9LMA6vBzwADAzr81RBSWYlMfa/cDHnHaFL31w4mQwMUcqXOvemoqe6sTSq1KI0TTtvYbxPt0Lui8tEPw==",
+          "requires": {
+            "@miniflare/core": "2.5.1",
+            "@miniflare/shared": "2.5.1",
+            "@miniflare/storage-memory": "2.5.1",
+            "undici": "5.5.1"
+          }
+        },
+        "@miniflare/html-rewriter": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.5.1.tgz",
+          "integrity": "sha512-fdO1qme8ukucejRz5yXJN/F4B9qEDRbBLPOEG94zwx8bHGGIo5VX15+J6oHubhjifLwzNuvOcg16Bu5dyR1KxQ==",
+          "requires": {
+            "@miniflare/core": "2.5.1",
+            "@miniflare/shared": "2.5.1",
+            "html-rewriter-wasm": "^0.4.1",
+            "undici": "5.5.1"
+          }
+        },
+        "@miniflare/http-server": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.5.1.tgz",
+          "integrity": "sha512-K+VoBU0LN8/oku/JWLEyX8wrp9fiaTC8/dosbY/6VWizyIrgQze16uD21GnK5+NBtbCAtLRryS5dZ3PnhiTR1w==",
+          "requires": {
+            "@miniflare/core": "2.5.1",
+            "@miniflare/shared": "2.5.1",
+            "@miniflare/web-sockets": "2.5.1",
+            "kleur": "^4.1.4",
+            "selfsigned": "^2.0.0",
+            "undici": "5.5.1",
+            "ws": "^8.2.2",
+            "youch": "^2.2.2"
+          }
+        },
+        "@miniflare/kv": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.5.1.tgz",
+          "integrity": "sha512-ODTUqI7on3egHluBpFHifO0a9QFQUZscciASWKxGOt8VDp1vp0vIfU9ykQZrdZYFVeSKNVlUNqNQx+NMYZ6gIg==",
+          "requires": {
+            "@miniflare/shared": "2.5.1"
+          }
+        },
+        "@miniflare/runner-vm": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.5.1.tgz",
+          "integrity": "sha512-7U7BPgzaikwWkAMonlmyy4lDpW1H7mqHFr7NdK9kA6BbXZ2GY6uro69QsGw0c4Y/vyKBodKiqXAq53iGdM3Kug==",
+          "requires": {
+            "@miniflare/shared": "2.5.1"
+          }
+        },
+        "@miniflare/scheduler": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.5.1.tgz",
+          "integrity": "sha512-ybho5Kg3Cfl4E0JleKAbiv/RTA+/PVqH6Y/PuCH2oowSM7qeAvFkrwiRvxtN7BuAl+5lsGyVxFe4gL+weXohEw==",
+          "requires": {
+            "@miniflare/core": "2.5.1",
+            "@miniflare/shared": "2.5.1",
+            "cron-schedule": "^3.0.4"
+          }
+        },
+        "@miniflare/shared": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.5.1.tgz",
+          "integrity": "sha512-DObgqbFml3qetIBtZa8fNqkBqUH9XtI6rdrWtTYVrx0rzKsd5PDf6gdMoxy7v1rr9zBAipKJxrcBqlEgjPl53Q==",
+          "requires": {
+            "ignore": "^5.1.8",
+            "kleur": "^4.1.4"
+          }
+        },
+        "@miniflare/sites": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.5.1.tgz",
+          "integrity": "sha512-7V/fAzR50LYgMcOfoCaoppqBCjagBpGWFbZgMyJi/Hj4oVlSIzxo+424hzdjitNzikCpv+AryF9tXfy9j6qiOg==",
+          "requires": {
+            "@miniflare/kv": "2.5.1",
+            "@miniflare/shared": "2.5.1",
+            "@miniflare/storage-file": "2.5.1"
+          }
+        },
+        "@miniflare/storage-file": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.5.1.tgz",
+          "integrity": "sha512-o12KFXgc1M0nHD98mrA/IqwBsJ6KYLWH9NaTwqLhxhpGz/KSo5kWb7z/vrz2I/Rk2XR/gHSYQm2XR9XE6IJCdA==",
+          "requires": {
+            "@miniflare/shared": "2.5.1",
+            "@miniflare/storage-memory": "2.5.1"
+          }
+        },
+        "@miniflare/storage-memory": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.5.1.tgz",
+          "integrity": "sha512-LIdBEFcwY7yLCeowO34p5bajRsvU1XuQjXIqcgfiCVt1+qa3D0seELTpW1NSFEJzxulVtu/KsScEug9GipEt7A==",
+          "requires": {
+            "@miniflare/shared": "2.5.1"
+          }
+        },
+        "@miniflare/watcher": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.5.1.tgz",
+          "integrity": "sha512-8oOdgWA7CZ7uIAwbjqSrhDnuQXRJqd9e3yDHsMa91E/jkC/GDmlt5SJh6VEMlNDtBGWd661IpVErZf7injI52w==",
+          "requires": {
+            "@miniflare/shared": "2.5.1"
+          }
+        },
+        "@miniflare/web-sockets": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.5.1.tgz",
+          "integrity": "sha512-GyXHoDAI5LDF87rmD+d0cSoN7Xs2pCYjSyUR6Vf6exkS4CN6F/Rtr8vIM5+om9kRkS6qxAyOYjWeEqBOjLm/og==",
+          "requires": {
+            "@miniflare/core": "2.5.1",
+            "@miniflare/shared": "2.5.1",
+            "undici": "5.5.1",
+            "ws": "^8.2.2"
+          }
         },
         "dotenv": {
           "version": "16.0.0",
@@ -36062,6 +36468,31 @@
             "p-locate": "^6.0.0"
           }
         },
+        "miniflare": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.5.1.tgz",
+          "integrity": "sha512-PT56C/j7U6n7WDxnIUHu0d8EY/gedPRsta2b+LsrIHGZPSkxAcPzf2DgbbPU7obv0C4hT9H0GL1fWpWtr2SbDQ==",
+          "requires": {
+            "@miniflare/cache": "2.5.1",
+            "@miniflare/cli-parser": "2.5.1",
+            "@miniflare/core": "2.5.1",
+            "@miniflare/durable-objects": "2.5.1",
+            "@miniflare/html-rewriter": "2.5.1",
+            "@miniflare/http-server": "2.5.1",
+            "@miniflare/kv": "2.5.1",
+            "@miniflare/runner-vm": "2.5.1",
+            "@miniflare/scheduler": "2.5.1",
+            "@miniflare/shared": "2.5.1",
+            "@miniflare/sites": "2.5.1",
+            "@miniflare/storage-file": "2.5.1",
+            "@miniflare/storage-memory": "2.5.1",
+            "@miniflare/web-sockets": "2.5.1",
+            "kleur": "^4.1.4",
+            "semiver": "^1.1.0",
+            "source-map-support": "^0.5.20",
+            "undici": "5.5.1"
+          }
+        },
         "p-limit": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
@@ -36093,14 +36524,12 @@
         "undici": {
           "version": "5.5.1",
           "resolved": "https://registry.npmjs.org/undici/-/undici-5.5.1.tgz",
-          "integrity": "sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw==",
-          "dev": true
+          "integrity": "sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw=="
         },
         "ws": {
           "version": "8.5.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
           "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-          "dev": true,
           "requires": {}
         },
         "yocto-queue": {

--- a/packages/jest-environment-wrangler/package.json
+++ b/packages/jest-environment-wrangler/package.json
@@ -17,6 +17,6 @@
   "author": "wrangler@cloudflare.com",
   "license": "ISC",
   "dependencies": {
-    "jest-environment-miniflare": "^2.5.0"
+    "jest-environment-miniflare": "^2.5.1"
   }
 }

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -41,7 +41,7 @@
     "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
     "blake3-wasm": "^2.1.5",
     "esbuild": "0.14.34",
-    "miniflare": "^2.5.0",
+    "miniflare": "^2.5.1",
     "nanoid": "^3.3.3",
     "path-to-regexp": "^6.2.0",
     "selfsigned": "^2.0.1",


### PR DESCRIPTION
Hey! 👋 This PR upgrades `miniflare` to version `2.5.1`, addressing security issues in `undici`, `node-forge` and `minimist`. See the [full changelog here](https://github.com/cloudflare/miniflare/releases/tag/v2.5.1).