### PR TITLE
fix: disable emitting types to fix the build

### DIFF
--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -31,7 +31,6 @@
 	"license": "MIT OR Apache-2.0",
 	"author": "wrangler@cloudflare.com",
 	"main": "wrangler-dist/cli.js",
-	"types": "wrangler-dist/cli.d.ts",
 	"bin": {
 		"wrangler": "./bin/wrangler.js",
 		"wrangler2": "./bin/wrangler.js"
@@ -49,7 +48,7 @@
 		"Cloudflare_CA.pem"
 	],
 	"scripts": {
-		"build": "npm run clean && npm run bundle && npm run emit-types",
+		"build": "npm run clean && npm run bundle",
 		"bundle": "node -r esbuild-register scripts/bundle.ts",
 		"check:type": "tsc",
 		"clean": "rm -rf wrangler-dist miniflare-dist emitted-types",


### PR DESCRIPTION
We have a problem where types aren't being emitted correctly, and it's breaking the build on some machines, blocking folks from iterating on wrangler. This fix removes that step from the build right now while we can fix it.

No changeset here for the moment.

--- 

cc @caass 