### PR TITLE
bugfix: Allow route setting to be `""`

### DIFF
--- a/.changeset/thirty-eagles-add.md
+++ b/.changeset/thirty-eagles-add.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+bugfix: Allow route setting to be `""`
+Previously Wrangler1 had allowed for `route = ""`.
+Wrangler now will allow for empty `route = ""` to represent not setting a route, while providing a warning.
+
+resolves #1329

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -495,6 +495,23 @@ describe("publish", () => {
       await runWrangler("publish ./index");
     });
 
+    it("should publish with an empty string route", async () => {
+      writeWranglerToml({
+        route: "",
+      });
+      writeWorkerSource();
+      mockUpdateWorkerRequest({ enabled: false });
+      mockUploadWorkerRequest({ expectedType: "esm" });
+      mockSubDomainRequest();
+      mockPublishRoutesRequest({ routes: [""] });
+      await runWrangler("publish ./index");
+      expect(std.warn).toMatchInlineSnapshot(`
+        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mRoute/s is being set as an empty string[0m
+
+        "
+      `);
+    });
+
     it("should publish to a route with a pattern/{zone_id|zone_name} combo", async () => {
       writeWranglerToml({
         routes: [

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -637,7 +637,7 @@ function normalizeAndValidateModulePaths(
  * or an object that looks like {pattern: string, zone_id: string }
  */
 function isValidRouteValue(item: unknown): boolean {
-  if (!item) {
+  if (!item && item !== "") {
     return false;
   }
   if (typeof item === "string") {

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -236,8 +236,12 @@ export default async function publish(props: Props): Promise<void> {
     Or you could pass it in your terminal as \`--compatibility-date ${compatibilityDateStr}\`
 See https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.`);
   }
-
   const triggers = props.triggers || config.triggers?.crons;
+
+  if (config.route === "") {
+    logger.warn("Route/s is being set as an empty string");
+  }
+  // The empty string gets swallowed by the ternary default to an empty array
   const routes =
     props.routes ?? config.routes ?? (config.route ? [config.route] : []) ?? [];
   const routesOnly: Array<Route> = [];


### PR DESCRIPTION
Previously Wrangler1 had allowed for `route = ""`.
Wrangler now will allow for empty `route = ""` to represent not setting a route, while providing a warning.

resolves #1329