### PR TITLE
feat: cache account id selection

### DIFF
--- a/.changeset/silent-ears-jam.md
+++ b/.changeset/silent-ears-jam.md
@@ -1,0 +1,17 @@
+---
+"wrangler": patch
+---
+
+feat: cache account id selection
+
+This adds caching for account id fetch/selection for all wrangler commands.
+
+Currently, if we have an api/oauth token, but haven't provided an account id, we fetch account information from cloudflare. If a user has just one account id, we automatically choose that. If there are more than one, then we show a dropdown and ask the user to pick one. This is convenient, and lets the user not have to specify their account id when starting a project.
+
+However, if does make startup slow, since it has to do that fetch every time. It's also annoying for folks with multiple account ids because they have to pick their account id every time.
+
+So we now cache the account details into `node_modules/.cache/wrangler` (much like pages already does with account id and project name).
+
+This patch also refactors `config-cache.ts`; it only caches if there's a `node_modules` folder, and it looks for the closest node_modules folder (and not directly in cwd). I also added tests for when a `node_modules` folder isn't available. It also trims the message that we log to terminal.
+
+Closes https://github.com/cloudflare/wrangler2/issues/300

--- a/packages/wrangler/src/__tests__/config-cache-without-cache-dir.test.ts
+++ b/packages/wrangler/src/__tests__/config-cache-without-cache-dir.test.ts
@@ -1,4 +1,3 @@
-import { mkdirSync } from "node:fs";
 import { getConfigCache, saveToConfigCache } from "../config-cache";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { runInTempDir } from "./helpers/run-in-tmp";
@@ -11,10 +10,7 @@ interface PagesConfigCache {
 describe("config cache", () => {
 	runInTempDir();
 	mockConsoleMethods();
-	beforeEach(() => {
-		mkdirSync("node_modules");
-	});
-
+	// In this set of tests, we don't create a node_modules folder
 	const pagesConfigCacheFilename = "pages-config-cache.json";
 
 	it("should return an empty config if no file exists", () => {
@@ -23,20 +19,20 @@ describe("config cache", () => {
 		).toMatchInlineSnapshot(`Object {}`);
 	});
 
-	it("should read and write values without overriding old ones", () => {
+	it("should ignore attempts to cache values ", () => {
 		saveToConfigCache<PagesConfigCache>(pagesConfigCacheFilename, {
 			account_id: "some-account-id",
 			pages_project_name: "foo",
 		});
-		expect(
-			getConfigCache<PagesConfigCache>(pagesConfigCacheFilename).account_id
-		).toEqual("some-account-id");
+		expect(getConfigCache<PagesConfigCache>(pagesConfigCacheFilename)).toEqual(
+			{}
+		);
 
 		saveToConfigCache<PagesConfigCache>(pagesConfigCacheFilename, {
 			pages_project_name: "bar",
 		});
-		expect(
-			getConfigCache<PagesConfigCache>(pagesConfigCacheFilename).account_id
-		).toEqual("some-account-id");
+		expect(getConfigCache<PagesConfigCache>(pagesConfigCacheFilename)).toEqual(
+			{}
+		);
 	});
 });

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -11,6 +11,7 @@ import { getVarsForDev } from "./dev/dev-vars";
 import { getEntry } from "./entry";
 import { logger } from "./logger";
 import { getAssetPaths, getSiteAssetPaths } from "./sites";
+import { getAccountFromCache } from "./user";
 import { getZoneIdFromHost, getZoneForRoute, getHostFromRoute } from "./zones";
 import {
 	printWranglerBanner,
@@ -477,7 +478,7 @@ export async function startDev(args: ArgumentsCamelCase<DevArgs>) {
 					enableLocalPersistence={
 						args["experimental-enable-local-persistence"] || false
 					}
-					accountId={config.account_id}
+					accountId={config.account_id || getAccountFromCache()?.id}
 					assetPaths={assetPaths}
 					port={args.port || config.dev.port || (await getLocalPort())}
 					ip={args.ip || config.dev.ip}

--- a/packages/wrangler/src/is-interactive.ts
+++ b/packages/wrangler/src/is-interactive.ts
@@ -1,0 +1,12 @@
+/**
+ * Test whether the process is "interactive".
+ * Reasons it may not be interactive: it could be running in CI,
+ * or you're piping values from / to another process, etc
+ */
+export default function isInteractive(): boolean {
+	try {
+		return Boolean(process.stdin.isTTY && process.stdout.isTTY);
+	} catch {
+		return false;
+	}
+}

--- a/packages/wrangler/src/user/choose-account.tsx
+++ b/packages/wrangler/src/user/choose-account.tsx
@@ -15,7 +15,7 @@ export type ChooseAccountItem = {
  */
 export function ChooseAccount(props: {
 	accounts: ChooseAccountItem[];
-	onSelect: (accountId: string) => void;
+	onSelect: (account: { name: string; id: string }) => void;
 	onError: (error: Error) => void;
 }) {
 	return (
@@ -29,7 +29,7 @@ export function ChooseAccount(props: {
 				}))}
 				onSelect={(item) => {
 					logger.log(`Using account: "${item.value.name} - ${item.value.id}"`);
-					props.onSelect(item.value.id);
+					props.onSelect({ id: item.value.id, name: item.value.name });
 				}}
 			/>
 		</>


### PR DESCRIPTION
This adds caching for account id fetch/selection for all wrangler commands.

Currently, if we have an api/oauth token, but haven't provided an account id, we fetch account information from cloudflare. If a user has just one account id, we automatically choose that. If there are more than one, then we show a dropdown and ask the user to pick one. This is convenient, and lets the user not have to specify their account id when starting a project.

However, if does make startup slow, since it has to do that fetch every time. It's also annoying for folks with multiple account ids because they have to pick their account id every time.

So we now cache the account details into `node_modules/.cache/wrangler` (much like pages already does with account id and project name).

This patch also refactors `config-cache.ts`; it only caches if there's a `node_modules` folder, and it looks for the closest node_modules folder (and not directly in cwd). I also added tests for when a `node_modules` folder isn't available. It also trims the message that we log to terminal.

Closes https://github.com/cloudflare/wrangler2/issues/300

--- 

@GregBrimble Two changes in behaviour here for pages: 
- this will not cache account selection in projects without a node_modules folder. We can fix that by working on https://github.com/cloudflare/wrangler2/issues/1318 
- I think this will log "Retrieving cached values..." twice. It's not too intrusive, but we could fix it by not caching the account_id in pages code at all (since wrangler will do it anyway). 

Happy to iterate on this a bit, putting it out there for discussion. Let's chat about it during the week. 