### PR TITLE
polish: add an experimental warning if `--assets` is used

### DIFF
--- a/.changeset/rude-radios-buy.md
+++ b/.changeset/rude-radios-buy.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+polish: add an experimental warning if `--assets` is used
+
+We already have a warning when `config.assets` is used, this adds it for the cli argument as well.

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -969,6 +969,47 @@ describe("wrangler dev", () => {
       await runWrangler("dev --assets abc");
       expect((Dev as jest.Mock).mock.calls[2][0].isWorkersSite).toEqual(false);
     });
+
+    it("should warn if --assets is used", async () => {
+      writeWranglerToml({
+        main: "./index.js",
+      });
+      fs.writeFileSync("index.js", `export default {};`);
+
+      await runWrangler('dev --assets "./assets"');
+      expect(std).toMatchInlineSnapshot(`
+        Object {
+          "debug": "",
+          "err": "",
+          "out": "",
+          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe --assets argument is experimental and may change or break at any time[0m
+
+        ",
+        }
+      `);
+    });
+
+    it("should warn if config.assets is used", async () => {
+      writeWranglerToml({
+        main: "./index.js",
+        assets: "./assets",
+      });
+      fs.writeFileSync("index.js", `export default {};`);
+
+      await runWrangler("dev");
+      expect(std).toMatchInlineSnapshot(`
+        Object {
+          "debug": "",
+          "err": "",
+          "out": "",
+          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+
+            - \\"assets\\" fields are experimental and may change or break at any time.
+
+        ",
+        }
+      `);
+    });
   });
 
   describe("--inspect", () => {

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -1416,7 +1416,10 @@ addEventListener('fetch', event => {});`
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev",
-          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mUsing the latest version of the Workers runtime. To silence this warning, please choose a specific version of the runtime with --compatibility-date, or add a compatibility_date to your wrangler.toml.[0m
+          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe --assets argument is experimental and may change or break at any time[0m
+
+
+        [33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mUsing the latest version of the Workers runtime. To silence this warning, please choose a specific version of the runtime with --compatibility-date, or add a compatibility_date to your wrangler.toml.[0m
 
 
 
@@ -1501,7 +1504,9 @@ addEventListener('fetch', event => {});`
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev",
-          "warn": "",
+          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe --assets argument is experimental and may change or break at any time[0m
+
+        ",
         }
       `);
     });
@@ -1525,7 +1530,9 @@ addEventListener('fetch', event => {});`
         ",
           "out": "
         [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m",
-          "warn": "",
+          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe --assets argument is experimental and may change or break at any time[0m
+
+        ",
         }
       `);
     });
@@ -1633,6 +1640,97 @@ addEventListener('fetch', event => {});`
         ",
           "out": "
         [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m",
+          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+
+            - \\"assets\\" fields are experimental and may change or break at any time.
+
+        ",
+        }
+      `);
+    });
+
+    it("should warn if --assets is used", async () => {
+      writeWranglerToml({
+        main: "./index.js",
+      });
+      const assets = [
+        { filePath: "subdir/file-1.txt", content: "Content of file-1" },
+        { filePath: "subdir/file-2.txt", content: "Content of file-2" },
+      ];
+      const kvNamespace = {
+        title: "__test-name-workers_sites_assets",
+        id: "__test-name-workers_sites_assets-id",
+      };
+      fs.writeFileSync("index.js", `export default {};`);
+      writeWorkerSource();
+      writeAssets(assets);
+      mockUploadWorkerRequest({
+        expectedMainModule: "stdin.js",
+      });
+      mockSubDomainRequest();
+      mockListKVNamespacesRequest(kvNamespace);
+      mockKeyListRequest(kvNamespace.id, []);
+      mockUploadAssetsToKVRequest(kvNamespace.id, assets);
+
+      await runWrangler("publish --assets ./assets");
+      expect(std).toMatchInlineSnapshot(`
+        Object {
+          "debug": "",
+          "err": "",
+          "out": "Reading subdir/file-1.txt...
+        Uploading as subdir/file-1.2ca234f380.txt...
+        Reading subdir/file-2.txt...
+        Uploading as subdir/file-2.5938485188.txt...
+        ↗️  Done syncing assets
+        Total Upload: 52xx KiB / gzip: 13xx KiB
+        Uploaded test-name (TIMINGS)
+        Published test-name (TIMINGS)
+          test-name.test-sub-domain.workers.dev",
+          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe --assets argument is experimental and may change or break at any time[0m
+
+        ",
+        }
+      `);
+    });
+
+    it("should warn if config.assets is used", async () => {
+      writeWranglerToml({
+        main: "./index.js",
+        assets: "./assets",
+      });
+      const assets = [
+        { filePath: "subdir/file-1.txt", content: "Content of file-1" },
+        { filePath: "subdir/file-2.txt", content: "Content of file-2" },
+      ];
+      const kvNamespace = {
+        title: "__test-name-workers_sites_assets",
+        id: "__test-name-workers_sites_assets-id",
+      };
+      fs.writeFileSync("index.js", `export default {};`);
+      writeWorkerSource();
+      writeAssets(assets);
+      mockUploadWorkerRequest({
+        expectedMainModule: "stdin.js",
+      });
+      mockSubDomainRequest();
+      mockListKVNamespacesRequest(kvNamespace);
+      mockKeyListRequest(kvNamespace.id, []);
+      mockUploadAssetsToKVRequest(kvNamespace.id, assets);
+
+      await runWrangler("publish");
+      expect(std).toMatchInlineSnapshot(`
+        Object {
+          "debug": "",
+          "err": "",
+          "out": "Reading subdir/file-1.txt...
+        Uploading as subdir/file-1.2ca234f380.txt...
+        Reading subdir/file-2.txt...
+        Uploading as subdir/file-2.5938485188.txt...
+        ↗️  Done syncing assets
+        Total Upload: 52xx KiB / gzip: 13xx KiB
+        Uploaded test-name (TIMINGS)
+        Published test-name (TIMINGS)
+          test-name.test-sub-domain.workers.dev",
           "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
 
             - \\"assets\\" fields are experimental and may change or break at any time.
@@ -2655,7 +2753,9 @@ addEventListener('fetch', event => {});`
         Uploaded test-name (TIMINGS)
         Published test-name (TIMINGS)
           test-name.test-sub-domain.workers.dev",
-          "warn": "",
+          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe --assets argument is experimental and may change or break at any time[0m
+
+        ",
         }
       `);
     });

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -275,6 +275,12 @@ export async function devHandler(args: ArgumentsCamelCase<DevArgs>) {
       );
     }
 
+    if (args.assets) {
+      logger.warn(
+        "The --assets argument is experimental and may change or break at any time"
+      );
+    }
+
     const upstreamProtocol =
       args["upstream-protocol"] || config.dev.upstream_protocol;
     if (upstreamProtocol === "http") {

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -501,6 +501,12 @@ function createCLIParser(argv: string[]) {
         );
       }
 
+      if (args.assets) {
+        logger.warn(
+          "The --assets argument is experimental and may change or break at any time"
+        );
+      }
+
       if (args.latest) {
         logger.warn(
           "Using the latest version of the Workers runtime. To silence this warning, please choose a specific version of the runtime with --compatibility-date, or add a compatibility_date to your wrangler.toml.\n"


### PR DESCRIPTION
We already have a warning when `config.assets` is used, this adds it for the cli argument as well.