### PR TITLE
Implementation of support for `--metadata` in `kv:key put`

### DIFF
--- a/.changeset/forty-chefs-reflect.md
+++ b/.changeset/forty-chefs-reflect.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: add missing `metadata` option to `kv:key put`
+
+Closes #1441


### PR DESCRIPTION
It's now possible to express metadata inline without a need to use the `kv:bulk put` with single entry

Closes #1441 