### PR TITLE
feat: commands to manage worker namespaces

### DIFF
--- a/.changeset/eighty-otters-hide.md
+++ b/.changeset/eighty-otters-hide.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+feat: commands to manage worker namespaces
+
+This adds commands to create, delete, list, and get info for "worker namespaces" (name to be bikeshed-ed). This is based on work by @aaronlisman in https://github.com/cloudflare/wrangler2/pull/1310.

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -28,29 +28,30 @@ describe("wrangler", () => {
 			await runWrangler();
 
 			expect(std.out).toMatchInlineSnapshot(`
-        "wrangler
+			"wrangler
 
-        Commands:
-          wrangler init [name]       📥 Create a wrangler.toml configuration file
-          wrangler dev [script]      👂 Start a local server for developing your worker
-          wrangler publish [script]  🆙 Publish your Worker to Cloudflare.
-          wrangler tail [name]       🦚 Starts a log tailing session for a published Worker.
-          wrangler secret            🤫 Generate a secret that can be referenced in the worker script
-          wrangler kv:namespace      🗂️  Interact with your Workers KV Namespaces
-          wrangler kv:key            🔑 Individually manage Workers KV key-value pairs
-          wrangler kv:bulk           💪 Interact with multiple Workers KV key-value pairs at once
-          wrangler pages             ⚡️ Configure Cloudflare Pages
-          wrangler r2                📦 Interact with an R2 store
-          wrangler pubsub            📮 Interact and manage Pub/Sub Brokers
-          wrangler login             🔓 Login to Cloudflare
-          wrangler logout            🚪 Logout from Cloudflare
-          wrangler whoami            🕵️  Retrieve your user info and test your auth config
+			Commands:
+			  wrangler init [name]       📥 Create a wrangler.toml configuration file
+			  wrangler dev [script]      👂 Start a local server for developing your worker
+			  wrangler publish [script]  🆙 Publish your Worker to Cloudflare.
+			  wrangler tail [name]       🦚 Starts a log tailing session for a published Worker.
+			  wrangler secret            🤫 Generate a secret that can be referenced in the worker script
+			  wrangler kv:namespace      🗂️  Interact with your Workers KV Namespaces
+			  wrangler kv:key            🔑 Individually manage Workers KV key-value pairs
+			  wrangler kv:bulk           💪 Interact with multiple Workers KV key-value pairs at once
+			  wrangler pages             ⚡️ Configure Cloudflare Pages
+			  wrangler r2                📦 Interact with an R2 store
+			  wrangler worker-namespace  📦 Interact with a worker namespace
+			  wrangler pubsub            📮 Interact and manage Pub/Sub Brokers
+			  wrangler login             🔓 Login to Cloudflare
+			  wrangler logout            🚪 Logout from Cloudflare
+			  wrangler whoami            🕵️  Retrieve your user info and test your auth config
 
-        Flags:
-          -c, --config   Path to .toml configuration file  [string]
-          -h, --help     Show help  [boolean]
-          -v, --version  Show version number  [boolean]"
-      `);
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]"
+		`);
 
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
@@ -65,35 +66,36 @@ describe("wrangler", () => {
 			);
 
 			expect(std.out).toMatchInlineSnapshot(`
-        "
-        wrangler
+			"
+			wrangler
 
-        Commands:
-          wrangler init [name]       📥 Create a wrangler.toml configuration file
-          wrangler dev [script]      👂 Start a local server for developing your worker
-          wrangler publish [script]  🆙 Publish your Worker to Cloudflare.
-          wrangler tail [name]       🦚 Starts a log tailing session for a published Worker.
-          wrangler secret            🤫 Generate a secret that can be referenced in the worker script
-          wrangler kv:namespace      🗂️  Interact with your Workers KV Namespaces
-          wrangler kv:key            🔑 Individually manage Workers KV key-value pairs
-          wrangler kv:bulk           💪 Interact with multiple Workers KV key-value pairs at once
-          wrangler pages             ⚡️ Configure Cloudflare Pages
-          wrangler r2                📦 Interact with an R2 store
-          wrangler pubsub            📮 Interact and manage Pub/Sub Brokers
-          wrangler login             🔓 Login to Cloudflare
-          wrangler logout            🚪 Logout from Cloudflare
-          wrangler whoami            🕵️  Retrieve your user info and test your auth config
+			Commands:
+			  wrangler init [name]       📥 Create a wrangler.toml configuration file
+			  wrangler dev [script]      👂 Start a local server for developing your worker
+			  wrangler publish [script]  🆙 Publish your Worker to Cloudflare.
+			  wrangler tail [name]       🦚 Starts a log tailing session for a published Worker.
+			  wrangler secret            🤫 Generate a secret that can be referenced in the worker script
+			  wrangler kv:namespace      🗂️  Interact with your Workers KV Namespaces
+			  wrangler kv:key            🔑 Individually manage Workers KV key-value pairs
+			  wrangler kv:bulk           💪 Interact with multiple Workers KV key-value pairs at once
+			  wrangler pages             ⚡️ Configure Cloudflare Pages
+			  wrangler r2                📦 Interact with an R2 store
+			  wrangler worker-namespace  📦 Interact with a worker namespace
+			  wrangler pubsub            📮 Interact and manage Pub/Sub Brokers
+			  wrangler login             🔓 Login to Cloudflare
+			  wrangler logout            🚪 Logout from Cloudflare
+			  wrangler whoami            🕵️  Retrieve your user info and test your auth config
 
-        Flags:
-          -c, --config   Path to .toml configuration file  [string]
-          -h, --help     Show help  [boolean]
-          -v, --version  Show version number  [boolean]"
-      `);
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]"
+		`);
 			expect(std.err).toMatchInlineSnapshot(`
-        "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mUnknown argument: invalid-command[0m
+			        "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mUnknown argument: invalid-command[0m
 
-        "
-      `);
+			        "
+		      `);
 		});
 	});
 
@@ -121,98 +123,98 @@ describe("wrangler", () => {
 			await runWrangler("secret");
 			await endEventLoop();
 			expect(std.out).toMatchInlineSnapshot(`
-        "wrangler secret
+			        "wrangler secret
 
-        🤫 Generate a secret that can be referenced in the worker script
+			        🤫 Generate a secret that can be referenced in the worker script
 
-        Commands:
-          wrangler secret put <key>     Create or update a secret variable for a script
-          wrangler secret delete <key>  Delete a secret variable from a script
-          wrangler secret list          List all secrets for a script
+			        Commands:
+			          wrangler secret put <key>     Create or update a secret variable for a script
+			          wrangler secret delete <key>  Delete a secret variable from a script
+			          wrangler secret list          List all secrets for a script
 
-        Flags:
-          -c, --config   Path to .toml configuration file  [string]
-          -h, --help     Show help  [boolean]
-          -v, --version  Show version number  [boolean]"
-      `);
+			        Flags:
+			          -c, --config   Path to .toml configuration file  [string]
+			          -h, --help     Show help  [boolean]
+			          -v, --version  Show version number  [boolean]"
+		      `);
 		});
 
 		it("no subcommand 'kv:namespace' should display a list of available subcommands", async () => {
 			await runWrangler("kv:namespace");
 			await endEventLoop();
 			expect(std.out).toMatchInlineSnapshot(`
-        "wrangler kv:namespace
+			        "wrangler kv:namespace
 
-        🗂️  Interact with your Workers KV Namespaces
+			        🗂️  Interact with your Workers KV Namespaces
 
-        Commands:
-          wrangler kv:namespace create <namespace>  Create a new namespace
-          wrangler kv:namespace list                Outputs a list of all KV namespaces associated with your account id.
-          wrangler kv:namespace delete              Deletes a given namespace.
+			        Commands:
+			          wrangler kv:namespace create <namespace>  Create a new namespace
+			          wrangler kv:namespace list                Outputs a list of all KV namespaces associated with your account id.
+			          wrangler kv:namespace delete              Deletes a given namespace.
 
-        Flags:
-          -c, --config   Path to .toml configuration file  [string]
-          -h, --help     Show help  [boolean]
-          -v, --version  Show version number  [boolean]"
-      `);
+			        Flags:
+			          -c, --config   Path to .toml configuration file  [string]
+			          -h, --help     Show help  [boolean]
+			          -v, --version  Show version number  [boolean]"
+		      `);
 		});
 
 		it("no subcommand 'kv:key' should display a list of available subcommands", async () => {
 			await runWrangler("kv:key");
 			await endEventLoop();
 			expect(std.out).toMatchInlineSnapshot(`
-        "wrangler kv:key
+			        "wrangler kv:key
 
-        🔑 Individually manage Workers KV key-value pairs
+			        🔑 Individually manage Workers KV key-value pairs
 
-        Commands:
-          wrangler kv:key put <key> [value]  Writes a single key/value pair to the given namespace.
-          wrangler kv:key list               Outputs a list of all keys in a given namespace.
-          wrangler kv:key get <key>          Reads a single value by key from the given namespace.
-          wrangler kv:key delete <key>       Removes a single key value pair from the given namespace.
+			        Commands:
+			          wrangler kv:key put <key> [value]  Writes a single key/value pair to the given namespace.
+			          wrangler kv:key list               Outputs a list of all keys in a given namespace.
+			          wrangler kv:key get <key>          Reads a single value by key from the given namespace.
+			          wrangler kv:key delete <key>       Removes a single key value pair from the given namespace.
 
-        Flags:
-          -c, --config   Path to .toml configuration file  [string]
-          -h, --help     Show help  [boolean]
-          -v, --version  Show version number  [boolean]"
-      `);
+			        Flags:
+			          -c, --config   Path to .toml configuration file  [string]
+			          -h, --help     Show help  [boolean]
+			          -v, --version  Show version number  [boolean]"
+		      `);
 		});
 
 		it("no subcommand 'kv:bulk' should display a list of available subcommands", async () => {
 			await runWrangler("kv:bulk");
 			await endEventLoop();
 			expect(std.out).toMatchInlineSnapshot(`
-        "wrangler kv:bulk
+			        "wrangler kv:bulk
 
-        💪 Interact with multiple Workers KV key-value pairs at once
+			        💪 Interact with multiple Workers KV key-value pairs at once
 
-        Commands:
-          wrangler kv:bulk put <filename>     Upload multiple key-value pairs to a namespace
-          wrangler kv:bulk delete <filename>  Delete multiple key-value pairs from a namespace
+			        Commands:
+			          wrangler kv:bulk put <filename>     Upload multiple key-value pairs to a namespace
+			          wrangler kv:bulk delete <filename>  Delete multiple key-value pairs from a namespace
 
-        Flags:
-          -c, --config   Path to .toml configuration file  [string]
-          -h, --help     Show help  [boolean]
-          -v, --version  Show version number  [boolean]"
-      `);
+			        Flags:
+			          -c, --config   Path to .toml configuration file  [string]
+			          -h, --help     Show help  [boolean]
+			          -v, --version  Show version number  [boolean]"
+		      `);
 		});
 
 		it("no subcommand 'r2' should display a list of available subcommands", async () => {
 			await runWrangler("r2");
 			await endEventLoop();
 			expect(std.out).toMatchInlineSnapshot(`
-        "wrangler r2
+			        "wrangler r2
 
-        📦 Interact with an R2 store
+			        📦 Interact with an R2 store
 
-        Commands:
-          wrangler r2 bucket  Manage R2 buckets
+			        Commands:
+			          wrangler r2 bucket  Manage R2 buckets
 
-        Flags:
-          -c, --config   Path to .toml configuration file  [string]
-          -h, --help     Show help  [boolean]
-          -v, --version  Show version number  [boolean]"
-      `);
+			        Flags:
+			          -c, --config   Path to .toml configuration file  [string]
+			          -h, --help     Show help  [boolean]
+			          -v, --version  Show version number  [boolean]"
+		      `);
 		});
 	});
 
@@ -220,16 +222,16 @@ describe("wrangler", () => {
 		it("should print a deprecation message for 'generate'", async () => {
 			await runWrangler("generate").catch((err) => {
 				expect(err.message).toMatchInlineSnapshot(`
-          "Deprecation:
-          \`wrangler generate\` has been deprecated.
-          Try running \`wrangler init\` to generate a basic Worker, or cloning the template repository instead:
+			          "Deprecation:
+			          \`wrangler generate\` has been deprecated.
+			          Try running \`wrangler init\` to generate a basic Worker, or cloning the template repository instead:
 
-          \`\`\`
-          git clone https://github.com/cloudflare/worker-template
-          \`\`\`
+			          \`\`\`
+			          git clone https://github.com/cloudflare/worker-template
+			          \`\`\`
 
-          Please refer to https://developers.cloudflare.com/workers/wrangler/deprecations/#generate for more information."
-        `);
+			          Please refer to https://developers.cloudflare.com/workers/wrangler/deprecations/#generate for more information."
+		        `);
 			});
 		});
 	});
@@ -242,16 +244,16 @@ describe("wrangler", () => {
 		await runWrangler("build");
 		await endEventLoop();
 		expect(std.out).toMatchInlineSnapshot(`
-      "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mDeprecation: \`wrangler build\` has been deprecated.[0m
+		      "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mDeprecation: \`wrangler build\` has been deprecated.[0m
 
-        Please refer to [4mhttps://developers.cloudflare.com/workers/wrangler/migration/deprecations/#build[0m
-        for more information.
-        Attempting to run \`wrangler publish --dry-run --outdir=dist\` for you instead:
+		        Please refer to [4mhttps://developers.cloudflare.com/workers/wrangler/migration/deprecations/#build[0m
+		        for more information.
+		        Attempting to run \`wrangler publish --dry-run --outdir=dist\` for you instead:
 
 
-      --dry-run: exiting now.
-      Total Upload: 0xx KiB / gzip: 0xx KiB"
-    `);
+		      --dry-run: exiting now.
+		      Total Upload: 0xx KiB / gzip: 0xx KiB"
+	    `);
 	});
 });
 

--- a/packages/wrangler/src/__tests__/worker-namespace.test.ts
+++ b/packages/wrangler/src/__tests__/worker-namespace.test.ts
@@ -1,0 +1,327 @@
+import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
+import { setMockResponse, unsetAllMocks } from "./helpers/mock-cfetch";
+import { mockConsoleMethods } from "./helpers/mock-console";
+import { runInTempDir } from "./helpers/run-in-tmp";
+import { runWrangler } from "./helpers/run-wrangler";
+
+describe("worker-namespace", () => {
+	runInTempDir();
+	const std = mockConsoleMethods();
+	mockAccountId();
+	mockApiToken();
+
+	afterEach(() => {
+		unsetAllMocks();
+	});
+
+	it("should should display a list of available subcommands, for worker-namespace with no subcommand", async () => {
+		await runWrangler("worker-namespace");
+
+		// wait a tick for the help menu to be printed
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(std).toMatchInlineSnapshot(`
+		Object {
+		  "debug": "",
+		  "err": "",
+		  "out": "wrangler worker-namespace
+
+		📦 Interact with a worker namespace
+
+		Commands:
+		  wrangler worker-namespace list                          List all Worker namespaces
+		  wrangler worker-namespace get <name>                    Get information about a Worker namespace
+		  wrangler worker-namespace create <name>                 Create a Worker namespace
+		  wrangler worker-namespace delete <name>                 Delete a Worker namespace
+		  wrangler worker-namespace rename <old-name> <new-name>  Rename a Worker namespace
+
+		Flags:
+		  -c, --config   Path to .toml configuration file  [string]
+		  -h, --help     Show help  [boolean]
+		  -v, --version  Show version number  [boolean]",
+		  "warn": "",
+		}
+	`);
+	});
+
+	describe("create namespace", () => {
+		function mockCreateRequest(expectedName: string) {
+			const requests = { count: 0 };
+			setMockResponse(
+				"/accounts/:accountId/workers/dispatch/namespaces",
+				([_url], init) => {
+					requests.count += 1;
+
+					const incomingText = init.body?.toString() || "";
+					const { name: namespace_name } = JSON.parse(incomingText);
+
+					expect(init.method).toBe("POST");
+					expect(namespace_name).toEqual(expectedName);
+
+					return {
+						namespace_id: "some-namespace-id",
+						namespace_name: "namespace-name",
+						created_on: "2022-06-29T14:30:08.16152Z",
+						created_by: "1fc1df98cc4420fe00367c3ab68c1639",
+						modified_on: "2022-06-29T14:30:08.16152Z",
+						modified_by: "1fc1df98cc4420fe00367c3ab68c1639",
+					};
+				}
+			);
+			return requests;
+		}
+
+		it("should display help for create", async () => {
+			await expect(
+				runWrangler("worker-namespace create")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`"Not enough non-option arguments: got 0, need at least 1"`
+			);
+
+			expect(std.out).toMatchInlineSnapshot(`
+			"
+			wrangler worker-namespace create <name>
+
+			Create a Worker namespace
+
+			Positionals:
+			  name  Name of the Worker namespace  [string] [required]
+
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]"
+		`);
+		});
+
+		it("should attempt to create the given namespace", async () => {
+			const namespaceName = "my-namespace";
+			const requests = mockCreateRequest(namespaceName);
+			await runWrangler(`worker-namespace create ${namespaceName}`);
+			expect(requests.count).toEqual(1);
+
+			expect(std.out).toMatchInlineSnapshot(
+				`"Created Worker namespace \\"my-namespace\\" with ID \\"some-namespace-id\\""`
+			);
+		});
+	});
+
+	describe("delete namespace", () => {
+		function mockDeleteRequest(expectedName: string) {
+			const requests = { count: 0 };
+			setMockResponse(
+				"/accounts/:accountId/workers/dispatch/namespaces/:namespaceName",
+				([_url, _, namespaceName], init) => {
+					requests.count += 1;
+
+					expect(init.method).toBe("DELETE");
+					expect(namespaceName).toEqual(expectedName);
+
+					return null;
+				}
+			);
+			return requests;
+		}
+
+		it("should display help for delete", async () => {
+			await expect(
+				runWrangler("worker-namespace create")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`"Not enough non-option arguments: got 0, need at least 1"`
+			);
+
+			expect(std.out).toMatchInlineSnapshot(`
+			"
+			wrangler worker-namespace create <name>
+
+			Create a Worker namespace
+
+			Positionals:
+			  name  Name of the Worker namespace  [string] [required]
+
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]"
+		`);
+		});
+
+		it("should try to delete the given namespace", async () => {
+			const namespaceName = "my-namespace";
+			const requests = mockDeleteRequest(namespaceName);
+			await runWrangler(`worker-namespace delete ${namespaceName}`);
+			expect(requests.count).toBe(1);
+
+			expect(std.out).toMatchInlineSnapshot(
+				`"Deleted Worker namespace \\"my-namespace\\""`
+			);
+		});
+	});
+
+	describe("get namespace", () => {
+		function mockInfoRequest(expectedName: string) {
+			const requests = { count: 0 };
+			setMockResponse(
+				"/accounts/:accountId/workers/dispatch/namespaces/:namespaceName",
+				([_url, _, namespaceName], _init) => {
+					requests.count += 1;
+
+					expect(namespaceName).toEqual(expectedName);
+
+					return {
+						namespace_id: "some-namespace-id",
+						namespace_name: "namespace-name",
+						created_on: "2022-06-29T14:30:08.16152Z",
+						created_by: "1fc1df98cc4420fe00367c3ab68c1639",
+						modified_on: "2022-06-29T14:30:08.16152Z",
+						modified_by: "1fc1df98cc4420fe00367c3ab68c1639",
+					};
+				}
+			);
+			return requests;
+		}
+
+		it("should display help for get", async () => {
+			await expect(
+				runWrangler("worker-namespace get")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`"Not enough non-option arguments: got 0, need at least 1"`
+			);
+
+			expect(std.out).toMatchInlineSnapshot(`
+			        "
+			        wrangler worker-namespace get <name>
+
+			        Get information about a Worker namespace
+
+			        Positionals:
+			          name  Name of the Worker namespace  [string] [required]
+
+			        Flags:
+			          -c, --config   Path to .toml configuration file  [string]
+			          -h, --help     Show help  [boolean]
+			          -v, --version  Show version number  [boolean]"
+		      `);
+		});
+
+		it("should attempt to get info for the given namespace", async () => {
+			const namespaceName = "my-namespace";
+			const requests = mockInfoRequest(namespaceName);
+			await runWrangler(`worker-namespace get ${namespaceName}`);
+			expect(requests.count).toBe(1);
+
+			expect(std.out).toMatchInlineSnapshot(`
+			"{
+			  namespace_id: 'some-namespace-id',
+			  namespace_name: 'namespace-name',
+			  created_on: '2022-06-29T14:30:08.16152Z',
+			  created_by: '1fc1df98cc4420fe00367c3ab68c1639',
+			  modified_on: '2022-06-29T14:30:08.16152Z',
+			  modified_by: '1fc1df98cc4420fe00367c3ab68c1639'
+			}"
+		`);
+		});
+	});
+
+	describe("list namespaces", () => {
+		function mockListRequest() {
+			const requests = { count: 0 };
+			setMockResponse(
+				"/accounts/:accountId/workers/dispatch/namespaces",
+				([_url, _, _page, _perPage], _init) => {
+					requests.count += 1;
+
+					return [
+						{
+							namespace_id: "some-namespace-id",
+							namespace_name: "namespace-name",
+							created_on: "2022-06-29T14:30:08.16152Z",
+							created_by: "1fc1df98cc4420fe00367c3ab68c1639",
+							modified_on: "2022-06-29T14:30:08.16152Z",
+							modified_by: "1fc1df98cc4420fe00367c3ab68c1639",
+						},
+					];
+				}
+			);
+			return requests;
+		}
+
+		it("should list all namespaces", async () => {
+			const requests = mockListRequest();
+			await runWrangler("worker-namespace list");
+			expect(requests.count).toBe(1);
+			expect(std.out).toMatchInlineSnapshot(`
+			"[
+			  {
+			    namespace_id: 'some-namespace-id',
+			    namespace_name: 'namespace-name',
+			    created_on: '2022-06-29T14:30:08.16152Z',
+			    created_by: '1fc1df98cc4420fe00367c3ab68c1639',
+			    modified_on: '2022-06-29T14:30:08.16152Z',
+			    modified_by: '1fc1df98cc4420fe00367c3ab68c1639'
+			  }
+			]"
+		`);
+		});
+	});
+
+	describe("rename namespace", () => {
+		function mockRenameRequest(expectedName: string) {
+			const requests = { count: 0 };
+			setMockResponse(
+				"/accounts/:accountId/workers/dispatch/namespaces/:namespaceName",
+				([_url, _, namespaceName], init) => {
+					requests.count += 1;
+
+					expect(init.method).toEqual("PUT");
+					expect(namespaceName).toEqual(expectedName);
+
+					return {
+						namespace_id: "some-namespace-id",
+						namespace_name: "namespace-name",
+						created_on: "2022-06-29T14:30:08.16152Z",
+						created_by: "1fc1df98cc4420fe00367c3ab68c1639",
+						modified_on: "2022-06-29T14:30:08.16152Z",
+						modified_by: "1fc1df98cc4420fe00367c3ab68c1639",
+					};
+				}
+			);
+			return requests;
+		}
+
+		it("should display help for rename", async () => {
+			await expect(
+				runWrangler("worker-namespace rename")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`"Not enough non-option arguments: got 0, need at least 2"`
+			);
+
+			expect(std.out).toMatchInlineSnapshot(`
+			"
+			wrangler worker-namespace rename <old-name> <new-name>
+
+			Rename a Worker namespace
+
+			Positionals:
+			  old-name  Name of the Worker namespace  [string] [required]
+			  new-name  New name of the Worker namespace  [string] [required]
+
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]"
+		`);
+		});
+
+		it("should attempt to rename the given namespace", async () => {
+			const namespaceName = "my-namespace";
+			const newName = "new-namespace";
+			const requests = mockRenameRequest(namespaceName);
+			await runWrangler(`worker-namespace rename ${namespaceName} ${newName}`);
+			expect(requests.count).toBe(1);
+			expect(std.out).toMatchInlineSnapshot(
+				`"Renamed Worker namespace \\"my-namespace\\" to \\"new-namespace\\""`
+			);
+		});
+	});
+});

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -62,6 +62,7 @@ import {
 } from "./user";
 import { whoami } from "./whoami";
 
+import { workerNamespaceCommands } from "./worker-namespace";
 import type { Config } from "./config";
 import type { TailCLIFilters } from "./tail";
 import type { RawData } from "ws";
@@ -1711,6 +1712,14 @@ function createCLIParser(argv: string[]) {
 				return r2BucketYargs;
 			});
 	});
+
+	wrangler.command(
+		"worker-namespace",
+		"📦 Interact with a worker namespace",
+		(workerNamespaceYargs) => {
+			return workerNamespaceCommands(workerNamespaceYargs, subHelp);
+		}
+	);
 
 	wrangler.command(
 		"pubsub",

--- a/packages/wrangler/src/worker-namespace.ts
+++ b/packages/wrangler/src/worker-namespace.ts
@@ -1,0 +1,190 @@
+import { fetchResult } from "./cfetch";
+import { readConfig } from "./config";
+import { logger } from "./logger";
+import { requireAuth } from "./user";
+import { printWranglerBanner } from ".";
+import type { ConfigPath } from ".";
+import type { Argv, CommandModule } from "yargs";
+
+type Namespace = {
+	namespace_id: string;
+	namespace_name: string;
+	created_on: string;
+	created_by: string;
+	modified_on: string;
+	modified_by: string;
+};
+
+// Supporting Workers For Platforms
+// More details at https://blog.cloudflare.com/workers-for-platforms/
+
+/**
+ * Create a dynamic dispatch namespace.
+ */
+async function createWorkerNamespace(accountId: string, name: string) {
+	const namespace = await fetchResult<Namespace>(
+		`/accounts/${accountId}/workers/dispatch/namespaces`,
+		{
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ name }),
+		}
+	);
+	logger.log(
+		`Created Worker namespace "${name}" with ID "${namespace.namespace_id}"`
+	);
+}
+
+/**
+ * Delete a dynamic dispatch namespace.
+ */
+async function deleteWorkerNamespace(accountId: string, name: string) {
+	await fetchResult(
+		`/accounts/${accountId}/workers/dispatch/namespaces/${name}`,
+		{ method: "DELETE" }
+	);
+	logger.log(`Deleted Worker namespace "${name}"`);
+}
+
+/**
+ * List all created dynamic dispatch namespaces for an account
+ */
+async function listWorkerNamespaces(accountId: string) {
+	logger.log(
+		await fetchResult<Namespace>(
+			`/accounts/${accountId}/workers/dispatch/namespaces`,
+			{
+				headers: {
+					"Content-Type": "application/json",
+				},
+			}
+		)
+	);
+}
+
+/**
+ * Get info for a specific dynamic dispatch namespace
+ */
+async function getWorkerNamespaceInfo(accountId: string, name: string) {
+	logger.log(
+		await fetchResult<Namespace>(
+			`/accounts/${accountId}/workers/dispatch/namespaces/${name}`,
+			{
+				headers: {
+					"Content-Type": "application/json",
+				},
+			}
+		)
+	);
+}
+
+/**
+ * Rename a dynamic dispatch namespace
+ */
+async function renameWorkerNamespace(
+	accountId: string,
+	oldName: string,
+	newName: string
+) {
+	printWranglerBanner();
+
+	await fetchResult(
+		`/accounts/${accountId}/workers/dispatch/namespaces/${oldName}`,
+		{
+			method: "PUT",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ name: newName }),
+		}
+	);
+	logger.log(`Renamed Worker namespace "${oldName}" to "${newName}"`);
+}
+
+export function workerNamespaceCommands(
+	workerNamespaceYargs: Argv,
+	subHelp: CommandModule
+): Argv {
+	return workerNamespaceYargs
+		.command(subHelp)
+		.command("list", "List all Worker namespaces", {}, async (args) => {
+			const config = readConfig(args.config as ConfigPath, args);
+			const accountId = await requireAuth(config);
+			await listWorkerNamespaces(accountId);
+		})
+		.command(
+			"get <name>",
+			"Get information about a Worker namespace",
+			(yargs) => {
+				return yargs.positional("name", {
+					describe: "Name of the Worker namespace",
+					type: "string",
+					demandOption: true,
+				});
+			},
+			async (args) => {
+				const config = readConfig(args.config as ConfigPath, args);
+				const accountId = await requireAuth(config);
+				await getWorkerNamespaceInfo(accountId, args.name);
+			}
+		)
+		.command(
+			"create <name>",
+			"Create a Worker namespace",
+			(yargs) => {
+				return yargs.positional("name", {
+					describe: "Name of the Worker namespace",
+					type: "string",
+					demandOption: true,
+				});
+			},
+			async (args) => {
+				await printWranglerBanner();
+				const config = readConfig(args.config as ConfigPath, args);
+				const accountId = await requireAuth(config);
+				await createWorkerNamespace(accountId, args.name);
+			}
+		)
+		.command(
+			"delete <name>",
+			"Delete a Worker namespace",
+			(yargs) => {
+				return yargs.positional("name", {
+					describe: "Name of the Worker namespace",
+					type: "string",
+					demandOption: true,
+				});
+			},
+			async (args) => {
+				await printWranglerBanner();
+				const config = readConfig(args.config as ConfigPath, args);
+				const accountId = await requireAuth(config);
+				await deleteWorkerNamespace(accountId, args.name);
+			}
+		)
+		.command(
+			"rename <old-name> <new-name>",
+			"Rename a Worker namespace",
+			(yargs) => {
+				return yargs
+					.positional("old-name", {
+						describe: "Name of the Worker namespace",
+						type: "string",
+						demandOption: true,
+					})
+					.positional("new-name", {
+						describe: "New name of the Worker namespace",
+						type: "string",
+						demandOption: true,
+					});
+			},
+			async (args) => {
+				await printWranglerBanner();
+				const config = readConfig(args.config as ConfigPath, args);
+				const accountId = await requireAuth(config);
+				await renameWorkerNamespace(accountId, args.oldName, args.newName);
+			}
+		);
+}


### PR DESCRIPTION
Hide whitespace changes for this review!

---

This adds commands to create, delete, list, and get info for "worker namespaces" (name to be bikeshed-ed). This is based on work by @aaronlisman in https://github.com/cloudflare/wrangler2/pull/1310.