### PR TITLE
Check for assets in config file as well as CLI arg

### DIFF
--- a/.changeset/odd-cats-turn.md
+++ b/.changeset/odd-cats-turn.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Check for assets in config file as well as CLI arg
+
+Allow specifying `[assets]` in a wrangler.toml file.

--- a/packages/wrangler/src/entry.ts
+++ b/packages/wrangler/src/entry.ts
@@ -39,7 +39,7 @@ export async function getEntry(
 				? path.resolve(config.site?.["entry-point"])
 				: // site.entry-point could be a directory
 				  path.resolve(config.site?.["entry-point"], "index.js");
-		} else if (args.assets) {
+		} else if (args.assets || config.assets) {
 			file = path.resolve(__dirname, "../templates/no-op-worker.js");
 		} else {
 			throw new Error(


### PR DESCRIPTION
Allow specifying `[assets]` in a wrangler.toml file.
