### PR TITLE
fix: rename `--no-build` to `--no-bundle`

### DIFF
--- a/.changeset/rotten-candles-visit.md
+++ b/.changeset/rotten-candles-visit.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: rename `--no-build` to `--no-bundle`
+
+This fix renames the `--no-build` cli arg to `--no-bundle`. `no-build` wasn't a great name because it would imply that we don't run custom builds specified under `[build]` which isn't true. So we rename closer to what wrangler actually does, which is bundling the input. This also makes it clearer that it's a single file upload.

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -889,7 +889,7 @@ describe("wrangler dev", () => {
 
 			Options:
 			      --name                                       Name of the worker  [string]
-			      --no-build                                   Skip internal build steps and directly publish script  [boolean] [default: false]
+			      --no-bundle                                  Skip internal build steps and directly publish script  [boolean] [default: false]
 			      --format                                     Choose an entry type  [deprecated] [choices: \\"modules\\", \\"service-worker\\"]
 			  -e, --env                                        Perform on a specific environment  [string]
 			      --compatibility-date                         Date to use for compatibility checks  [string]

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -6025,7 +6025,7 @@ addEventListener('fetch', event => {});`
 		});
 	});
 
-	describe("--no-build", () => {
+	describe("--no-bundle", () => {
 		it("should not transform the source code before publishing it", async () => {
 			writeWranglerToml();
 			const scriptContent = `
@@ -6033,7 +6033,7 @@ addEventListener('fetch', event => {});`
       const xyz = 123; // a statement that would otherwise be compiled out
     `;
 			fs.writeFileSync("index.js", scriptContent);
-			await runWrangler("publish index.js --no-build --dry-run --outdir dist");
+			await runWrangler("publish index.js --no-bundle --dry-run --outdir dist");
 			expect(fs.readFileSync("dist/index.js", "utf-8")).toMatch(scriptContent);
 		});
 	});

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -29,6 +29,7 @@ interface DevArgs {
 	config?: string;
 	script?: string;
 	name?: string;
+	bundle?: boolean;
 	build?: boolean;
 	format?: string;
 	env?: string;
@@ -74,17 +75,17 @@ export function devOptions(yargs: Argv): Argv<DevArgs> {
 				type: "string",
 				requiresArg: true,
 			})
-			// We want to have a --no-build flag, but yargs requires that
-			// we also have a --build flag (that it adds the --no to by itself)
-			// So we make a --build flag, but hide it, and then add a --no-build flag
+			// We want to have a --no-bundle flag, but yargs requires that
+			// we also have a --bundle flag (that it adds the --no to by itself)
+			// So we make a --bundle flag, but hide it, and then add a --no-bundle flag
 			// that's visible to the user but doesn't "do" anything.
-			.option("build", {
+			.option("bundle", {
 				describe: "Run wrangler's compilation step before publishing",
 				type: "boolean",
 				default: true,
 				hidden: true,
 			})
-			.option("no-build", {
+			.option("no-bundle", {
 				describe: "Skip internal build steps and directly publish script",
 				type: "boolean",
 				default: false,
@@ -453,7 +454,7 @@ export async function startDev(args: ArgumentsCamelCase<DevArgs>) {
 			return (
 				<Dev
 					name={getScriptName({ name: args.name, env: args.env }, config)}
-					noBuild={!args.build}
+					noBundle={!args.bundle}
 					entry={entry}
 					env={args.env}
 					zone={zoneId}

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -24,7 +24,7 @@ import type { CfWorkerInit } from "../worker";
 
 export type DevProps = {
 	name: string | undefined;
-	noBuild: boolean;
+	noBundle: boolean;
 	entry: Entry;
 	port: number;
 	ip: string;
@@ -155,7 +155,7 @@ function DevSession(props: DevSessionProps) {
 		minify: props.minify,
 		nodeCompat: props.nodeCompat,
 		define: props.define,
-		noBuild: props.noBuild,
+		noBundle: props.noBundle,
 	});
 
 	return props.local ? (

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -28,7 +28,7 @@ export function useEsbuild({
 	minify,
 	nodeCompat,
 	define,
-	noBuild,
+	noBundle,
 }: {
 	entry: Entry;
 	destination: string | undefined;
@@ -40,7 +40,7 @@ export function useEsbuild({
 	tsconfig: string | undefined;
 	minify: boolean | undefined;
 	nodeCompat: boolean | undefined;
-	noBuild: boolean;
+	noBundle: boolean;
 }): EsbuildBundle | undefined {
 	const [bundle, setBundle] = useState<EsbuildBundle>();
 	const { exit } = useApp();
@@ -76,7 +76,7 @@ export function useEsbuild({
 				bundleType,
 				modules,
 				stop,
-			}: Awaited<ReturnType<typeof bundleWorker>> = noBuild
+			}: Awaited<ReturnType<typeof bundleWorker>> = noBundle
 				? {
 						modules: [],
 						resolvedEntryPointPath: entry.file,
@@ -99,9 +99,9 @@ export function useEsbuild({
 			// Capture the `stop()` method to use as the `useEffect()` destructor.
 			stopWatching = stop;
 
-			// if "noBuild" is true, then we need to manually watch the entry point and
+			// if "noBundle" is true, then we need to manually watch the entry point and
 			// trigger "builds" when it changes
-			if (noBuild) {
+			if (noBundle) {
 				const watcher = watch(entry.file, {
 					persistent: true,
 				}).on("change", async (_event) => {
@@ -141,7 +141,7 @@ export function useEsbuild({
 		rules,
 		tsconfig,
 		exit,
-		noBuild,
+		noBundle,
 		minify,
 		nodeCompat,
 		define,

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -372,17 +372,17 @@ function createCLIParser(argv: string[]) {
 						type: "string",
 						requiresArg: true,
 					})
-					// We want to have a --no-build flag, but yargs requires that
-					// we also have a --build flag (that it adds the --no to by itself)
-					// So we make a --build flag, but hide it, and then add a --no-build flag
+					// We want to have a --no-bundle flag, but yargs requires that
+					// we also have a --bundle flag (that it adds the --no to by itself)
+					// So we make a --bundle flag, but hide it, and then add a --no-bundle flag
 					// that's visible to the user but doesn't "do" anything.
-					.option("build", {
+					.option("bundle", {
 						describe: "Run wrangler's compilation step before publishing",
 						type: "boolean",
 						default: true,
 						hidden: true,
 					})
-					.option("no-build", {
+					.option("no-bundle", {
 						describe: "Skip internal build steps and directly publish script",
 						type: "boolean",
 						default: false,
@@ -564,7 +564,7 @@ function createCLIParser(argv: string[]) {
 				isWorkersSite: Boolean(args.site || config.site),
 				outDir: args.outdir,
 				dryRun: args.dryRun,
-				noBuild: !args.build,
+				noBundle: !args.bundle,
 			});
 		}
 	);

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -46,7 +46,7 @@ type Props = {
 	nodeCompat: boolean | undefined;
 	outDir: string | undefined;
 	dryRun: boolean | undefined;
-	noBuild: boolean | undefined;
+	noBundle: boolean | undefined;
 };
 
 type RouteObject = ZoneIdRoute | ZoneNameRoute | CustomDomainRoute;
@@ -341,7 +341,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		);
 	}
 	try {
-		if (props.noBuild) {
+		if (props.noBundle) {
 			// if we're not building, let's just copy the entry to the destination directory
 			const destinationDir =
 				typeof destination === "string" ? destination : destination.path;
@@ -356,7 +356,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			modules,
 			resolvedEntryPointPath,
 			bundleType,
-		}: Awaited<ReturnType<typeof bundleWorker>> = props.noBuild
+		}: Awaited<ReturnType<typeof bundleWorker>> = props.noBundle
 			? // we can skip the whole bundling step and mock a bundle here
 			  {
 					modules: [],


### PR DESCRIPTION
This fix renames the `--no-build` cli arg to `--no-bundle`. `no-build` wasn't a great name because it would imply that we don't run custom builds specified under `[build]` which isn't true. So we rename closer to what wrangler actually does, which is bundling the input. This also makes it clearer that it's a single file upload.