### PR TITLE
feat: bind a worker with `[worker_namespaces]`

### DIFF
--- a/.changeset/sweet-wasps-clean.md
+++ b/.changeset/sweet-wasps-clean.md
@@ -1,0 +1,15 @@
+---
+"wrangler": patch
+---
+
+feat: bind a worker with `[worker_namespaces]`
+
+This feature les you bind a worker to a dynamic dispatch namespaces, which may have other workers bound inside it. (See https://blog.cloudflare.com/workers-for-platforms/). Inside your `wrangler.toml`, you would add
+
+```toml
+[[worker_namespaces]]
+binding = 'dispatcher' # available as env.dispatcher in your worker
+namespace = 'namespace-name' # the name of the namespace being bound
+```
+
+Based on work by @aaronlisman in https://github.com/cloudflare/wrangler2/pull/1310

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -5303,6 +5303,48 @@ addEventListener('fetch', event => {});`
 			});
 		});
 
+		describe("[worker_namespaces]", () => {
+			it("should support bindings to a worker namespace", async () => {
+				writeWranglerToml({
+					worker_namespaces: [
+						{
+							binding: "foo",
+							namespace: "Foo",
+						},
+					],
+				});
+				writeWorkerSource();
+				mockSubDomainRequest();
+				mockUploadWorkerRequest({
+					expectedBindings: [
+						{
+							type: "namespace",
+							name: "foo",
+							namespace: "Foo",
+						},
+					],
+				});
+				await runWrangler("publish index.js");
+				expect(std.out).toMatchInlineSnapshot(`
+			          "Your worker has access to the following bindings:
+			          - Worker Namespaces:
+			            - foo: Foo
+			          Total Upload: 0xx KiB / gzip: 0xx KiB
+			          Uploaded test-name (TIMINGS)
+			          Published test-name (TIMINGS)
+			            test-name.test-sub-domain.workers.dev"
+		        `);
+				expect(std.err).toMatchInlineSnapshot(`""`);
+				expect(std.warn).toMatchInlineSnapshot(`
+			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+
+			    - \\"worker_namespaces\\" fields are experimental and may change or break at any time.
+
+			"
+		`);
+			});
+		});
+
 		describe("[unsafe]", () => {
 			it("should warn if using unsafe bindings", async () => {
 				writeWranglerToml({
@@ -5962,6 +6004,7 @@ addEventListener('fetch', event => {});`
 			        }
 		      `);
 		});
+
 		it("should print the bundle size, with API errors", async () => {
 			setMockRawResponse(
 				"/accounts/:accountId/workers/scripts/:scriptName",

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -202,6 +202,22 @@ interface EnvironmentInheritable {
 	node_compat: boolean | undefined;
 
 	/**
+	 * Specifies namespace bindings that are bound to this Worker environment.
+	 *
+	 * NOTE: This field is not automatically inherited from the top level environment,
+	 * and so must be specified in every named environment.
+	 *
+	 * @default `[]`
+	 * @nonInheritable
+	 */
+	worker_namespaces: {
+		/** The binding name used to refer to the bound service. */
+		binding: string;
+		/** The namespace to bind to. */
+		namespace: string;
+	}[];
+
+	/**
 	 * TODO: remove this as it has been deprecated.
 	 *
 	 * This is just here for now because the `route` commands use it.

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -90,6 +90,7 @@ export function printBindings(bindings: CfWorkerInit["bindings"]) {
 		unsafe,
 		vars,
 		wasm_modules,
+		worker_namespaces,
 	} = bindings;
 
 	if (data_blobs !== undefined && Object.keys(data_blobs).length > 0) {
@@ -202,6 +203,18 @@ export function printBindings(bindings: CfWorkerInit["bindings"]) {
 				key,
 				value: truncate(value),
 			})),
+		});
+	}
+
+	if (worker_namespaces !== undefined && worker_namespaces.length > 0) {
+		output.push({
+			type: "Worker Namespaces",
+			entries: worker_namespaces.map(({ binding, namespace }) => {
+				return {
+					key: binding,
+					value: namespace,
+				};
+			}),
 		});
 	}
 

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -832,6 +832,7 @@ function normalizeAndValidateEnvironment(
 
 	experimental(diagnostics, rawEnv, "unsafe");
 	experimental(diagnostics, rawEnv, "services");
+	experimental(diagnostics, rawEnv, "worker_namespaces");
 
 	const route = normalizeAndValidateRoute(diagnostics, topLevelEnv, rawEnv);
 
@@ -1015,6 +1016,16 @@ function normalizeAndValidateEnvironment(
 			envName,
 			"services",
 			validateBindingArray(envName, validateServiceBinding),
+			[]
+		),
+		worker_namespaces: notInheritable(
+			diagnostics,
+			topLevelEnv,
+			rawConfig,
+			rawEnv,
+			envName,
+			"worker_namespaces",
+			validateBindingArray(envName, validateWorkerNamespaceBinding),
 			[]
 		),
 		unsafe: notInheritable(
@@ -1664,6 +1675,7 @@ const validateBindingsHaveUniqueNames = (
 
 	return !hasDuplicates;
 };
+
 const validateServiceBinding: ValidatorFn = (diagnostics, field, value) => {
 	if (typeof value !== "object" || value === null) {
 		diagnostics.errors.push(
@@ -1692,6 +1704,38 @@ const validateServiceBinding: ValidatorFn = (diagnostics, field, value) => {
 	if (!isOptionalProperty(value, "environment", "string")) {
 		diagnostics.errors.push(
 			`"${field}" bindings should have a string "environment" field but got ${JSON.stringify(
+				value
+			)}.`
+		);
+		isValid = false;
+	}
+	return isValid;
+};
+
+const validateWorkerNamespaceBinding: ValidatorFn = (
+	diagnostics,
+	field,
+	value
+) => {
+	if (typeof value !== "object" || value === null) {
+		diagnostics.errors.push(
+			`"${field}" binding should be objects, but got ${JSON.stringify(value)}`
+		);
+		return false;
+	}
+	let isValid = true;
+	// Worker namespace bindings must have a binding, and a namespace.
+	if (!isRequiredProperty(value, "binding", "string")) {
+		diagnostics.errors.push(
+			`"${field}" should have a string "binding" field but got ${JSON.stringify(
+				value
+			)}.`
+		);
+		isValid = false;
+	}
+	if (!isRequiredProperty(value, "namespace", "string")) {
+		diagnostics.errors.push(
+			`"${field}" should have a string "namespace" field but got ${JSON.stringify(
 				value
 			)}.`
 		);

--- a/packages/wrangler/src/create-worker-upload-form.ts
+++ b/packages/wrangler/src/create-worker-upload-form.ts
@@ -50,6 +50,7 @@ export interface WorkerMetadata {
 		  }
 		| { type: "r2_bucket"; name: string; bucket_name: string }
 		| { type: "service"; name: string; service: string; environment?: string }
+		| { type: "namespace"; name: string; namespace: string }
 	)[];
 }
 
@@ -113,6 +114,14 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
 			type: "service",
 			service,
 			...(environment && { environment }),
+		});
+	});
+
+	bindings.worker_namespaces?.forEach(({ binding, namespace }) => {
+		metadataBindings.push({
+			name: binding,
+			type: "namespace",
+			namespace,
 		});
 	});
 

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -25,6 +25,7 @@ import {
 
 import type { Config } from "./config";
 import type { Route } from "./config/environment";
+import type { CfWorkerInit } from "./worker";
 import type { RequestInit } from "undici";
 import type { Argv, ArgumentsCamelCase } from "yargs";
 
@@ -371,7 +372,9 @@ export async function startDev(args: ArgumentsCamelCase<DevArgs>) {
 		}
 
 		// eslint-disable-next-line no-inner-declarations
-		async function getBindings(configParam: Config) {
+		async function getBindings(
+			configParam: Config
+		): Promise<CfWorkerInit["bindings"]> {
 			return {
 				kv_namespaces: configParam.kv_namespaces?.map(
 					({ binding, preview_id, id: _id }) => {
@@ -415,6 +418,7 @@ export async function startDev(args: ArgumentsCamelCase<DevArgs>) {
 						};
 					}
 				),
+				worker_namespaces: configParam.worker_namespaces,
 				services: configParam.services,
 				unsafe: configParam.unsafe?.bindings,
 			};

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -916,6 +916,7 @@ function createCLIParser(argv: string[]) {
 											wasm_modules: {},
 											text_blobs: {},
 											data_blobs: {},
+											worker_namespaces: [],
 											unsafe: [],
 										},
 										modules: [],

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -426,6 +426,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			durable_objects: config.durable_objects,
 			r2_buckets: config.r2_buckets,
 			services: config.services,
+			worker_namespaces: config.worker_namespaces,
 			unsafe: config.unsafe?.bindings,
 		};
 

--- a/packages/wrangler/src/worker.ts
+++ b/packages/wrangler/src/worker.ts
@@ -122,6 +122,11 @@ interface CfService {
 	environment?: string;
 }
 
+interface CfWorkerNamespace {
+	binding: string;
+	namespace: string;
+}
+
 interface CfUnsafeBinding {
 	name: string;
 	type: string;
@@ -168,6 +173,7 @@ export interface CfWorkerInit {
 		durable_objects: { bindings: CfDurableObject[] } | undefined;
 		r2_buckets: CfR2Bucket[] | undefined;
 		services: CfService[] | undefined;
+		worker_namespaces: CfWorkerNamespace[] | undefined;
 		unsafe: CfUnsafeBinding[] | undefined;
 	};
 	migrations: CfDurableObjectMigrations | undefined;


### PR DESCRIPTION
This feature les you bind a worker to a dynamic dispatch namespaces, which may have other workers bound inside it. (See https://blog.cloudflare.com/workers-for-platforms/). Inside your `wrangler.toml`, you would add
```toml
[[worker_namespaces]]
binding = 'dispatcher' # available as env.dispatcher in your worker
namespace = 'namespace-name' # the name of the namespace being bound
```

Based on work by @aaronlisman in https://github.com/cloudflare/wrangler2/pull/1310