### PR TITLE
feat: add cache control options to `config.assets`

### DIFF
--- a/.changeset/healthy-elephants-vanish.md
+++ b/.changeset/healthy-elephants-vanish.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+feat: add cache control options to `config.assets`
+
+This adds cache control options to `config.assets`. This is already supported by the backing library (`@cloudflare/kv-asset-handler`) so we simply pass on the options at its callsite.
+
+Additionally, this adds a configuration field to serve an app in "single page app" mode, where a root index.html is served for all html/404 requests (also powered by the same library).

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -1038,6 +1038,7 @@ describe("wrangler dev", () => {
 		it("should error if config.assets and --site are used together", async () => {
 			writeWranglerToml({
 				main: "./index.js",
+				// @ts-expect-error we allow string inputs here
 				assets: "abc",
 			});
 			fs.writeFileSync("index.js", `export default {};`);
@@ -1051,6 +1052,7 @@ describe("wrangler dev", () => {
 		it("should error if config.assets and config.site are used together", async () => {
 			writeWranglerToml({
 				main: "./index.js",
+				// @ts-expect-error we allow string inputs here
 				assets: "abc",
 				site: {
 					bucket: "xyz",
@@ -1102,6 +1104,7 @@ describe("wrangler dev", () => {
 		it("should warn if config.assets is used", async () => {
 			writeWranglerToml({
 				main: "./index.js",
+				// @ts-expect-error we allow string inputs here
 				assets: "./assets",
 			});
 			fs.writeFileSync("index.js", `export default {};`);

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -1551,28 +1551,28 @@ addEventListener('fetch', event => {});`
 			await runWrangler("publish --assets assets --latest --name test-name");
 
 			expect(std).toMatchInlineSnapshot(`
-			        Object {
-			          "debug": "",
-			          "err": "",
-			          "out": "Reading file-1.txt...
-			        Uploading as file-1.2ca234f380.txt...
-			        Reading file-2.txt...
-			        Uploading as file-2.5938485188.txt...
-			        ↗️  Done syncing assets
-			        Total Upload: 52xx KiB / gzip: 13xx KiB
-			        Uploaded test-name (TIMINGS)
-			        Published test-name (TIMINGS)
-			          https://test-name.test-sub-domain.workers.dev",
-			          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe --assets argument is experimental and may change or break at any time[0m
+			Object {
+			  "debug": "",
+			  "err": "",
+			  "out": "Reading file-1.txt...
+			Uploading as file-1.2ca234f380.txt...
+			Reading file-2.txt...
+			Uploading as file-2.5938485188.txt...
+			↗️  Done syncing assets
+			Total Upload: 52xx KiB / gzip: 14xx KiB
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe --assets argument is experimental and may change or break at any time[0m
 
 
-			        [33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mUsing the latest version of the Workers runtime. To silence this warning, please choose a specific version of the runtime with --compatibility-date, or add a compatibility_date to your wrangler.toml.[0m
+			[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mUsing the latest version of the Workers runtime. To silence this warning, please choose a specific version of the runtime with --compatibility-date, or add a compatibility_date to your wrangler.toml.[0m
 
 
 
-			        ",
-			        }
-		      `);
+			",
+			}
+		`);
 		});
 	});
 
@@ -1639,23 +1639,23 @@ addEventListener('fetch', event => {});`
 			await runWrangler("publish --assets assets");
 
 			expect(std).toMatchInlineSnapshot(`
-			        Object {
-			          "debug": "",
-			          "err": "",
-			          "out": "Reading file-1.txt...
-			        Uploading as file-1.2ca234f380.txt...
-			        Reading file-2.txt...
-			        Uploading as file-2.5938485188.txt...
-			        ↗️  Done syncing assets
-			        Total Upload: 52xx KiB / gzip: 13xx KiB
-			        Uploaded test-name (TIMINGS)
-			        Published test-name (TIMINGS)
-			          https://test-name.test-sub-domain.workers.dev",
-			          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe --assets argument is experimental and may change or break at any time[0m
+			Object {
+			  "debug": "",
+			  "err": "",
+			  "out": "Reading file-1.txt...
+			Uploading as file-1.2ca234f380.txt...
+			Reading file-2.txt...
+			Uploading as file-2.5938485188.txt...
+			↗️  Done syncing assets
+			Total Upload: 52xx KiB / gzip: 14xx KiB
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe --assets argument is experimental and may change or break at any time[0m
 
-			        ",
-			        }
-		      `);
+			",
+			}
+		`);
 		});
 
 		it("should error when trying to use --assets with a service-worker Worker", async () => {
@@ -1738,6 +1738,7 @@ addEventListener('fetch', event => {});`
 		it("should error if config.assets and --site are used together", async () => {
 			writeWranglerToml({
 				main: "./index.js",
+				// @ts-expect-error we allow string inputs here
 				assets: "abc",
 			});
 			writeWorkerSource();
@@ -1767,6 +1768,7 @@ addEventListener('fetch', event => {});`
 		it("should error if config.assets and config.site are used together", async () => {
 			writeWranglerToml({
 				main: "./index.js",
+				// @ts-expect-error we allow string inputs here
 				assets: "abc",
 				site: {
 					bucket: "xyz",
@@ -1821,28 +1823,29 @@ addEventListener('fetch', event => {});`
 
 			await runWrangler("publish --assets ./assets");
 			expect(std).toMatchInlineSnapshot(`
-			        Object {
-			          "debug": "",
-			          "err": "",
-			          "out": "Reading subdir/file-1.txt...
-			        Uploading as subdir/file-1.2ca234f380.txt...
-			        Reading subdir/file-2.txt...
-			        Uploading as subdir/file-2.5938485188.txt...
-			        ↗️  Done syncing assets
-			        Total Upload: 52xx KiB / gzip: 13xx KiB
-			        Uploaded test-name (TIMINGS)
-			        Published test-name (TIMINGS)
-			          https://test-name.test-sub-domain.workers.dev",
-			          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe --assets argument is experimental and may change or break at any time[0m
+			Object {
+			  "debug": "",
+			  "err": "",
+			  "out": "Reading subdir/file-1.txt...
+			Uploading as subdir/file-1.2ca234f380.txt...
+			Reading subdir/file-2.txt...
+			Uploading as subdir/file-2.5938485188.txt...
+			↗️  Done syncing assets
+			Total Upload: 52xx KiB / gzip: 14xx KiB
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe --assets argument is experimental and may change or break at any time[0m
 
-			        ",
-			        }
-		      `);
+			",
+			}
+		`);
 		});
 
 		it("should warn if config.assets is used", async () => {
 			writeWranglerToml({
 				main: "./index.js",
+				// @ts-expect-error we allow string inputs here
 				assets: "./assets",
 			});
 			const assets = [
@@ -1866,25 +1869,25 @@ addEventListener('fetch', event => {});`
 
 			await runWrangler("publish");
 			expect(std).toMatchInlineSnapshot(`
-			        Object {
-			          "debug": "",
-			          "err": "",
-			          "out": "Reading subdir/file-1.txt...
-			        Uploading as subdir/file-1.2ca234f380.txt...
-			        Reading subdir/file-2.txt...
-			        Uploading as subdir/file-2.5938485188.txt...
-			        ↗️  Done syncing assets
-			        Total Upload: 52xx KiB / gzip: 13xx KiB
-			        Uploaded test-name (TIMINGS)
-			        Published test-name (TIMINGS)
-			          https://test-name.test-sub-domain.workers.dev",
-			          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+			Object {
+			  "debug": "",
+			  "err": "",
+			  "out": "Reading subdir/file-1.txt...
+			Uploading as subdir/file-1.2ca234f380.txt...
+			Reading subdir/file-2.txt...
+			Uploading as subdir/file-2.5938485188.txt...
+			↗️  Done syncing assets
+			Total Upload: 52xx KiB / gzip: 14xx KiB
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
 
-			            - \\"assets\\" fields are experimental and may change or break at any time.
+			    - \\"assets\\" fields are experimental and may change or break at any time.
 
-			        ",
-			        }
-		      `);
+			",
+			}
+		`);
 		});
 
 		it("should not contain backslash for assets with nested directories", async () => {
@@ -2891,23 +2894,23 @@ addEventListener('fetch', event => {});`
 			await runWrangler("publish --assets .");
 
 			expect(std).toMatchInlineSnapshot(`
-			        Object {
-			          "debug": "",
-			          "err": "",
-			          "out": "Reading file-1.txt...
-			        Uploading as file-1.2ca234f380.txt...
-			        Reading file-2.txt...
-			        Uploading as file-2.5938485188.txt...
-			        ↗️  Done syncing assets
-			        Total Upload: 52xx KiB / gzip: 13xx KiB
-			        Uploaded test-name (TIMINGS)
-			        Published test-name (TIMINGS)
-			          https://test-name.test-sub-domain.workers.dev",
-			          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe --assets argument is experimental and may change or break at any time[0m
+			Object {
+			  "debug": "",
+			  "err": "",
+			  "out": "Reading file-1.txt...
+			Uploading as file-1.2ca234f380.txt...
+			Reading file-2.txt...
+			Uploading as file-2.5938485188.txt...
+			↗️  Done syncing assets
+			Total Upload: 52xx KiB / gzip: 14xx KiB
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe --assets argument is experimental and may change or break at any time[0m
 
-			        ",
-			        }
-		      `);
+			",
+			}
+		`);
 		});
 	});
 

--- a/packages/wrangler/src/config/config.ts
+++ b/packages/wrangler/src/config/config.ts
@@ -127,8 +127,13 @@ export interface ConfigFields<Dev extends RawDevConfig> {
 	 * This can either be a string, or an object with additional config fields.
 	 */
 	assets:
-		| string
-		| { bucket: string; include: string[]; exclude: string[] }
+		| {
+				bucket: string;
+				include: string[];
+				exclude: string[];
+				browser_TTL: number | undefined;
+				serve_single_page_app: boolean;
+		  }
 		| undefined;
 
 	/**

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -537,6 +537,7 @@ export async function startDev(args: StartDevOptions) {
 					liveReload={args.liveReload || false}
 					accountId={config.account_id || getAccountFromCache()?.id}
 					assetPaths={assetPaths}
+					assetsConfig={config.assets}
 					port={args.port || config.dev.port || (await getLocalPort())}
 					ip={args.ip || config.dev.ip}
 					inspectorPort={

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -46,6 +46,7 @@ export type DevProps = {
 	crons: Config["triggers"]["crons"];
 	isWorkersSite: boolean;
 	assetPaths: AssetPaths | undefined;
+	assetsConfig: Config["assets"];
 	compatibilityDate: string;
 	compatibilityFlags: string[] | undefined;
 	usageModel: "bundled" | "unbound" | undefined;
@@ -171,6 +172,7 @@ function DevSession(props: DevSessionProps) {
 		nodeCompat: props.nodeCompat,
 		define: props.define,
 		noBundle: props.noBundle,
+		assets: props.assetsConfig,
 	});
 
 	return props.local ? (

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -23,6 +23,7 @@ export function useEsbuild({
 	jsxFactory,
 	jsxFragment,
 	rules,
+	assets,
 	serveAssetsFromWorker,
 	tsconfig,
 	minify,
@@ -35,6 +36,7 @@ export function useEsbuild({
 	jsxFactory: string | undefined;
 	jsxFragment: string | undefined;
 	rules: Config["rules"];
+	assets: Config["assets"];
 	define: Config["define"];
 	serveAssetsFromWorker: boolean;
 	tsconfig: string | undefined;
@@ -94,6 +96,11 @@ export function useEsbuild({
 						nodeCompat,
 						define,
 						checkFetch: true,
+						assets: assets && {
+							...assets,
+							// disable the cache in dev
+							bypassCache: true,
+						},
 				  });
 
 			// Capture the `stop()` method to use as the `useEffect()` destructor.
@@ -145,6 +152,7 @@ export function useEsbuild({
 		minify,
 		nodeCompat,
 		define,
+		assets,
 	]);
 	return bundle;
 }

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -383,6 +383,11 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 						nodeCompat,
 						define: config.define,
 						checkFetch: false,
+						assets: config.assets && {
+							...config.assets,
+							// enable the cache when publishing
+							bypassCache: false,
+						},
 					}
 			  );
 

--- a/packages/wrangler/templates/serve-static-assets.ts
+++ b/packages/wrangler/templates/serve-static-assets.ts
@@ -24,6 +24,8 @@ export default {
 		let options = {
 			ASSET_MANIFEST,
 			ASSET_NAMESPACE: env.__STATIC_CONTENT,
+			cacheControl: __CACHE_CONTROL_OPTIONS__,
+			serveSinglePageApp: __SERVE_SINGLE_PAGE_APP__,
 		};
 
 		try {


### PR DESCRIPTION
This adds cache control options to `config.assets`. This is already supported by the backing library (`@cloudflare/kv-asset-handler`) so we simply pass on the options at its callsite.

Additionally, this adds a configuration field to serve an app in "single page app" mode, where a root index.html is served for all html/404 requests (also powered by the same library).

--- 

This seems to work, but using the preview builds to take it through the paces as well. Open for review!