### PR TITLE
ci: ensure that the SPARROW_SOURCE_KEY is included in release builds

### DIFF
--- a/.changeset/twenty-spiders-itch.md
+++ b/.changeset/twenty-spiders-itch.md
@@ -1,0 +1,10 @@
+---
+"wrangler": patch
+---
+
+ci: ensure that the SPARROW_SOURCE_KEY is included in release builds
+
+Previously, we were including the key in the "build" step of the release job.
+But this is only there to check that the build doesn't fail.
+The build is re-run inside the publish step, which is part of the "changeset" step.
+Now, we include the key in the "changeset" step to ensure it is there in the build that is published.

--- a/.github/workflows/prereleases.yml
+++ b/.github/workflows/prereleases.yml
@@ -44,7 +44,7 @@ jobs:
         run: npm publish --tag beta
         env:
           NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-          # this is the "test/staging" key for sparrow
+          # this is the "test/staging" key for sparrow analytics
           SPARROW_SOURCE_KEY: "5adf183f94b3436ba78d67f506965998"
         working-directory: packages/wrangler
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,13 +36,10 @@ jobs:
         if: steps.node-modules-cache.outputs.cache-hit != 'true' || runner.os == 'Windows'
         run: npm ci
 
-      - name: Build
+      - name: Check the build
         run: npm run build
-        env:
-          # this is the "production" key for sparrow
-          SPARROW_SOURCE_KEY: "50598e014ed44c739ec8074fdc16057c"
 
-      - name: Check for errors
+      - name: Check for other errors
         run: npm run check
 
       - name: Create Version PR or Publish to NPM
@@ -54,3 +51,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          # This is the "production" key for sparrow analytics.
+          # Include this here because this step will rebuild Wrangler and needs to have this available
+          SPARROW_SOURCE_KEY: "50598e014ed44c739ec8074fdc16057c"


### PR DESCRIPTION
Previously, we were including the key in the "build" step of the release job.
But this is only there to check that the build doesn't fail.
The build is re-run inside the publish step, which is part of the "changeset" step.
Now, we include the key in the "changeset" step to ensure it is there in the build that is published.