### PR TITLE
feat:  working directory pathing

### DIFF
--- a/.changeset/large-lizards-enjoy.md
+++ b/.changeset/large-lizards-enjoy.md
@@ -1,0 +1,10 @@
+---
+"wrangler": patch
+---
+
+feat: resolve `--site` cli arg relative to current working directory
+
+Before we were resolving the Site directory relative to the location of `wrangler.toml` at all times.
+Now the `--site` cli arg is resolved relative to current working directory.
+
+resolves #1243

--- a/packages/wrangler/src/sites.tsx
+++ b/packages/wrangler/src/sites.tsx
@@ -349,20 +349,24 @@ export function getAssetPaths(
  */
 export function getSiteAssetPaths(
   config: Config,
-  assetDirectory = config.site?.bucket,
+  assetDirectory?: string,
   includePatterns = config.site?.include ?? [],
   excludePatterns = config.site?.exclude ?? []
 ): AssetPaths | undefined {
-  const baseDirectory = path.resolve(
-    path.dirname(config.configPath ?? "wrangler.toml")
-  );
+  const baseDirectory = assetDirectory
+    ? process.cwd()
+    : path.resolve(path.dirname(config.configPath ?? "wrangler.toml"));
 
-  return assetDirectory
-    ? {
-        baseDirectory,
-        assetDirectory,
-        includePatterns,
-        excludePatterns,
-      }
-    : undefined;
+  assetDirectory ??= config.site?.bucket;
+
+  if (assetDirectory) {
+    return {
+      baseDirectory,
+      assetDirectory,
+      includePatterns,
+      excludePatterns,
+    };
+  } else {
+    return undefined;
+  }
 }


### PR DESCRIPTION
Before we were resolving the Site directory relative to the location of  at all times.
Now the  is resolved relative to current working directory. Additionally, we added logging of where
the configuration is being read from.

resolves #1243