### PR TITLE
polish: bundle reporter was not printing during publish errors

### DIFF
--- a/.changeset/forty-doors-argue.md
+++ b/.changeset/forty-doors-argue.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+polish: bundle reporter was not printing during publish errors
+
+The reporter is now called before the publish API call, printing every time.
+
+resolves #1328

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -427,6 +427,11 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
       usage_model: config.usage_model,
     };
 
+    void printBundleSize(
+      { name: path.basename(resolvedEntryPointPath), content: content },
+      modules
+    );
+
     const withoutStaticAssets = {
       ...bindings,
       kv_namespaces: config.kv_namespaces,
@@ -453,10 +458,6 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
         )
       ).available_on_subdomain;
     }
-    void printBundleSize(
-      { name: path.basename(resolvedEntryPointPath), content: content },
-      modules
-    );
   } finally {
     if (typeof destination !== "string") {
       // this means we're using a temp dir,


### PR DESCRIPTION
The reporter is now called before the publish API call, printing every time.
Additionally added a test that handles a `publish` failure indicating "script exceeding size limits" and the bundle size is still printed. 

resolves #1328