### PR TITLE
Github action to publish `wrangler@d1` releases

### DIFF
--- a/.github/workflows/d1.yml
+++ b/.github/workflows/d1.yml
@@ -1,0 +1,52 @@
+name: D1
+
+on:
+  push:
+    branches:
+      - d1
+
+jobs:
+  release:
+    if: ${{ github.repository_owner == 'cloudflare' }}
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js 16.7
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.7
+          cache: "npm" # cache ~/.npm in case 'npm ci' needs to run
+
+      - uses: actions/cache@v3
+        id: node-modules-cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install NPM Dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Check for errors
+        run: npm run check
+
+      - name: Modify package.json version
+        run: node .github/version-script.js
+
+      - name: Publish to NPM
+        run: npm publish --tag d1
+        env:
+          NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+        working-directory: packages/wrangler


### PR DESCRIPTION
This github action runs on all pushes to the d1 branch, and publishes a tagged version og wrangler to npm (`wrangler@d1`). We're using this for closed beta testing of D1, the new Workers database.