### PR TITLE
Remove delegation message

### DIFF
--- a/.changeset/curly-ladybugs-repeat.md
+++ b/.changeset/curly-ladybugs-repeat.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Remove delegation message when global wrangler delegates to a local installation
+
+A message used for debugging purposes was accidentally left in. Now it's gone.

--- a/.changeset/curly-ladybugs-repeat.md
+++ b/.changeset/curly-ladybugs-repeat.md
@@ -4,4 +4,5 @@
 
 Remove delegation message when global wrangler delegates to a local installation
 
-A message used for debugging purposes was accidentally left in. Now it's gone.
+A message used for debugging purposes was accidentally left in, and confused some
+folks. Now it'll only appear when `WRANGLER_LOG` is set to `debug`.

--- a/packages/wrangler/bin/wrangler.js
+++ b/packages/wrangler/bin/wrangler.js
@@ -87,9 +87,6 @@ function runDelegatedWrangler() {
 	} = JSON.parse(fs.readFileSync(packageJsonPath));
 	const resolvedBinaryPath = path.resolve(packageJsonPath, "..", binaryPath);
 
-	console.log(
-		`Delegating to locally-installed version of wrangler @ v${version}`
-	);
 	// this call to `spawn` is simpler because the delegated version will do all
 	// of the other work.
 	return spawn(

--- a/packages/wrangler/bin/wrangler.js
+++ b/packages/wrangler/bin/wrangler.js
@@ -6,7 +6,10 @@ const os = require("os");
 const semiver = require("semiver");
 
 const MIN_NODE_VERSION = "16.7.0";
-const debug = process.env["WRANGLER_LOG"] === "debug" ? console.log : () => {};
+const debug =
+	process.env["WRANGLER_LOG"] === "debug"
+		? (...args) => console.log(...args)
+		: () => {};
 
 let wranglerProcess;
 

--- a/packages/wrangler/bin/wrangler.js
+++ b/packages/wrangler/bin/wrangler.js
@@ -6,6 +6,7 @@ const os = require("os");
 const semiver = require("semiver");
 
 const MIN_NODE_VERSION = "16.7.0";
+const debug = process.env["WRANGLER_LOG"] === "debug" ? console.log : () => {};
 
 let wranglerProcess;
 
@@ -86,6 +87,8 @@ function runDelegatedWrangler() {
 		version,
 	} = JSON.parse(fs.readFileSync(packageJsonPath));
 	const resolvedBinaryPath = path.resolve(packageJsonPath, "..", binaryPath);
+
+	debug(`Delegating to locally-installed version of wrangler @ v${version}`);
 
 	// this call to `spawn` is simpler because the delegated version will do all
 	// of the other work.


### PR DESCRIPTION
I accidentally left in a message that would print "Delegating to locally-installed wrangler@{version}".
This was for debugging, and really wrangler should just do this without confusing the user.
