### PR TITLE
polish: set `checkjs: false` and `jsx: "react"` in newly created projects

### DIFF
--- a/.changeset/pink-eggs-drive.md
+++ b/.changeset/pink-eggs-drive.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+polish: set `checkjs: false` and `jsx: "react"` in newly created projects
+
+When we create a new project, it's annoying having to set jsx: "react" when that's the overwhelmingly default choice, our compiler is setup to do it automatically, and the tsc error message isn't helpful. So we set `jsx: "react"` in the generated tsconfig.
+
+Setting `checkJs: true` is also annoying because it's _not_ a common choice. So we set `checkJs: false` in the generated tsconfig.

--- a/packages/wrangler/templates/tsconfig.json
+++ b/packages/wrangler/templates/tsconfig.json
@@ -15,7 +15,7 @@
 		"lib": [
 			"es2021"
 		] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
-		// "jsx": "preserve",                                /* Specify what JSX code is generated. */
+		"jsx": "react" /* Specify what JSX code is generated. */,
 		// "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
 		// "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
 		// "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */
@@ -42,7 +42,7 @@
 
 		/* JavaScript Support */
 		"allowJs": true /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */,
-		"checkJs": true /* Enable error reporting in type-checked JavaScript files. */,
+		"checkJs": false /* Enable error reporting in type-checked JavaScript files. */,
 		// "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`. */
 
 		/* Emit */


### PR DESCRIPTION
When we create a new project, it's annoying having to set `jsx: "react"` when that's the overwhelmingly default choice, our compiler is setup to do it automatically, and the tsc error message isn't helpful. So we set `jsx: "react"` in the generated tsconfig.

Setting `checkJs: true` is also annoying because it's _not_ a common choice. So we set `checkJs: false` in the generated tsconfig.