### PR TITLE
Check `npm_config_user_agent` to guess a user's package manager

### DIFF
--- a/.changeset/strong-bulldogs-check.md
+++ b/.changeset/strong-bulldogs-check.md
@@ -1,0 +1,14 @@
+---
+"wrangler": patch
+---
+
+Check `npm_config_user_agent` to guess a user's package manager
+
+The environment variable `npm_config_user_agent` can be used to guess the package manager
+that was used to execute wrangler. It's imperfect (just like regular user agent sniffing!)
+but the package managers we support all set this property:
+
+- [npm](https://github.com/npm/cli/blob/1415b4bdeeaabb6e0ba12b6b1b0cc56502bd64ab/lib/utils/config/definitions.js#L1945-L1979)
+- [pnpm](https://github.com/pnpm/pnpm/blob/cd4f9341e966eb8b411462b48ff0c0612e0a51a7/packages/plugin-commands-script-runners/src/makeEnv.ts#L14)
+- [yarn](https://yarnpkg.com/advanced/lifecycle-scripts#environment-variables)
+- [yarn classic](https://github.com/yarnpkg/yarn/pull/4330)

--- a/packages/wrangler/src/package-manager.ts
+++ b/packages/wrangler/src/package-manager.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
+import { env } from "node:process";
 import { execa, execaCommandSync } from "execa";
 import { logger } from "./logger";
 
@@ -19,7 +20,9 @@ export async function getPackageManager(cwd: string): Promise<PackageManager> {
 	const hasYarnLock = existsSync(join(cwd, "yarn.lock"));
 	const hasNpmLock = existsSync(join(cwd, "package-lock.json"));
 	const hasPnpmLock = existsSync(join(cwd, "pnpm-lock.yaml"));
+	const userAgent = sniffUserAgent();
 
+	// check for lockfiles
 	if (hasNpmLock) {
 		if (hasNpm) {
 			logger.log(
@@ -60,6 +63,19 @@ export async function getPackageManager(cwd: string): Promise<PackageManager> {
 		}
 	}
 
+	// check the user agent
+	if (userAgent === "npm" && hasNpm) {
+		logger.log("Using npm as package manager.");
+		return { ...NpmPackageManager, cwd };
+	} else if (userAgent === "pnpm" && hasPnpm) {
+		logger.log("Using pnpm as package manager.");
+		return { ...PnpmPackageManager, cwd };
+	} else if (userAgent === "yarn" && hasYarn) {
+		logger.log("Using yarn as package manager.");
+		return { ...YarnPackageManager, cwd };
+	}
+
+	// lastly, check what's installed
 	if (hasNpm) {
 		logger.log("Using npm as package manager.");
 		return { ...NpmPackageManager, cwd };
@@ -171,4 +187,33 @@ function supportsNpm(): Promise<boolean> {
 
 function supportsPnpm(): Promise<boolean> {
 	return supports("pnpm");
+}
+
+/**
+ * The environment variable `npm_config_user_agent` can be used to
+ * guess the package manager that was used to execute wrangler.
+ * It's imperfect (just like regular user agent sniffing!)
+ * but the package managers we support all set this property:
+ *
+ * - [npm](https://github.com/npm/cli/blob/1415b4bdeeaabb6e0ba12b6b1b0cc56502bd64ab/lib/utils/config/definitions.js#L1945-L1979)
+ * - [pnpm](https://github.com/pnpm/pnpm/blob/cd4f9341e966eb8b411462b48ff0c0612e0a51a7/packages/plugin-commands-script-runners/src/makeEnv.ts#L14)
+ * - [yarn](https://yarnpkg.com/advanced/lifecycle-scripts#environment-variables)
+ */
+function sniffUserAgent(): "npm" | "pnpm" | "yarn" | undefined {
+	const userAgent = env.npm_config_user_agent;
+	if (userAgent === undefined) {
+		return undefined;
+	}
+
+	if (userAgent.includes("yarn")) {
+		return "yarn";
+	}
+
+	if (userAgent.includes("pnpm")) {
+		return "pnpm";
+	}
+
+	if (userAgent.includes("npm")) {
+		return "npm";
+	}
 }


### PR DESCRIPTION
The environment variable `npm_config_user_agent` can be used to guess the package manager
that was used to execute wrangler. It's imperfect (just like regular user agent sniffing!)
but the package managers we support all set this property:

- [npm](https://github.com/npm/cli/blob/1415b4bdeeaabb6e0ba12b6b1b0cc56502bd64ab/lib/utils/config/definitions.js#L1945-L1979)
- [pnpm](https://github.com/pnpm/pnpm/blob/cd4f9341e966eb8b411462b48ff0c0612e0a51a7/packages/plugin-commands-script-runners/src/makeEnv.ts#L14)
- [yarn](https://yarnpkg.com/advanced/lifecycle-scripts#environment-variables)
- [yarn classic](https://github.com/yarnpkg/yarn/pull/4330)

Closes #1202
