### PR TITLE
fix: Fail intentionally on older versions of node.

### DIFF
--- a/.changeset/heavy-comics-sell.md
+++ b/.changeset/heavy-comics-sell.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: ensure that a helpful error message is shown when on unsupported versions of node.js
+
+Our entrypoint for wrangler (`bin/wrangler.js`) needs to run in older versions of node and log a message to the user that they need to upgrade their version of node. Sometimes we use syntax in this entrypoint that doesn't run in older versions of node. crashing the script and failing to log the message. This fix adds a test in CI to make sure we don't regress on that behaviour (as well as fixing the current newer syntax usage)
+
+Fixes https://github.com/cloudflare/wrangler2/issues/1443

--- a/.github/workflows/test-old-node-error.yml
+++ b/.github/workflows/test-old-node-error.yml
@@ -1,0 +1,24 @@
+name: Test old node.js version
+
+on: pull_request
+
+jobs:
+  check:
+    name: "Checks"
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js v10
+        uses: actions/setup-node@v3
+        with:
+          node-version: 10.24.1
+
+      - name: Check for error message
+        run: node packages/wrangler/src/__tests__/test-old-node-version.js

--- a/fixtures/local-mode-tests/package.json
+++ b/fixtures/local-mode-tests/package.json
@@ -1,27 +1,20 @@
 {
 	"name": "local-mode-tests",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"private": true,
 	"description": "",
+	"keywords": [],
+	"license": "ISC",
+	"author": "",
 	"main": "index.js",
 	"scripts": {
 		"check:type": "tsc",
 		"test": "npx jest --forceExit"
 	},
-	"devDependencies": {
-		"@cloudflare/workers-types": "^3.2.0"
-	},
-	"keywords": [],
-	"author": "",
-	"license": "ISC",
 	"jest": {
 		"restoreMocks": true,
-		"testTimeout": 30000,
 		"testRegex": ".*.(test|spec)\\.[jt]sx?$",
-		"transformIgnorePatterns": [
-			"node_modules/(?!find-up|locate-path|p-locate|p-limit|p-timeout|p-queue|yocto-queue|path-exists|execa|strip-final-newline|npm-run-path|path-key|onetime|mimic-fn|human-signals|is-stream|get-port|supports-color|pretty-bytes)",
-			"wrangler-dist/cli.js"
-		],
+		"testTimeout": 30000,
 		"transform": {
 			"^.+\\.c?(t|j)sx?$": [
 				"esbuild-jest",
@@ -29,6 +22,13 @@
 					"sourcemap": true
 				}
 			]
-		}
+		},
+		"transformIgnorePatterns": [
+			"node_modules/(?!find-up|locate-path|p-locate|p-limit|p-timeout|p-queue|yocto-queue|path-exists|execa|strip-final-newline|npm-run-path|path-key|onetime|mimic-fn|human-signals|is-stream|get-port|supports-color|pretty-bytes)",
+			"wrangler-dist/cli.js"
+		]
+	},
+	"devDependencies": {
+		"@cloudflare/workers-types": "^3.2.0"
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
 			}
 		},
 		"fixtures/local-mode-tests": {
-			"version": "1.0.0",
+			"version": "1.0.1",
 			"license": "ISC",
 			"devDependencies": {
 				"@cloudflare/workers-types": "^3.2.0"
@@ -20849,7 +20849,6 @@
 				"nanoid": "^3.3.3",
 				"path-to-regexp": "^6.2.0",
 				"selfsigned": "^2.0.1",
-				"semiver": "^1.1.0",
 				"xxhash-wasm": "^1.0.1"
 			},
 			"bin": {
@@ -35659,7 +35658,6 @@
 				"react": "^17.0.2",
 				"react-error-boundary": "^3.1.4",
 				"selfsigned": "^2.0.1",
-				"semiver": "^1.1.0",
 				"serve-static": "^1.15.0",
 				"signal-exit": "^3.0.7",
 				"supports-color": "^9.2.2",

--- a/packages/wrangler/bin/wrangler.js
+++ b/packages/wrangler/bin/wrangler.js
@@ -3,7 +3,6 @@ const { spawn } = require("child_process");
 const path = require("path");
 const fs = require("fs");
 const os = require("os");
-const semiver = require("semiver");
 
 const MIN_NODE_VERSION = "16.7.0";
 const debug =
@@ -21,8 +20,8 @@ function runWrangler() {
 		// Note Volta and nvm are also recommended in the official docs:
 		// https://developers.cloudflare.com/workers/get-started/guide#2-install-the-workers-cli
 		console.error(
-			`Wrangler requires at least Node.js v${MIN_NODE_VERSION}. You are using v${process.versions.node}.
-You should use the latest Node.js version if possible, as Cloudflare Workers use a very up-to-date version of V8.
+			`Wrangler requires at least node.js v${MIN_NODE_VERSION}. You are using v${process.versions.node}. Please update your version of node.js.
+
 Consider using a Node.js version manager such as https://volta.sh/ or https://github.com/nvm-sh/nvm.`
 		);
 		process.exitCode = 1;
@@ -128,10 +127,42 @@ async function main() {
 }
 
 process.on("SIGINT", () => {
-	wranglerProcess?.kill();
+	wranglerProcess && wranglerProcess.kill();
 });
 process.on("SIGTERM", () => {
-	wranglerProcess?.kill();
+	wranglerProcess && wranglerProcess.kill();
 });
+
+// semiver implementation via https://github.com/lukeed/semiver/blob/ae7eebe6053c96be63032b14fb0b68e2553fcac4/src/index.js
+
+/**
+MIT License
+
+Copyright (c) Luke Edwards <luke.edwards05@gmail.com> (lukeed.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+ */
+
+var fn = new Intl.Collator(0, { numeric: 1 }).compare;
+
+function semiver(a, b, bool) {
+	a = a.split(".");
+	b = b.split(".");
+
+	return (
+		fn(a[0], b[0]) ||
+		fn(a[1], b[1]) ||
+		((b[2] = b.slice(2).join(".")),
+		(bool = /[.-]/.test((a[2] = a.slice(2).join(".")))),
+		bool == /[.-]/.test(b[2]) ? fn(a[2], b[2]) : bool ? -1 : 1)
+	);
+}
+
+// end semiver implementation
 
 void main();

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -93,7 +93,6 @@
 		"nanoid": "^3.3.3",
 		"path-to-regexp": "^6.2.0",
 		"selfsigned": "^2.0.1",
-		"semiver": "^1.1.0",
 		"xxhash-wasm": "^1.0.1"
 	},
 	"devDependencies": {

--- a/packages/wrangler/src/__tests__/test-old-node-version.js
+++ b/packages/wrangler/src/__tests__/test-old-node-version.js
@@ -1,0 +1,31 @@
+// this test has to be run with a version of node.js older than 16.7 to pass
+
+const { spawn } = require("child_process");
+const path = require("path");
+
+const assert = require("assert");
+
+const wranglerProcess = spawn(
+	"node",
+	[path.join(__dirname, "../../bin/wrangler.js")],
+	{ stdio: "pipe" }
+);
+
+const messageToMatch = "Wrangler requires at least node.js v16.7.0";
+
+wranglerProcess.once("exit", (code) => {
+	try {
+		const errorMessage = wranglerProcess.stderr.read().toString();
+
+		assert(code === 1, "Expected exit code 1");
+		assert(
+			errorMessage.includes(messageToMatch),
+			`Expected error message to include "${messageToMatch}"`
+		);
+	} catch (err) {
+		console.error("Error:", err);
+		throw new Error(
+			"This test has to be run with a version of node.js under 16.7 to pass"
+		);
+	}
+});


### PR DESCRIPTION
Our entrypoint for wrangler (`bin/wrangler.js`) needs to run in older versions of node and log a message to the user that they need to upgrade their version of node. Sometimes we use synatx in this entrypoint that doesn't run in older versions of node. crashing the script and failing to log the message. This fix adds a test in CI to make sure we don't regress on that behaviour (as well as fixing the current newer syntax usage)

Fixes https://github.com/cloudflare/wrangler2/issues/1443
