### PR TITLE
Sort package.json files during prettier runs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
 				"jest": "^27.5.1",
 				"npm-run-all": "^4.1.5",
 				"prettier": "^2.6.2",
+				"prettier-plugin-packagejson": "^2.2.18",
 				"typescript": "^4.6.3"
 			},
 			"engines": {
@@ -3000,7 +3001,6 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
 			"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
-			"dev": true,
 			"dependencies": {
 				"@types/minimatch": "*",
 				"@types/node": "*"
@@ -3105,8 +3105,7 @@
 		"node_modules/@types/minimatch": {
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-			"integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
-			"dev": true
+			"integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
 		},
 		"node_modules/@types/minimist": {
 			"version": "1.2.2",
@@ -8398,6 +8397,14 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/git-hooks-list": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-1.0.3.tgz",
+			"integrity": "sha512-Y7wLWcrLUXwk2noSka166byGCvhMtDRpgHdzCno1UQv/n/Hegp++a2xBWJL1lJarnKD3SWaljD+0z1ztqxuKyQ==",
+			"funding": {
+				"url": "https://github.com/fisker/git-hooks-list?sponsor=1"
 			}
 		},
 		"node_modules/glob": {
@@ -15584,6 +15591,17 @@
 				"url": "https://github.com/prettier/prettier?sponsor=1"
 			}
 		},
+		"node_modules/prettier-plugin-packagejson": {
+			"version": "2.2.18",
+			"resolved": "https://registry.npmjs.org/prettier-plugin-packagejson/-/prettier-plugin-packagejson-2.2.18.tgz",
+			"integrity": "sha512-iBjQ3IY6IayFrQHhXvg+YvKprPUUiIJ04Vr9+EbeQPfwGajznArIqrN33c5bi4JcIvmLHGROIMOm9aYakJj/CA==",
+			"dependencies": {
+				"sort-package-json": "1.57.0"
+			},
+			"peerDependencies": {
+				"prettier": ">= 1.16.0"
+			}
+		},
 		"node_modules/pretty-bytes": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.0.0.tgz",
@@ -17394,6 +17412,53 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/sort-object-keys": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.3.tgz",
+			"integrity": "sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg=="
+		},
+		"node_modules/sort-package-json": {
+			"version": "1.57.0",
+			"resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-1.57.0.tgz",
+			"integrity": "sha512-FYsjYn2dHTRb41wqnv+uEqCUvBpK3jZcTp9rbz2qDTmel7Pmdtf+i2rLaaPMRZeSVM60V3Se31GyWFpmKs4Q5Q==",
+			"dependencies": {
+				"detect-indent": "^6.0.0",
+				"detect-newline": "3.1.0",
+				"git-hooks-list": "1.0.3",
+				"globby": "10.0.0",
+				"is-plain-obj": "2.1.0",
+				"sort-object-keys": "^1.1.3"
+			},
+			"bin": {
+				"sort-package-json": "cli.js"
+			}
+		},
+		"node_modules/sort-package-json/node_modules/globby": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-10.0.0.tgz",
+			"integrity": "sha512-3LifW9M4joGZasyYPz2A1U74zbC/45fvpXUvO/9KbSa+VV0aGZarWkfdgKyR9sExNP0t0x0ss/UMJpNpcaTspw==",
+			"dependencies": {
+				"@types/glob": "^7.1.1",
+				"array-union": "^2.1.0",
+				"dir-glob": "^3.0.1",
+				"fast-glob": "^3.0.3",
+				"glob": "^7.1.3",
+				"ignore": "^5.1.1",
+				"merge2": "^1.2.3",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/sort-package-json/node_modules/is-plain-obj": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/source-list-map": {
@@ -23123,7 +23188,6 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
 			"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
-			"dev": true,
 			"requires": {
 				"@types/minimatch": "*",
 				"@types/node": "*"
@@ -23217,8 +23281,7 @@
 		"@types/minimatch": {
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-			"integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
-			"dev": true
+			"integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
 		},
 		"@types/minimist": {
 			"version": "1.2.2"
@@ -26847,6 +26910,11 @@
 		},
 		"get-value": {
 			"version": "2.0.6"
+		},
+		"git-hooks-list": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-1.0.3.tgz",
+			"integrity": "sha512-Y7wLWcrLUXwk2noSka166byGCvhMtDRpgHdzCno1UQv/n/Hegp++a2xBWJL1lJarnKD3SWaljD+0z1ztqxuKyQ=="
 		},
 		"glob": {
 			"version": "7.2.0",
@@ -32045,6 +32113,14 @@
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
 			"integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
 		},
+		"prettier-plugin-packagejson": {
+			"version": "2.2.18",
+			"resolved": "https://registry.npmjs.org/prettier-plugin-packagejson/-/prettier-plugin-packagejson-2.2.18.tgz",
+			"integrity": "sha512-iBjQ3IY6IayFrQHhXvg+YvKprPUUiIJ04Vr9+EbeQPfwGajznArIqrN33c5bi4JcIvmLHGROIMOm9aYakJj/CA==",
+			"requires": {
+				"sort-package-json": "1.57.0"
+			}
+		},
 		"pretty-bytes": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.0.0.tgz",
@@ -33386,6 +33462,46 @@
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
+				}
+			}
+		},
+		"sort-object-keys": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.3.tgz",
+			"integrity": "sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg=="
+		},
+		"sort-package-json": {
+			"version": "1.57.0",
+			"resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-1.57.0.tgz",
+			"integrity": "sha512-FYsjYn2dHTRb41wqnv+uEqCUvBpK3jZcTp9rbz2qDTmel7Pmdtf+i2rLaaPMRZeSVM60V3Se31GyWFpmKs4Q5Q==",
+			"requires": {
+				"detect-indent": "^6.0.0",
+				"detect-newline": "3.1.0",
+				"git-hooks-list": "1.0.3",
+				"globby": "10.0.0",
+				"is-plain-obj": "2.1.0",
+				"sort-object-keys": "^1.1.3"
+			},
+			"dependencies": {
+				"globby": {
+					"version": "10.0.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-10.0.0.tgz",
+					"integrity": "sha512-3LifW9M4joGZasyYPz2A1U74zbC/45fvpXUvO/9KbSa+VV0aGZarWkfdgKyR9sExNP0t0x0ss/UMJpNpcaTspw==",
+					"requires": {
+						"@types/glob": "^7.1.1",
+						"array-union": "^2.1.0",
+						"dir-glob": "^3.0.1",
+						"fast-glob": "^3.0.3",
+						"glob": "^7.1.3",
+						"ignore": "^5.1.1",
+						"merge2": "^1.2.3",
+						"slash": "^3.0.0"
+					}
+				},
+				"is-plain-obj": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+					"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 		"jest": "^27.5.1",
 		"npm-run-all": "^4.1.5",
 		"prettier": "^2.6.2",
+		"prettier-plugin-packagejson": "^2.2.18",
 		"typescript": "^4.6.3"
 	},
 	"scripts": {

--- a/packages/create-workers-app/package.json
+++ b/packages/create-workers-app/package.json
@@ -1,11 +1,11 @@
 {
 	"name": "create-workers-app",
 	"version": "1.0.0",
+	"private": true,
 	"description": "",
-	"main": "index.js",
-	"scripts": {},
 	"keywords": [],
-	"author": "",
 	"license": "ISC",
-	"private": true
+	"author": "",
+	"main": "index.js",
+	"scripts": {}
 }

--- a/packages/jest-environment-wrangler/package.json
+++ b/packages/jest-environment-wrangler/package.json
@@ -2,21 +2,21 @@
 	"name": "jest-environment-wrangler",
 	"version": "0.0.31",
 	"description": "A jest environment for Cloudflare Workers, powered by wrangler.",
-	"main": "dist/index.js",
-	"scripts": {
-		"build": "esbuild src/index.ts --outfile=dist/index.js --target=es2020 --sourcemap --platform=node --format=cjs",
-		"check:type": "tsc"
-	},
-	"prepublishOnly": "npm run build",
 	"keywords": [
 		"jest",
 		"wrangler",
 		"cloudflare",
 		"cloudflare-workers"
 	],
-	"author": "wrangler@cloudflare.com",
 	"license": "ISC",
+	"author": "wrangler@cloudflare.com",
+	"main": "dist/index.js",
+	"scripts": {
+		"build": "esbuild src/index.ts --outfile=dist/index.js --target=es2020 --sourcemap --platform=node --format=cjs",
+		"check:type": "tsc"
+	},
 	"dependencies": {
 		"jest-environment-miniflare": "^2.5.1"
-	}
+	},
+	"prepublishOnly": "npm run build"
 }

--- a/packages/prerelease-registry/package.json
+++ b/packages/prerelease-registry/package.json
@@ -1,21 +1,21 @@
 {
 	"name": "prerelease-registry",
-	"private": true,
 	"version": "0.0.1",
+	"private": true,
 	"main": "_worker.js",
 	"scripts": {
 		"build": "npx wrangler pages functions build --fallback-service='' ./functions/routes",
 		"check:type": "tsc",
-		"prestart": "npm run build",
-		"start": "npx wrangler dev _worker.js",
 		"prepublish": "npm run build",
-		"publish": "npx wrangler publish _worker.js"
+		"publish": "npx wrangler publish _worker.js",
+		"prestart": "npm run build",
+		"start": "npx wrangler dev _worker.js"
+	},
+	"dependencies": {
+		"jszip": "^3.7.1"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^3.3.1",
 		"typescript": "^4.5.5"
-	},
-	"dependencies": {
-		"jszip": "^3.7.1"
 	}
 }

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -1,18 +1,7 @@
 {
 	"name": "wrangler",
 	"version": "2.0.16",
-	"author": "wrangler@cloudflare.com",
 	"description": "Command-line interface for all things Cloudflare Workers",
-	"bin": {
-		"wrangler": "./bin/wrangler.js",
-		"wrangler2": "./bin/wrangler.js"
-	},
-	"main": "wrangler-dist/cli.js",
-	"license": "MIT OR Apache-2.0",
-	"bugs": {
-		"url": "https://github.com/cloudflare/wrangler2/issues"
-	},
-	"homepage": "https://github.com/cloudflare/wrangler2#readme",
 	"keywords": [
 		"wrangler",
 		"cloudflare",
@@ -29,13 +18,69 @@
 		"webassembly",
 		"rust",
 		"emscripten",
-		"rust",
 		"typescript",
 		"graphql",
 		"router",
 		"http",
 		"cli"
 	],
+	"homepage": "https://github.com/cloudflare/wrangler2#readme",
+	"bugs": {
+		"url": "https://github.com/cloudflare/wrangler2/issues"
+	},
+	"license": "MIT OR Apache-2.0",
+	"author": "wrangler@cloudflare.com",
+	"main": "wrangler-dist/cli.js",
+	"bin": {
+		"wrangler": "./bin/wrangler.js",
+		"wrangler2": "./bin/wrangler.js"
+	},
+	"files": [
+		"src",
+		"bin",
+		"miniflare-config-stubs",
+		"miniflare-dist",
+		"wrangler-dist",
+		"templates",
+		"vendor",
+		"import_meta_url.js",
+		"kv-asset-handler.js",
+		"Cloudflare_CA.pem"
+	],
+	"scripts": {
+		"build": "npm run clean && npm run bundle",
+		"bundle": "node -r esbuild-register scripts/bundle.ts",
+		"check:type": "tsc",
+		"clean": "rm -rf wrangler-dist miniflare-dist",
+		"dev": "npm run clean && concurrently -c black,blue 'npm run bundle -- --watch' 'npm run check:type -- --watch --preserveWatchOutput'",
+		"prepublishOnly": "SOURCEMAPS=false npm run build",
+		"start": "npm run bundle && NODE_OPTIONS=--enable-source-maps ./bin/wrangler.js",
+		"test": "jest --silent=false --verbose=true",
+		"test-watch": "npm run test -- --runInBand --testTimeout=50000 --watch"
+	},
+	"jest": {
+		"moduleNameMapper": {
+			"clipboardy": "<rootDir>/src/__tests__/helpers/clipboardy-mock.js",
+			"miniflare/cli": "<rootDir>/../../node_modules/miniflare/dist/src/cli.js"
+		},
+		"restoreMocks": true,
+		"setupFilesAfterEnv": [
+			"<rootDir>/src/__tests__/jest.setup.ts"
+		],
+		"testRegex": ".*.(test|spec)\\.[jt]sx?$",
+		"testTimeout": 30000,
+		"transform": {
+			"^.+\\.c?(t|j)sx?$": [
+				"esbuild-jest",
+				{
+					"sourcemap": true
+				}
+			]
+		},
+		"transformIgnorePatterns": [
+			"node_modules/(?!find-up|locate-path|p-locate|p-limit|p-timeout|p-queue|yocto-queue|path-exists|execa|strip-final-newline|npm-run-path|path-key|onetime|mimic-fn|human-signals|is-stream|get-port|supports-color|pretty-bytes)"
+		]
+	},
 	"dependencies": {
 		"@cloudflare/kv-asset-handler": "^0.2.0",
 		"@esbuild-plugins/node-globals-polyfill": "^0.1.1",
@@ -48,9 +93,6 @@
 		"selfsigned": "^2.0.1",
 		"semiver": "^1.1.0",
 		"xxhash-wasm": "^1.0.1"
-	},
-	"optionalDependencies": {
-		"fsevents": "~2.3.2"
 	},
 	"devDependencies": {
 		"@iarna/toml": "^3.0.0",
@@ -106,53 +148,10 @@
 		"ws": "^8.5.0",
 		"yargs": "^17.4.1"
 	},
-	"files": [
-		"src",
-		"bin",
-		"miniflare-config-stubs",
-		"miniflare-dist",
-		"wrangler-dist",
-		"templates",
-		"vendor",
-		"import_meta_url.js",
-		"kv-asset-handler.js",
-		"Cloudflare_CA.pem"
-	],
-	"scripts": {
-		"clean": "rm -rf wrangler-dist miniflare-dist",
-		"check:type": "tsc",
-		"bundle": "node -r esbuild-register scripts/bundle.ts",
-		"build": "npm run clean && npm run bundle",
-		"dev": "npm run clean && concurrently -c black,blue 'npm run bundle -- --watch' 'npm run check:type -- --watch --preserveWatchOutput'",
-		"prepublishOnly": "SOURCEMAPS=false npm run build",
-		"start": "npm run bundle && NODE_OPTIONS=--enable-source-maps ./bin/wrangler.js",
-		"test": "jest --silent=false --verbose=true",
-		"test-watch": "npm run test -- --runInBand --testTimeout=50000 --watch"
+	"optionalDependencies": {
+		"fsevents": "~2.3.2"
 	},
 	"engines": {
 		"node": ">=16.7.0"
-	},
-	"jest": {
-		"restoreMocks": true,
-		"testTimeout": 30000,
-		"testRegex": ".*.(test|spec)\\.[jt]sx?$",
-		"transformIgnorePatterns": [
-			"node_modules/(?!find-up|locate-path|p-locate|p-limit|p-timeout|p-queue|yocto-queue|path-exists|execa|strip-final-newline|npm-run-path|path-key|onetime|mimic-fn|human-signals|is-stream|get-port|supports-color|pretty-bytes)"
-		],
-		"moduleNameMapper": {
-			"clipboardy": "<rootDir>/src/__tests__/helpers/clipboardy-mock.js",
-			"miniflare/cli": "<rootDir>/../../node_modules/miniflare/dist/src/cli.js"
-		},
-		"transform": {
-			"^.+\\.c?(t|j)sx?$": [
-				"esbuild-jest",
-				{
-					"sourcemap": true
-				}
-			]
-		},
-		"setupFilesAfterEnv": [
-			"<rootDir>/src/__tests__/jest.setup.ts"
-		]
 	}
 }

--- a/packages/wranglerjs-compat-webpack-plugin/package.json
+++ b/packages/wranglerjs-compat-webpack-plugin/package.json
@@ -2,20 +2,43 @@
 	"name": "wranglerjs-compat-webpack-plugin",
 	"version": "0.0.5",
 	"description": "A webpack plugin to emulate the behavior of wrangler1's `type = webpack`",
-	"author": "wrangler@cloudflare.com",
-	"license": "MIT OR Apache-2.0",
-	"type": "commonjs",
-	"main": "lib/index.js",
-	"types": "lib/index.d.ts",
+	"homepage": "https://github.com/cloudflare/wrangler2#readme",
 	"bugs": {
 		"url": "https://github.com/cloudflare/wrangler2/issues"
 	},
-	"homepage": "https://github.com/cloudflare/wrangler2#readme",
+	"license": "MIT OR Apache-2.0",
+	"author": "wrangler@cloudflare.com",
+	"type": "commonjs",
+	"main": "lib/index.js",
+	"types": "lib/index.d.ts",
 	"scripts": {
 		"build": "run-p build:*",
 		"build:d.ts": "tsc",
 		"build:js": "esbuild src/index.ts --bundle --platform=node --external:execa --external:webpack --external:esbuild --external:rimraf --target=node16.7 --outfile=lib/index.js --format=cjs --sourcemap",
 		"test:plugin": "jest"
+	},
+	"jest": {
+		"moduleNameMapper": {
+			"clipboardy": "<rootDir>/../wrangler/src/__tests__/helpers/clipboardy-mock.js",
+			"miniflare/cli": "<rootDir>/../../node_modules/miniflare/dist/src/cli.js"
+		},
+		"restoreMocks": true,
+		"setupFilesAfterEnv": [
+			"<rootDir>/src/__tests__/jest.setup.ts"
+		],
+		"testRegex": ".*.(test|spec)\\.[jt]sx?$",
+		"testTimeout": 180000,
+		"transform": {
+			"^.+\\.c?(t|j)sx?$": [
+				"esbuild-jest",
+				{
+					"sourcemap": true
+				}
+			]
+		},
+		"transformIgnorePatterns": [
+			"node_modules/(?!find-up|locate-path|p-locate|p-limit|yocto-queue|path-exists|execa|strip-final-newline|npm-run-path|path-key|onetime|mimic-fn|human-signals|is-stream|get-port|supports-color)"
+		]
 	},
 	"dependencies": {
 		"rimraf": "^3.0.2"
@@ -37,28 +60,5 @@
 		"typescript": "^4.6.3",
 		"undici": "^5.0.0",
 		"webpack": "^4.46.0"
-	},
-	"jest": {
-		"restoreMocks": true,
-		"testTimeout": 180000,
-		"testRegex": ".*.(test|spec)\\.[jt]sx?$",
-		"transformIgnorePatterns": [
-			"node_modules/(?!find-up|locate-path|p-locate|p-limit|yocto-queue|path-exists|execa|strip-final-newline|npm-run-path|path-key|onetime|mimic-fn|human-signals|is-stream|get-port|supports-color)"
-		],
-		"moduleNameMapper": {
-			"clipboardy": "<rootDir>/../wrangler/src/__tests__/helpers/clipboardy-mock.js",
-			"miniflare/cli": "<rootDir>/../../node_modules/miniflare/dist/src/cli.js"
-		},
-		"transform": {
-			"^.+\\.c?(t|j)sx?$": [
-				"esbuild-jest",
-				{
-					"sourcemap": true
-				}
-			]
-		},
-		"setupFilesAfterEnv": [
-			"<rootDir>/src/__tests__/jest.setup.ts"
-		]
 	}
 }


### PR DESCRIPTION
Using [prettier-plugin-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson),
we can keep package.json files organized. I've kind of had a headache
sometimes trying to find stuff in wrangler's package.json, so I thought
this might help.
