### PR TITLE
Added Global API Key (X-Auth-Key) support to Wrangler

### DIFF
--- a/.changeset/thick-meals-itch.md
+++ b/.changeset/thick-meals-itch.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+feat: add support for CLOUDFLARE_API_KEY + CLOUDFLARE_EMAIL to authorise
+
+This adds support for using the CLOUDFLARE_API_KEY + CLOUDFLARE_EMAIL env vars for authorising a user. This also adds support for CF_API_KEY + CF_EMAIL from wrangler 1, with a deprecation warning.

--- a/packages/wrangler/src/__tests__/whoami.test.tsx
+++ b/packages/wrangler/src/__tests__/whoami.test.tsx
@@ -64,8 +64,8 @@ describe("getUserInfo()", () => {
 
   it("should say it's using a Global API Key when one is set", async () => {
     process.env = {
-      CLOUDFLARE_GLOBAL_API_KEY: "123456789",
-      CLOUDFLARE_GLOBAL_API_EMAIL: "user@example.com",
+      CLOUDFLARE_API_KEY: "123456789",
+      CLOUDFLARE_EMAIL: "user@example.com",
     };
     setMockResponse("/accounts", () => {
       return [
@@ -90,8 +90,8 @@ describe("getUserInfo()", () => {
 
   it("should use a Global API Key in preference to an API key", async () => {
     process.env = {
-      CLOUDFLARE_GLOBAL_API_KEY: "123456789",
-      CLOUDFLARE_GLOBAL_API_EMAIL: "user@example.com",
+      CLOUDFLARE_API_KEY: "123456789",
+      CLOUDFLARE_EMAIL: "user@example.com",
       CLOUDFLARE_API_TOKEN: "123456789",
     };
     setMockResponse("/accounts", () => {
@@ -117,7 +117,7 @@ describe("getUserInfo()", () => {
 
   it("should return undefined only a Global API Key, but not Email, is set", async () => {
     process.env = {
-      CLOUDFLARE_GLOBAL_API_KEY: "123456789",
+      CLOUDFLARE_API_KEY: "123456789",
     };
     const userInfo = await getUserInfo();
     expect(userInfo).toEqual(undefined);

--- a/packages/wrangler/src/__tests__/whoami.test.tsx
+++ b/packages/wrangler/src/__tests__/whoami.test.tsx
@@ -88,7 +88,7 @@ describe("getUserInfo()", () => {
     });
   });
 
-  it("should use a Global API Key in preference to an API key", async () => {
+  it("should use a Global API Key in preference to an API token", async () => {
     process.env = {
       CLOUDFLARE_API_KEY: "123456789",
       CLOUDFLARE_EMAIL: "user@example.com",

--- a/packages/wrangler/src/user/env-vars.ts
+++ b/packages/wrangler/src/user/env-vars.ts
@@ -1,12 +1,41 @@
 import { getEnvironmentVariableFactory } from "../environment-variables";
 
-/**
- * Try to read the API token from the environment.
- */
-export const getCloudflareAPITokenFromEnv = getEnvironmentVariableFactory({
+export type ApiCredentials =
+  | {
+      apiToken: string;
+    }
+  | {
+      authKey: string;
+      authEmail: string;
+    };
+
+const getCloudflareAPITokenFromEnv = getEnvironmentVariableFactory({
   variableName: "CLOUDFLARE_API_TOKEN",
   deprecatedName: "CF_API_TOKEN",
 });
+const getCloudflareGlobalAuthKeyFromEnv = getEnvironmentVariableFactory({
+  variableName: "CLOUDFLARE_GLOBAL_API_KEY",
+  deprecatedName: "CF_API_KEY",
+});
+const getCloudflareGlobalAuthEmailFromEnv = getEnvironmentVariableFactory({
+  variableName: "CLOUDFLARE_GLOBAL_API_EMAIL",
+  deprecatedName: "CF_EMAIL",
+});
+
+/**
+ * Try to read an API token or Global Auth from the environment.
+ */
+export function getAuthFromEnv(): ApiCredentials | undefined {
+  const globalApiKey = getCloudflareGlobalAuthKeyFromEnv();
+  const globalApiEmail = getCloudflareGlobalAuthEmailFromEnv();
+  const apiToken = getCloudflareAPITokenFromEnv();
+
+  if (globalApiKey && globalApiEmail) {
+    return { authKey: globalApiKey, authEmail: globalApiEmail };
+  } else if (apiToken) {
+    return { apiToken };
+  }
+}
 
 /**
  * Try to read the account ID from the environment.

--- a/packages/wrangler/src/user/env-vars.ts
+++ b/packages/wrangler/src/user/env-vars.ts
@@ -14,11 +14,11 @@ const getCloudflareAPITokenFromEnv = getEnvironmentVariableFactory({
   deprecatedName: "CF_API_TOKEN",
 });
 const getCloudflareGlobalAuthKeyFromEnv = getEnvironmentVariableFactory({
-  variableName: "CLOUDFLARE_GLOBAL_API_KEY",
+  variableName: "CLOUDFLARE_API_KEY",
   deprecatedName: "CF_API_KEY",
 });
 const getCloudflareGlobalAuthEmailFromEnv = getEnvironmentVariableFactory({
-  variableName: "CLOUDFLARE_GLOBAL_API_EMAIL",
+  variableName: "CLOUDFLARE_EMAIL",
   deprecatedName: "CF_EMAIL",
 });
 

--- a/packages/wrangler/src/worker.ts
+++ b/packages/wrangler/src/worker.ts
@@ -1,13 +1,15 @@
 /**
  * A Cloudflare account.
  */
+import type { ApiCredentials } from "./user";
+
 export interface CfAccount {
   /**
    * An API token.
    *
    * @link https://api.cloudflare.com/#user-api-tokens-properties
    */
-  apiToken: string;
+  apiToken: ApiCredentials;
   /**
    * An account ID.
    */


### PR DESCRIPTION
Closes #1072 

* A user _must_ supply _both_ an Global API Key and Email for this to work.
* Can use `CLOUDFLARE_API_KEY` and `CLOUDFLARE_EMAIL` or the deprecated `CF_API_KEY` and `CF_EMAIL` keys.
* Takes precedence over `CLOUDFLARE_API_TOKEN` and oAuth.

Refactored the assumption that an `apiToken` was a string and have replaced that with an `ApiCredentials` type:

```ts
export type ApiCredentials =
  | {
      apiToken: string;
    }
  | {
      authKey: string;
      authEmail: string;
    };
```

This flowed _fairly_ easily through the code, picked up inside `addAuthorizationHeaderIfUnspecified`:

```ts
function addAuthorizationHeaderIfUnspecified(
  headers: Record<string, string>,
  auth: ApiCredentials
): void {
  if (!("Authorization" in headers)) {
    if ("apiToken" in auth) {
      headers["Authorization"] = `Bearer ${auth.apiToken}`;
    } else {
      headers["X-Auth-Key"] = auth.authKey;
      headers["X-Auth-Email"] = auth.authEmail;
    }
  }
}
```

I chose to preserve the semantics that if the code has injected a specific `Authorization` header, we should send it on rather than replacing it with the global Key/Email (since it's used for time-limited JWTs for Pages uploads)