### PR TITLE
fix: Exponentially backoff when retrying a call to /upload

### DIFF
--- a/.changeset/spicy-flowers-itch.md
+++ b/.changeset/spicy-flowers-itch.md
@@ -2,4 +2,6 @@
 "wrangler": patch
 ---
 
-fix: Exponentially backoff when retrying a call to /upload
+fix: `wrangler pages publish` now more reliably retries an upload in case of a failure
+
+When `wrangler pages publish` is run, we make calls to an upload endpoint which could be rate limited and therefore fail. We currently retry those calls after a linear backoff. This change makes that backoff exponential which should reduce the likelihood of subsequent calls being rate limited.

--- a/.changeset/spicy-flowers-itch.md
+++ b/.changeset/spicy-flowers-itch.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Exponentially backoff when retrying a call to /upload

--- a/packages/wrangler/src/pages/upload.tsx
+++ b/packages/wrangler/src/pages/upload.tsx
@@ -282,9 +282,9 @@ export const upload = async (
 				});
 			} catch (e) {
 				if (attempts < MAX_UPLOAD_ATTEMPTS) {
-					// Linear backoff, 0 second first time, then 1 second etc.
+					// Exponential backoff, 1 second first time, then 2 second, then 4 second etc.
 					await new Promise((resolvePromise) =>
-						setTimeout(resolvePromise, attempts++ * 1000)
+						setTimeout(resolvePromise, Math.pow(2, attempts++) * 1000)
 					);
 
 					if ((e as { code: number }).code === 8000013) {


### PR DESCRIPTION
Currently we have a linear backoff when retrying HTTP calls to our upload endpoint. We're seeing some instances of rate limits that users are hitting. An exponential backoff here should tame that for the moment.