### PR TITLE
fix(upload): add helper to check for expired JWT

### DIFF
--- a/packages/wrangler/src/pages/upload.tsx
+++ b/packages/wrangler/src/pages/upload.tsx
@@ -18,6 +18,7 @@ import React from "react";
 import { fetchResult } from "../cfetch";
 import { FatalError } from "../errors";
 import { logger } from "../logger";
+import { ParseError } from "../parse";
 import {
 	BULK_UPLOAD_CONCURRENCY,
 	MAX_BUCKET_FILE_COUNT,
@@ -27,7 +28,6 @@ import {
 import { pagesBetaWarning } from "./utils";
 import type { UploadPayloadFile } from "./types";
 import type { ArgumentsCamelCase, Argv } from "yargs";
-import { ParseError } from "../parse";
 
 type UploadArgs = {
 	directory: string;

--- a/packages/wrangler/src/pages/upload.tsx
+++ b/packages/wrangler/src/pages/upload.tsx
@@ -286,7 +286,7 @@ export const upload = async (
 			}
 		};
 
-		await queue.add(() =>
+		queue.add(() =>
 			doUpload().then(
 				() => {
 					counter += bucket.files.length;
@@ -369,13 +369,20 @@ export const upload = async (
 };
 
 // Decode and check that the current JWT has not expired
-function isJwtExpired(token: string): boolean {
-	const decodedJwt = JSON.parse(
-		Buffer.from(token.split(".")[1], "base64").toString()
-	);
-	const dateNow = new Date().getTime() / 1000;
+function isJwtExpired(token: string): boolean | undefined {
+	try {
+		const decodedJwt = JSON.parse(
+			Buffer.from(token.split(".")[1], "base64").toString()
+		);
 
-	return decodedJwt.exp < dateNow;
+		const dateNow = new Date().getTime() / 1000;
+
+		return decodedJwt.exp <= dateNow;
+	} catch (e) {
+		if (e instanceof Error) {
+			throw new Error(`Invalid token: ${e.message}`);
+		}
+	}
 }
 
 function formatTime(duration: number) {


### PR DESCRIPTION
This is changing the way JWT Expiration errors are checked during the pages direct upload process. Previously the error was being checked for a specific error code that does not exist on the `ParseError` being thrown in the case the JWT has expired while uploading. This adds a second condition that decodes the current JWT and validates that token has not expired.