### PR TITLE
polish: tweak static assets facade to log only real errors

### DIFF
--- a/.changeset/silly-flowers-yawn.md
+++ b/.changeset/silly-flowers-yawn.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+polish: tweak static assets facade to log only real errors
+
+This prevents the abundance of NotFoundErrors being unnecessaryily logged.


### PR DESCRIPTION
This prevents the abundance of NotFoundErrors being unnecessaryily logged.