### PR TITLE
feat: implement 'dispatch namespaces'

### DIFF
--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -31,6 +31,7 @@ describe("normalizeAndValidateConfig()", () => {
         upstream_protocol: "https",
         host: undefined,
       },
+      dispatch_namespaces: [],
       durable_objects: {
         bindings: [],
       },
@@ -63,6 +64,7 @@ describe("normalizeAndValidateConfig()", () => {
       zone_id: undefined,
       minify: undefined,
       node_compat: undefined,
+      namespace_name: undefined,
     });
     expect(diagnostics.hasErrors()).toBe(false);
     expect(diagnostics.hasWarnings()).toBe(false);

--- a/packages/wrangler/src/__tests__/dispatch.test.ts
+++ b/packages/wrangler/src/__tests__/dispatch.test.ts
@@ -1,0 +1,183 @@
+import { randomUUID } from "crypto";
+import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
+import {
+  setMockResponse,
+  unsetAllMocks,
+} from "./helpers/mock-cfetch";
+import { mockConsoleMethods } from "./helpers/mock-console";
+import { runInTempDir } from "./helpers/run-in-tmp";
+import { runWrangler } from "./helpers/run-wrangler";
+
+// Asserting within mock responses get swallowed, so run them out-of-band
+const outOfBandTests: (() => void)[] = [];
+function assertLater(fn: () => void) {
+  outOfBandTests.push(fn);
+}
+
+describe("pages", () => {
+  runInTempDir();
+  const std = mockConsoleMethods();
+  function endEventLoop() {
+    return new Promise((resolve) => setImmediate(resolve));
+  }
+  beforeEach(() => {
+    outOfBandTests.length = 0;
+  });
+  afterEach(() => {
+    outOfBandTests.forEach((fn) => fn());
+  });
+
+  it("should should display a list of available subcommands, for dispatch-namespace with no subcommand", async () => {
+    await runWrangler("dispatch-namespace");
+    await endEventLoop();
+
+    expect(std.out).toMatchInlineSnapshot(`
+      "wrangler dispatch-namespace
+
+      Commands:
+        wrangler dispatch-namespace create <namespace-name>  Creates a dispatch namespace
+        wrangler dispatch-namespace delete <namespace-name>  Deletes a dispatch namespace
+
+      Flags:
+        -c, --config   Path to .toml configuration file  [string]
+        -h, --help     Show help  [boolean]
+        -v, --version  Show version number  [boolean]"
+    `);
+  });
+
+  describe("create namespace", () => {
+    mockAccountId();
+    mockApiToken();
+
+    afterEach(() => {
+      unsetAllMocks();
+    });
+
+    function mockCreateRequest(expectedName: string) {
+      const requests = { count: 0, lastUUID: "" };
+      setMockResponse(
+        "/accounts/:accountId/workers/dispatch/namespaces",
+        ([_url], init) => {
+          requests.count += 1;
+
+          const incomingText = init.body?.toString() || "";
+          const { name: namespace_name } = JSON.parse(incomingText);
+
+          assertLater(() => {
+            expect(init.method).toBe("POST");
+            expect(incomingText).toBeDefined();
+            expect(namespace_name).toEqual(expectedName);
+          });
+
+          const newUUID = randomUUID().replaceAll("-", "");
+          requests.lastUUID = newUUID;
+          return {
+            namespace_name,
+            namespace_id: newUUID,
+          };
+        }
+      );
+      return requests;
+    }
+
+    it("should display help for create", async () => {
+      await expect(
+        runWrangler("dispatch-namespace create")
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Not enough non-option arguments: got 0, need at least 1"`
+      );
+      await endEventLoop();
+
+      expect(std.out).toMatchInlineSnapshot(`
+        "
+        wrangler dispatch-namespace create <namespace-name>
+
+        Creates a dispatch namespace
+
+        Positionals:
+          namespace-name  Name of the namespace to create  [string] [required]
+
+        Flags:
+          -c, --config   Path to .toml configuration file  [string]
+          -h, --help     Show help  [boolean]
+          -v, --version  Show version number  [boolean]"
+      `);
+    });
+
+    it("should attempt to create the given namespace", async () => {
+      const namespaceName = "my-namespace";
+      const requests = mockCreateRequest(namespaceName);
+      await runWrangler(`dispatch-namespace create ${namespaceName}`);
+      await endEventLoop();
+      expect(requests.count).toEqual(1);
+      const newUUID = requests.lastUUID;
+
+      expect(std.out).toMatchInlineSnapshot(
+        `"Created namespace my-namespace with ID ${newUUID}"`
+      );
+    });
+  });
+
+  describe("delete namespace", () => {
+    mockAccountId();
+    mockApiToken();
+
+    afterEach(() => {
+      unsetAllMocks();
+    });
+
+    function mockDeleteRequest(expectedName: string) {
+      const requests = { count: 0 };
+      setMockResponse(
+        "/accounts/:accountId/workers/dispatch/namespaces/:namespaceName",
+        ([_url, _, namespaceName], init) => {
+          requests.count += 1;
+
+          assertLater(() => {
+            expect(init.method).toBe("DELETE");
+            expect(namespaceName).toEqual(expectedName);
+          });
+
+          return {};
+        }
+      );
+      return requests;
+    }
+
+    it("should display help for delete", async () => {
+      await expect(
+        runWrangler("dispatch-namespace create")
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Not enough non-option arguments: got 0, need at least 1"`
+      );
+      await endEventLoop();
+
+      expect(std.out).toMatchInlineSnapshot(`
+        "
+        wrangler dispatch-namespace create <namespace-name>
+
+        Creates a dispatch namespace
+
+        Positionals:
+          namespace-name  Name of the namespace to create  [string] [required]
+
+        Flags:
+          -c, --config   Path to .toml configuration file  [string]
+          -h, --help     Show help  [boolean]
+          -v, --version  Show version number  [boolean]"
+      `);
+    });
+
+    it("should try to delete the given namespace", async () => {
+      const namespaceName = "my-namespace";
+      const requests = mockDeleteRequest(namespaceName);
+      await runWrangler(`dispatch-namespace delete ${namespaceName}`);
+      await endEventLoop();
+      expect(requests.count).toBe(1);
+
+      expect(std.out).toMatchInlineSnapshot(
+        `"Deleted namespace my-namespace."`
+      );
+    });
+  });
+});

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -50,6 +50,13 @@ interface EnvironmentInheritable {
   account_id: string | undefined;
 
   /**
+   * The name of the namespace this worker should be uploaded to. This option conflicts withs
+   * routes, cron triggers, and other ways of running a worker besides dispatching to it via
+   * a namespace binding bound to the namespace it was uploaded to.
+   */
+  namespace_name: string | undefined;
+
+  /**
    * A date in the form yyyy-mm-dd, which will be used to determine
    * which version of the Workers runtime is used.
    *
@@ -303,6 +310,22 @@ interface EnvironmentNonInheritable {
     service: string;
     /** The environment of the service (e.g. production, staging, etc). */
     environment?: string;
+  }[];
+
+  /**
+   * Specifies namespace bindings that are bound to this Worker environment.
+   *
+   * NOTE: This field is not automatically inherited from the top level environment,
+   * and so must be specified in every named environment.
+   *
+   * @default `[]`
+   * @nonInheritable
+   */
+  dispatch_namespaces: {
+    /** The binding name used to refer to the bound service. */
+    binding: string;
+    /** The namespace to bind to. */
+    namespace: string;
   }[];
 
   /**

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -86,6 +86,7 @@ export function printBindings(bindings: CfWorkerInit["bindings"]) {
     kv_namespaces,
     r2_buckets,
     services,
+    dispatch_namespaces,
     text_blobs,
     unsafe,
     vars,
@@ -160,6 +161,19 @@ export function printBindings(bindings: CfWorkerInit["bindings"]) {
         return {
           key: binding,
           value,
+        };
+      }),
+    });
+  }
+
+  if (dispatch_namespaces !== undefined && dispatch_namespaces.length > 0) {
+    output.push({
+      type: "Dispatch Namespaces",
+      entries: dispatch_namespaces.map(({ binding, namespace }) => {
+
+        return {
+          key: binding,
+          value: namespace,
         };
       }),
     });

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -796,6 +796,14 @@ function normalizeAndValidateEnvironment(
       undefined,
       undefined
     ),
+    namespace_name: inheritable(
+      diagnostics,
+      topLevelEnv,
+      rawEnv,
+      "namespace_name",
+      isString,
+      undefined
+    ),
     compatibility_date: inheritable(
       diagnostics,
       topLevelEnv,
@@ -934,6 +942,16 @@ function normalizeAndValidateEnvironment(
       envName,
       "services",
       validateBindingArray(envName, validateServiceBinding),
+      []
+    ),
+    dispatch_namespaces: notInheritable(
+      diagnostics,
+      topLevelEnv,
+      rawConfig,
+      rawEnv,
+      envName,
+      "dispatch_namespaces",
+      validateBindingArray(envName, validateNamespaceBinding),
       []
     ),
     unsafe: notInheritable(
@@ -1546,3 +1564,31 @@ const validateServiceBinding: ValidatorFn = (diagnostics, field, value) => {
   }
   return isValid;
 };
+const validateNamespaceBinding: ValidatorFn = (diagnostics, field, value) => {
+  if (typeof value !== "object" || value === null) {
+    diagnostics.errors.push(
+      `"${field}" bindings should be objects, but got ${JSON.stringify(value)}`
+    );
+    return false;
+  }
+  let isValid = true;
+  // Service bindings must have a binding, service, and environment.
+  if (!isRequiredProperty(value, "binding", "string")) {
+    diagnostics.errors.push(
+      `"${field}" bindings should have a string "binding" field but got ${JSON.stringify(
+        value
+      )}.`
+    );
+    isValid = false;
+  }
+  if (!isRequiredProperty(value, "namespace", "string")) {
+    diagnostics.errors.push(
+      `"${field}" bindings should have a string "namespace" field but got ${JSON.stringify(
+        value
+      )}.`
+    );
+    isValid = false;
+  }
+  return isValid;
+};
+

--- a/packages/wrangler/src/create-worker-upload-form.ts
+++ b/packages/wrangler/src/create-worker-upload-form.ts
@@ -50,6 +50,7 @@ export interface WorkerMetadata {
       }
     | { type: "r2_bucket"; name: string; bucket_name: string }
     | { type: "service"; name: string; service: string; environment?: string }
+    | { type: "namespace"; name: string; namespace: string }
   )[];
 }
 
@@ -113,6 +114,14 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
       type: "service",
       service,
       ...(environment && { environment }),
+    });
+  });
+
+  bindings.dispatch_namespaces?.forEach(({ binding, namespace }) => {
+    metadataBindings.push({
+      name: binding,
+      type: "namespace",
+      namespace,
     });
   });
 

--- a/packages/wrangler/src/create-worker-upload-form.ts
+++ b/packages/wrangler/src/create-worker-upload-form.ts
@@ -6,6 +6,24 @@ import type {
   CfDurableObjectMigrations,
 } from "./worker.js";
 
+export function getWorkerUrl(
+  accountId?: string,
+  scriptName?: string,
+  envName?: string,
+  namespaceName?: string,
+  notProd?: boolean,
+): string {
+  if (namespaceName) {
+    return `/accounts/${accountId}/workers/dispatch/namespaces/${namespaceName}/scripts/${scriptName}`;
+  }
+
+  if (notProd) {
+    return `/accounts/${accountId}/workers/services/${scriptName}/environments/${envName}`;
+  }
+
+  return `/accounts/${accountId}/workers/scripts/${scriptName}`;
+}
+
 export function toMimeType(type: CfModuleType): string {
   switch (type) {
     case "esm":

--- a/packages/wrangler/src/dispatch/create-namespace.ts
+++ b/packages/wrangler/src/dispatch/create-namespace.ts
@@ -1,8 +1,8 @@
 import { fetchResult } from "../cfetch";
 import { logger } from "../logger";
 
-import { namespacesPath } from ".";
-import type { Namespace } from ".";
+import { namespacesPath } from "./dispatch";
+import type { Namespace } from "./dispatch";
 
 interface Props {
     accountId: string

--- a/packages/wrangler/src/dispatch/create-namespace.ts
+++ b/packages/wrangler/src/dispatch/create-namespace.ts
@@ -1,0 +1,31 @@
+import { fetchResult } from "../cfetch";
+import { logger } from "../logger";
+
+import { namespacesPath } from ".";
+import type { Namespace } from ".";
+
+interface Props {
+    accountId: string
+
+    namespaceName: string
+}
+
+type CreateNamespaceRequest = {
+    name: string
+}
+
+export default async function createNamespace(props: Props): Promise<void> {
+    const body: CreateNamespaceRequest = {name: props.namespaceName}
+    const namespace = await fetchResult<Namespace>(
+        namespacesPath(props.accountId),
+        {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(body),
+        },
+    )
+
+    logger.log(`Created namespace ${props.namespaceName} with ID ${namespace.namespace_id}`)
+}

--- a/packages/wrangler/src/dispatch/delete-namespace.ts
+++ b/packages/wrangler/src/dispatch/delete-namespace.ts
@@ -1,0 +1,21 @@
+import { fetchResult } from "../cfetch";
+import { logger } from "../logger";
+
+import { namespacePath } from ".";
+
+type Props = {
+    accountId: string
+
+    namespaceName: string
+}
+
+export default async function deleteNamespace(props: Props): Promise<void> {
+    await fetchResult(
+        namespacePath(props.accountId, props.namespaceName),
+        {
+            method: "DELETE",
+        }
+    )
+
+    logger.log(`Deleted namespace ${props.namespaceName}.`)
+}

--- a/packages/wrangler/src/dispatch/delete-namespace.ts
+++ b/packages/wrangler/src/dispatch/delete-namespace.ts
@@ -1,7 +1,7 @@
 import { fetchResult } from "../cfetch";
 import { logger } from "../logger";
 
-import { namespacePath } from ".";
+import { namespacePath } from "./dispatch";
 
 type Props = {
     accountId: string

--- a/packages/wrangler/src/dispatch/dispatch.ts
+++ b/packages/wrangler/src/dispatch/dispatch.ts
@@ -3,7 +3,6 @@ import { requireAuth } from "../user";
 
 import createNamespace from './create-namespace'
 import deleteNamespace from './delete-namespace';
-import { wrangler } from '../.';
 
 import type { CommandModule } from 'yargs';
 
@@ -24,15 +23,6 @@ interface CreateArguments {
 interface DeleteArguments {
     "namespace-name": string
 }
-
-const subHelp: CommandModule = {
-    command: ["*"],
-    handler: async (args) => {
-        setImmediate(() =>
-        wrangler.parse([...args._.map((a) => `${a}`), "--help"])
-        );
-    },
-};
 
 const createNamespaceCommand: CommandModule<unknown, CreateArguments> = {
     command: "create <namespace-name>",

--- a/packages/wrangler/src/dispatch/index.ts
+++ b/packages/wrangler/src/dispatch/index.ts
@@ -1,0 +1,119 @@
+import { readConfig } from "../config";
+import { requireAuth } from "../user";
+
+import createNamespace from './create-namespace'
+import deleteNamespace from './delete-namespace';
+import { wrangler } from '../.';
+
+import type { CommandModule } from 'yargs';
+
+type Namespace = {
+    namespace_id: string,
+    namespace_name: string,
+    created_on: string,
+    created_by: string,
+    modified_on: string,
+    modified_by: string
+}
+
+// the only way to make tsc happy?
+interface CreateArguments {
+    "namespace-name": string
+}
+
+interface DeleteArguments {
+    "namespace-name": string
+}
+
+const subHelp: CommandModule = {
+    command: ["*"],
+    handler: async (args) => {
+        setImmediate(() =>
+        wrangler.parse([...args._.map((a) => `${a}`), "--help"])
+        );
+    },
+};
+
+const createNamespaceCommand: CommandModule<unknown, CreateArguments> = {
+    command: "create <namespace-name>",
+    describe: "Creates a dispatch namespace",
+    builder: (args) => {
+        return args.positional(
+            "namespace-name",
+            {
+                describe: "Name of the namespace to create",
+                type: "string",
+                demandOption: "true",
+            }
+        )
+    },
+    handler: async (args) => {
+        const config = readConfig(args.config as string | undefined, args);
+        const accountId = await requireAuth(config);
+        return createNamespace({
+            accountId,
+            namespaceName: args.namespaceName,
+        })
+    },
+};
+
+const deleteNamespaceCommand: CommandModule<unknown, DeleteArguments> = {
+    command: "delete <namespace-name>",
+    describe: "Deletes a dispatch namespace",
+    builder: (args) => {
+        return args.positional(
+            "namespace-name",
+            {
+                describe: "Name of the namespace to delete",
+                type: "string",
+                demandOption: "true",
+            }
+        )
+    },
+    handler: async (args) => {
+        const config = readConfig(args.config as string | undefined, args);
+        const accountId = await requireAuth(config);
+        return deleteNamespace({
+            accountId,
+            namespaceName: args.namespaceName,
+        })
+    },
+};
+
+function namespacesPath(accountId: string): string {
+    return `/accounts/${accountId}/workers/dispatch/namespaces`;
+}
+
+function namespacePath(accountId: string, namespaceName: string): string {
+    return `${namespacesPath(accountId)}/${namespaceName}`
+}
+
+function namespaceScriptsPath(accountId: string, namespaceName: string): string {
+    return `${namespacePath(accountId, namespaceName)}/scripts`
+}
+
+function namespaceScriptPath(accountId: string, namespaceName: string, scriptName: string): string {
+    return `${namespaceScriptsPath(accountId, namespaceName)}/${scriptName}`
+}
+
+export {
+    type Namespace,
+
+    namespacesPath,
+    namespacePath,
+    namespaceScriptsPath,
+    namespaceScriptPath,
+
+    createNamespace,
+    createNamespaceCommand,
+
+    deleteNamespace,
+    deleteNamespaceCommand,
+
+    // still to be implemented in API:
+    // fetchNamespace,
+    // fetchNamespaceCommand,
+    //
+    // listNamespaces,
+    // listNamespacesCommand,
+}

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -21,7 +21,7 @@ import { createWorkerUploadForm } from "./create-worker-upload-form";
 import Dev from "./dev/dev";
 import { getVarsForDev } from "./dev/dev-vars";
 import { confirm, prompt, select } from "./dialogs";
-import { createNamespaceCommand, deleteNamespaceCommand } from "./dispatch"
+import { createNamespaceCommand, deleteNamespaceCommand } from "./dispatch/dispatch"
 import { getEntry } from "./entry";
 import { DeprecationError } from "./errors";
 import {

--- a/packages/wrangler/src/worker.ts
+++ b/packages/wrangler/src/worker.ts
@@ -119,6 +119,11 @@ interface CfService {
   environment?: string;
 }
 
+interface CfDispatchNamespace {
+  binding: string;
+  namespace: string;
+}
+
 interface CfUnsafeBinding {
   name: string;
   type: string;
@@ -165,6 +170,7 @@ export interface CfWorkerInit {
     durable_objects: { bindings: CfDurableObject[] } | undefined;
     r2_buckets: CfR2Bucket[] | undefined;
     services: CfService[] | undefined;
+    dispatch_namespaces: CfDispatchNamespace[] | undefined;
     unsafe: CfUnsafeBinding[] | undefined;
   };
   migrations: CfDurableObjectMigrations | undefined;


### PR DESCRIPTION
Let me know if more, or more thorough, tests should be added.

The commands are hidden from help for now, as it's not widely available yet.

Besides the unit tests, I've tested manually on my own account and have been able to get the example below working.

=== commit message ===

This feature is for 'Workers for Platforms', and enables usage of a few
'namespaces' APIs to get the bare minimum example running.

New Commands:
  wrangler dispatch-namespace create <name>
  wrangler dispatch-namespace delete <name>

New Bindings:
  [[dispatch_namespaces]]
  name = "dispatcher"
  namespace = "my-namespace"

New Config:
  dispatch_namespace = "my-namespace"

Example usage would be to create a namespace with `dispatch-namespace
create my-namespace`, upload a worker *to* that namespace by including
`dispatch_namespace = "my-namespace"` in a worker's toml, and then
upload a worker with a 'namespace' binding that can be used to dispatch
to the worker we just uploaded (by including a `[[dispatch_namespaces]]`
binding in its `wrangler.toml`).

After doing those three things, you should be able to route to the last
worker and call out to the first worker using the new binding.