### PR TITLE
fix: don't crash cli on older versions of node

### DIFF
--- a/.changeset/cuddly-turkeys-love.md
+++ b/.changeset/cuddly-turkeys-love.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: don't crash cli on older versions of node
+
+The entry point for the cli `./bin/wrangler.js` wasn't being transpiled, which meant that any newer syntax would cause it to crash on older versions of node. This is a problem because we need this script to run even on unsupported versions so we can log a message telling the user their version of node is too old. The fix here is to just transpile the entry point as well.
+
+Fixes https://github.com/cloudflare/wrangler2/issues/1443

--- a/.changeset/kind-geckos-bathe.md
+++ b/.changeset/kind-geckos-bathe.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+chore: run emit-types only in CI
+
+This fix also runs `emit-types` only when doing a full build, so local dev is faster.
+
+Fixes https://github.com/cloudflare/wrangler2/issues/1435

--- a/.gitignore
+++ b/.gitignore
@@ -173,10 +173,12 @@ dist
 
 # End of https://www.toptal.com/developers/gitignore/api/node,macos
 
-wrangler-dist/
-miniflare-dist
+packages/wrangler/wrangler-dist/
+packages/wrangler/miniflare-dist/
+packages/wrangler/bin/
+packages/wrangler/emitted-types/
 packages/wrangler/wrangler.toml
 packages/prerelease-registry/_worker.js
 packages/wranglerjs-compat-webpack-plugin/lib
 .wrangler-1-cache
-emitted-types/
+

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"fixtures/*"
 	],
 	"scripts": {
-		"build": "npm run build --workspace=wrangler --workspace=jest-environment-wrangler --workspace=pages-plugin-example --workspace=wranglerjs-compat-webpack-plugin",
+		"build": "npm run build -w wrangler -w jest-environment-wrangler -w pages-plugin-example -w wranglerjs-compat-webpack-plugin && npm run emit-types -w wrangler",
 		"check": "run-p check:* --aggregate-output --continue-on-error",
 		"check:format": "prettier packages/** .changeset --check --ignore-unknown",
 		"check:lint": "eslint \"packages/**/*.[tj]s?(x)\" --cache --cache-strategy content --max-warnings=0",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -37,7 +37,6 @@
 		"wrangler2": "./bin/wrangler.js"
 	},
 	"files": [
-		"src",
 		"bin",
 		"miniflare-config-stubs",
 		"miniflare-dist",
@@ -49,12 +48,12 @@
 		"Cloudflare_CA.pem"
 	],
 	"scripts": {
-		"build": "npm run clean && npm run bundle && npm run emit-types",
+		"build": "npm run clean && npm run bundle",
 		"bundle": "node -r esbuild-register scripts/bundle.ts",
 		"check:type": "tsc",
-		"clean": "rm -rf wrangler-dist miniflare-dist emitted-types",
+		"clean": "rm -rf wrangler-dist miniflare-dist bin",
 		"dev": "npm run clean && concurrently -c black,blue 'npm run bundle -- --watch' 'npm run check:type -- --watch --preserveWatchOutput'",
-		"emit-types": "tsc -p tsconfig.emit.json && node -r esbuild-register scripts/emit-types.ts",
+		"emit-types": "rm -rf emitted-types && tsc -p tsconfig.emit.json && node -r esbuild-register scripts/emit-types.ts",
 		"prepublishOnly": "SOURCEMAPS=false npm run build",
 		"start": "npm run bundle && NODE_OPTIONS=--enable-source-maps ./bin/wrangler.js",
 		"test": "jest --silent=false --verbose=true",

--- a/packages/wrangler/scripts/bundle.ts
+++ b/packages/wrangler/scripts/bundle.ts
@@ -54,6 +54,18 @@ async function buildMiniflareCLI(flags: BuildFlags = {}) {
 	});
 }
 
+async function buildCLIEntryPoint(flags: BuildFlags = {}) {
+	await build({
+		entryPoints: ["./src/wrangler.js"],
+		outfile: "./bin/wrangler.js",
+		platform: "node",
+		format: "cjs",
+		target: "node10",
+		sourcemap: process.env.SOURCEMAPS !== "false",
+		watch: flags.watch ? watchLogger("./bin") : false,
+	});
+}
+
 async function run() {
 	// main cli
 	await buildMain();
@@ -61,12 +73,16 @@ async function run() {
 	// custom miniflare cli
 	await buildMiniflareCLI();
 
+	// cli entry point
+	await buildCLIEntryPoint();
+
 	// After built once completely, rerun them both in watch mode
 	if (process.argv.includes("--watch")) {
 		console.log("Built. Watching for changes...");
 		await Promise.all([
 			buildMain({ watch: true }),
 			buildMiniflareCLI({ watch: true }),
+			buildCLIEntryPoint({ watch: true }),
 		]);
 	}
 }


### PR DESCRIPTION
The entry point for the cli `./bin/wrangler.js` wasn't being transpiled, which meant that any newer syntax would cause it to crash on older versions of node. This is a problem because we need this script to run even on unsupported versions so we can log a message telling the user their version of node is too old. The fix here is to just transpile the entry point as well.

Additionally, this fix also runs `emit-types` only when doing a full build, so local dev is a little faster.

Fixes https://github.com/cloudflare/wrangler2/issues/1443
Fixes https://github.com/cloudflare/wrangler2/issues/1435