### PR TITLE
fix: show console error/warn logs when using `dev --local`

### DIFF
--- a/.changeset/shiny-avocados-smoke.md
+++ b/.changeset/shiny-avocados-smoke.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+---
+
+fix: show console.error/console.warn logs when using `dev --local`.
+
+Prior to this change, logging with console.error/console.warn in a Worker wouldn't output anything to the console when running in local mode. This was happening because stderr data event handler was being removed after the `Debugger listening...` string was found.
+
+This change updates the stderr data event handler to forward on all events to `process.stderr`.
+
+Closes #1324

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -251,16 +251,21 @@ function useLocalWorker({
 
       // parse the node inspector url (which may be received in chunks) from stderr
       let stderrData = "";
+      let inspectorUrlFound = false;
       local.current.stderr?.on("data", (data: Buffer) => {
-        stderrData += data.toString();
-        const matches =
-          /Debugger listening on (ws:\/\/127\.0\.0\.1:\d+\/[A-Za-z0-9-]+)[\r|\n]/.exec(
-            stderrData
-          );
-        if (matches) {
-          local.current?.stderr?.removeAllListeners("data");
-          setInspectorUrl(matches[1]);
+        if (!inspectorUrlFound) {
+          stderrData += data.toString();
+          const matches =
+            /Debugger listening on (ws:\/\/127\.0\.0\.1:\d+\/[A-Za-z0-9-]+)[\r|\n]/.exec(
+              stderrData
+            );
+          if (matches) {
+            inspectorUrlFound = true;
+            setInspectorUrl(matches[1]);
+          }
         }
+
+        process.stderr.write(data);
       });
 
       local.current.on("exit", (code) => {


### PR DESCRIPTION
Closes #1324 