### PR TITLE
chore: enable node's experimental fetch flag

### DIFF
--- a/.changeset/khaki-clocks-shop.md
+++ b/.changeset/khaki-clocks-shop.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+chore: enable node's experimental fetch flag
+
+We'd previously had some funny behaviour with undici clashing with node's own fetch supporting classes, and had turned off node's fetch implementation. Recent updates to undici appear to have fixed the issue, so let's turn it back on.
+
+Closes https://github.com/cloudflare/wrangler2/issues/834

--- a/packages/wrangler/bin/wrangler.js
+++ b/packages/wrangler/bin/wrangler.js
@@ -52,9 +52,6 @@ Consider using a Node.js version manager such as https://volta.sh/ or https://gi
 	return spawn(
 		process.execPath,
 		[
-			...(semiver(process.versions.node, "18.0.0") >= 0
-				? ["--no-experimental-fetch"] // TODO: remove this when https://github.com/cloudflare/wrangler2/issues/834 is properly fixed
-				: []),
 			"--no-warnings",
 			"--experimental-vm-modules",
 			...process.execArgv,


### PR DESCRIPTION
We'd previously had some funny behaviour with undici clashing with node's own fetch supporting classes, and had turned off node's fetch implementation. Recent updates to undici appear to have fixed the issue, so let's turn it back on.

Closes https://github.com/cloudflare/wrangler2/issues/834