### PR TITLE
test: fix leakage between tests

### DIFF
--- a/packages/wrangler/src/__tests__/https-options.test.ts
+++ b/packages/wrangler/src/__tests__/https-options.test.ts
@@ -6,7 +6,7 @@ import { mockConsoleMethods } from "./helpers/mock-console";
 import { runInTempDir } from "./helpers/run-in-tmp";
 
 describe("getHttpsOptions()", () => {
-	runInTempDir({ homedir: "./home" });
+	runInTempDir();
 	const std = mockConsoleMethods();
 
 	it("should use cached values if they have not expired", async () => {

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -29,7 +29,7 @@ import type { FormData, File } from "undici";
 describe("publish", () => {
 	mockAccountId();
 	mockApiToken();
-	runInTempDir({ homedir: "./home" });
+	runInTempDir();
 	const { setIsTTY } = useMockIsTTY();
 	const std = mockConsoleMethods();
 	const {
@@ -97,33 +97,23 @@ describe("publish", () => {
 				api_token: "some-api-token",
 			});
 
-			const accessTokenRequest = mockGrantAccessToken({ respondWith: "ok" });
-			mockGrantAuthorization({ respondWith: "success" });
-
 			await expect(runWrangler("publish index.js")).resolves.toBeUndefined();
 
-			expect(accessTokenRequest.actual.url).toEqual(
-				accessTokenRequest.expected.url
-			);
-
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Attempting to login via OAuth...
-			        Opening a link in your default browser: https://dash.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20pages%3Awrite%20zone%3Aread%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
-			        Successfully logged in.
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
-			        Uploaded test-name (TIMINGS)
-			        Published test-name (TIMINGS)
-			          test-name.test-sub-domain.workers.dev"
-		      `);
+			"Total Upload: 0xx KiB / gzip: 0xx KiB
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  test-name.test-sub-domain.workers.dev"
+		`);
 			expect(std.warn).toMatchInlineSnapshot(`
-			        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mIt looks like you have used Wrangler 1's \`config\` command to login with an API token.[0m
+			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mIt looks like you have used Wrangler 1's \`config\` command to login with an API token.[0m
 
-			          This is no longer supported in the current version of Wrangler.
-			          If you wish to authenticate via an API token then please set the \`CLOUDFLARE_API_TOKEN\`
-			          environment variable.
+			  This is no longer supported in the current version of Wrangler.
+			  If you wish to authenticate via an API token then please set the \`CLOUDFLARE_API_TOKEN\`
+			  environment variable.
 
-			        "
-		      `);
+			"
+		`);
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 

--- a/packages/wrangler/src/__tests__/user.test.ts
+++ b/packages/wrangler/src/__tests__/user.test.ts
@@ -18,7 +18,7 @@ import type { Config } from "../config";
 import type { UserAuthConfig } from "../user";
 
 describe("User", () => {
-	runInTempDir({ homedir: "./home" });
+	runInTempDir();
 	const std = mockConsoleMethods();
 	const {
 		mockOAuthServerCallback,
@@ -94,13 +94,10 @@ describe("User", () => {
 	// TODO: Improve OAuth mocking to handle `/token` endpoints from different calls
 	it("should handle errors for failed token refresh", async () => {
 		setIsTTY(false);
-		mockOAuthServerCallback();
 		writeAuthConfigFile({
 			oauth_token: "hunter2",
 			refresh_token: "Order 66",
 		});
-		mockGrantAuthorization({ respondWith: "success" });
-
 		mockExchangeRefreshTokenForAccessToken({
 			respondWith: "badResponse",
 		});
@@ -109,7 +106,7 @@ describe("User", () => {
 		await expect(
 			requireAuth({} as Config)
 		).rejects.toThrowErrorMatchingInlineSnapshot(
-			`"Did not login, quitting..."`
+			`"In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work. Please go to https://developers.cloudflare.com/api/tokens/create/ for instructions on how to create an api token, and assign its value to CLOUDFLARE_API_TOKEN."`
 		);
 	});
 

--- a/packages/wrangler/src/__tests__/whoami.test.tsx
+++ b/packages/wrangler/src/__tests__/whoami.test.tsx
@@ -16,7 +16,7 @@ import type { UserInfo } from "../whoami";
 describe("getUserInfo()", () => {
 	const ENV_COPY = process.env;
 
-	runInTempDir({ homedir: "./home" });
+	runInTempDir();
 	const std = mockConsoleMethods();
 	const { setIsTTY } = useMockIsTTY();
 
@@ -173,6 +173,16 @@ describe("getUserInfo()", () => {
 
 	it("should display a warning message if the config file contains a legacy api_token field", async () => {
 		writeAuthConfigFile({ api_token: "API_TOKEN" });
+		setMockResponse("/user", () => {
+			return { email: "user@example.com" };
+		});
+		setMockResponse("/accounts", () => {
+			return [
+				{ name: "Account One", id: "account-1" },
+				{ name: "Account Two", id: "account-2" },
+				{ name: "Account Three", id: "account-3" },
+			];
+		});
 		await getUserInfo();
 		expect(std.warn).toMatchInlineSnapshot(`
       "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mIt looks like you have used Wrangler 1's \`config\` command to login with an API token.[0m

--- a/packages/wrangler/src/https-options.ts
+++ b/packages/wrangler/src/https-options.ts
@@ -1,5 +1,5 @@
 import * as fs from "node:fs";
-import { homedir, networkInterfaces } from "node:os";
+import os from "node:os";
 import * as path from "node:path";
 import { promisify } from "node:util";
 import { logger } from "./logger";
@@ -17,7 +17,7 @@ const ONE_DAY_IN_MS = 86400000;
  * The certificates are self-signed and generated locally, and cached in the `CERT_ROOT` directory.
  */
 export async function getHttpsOptions() {
-	const certDirectory = path.join(homedir(), ".wrangler/local-cert");
+	const certDirectory = path.join(os.homedir(), ".wrangler/local-cert");
 	const keyPath = path.join(certDirectory, "key.pem");
 	const certPath = path.join(certDirectory, "cert.pem");
 
@@ -37,7 +37,10 @@ export async function getHttpsOptions() {
 		} catch (e) {
 			const message = e instanceof Error ? e.message : `${e}`;
 			logger.warn(
-				`Unable to cache generated self-signed certificate in ${certDirectory}.\n${message}`
+				`Unable to cache generated self-signed certificate in ${path.relative(
+					process.cwd(),
+					certDirectory
+				)}.\n${message}`
 			);
 		}
 		return { key, cert };
@@ -114,7 +117,7 @@ async function generateCertificate() {
  */
 function getAccessibleHosts(ipv4 = false): string[] {
 	const hosts: string[] = [];
-	Object.values(networkInterfaces()).forEach((net) =>
+	Object.values(os.networkInterfaces()).forEach((net) =>
 		net?.forEach(({ family, address }) => {
 			if (!ipv4 || family === "IPv4") hosts.push(address);
 		})

--- a/packages/wranglerjs-compat-webpack-plugin/src/__tests__/helpers/mock-config-dir.ts
+++ b/packages/wranglerjs-compat-webpack-plugin/src/__tests__/helpers/mock-config-dir.ts
@@ -1,15 +1,16 @@
 import fs from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
 
 /**
  * Create an environment variable telling wrangler 1 where to look for
  * ~/.wrangler/config/default.toml
  */
-export const mockConfigDir = ({ homedir = "." }: { homedir?: string }) => {
+export const mockConfigDir = () => {
 	beforeEach(() => {
-		const mockHomeDir = path.join(process.cwd(), homedir);
-		process.env.WRANGLER_HOME = mockHomeDir;
-		fs.mkdirSync(path.join(mockHomeDir, "config"), { recursive: true });
-		fs.writeFileSync(path.join(mockHomeDir, "config", "default.toml"), "");
+		const homeDirPath = path.join(process.cwd(), homedir());
+		process.env.WRANGLER_HOME = homeDirPath;
+		fs.mkdirSync(path.join(homeDirPath, "config"), { recursive: true });
+		fs.writeFileSync(path.join(homeDirPath, "config", "default.toml"), "");
 	});
 };

--- a/packages/wranglerjs-compat-webpack-plugin/src/__tests__/index.spec.ts
+++ b/packages/wranglerjs-compat-webpack-plugin/src/__tests__/index.spec.ts
@@ -17,8 +17,8 @@ import { cleanMessage } from "./helpers/pipe";
 
 mockAccountId();
 mockApiToken();
-runInTempDir({ homedir: "./home" });
-mockConfigDir({ homedir: "./home" });
+runInTempDir();
+mockConfigDir();
 
 afterEach(() => {
 	unsetAllMocks();


### PR DESCRIPTION
When mocking out `homedir` we were leaking data between tests.
This results in tests that were passing when they shouldn't and vice versa.

Now we always mock `homedir` and do so in a way that is contained to the test being run.

Affected tests have been cleaned up as necessary.