### PR TITLE
feat: export a dev function that folks can use in their own scripts to invoke wrangler dev

### DIFF
--- a/.changeset/little-horses-perform.md
+++ b/.changeset/little-horses-perform.md
@@ -1,0 +1,8 @@
+---
+"wrangler-dev-api-app": patch
+"wrangler": patch
+---
+
+feat: export an (unstable) function that folks can use in their own scripts to invoke wrangler's dev CLI
+
+Closes #1350

--- a/.changeset/little-horses-perform.md
+++ b/.changeset/little-horses-perform.md
@@ -1,5 +1,4 @@
 ---
-"wrangler-dev-api-app": patch
 "wrangler": patch
 ---
 

--- a/fixtures/wrangler-dev-api-app/package.json
+++ b/fixtures/wrangler-dev-api-app/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "wrangler-dev-api-app",
+	"version": "1.0.0",
+	"description": "",
+	"scripts": {
+		"dev": "node --no-warnings ./src/wrangler-dev.mjs"
+	},
+	"author": "",
+	"license": "ISC",
+	"private": true
+}

--- a/fixtures/wrangler-dev-api-app/src/index.js
+++ b/fixtures/wrangler-dev-api-app/src/index.js
@@ -1,0 +1,5 @@
+export default {
+  async fetch(request) {
+    return new Response(`${request.url} ${new Date()}`);
+  },
+};

--- a/fixtures/wrangler-dev-api-app/src/wrangler-dev.mjs
+++ b/fixtures/wrangler-dev-api-app/src/wrangler-dev.mjs
@@ -2,9 +2,11 @@ import undici from "undici";
 import wrangler from "wrangler";
 
 //since the script is invoked from the directory above, need to specify index.js is in src/
-await wrangler.unstable_dev("src/index.js");
+const worker = await wrangler.unstable_dev("src/index.js");
 
 const resp = await undici.fetch("http://localhost:8787/");
 const text = await resp.text();
 
 console.log("Invoked worker: ", text);
+
+await worker.stop();

--- a/fixtures/wrangler-dev-api-app/src/wrangler-dev.mjs
+++ b/fixtures/wrangler-dev-api-app/src/wrangler-dev.mjs
@@ -1,0 +1,10 @@
+import undici from "undici";
+import wrangler from "wrangler";
+
+//since the script is invoked from the directory above, need to specify index.js is in src/
+await wrangler.unstable_dev("src/index.js");
+
+const resp = await undici.fetch("http://localhost:8787/");
+const text = await resp.text();
+
+console.log("Invoked worker: ", text);

--- a/fixtures/wrangler-dev-api-app/wrangler.toml
+++ b/fixtures/wrangler-dev-api-app/wrangler.toml
@@ -1,1 +1,0 @@
-compatibility_date = "2022-03-31"

--- a/fixtures/wrangler-dev-api-app/wrangler.toml
+++ b/fixtures/wrangler-dev-api-app/wrangler.toml
@@ -1,0 +1,1 @@
+compatibility_date = "2022-03-31"

--- a/package-lock.json
+++ b/package-lock.json
@@ -148,6 +148,10 @@
 		"fixtures/workers-chat-demo": {
 			"version": "1.0.0"
 		},
+		"fixtures/wrangler-dev-api-app": {
+			"version": "1.0.0",
+			"license": "ISC"
+		},
 		"node_modules/@ampproject/remapping": {
 			"version": "2.0.2",
 			"license": "Apache-2.0",
@@ -19774,6 +19778,10 @@
 			"resolved": "packages/wrangler",
 			"link": true
 		},
+		"node_modules/wrangler-dev-api-app": {
+			"resolved": "fixtures/wrangler-dev-api-app",
+			"link": true
+		},
 		"node_modules/wranglerjs-compat-webpack-plugin": {
 			"resolved": "packages/wranglerjs-compat-webpack-plugin",
 			"link": true
@@ -35498,6 +35506,9 @@
 					"dev": true
 				}
 			}
+		},
+		"wrangler-dev-api-app": {
+			"version": "file:fixtures/wrangler-dev-api-app"
 		},
 		"wranglerjs-compat-webpack-plugin": {
 			"version": "file:packages/wranglerjs-compat-webpack-plugin",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -7,6 +7,7 @@
 		"wrangler": "./bin/wrangler.js",
 		"wrangler2": "./bin/wrangler.js"
 	},
+	"main": "wrangler-dist/cli.js",
 	"license": "MIT OR Apache-2.0",
 	"bugs": {
 		"url": "https://github.com/cloudflare/wrangler2/issues"

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -21,10 +21,11 @@ export async function unstable_dev(script: string, options: DevOptions) {
 	);
 
 	return new Promise<void>((resolve) => {
+		//startDev returns a stop function... how do we simulultaneously resolve here, and pass the result of startDev to the caller?
 		return startDev({
 			script: script,
 			...options,
-			local: false,
+			local: true,
 			onReady: resolve,
 			inspect: false,
 			logLevel: "none",

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -19,14 +19,16 @@ export async function unstable_dev(script: string, options: DevOptions) {
 	logger.warn(
 		`unstable_dev() is experimental\nunstable_dev()'s behaviour will likely change in future releases`
 	);
-	logger.loggerLevel = "error";
+
 	return new Promise<void>((resolve) => {
 		return startDev({
 			script: script,
 			...options,
-			isApi: true,
-			local: true,
+			local: false,
 			onReady: resolve,
+			inspect: false,
+			logLevel: "none",
+			showInteractiveDevSession: false,
 		});
 	});
 }

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -1,0 +1,32 @@
+import { startDev } from "../dev";
+import { logger } from "../logger";
+interface DevOptions {
+	env?: string;
+	ip?: string;
+	port?: number;
+	localProtocol?: "http" | "https";
+	assets?: string;
+	site?: string;
+	siteInclude?: string[];
+	siteExclude?: string[];
+	nodeCompat?: boolean;
+	experimentalEnableLocalPersistence?: boolean;
+	_: (string | number)[]; //yargs wants this
+	$0: string; //yargs wants this
+}
+
+export async function unstable_dev(script: string, options: DevOptions) {
+	logger.warn(
+		`unstable_dev() is experimental\nunstable_dev()'s behaviour will likely change in future releases`
+	);
+	logger.loggerLevel = "error";
+	return new Promise<void>((resolve) => {
+		return startDev({
+			script: script,
+			...options,
+			isApi: true,
+			local: true,
+			onReady: resolve,
+		});
+	});
+}

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -20,16 +20,20 @@ export async function unstable_dev(script: string, options: DevOptions) {
 		`unstable_dev() is experimental\nunstable_dev()'s behaviour will likely change in future releases`
 	);
 
-	return new Promise<void>((resolve) => {
-		//startDev returns a stop function... how do we simulultaneously resolve here, and pass the result of startDev to the caller?
-		return startDev({
-			script: script,
-			...options,
-			local: true,
-			onReady: resolve,
-			inspect: false,
-			logLevel: "none",
-			showInteractiveDevSession: false,
+	return new Promise<{ stop: () => void }>((resolve) => {
+		//lmao
+		return new Promise<Awaited<ReturnType<typeof startDev>>>((ready) => {
+			const devServer = startDev({
+				script: script,
+				...options,
+				local: true,
+				onReady: () => ready(devServer),
+				inspect: false,
+				logLevel: "none",
+				showInteractiveDevSession: false,
+			});
+		}).then((devServer) => {
+			resolve({ stop: devServer.stop });
 		});
 	});
 }

--- a/packages/wrangler/src/api/index.ts
+++ b/packages/wrangler/src/api/index.ts
@@ -1,0 +1,1 @@
+export { unstable_dev } from "./dev";

--- a/packages/wrangler/src/cli.ts
+++ b/packages/wrangler/src/cli.ts
@@ -1,13 +1,27 @@
 import "dotenv/config"; // Grab locally specified env params from a `.env` file.
 import process from "process";
 import { hideBin } from "yargs/helpers";
+import { unstable_dev } from "./api";
 import { FatalError } from "./errors";
 import { main } from ".";
 
-main(hideBin(process.argv)).catch((e) => {
-	// The logging of any error that was thrown from `main()` is handled in the `yargs.fail()` handler.
-	// Here we just want to ensure that the process exits with a non-zero code.
-	// We don't want to do this inside the `main()` function, since that would kill the process when running our tests.
-	const exitCode = (e instanceof FatalError && e.code) || 1;
-	process.exit(exitCode);
-});
+/**
+ * The main entrypoint for the CLI.
+ * main only gets called when the script is run directly, not when it's imported as a module.
+ */
+if (require.main) {
+	main(hideBin(process.argv)).catch((e) => {
+		// The logging of any error that was thrown from `main()` is handled in the `yargs.fail()` handler.
+		// Here we just want to ensure that the process exits with a non-zero code.
+		// We don't want to do this inside the `main()` function, since that would kill the process when running our tests.
+		const exitCode = (e instanceof FatalError && e.code) || 1;
+		process.exit(exitCode);
+	});
+}
+
+/**
+ * This is how we're exporting the API.
+ * It makes it possible to import wrangler from 'wrangler',
+ * and call wrangler.unstable_dev().
+ */
+module.exports = { unstable_dev };

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -500,7 +500,14 @@ export async function startDev(args: ArgumentsCamelCase<DevArgs>) {
 		}
 		const devReactElement = render(await getDevReactElement(config));
 		rerender = devReactElement.rerender;
-		return { devReactElement, watcher };
+		return {
+			devReactElement,
+			watcher,
+			stop: async () => {
+				devReactElement.unmount();
+				await devReactElement.waitUntilExit();
+			},
+		};
 	} finally {
 		await watcher?.close();
 	}

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -506,6 +506,8 @@ export async function startDev(args: ArgumentsCamelCase<DevArgs>) {
 			stop: async () => {
 				devReactElement.unmount();
 				await devReactElement.waitUntilExit();
+				await watcher?.close();
+				process.exit(0);
 			},
 		};
 	} finally {

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -57,8 +57,9 @@ interface DevArgs {
 	minify?: boolean;
 	"node-compat"?: boolean;
 	"experimental-enable-local-persistence"?: boolean;
-	isApi?: boolean;
 	onReady?: () => void;
+	logLevel?: "none" | "error" | "log" | "warn" | "debug";
+	showInteractiveDevSession?: boolean;
 }
 
 export function devOptions(yargs: Argv): Argv<DevArgs> {
@@ -248,9 +249,11 @@ export async function startDev(args: ArgumentsCamelCase<DevArgs>) {
 	let watcher: ReturnType<typeof watch> | undefined;
 	let rerender: (node: React.ReactNode) => void | undefined;
 	try {
-		if (!args.isApi) {
-			await printWranglerBanner();
+		if (args.logLevel) {
+			// we don't define a "none" logLevel, so "error" will do for now.
+			logger.loggerLevel = args.logLevel === "none" ? "error" : args.logLevel;
 		}
+		await printWranglerBanner();
 
 		const configPath =
 			(args.config as ConfigPath) ||
@@ -292,6 +295,7 @@ export async function startDev(args: ArgumentsCamelCase<DevArgs>) {
 		}
 
 		if (args.inspect) {
+			//devtools are enabled by default, but we still need to disable them if the caller doesn't want them
 			logger.warn(
 				"Passing --inspect is unnecessary, now you can always connect to devtools."
 			);
@@ -487,8 +491,10 @@ export async function startDev(args: ArgumentsCamelCase<DevArgs>) {
 					usageModel={config.usage_model}
 					bindings={bindings}
 					crons={config.triggers.crons}
-					isApi={args.isApi}
+					logLevel={args.logLevel}
 					onReady={args.onReady}
+					inspect={args.inspect}
+					showInteractiveDevSession={args.showInteractiveDevSession}
 				/>
 			);
 		}

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -55,6 +55,8 @@ export type DevProps = {
 	zone: string | undefined;
 	host: string | undefined;
 	routes: Route[] | undefined;
+	isApi?: boolean;
+	onReady?: () => void;
 };
 
 export function DevImplementation(props: DevProps): JSX.Element {
@@ -88,7 +90,8 @@ export function DevImplementation(props: DevProps): JSX.Element {
 
 	// only load the UI if we're running in a supported environment
 	const { isRawModeSupported } = useStdin();
-	return isRawModeSupported ? (
+	const showInteractiveDevSession = isRawModeSupported && !props.isApi;
+	return showInteractiveDevSession ? (
 		<InteractiveDevSession {...props} />
 	) : (
 		<DevSession {...props} local={props.initialMode === "local"} />
@@ -171,6 +174,8 @@ function DevSession(props: DevSessionProps) {
 			crons={props.crons}
 			localProtocol={props.localProtocol}
 			localUpstream={props.localUpstream}
+			isApi={props.isApi}
+			onReady={props.onReady}
 		/>
 	) : (
 		<Remote
@@ -193,6 +198,7 @@ function DevSession(props: DevSessionProps) {
 			zone={props.zone}
 			host={props.host}
 			routes={props.routes}
+			onReady={props.onReady}
 		/>
 	);
 }

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -55,8 +55,10 @@ export type DevProps = {
 	zone: string | undefined;
 	host: string | undefined;
 	routes: Route[] | undefined;
-	isApi?: boolean;
-	onReady?: () => void;
+	inspect: boolean | undefined;
+	logLevel: "none" | "error" | "log" | "warn" | "debug" | undefined;
+	onReady: (() => void) | undefined;
+	showInteractiveDevSession: boolean | undefined;
 };
 
 export function DevImplementation(props: DevProps): JSX.Element {
@@ -90,8 +92,8 @@ export function DevImplementation(props: DevProps): JSX.Element {
 
 	// only load the UI if we're running in a supported environment
 	const { isRawModeSupported } = useStdin();
-	const showInteractiveDevSession = isRawModeSupported && !props.isApi;
-	return showInteractiveDevSession ? (
+
+	return props.showInteractiveDevSession ?? isRawModeSupported ? (
 		<InteractiveDevSession {...props} />
 	) : (
 		<DevSession {...props} local={props.initialMode === "local"} />
@@ -174,7 +176,8 @@ function DevSession(props: DevSessionProps) {
 			crons={props.crons}
 			localProtocol={props.localProtocol}
 			localUpstream={props.localUpstream}
-			isApi={props.isApi}
+			logLevel={props.logLevel}
+			inspect={props.inspect}
 			onReady={props.onReady}
 		/>
 	) : (

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -31,8 +31,9 @@ interface LocalProps {
 	crons: Config["triggers"]["crons"];
 	localProtocol: "http" | "https";
 	localUpstream: string | undefined;
-	isApi?: boolean;
-	onReady?: () => void;
+	inspect: boolean | undefined;
+	onReady: (() => void) | undefined;
+	logLevel: "none" | "error" | "log" | "warn" | "debug" | undefined;
 }
 
 export function Local(props: LocalProps) {
@@ -61,8 +62,9 @@ function useLocalWorker({
 	crons,
 	localProtocol,
 	localUpstream,
-	isApi,
+	inspect,
 	onReady,
+	logLevel,
 }: LocalProps) {
 	// TODO: pass vars via command line
 	const local = useRef<ReturnType<typeof spawn>>();
@@ -190,7 +192,6 @@ function useLocalWorker({
 						(value) => [value.name, value.class_name]
 					)
 				),
-				isApi,
 				...(localPersistencePath
 					? {
 							kvPersist: path.join(localPersistencePath, "kv"),
@@ -225,6 +226,7 @@ function useLocalWorker({
 				logUnhandledRejections: true,
 				crons,
 				upstream,
+				disableLogs: logLevel === "none",
 			};
 
 			// The path to the Miniflare CLI assumes that this file is being run from
@@ -244,7 +246,7 @@ function useLocalWorker({
 				optionsArg,
 				// "--log=VERBOSE", // uncomment this to Miniflare to log "everything"!
 			];
-			if (!isApi) {
+			if (inspect) {
 				localServerOptions.push("--inspect"); // start Miniflare listening for a debugger to attach
 			}
 			// spawn isn't technically synchronous here
@@ -336,7 +338,8 @@ function useLocalWorker({
 		crons,
 		localProtocol,
 		localUpstream,
-		isApi,
+		inspect,
+		logLevel,
 		onReady,
 	]);
 	return { inspectorUrl };

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -254,7 +254,11 @@ function useLocalWorker({
 				cwd: path.dirname(scriptPath),
 			});
 			//TODO: instead of being lucky with spawn's timing, have miniflare-cli notify wrangler that it's ready in packages/wrangler/src/miniflare-cli/index.ts, after the mf.startScheduler promise resolves
-			onReady && onReady();
+			if (onReady) {
+				await new Promise((resolve) => setTimeout(resolve, 200));
+				onReady();
+			}
+
 			local.current.on("close", (code) => {
 				if (code) {
 					logger.log(`Miniflare process exited with code ${code}`);

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -36,6 +36,7 @@ export function Remote(props: {
 	zone: string | undefined;
 	host: string | undefined;
 	routes: Route[] | undefined;
+	onReady?: () => void;
 }) {
 	const [accountId, setAccountId] = useState(props.accountId);
 	const accountChoicesRef = useRef<Promise<ChooseAccountItem[]>>();
@@ -59,6 +60,7 @@ export function Remote(props: {
 		zone: props.zone,
 		host: props.host,
 		routes: props.routes,
+		onReady: props.onReady,
 	});
 
 	usePreviewServer({
@@ -129,6 +131,7 @@ export function useWorker(props: {
 	zone: string | undefined;
 	host: string | undefined;
 	routes: Route[] | undefined;
+	onReady?: () => void;
 }): CfPreviewToken | undefined {
 	const {
 		name,
@@ -142,6 +145,7 @@ export function useWorker(props: {
 		compatibilityFlags,
 		usageModel,
 		port,
+		onReady,
 	} = props;
 	const [token, setToken] = useState<CfPreviewToken | undefined>();
 
@@ -239,6 +243,7 @@ export function useWorker(props: {
 					abortController.signal
 				)
 			);
+			onReady?.();
 		}
 		start().catch((err) => {
 			// we want to log the error, but not end the process
@@ -283,6 +288,7 @@ export function useWorker(props: {
 		props.zone,
 		props.host,
 		props.routes,
+		onReady,
 	]);
 	return token;
 }

--- a/packages/wrangler/src/miniflare-cli/index.ts
+++ b/packages/wrangler/src/miniflare-cli/index.ts
@@ -28,7 +28,9 @@ async function main() {
 		...JSON.parse((args._[0] as string) ?? "{}"),
 		...requestContextCheckOptions,
 	};
-	config.log = config.isApi ? new NoOpLog() : new Log(logLevel);
+	//miniflare's logLevel 0 still logs routes, so lets override the logger
+	config.log = config.disableLogs ? new NoOpLog() : new Log(logLevel);
+
 	if (logLevel > LogLevel.INFO) {
 		console.log("OPTIONS:\n", JSON.stringify(config, null, 2));
 	}

--- a/packages/wrangler/src/miniflare-cli/index.ts
+++ b/packages/wrangler/src/miniflare-cli/index.ts
@@ -4,6 +4,16 @@ import { hideBin } from "yargs/helpers";
 import { enumKeys } from "./enum-keys";
 import { getRequestContextCheckOptions } from "./request-context";
 
+// miniflare defines this but importing it throws:
+// Dynamic require of "path" is not supported
+class NoOpLog extends Log {
+	log(): void {}
+
+	error(message: Error): void {
+		throw message;
+	}
+}
+
 async function main() {
 	const args = await yargs(hideBin(process.argv))
 		.help(false)
@@ -17,9 +27,8 @@ async function main() {
 	const config = {
 		...JSON.parse((args._[0] as string) ?? "{}"),
 		...requestContextCheckOptions,
-		log: new Log(logLevel),
 	};
-
+	config.log = config.isApi ? new NoOpLog() : new Log(logLevel);
 	if (logLevel > LogLevel.INFO) {
 		console.log("OPTIONS:\n", JSON.stringify(config, null, 2));
 	}


### PR DESCRIPTION
Added a warning: 
<img width="730" alt="image" src="https://user-images.githubusercontent.com/3822106/176405840-19fd5854-a941-4e9d-a9cc-7a498bf76dd2.png">

Things for follow-up releases:

- `unstable_dev` should return an object so you can just do:
  ```js
  const worker = await wrangler.unstable_dev(...)
  const resp =  await worker.fetch()
  ```
-  we should make miniflare notify wrangler that it's ready for requests (the remote dev worker supports this already)
- (for future us to deal with): split wrangler into `@wrangler/core` and `@wrangler/renderer` (or something) so prop-drilling to reach the core isn't necessary