### PR TITLE
fix: ensure that metrics user interactions do not break other UI

### DIFF
--- a/.changeset/khaki-tigers-raise.md
+++ b/.changeset/khaki-tigers-raise.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: ensure that metrics user interactions do not break other UI
+
+The new metrics usage capture may interact with the user if they have not yet set their metrics permission.
+Sending metrics was being done concurrently with other commands, so there was a chance that the metrics UI broke the other command's UI.
+Now we ensure that metrics UI will happen synchronously.

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -265,7 +265,7 @@ export async function startDev(args: ArgumentsCamelCase<DevArgs>) {
 			((args.script &&
 				findWranglerToml(path.dirname(args.script))) as ConfigPath);
 		let config = readConfig(configPath, args);
-		metrics.sendMetricsEvent(
+		await metrics.sendMetricsEvent(
 			"run dev",
 			{ local: args.local },
 			{ sendMetrics: config.send_metrics, offline: args.local }

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -501,7 +501,7 @@ function createCLIParser(argv: string[]) {
 				(args.config as ConfigPath) ||
 				(args.script && findWranglerToml(path.dirname(args.script)));
 			const config = readConfig(configPath, args);
-			metrics.sendMetricsEvent("deploy worker script", {
+			await metrics.sendMetricsEvent("deploy worker script", {
 				sendMetrics: config.send_metrics,
 			});
 			const entry = await getEntry(args, config, "publish");
@@ -644,7 +644,7 @@ function createCLIParser(argv: string[]) {
 				await printWranglerBanner();
 			}
 			const config = readConfig(args.config as ConfigPath, args);
-			metrics.sendMetricsEvent("begin log stream", {
+			await metrics.sendMetricsEvent("begin log stream", {
 				sendMetrics: config.send_metrics,
 			});
 
@@ -692,7 +692,7 @@ function createCLIParser(argv: string[]) {
 			onExit(async () => {
 				tail.terminate();
 				await deleteTail();
-				metrics.sendMetricsEvent("end log stream", {
+				await metrics.sendMetricsEvent("end log stream", {
 					sendMetrics: config.send_metrics,
 				});
 			});
@@ -711,7 +711,7 @@ function createCLIParser(argv: string[]) {
 						await setTimeout(100);
 						break;
 					case tail.CLOSED:
-						metrics.sendMetricsEvent("end log stream", {
+						await metrics.sendMetricsEvent("end log stream", {
 							sendMetrics: config.send_metrics,
 						});
 						throw new Error(
@@ -727,7 +727,7 @@ function createCLIParser(argv: string[]) {
 			tail.on("close", async () => {
 				tail.terminate();
 				await deleteTail();
-				metrics.sendMetricsEvent("end log stream", {
+				await metrics.sendMetricsEvent("end log stream", {
 					sendMetrics: config.send_metrics,
 				});
 			});
@@ -960,7 +960,7 @@ function createCLIParser(argv: string[]) {
 
 						try {
 							await submitSecret();
-							metrics.sendMetricsEvent("create encrypted variable", {
+							await metrics.sendMetricsEvent("create encrypted variable", {
 								sendMetrics: config.send_metrics,
 							});
 						} catch (e) {
@@ -1035,7 +1035,7 @@ function createCLIParser(argv: string[]) {
 									: `/accounts/${accountId}/workers/services/${scriptName}/environments/${args.env}/secrets`;
 
 							await fetchResult(`${url}/${args.key}`, { method: "DELETE" });
-							metrics.sendMetricsEvent("delete encrypted variable", {
+							await metrics.sendMetricsEvent("delete encrypted variable", {
 								sendMetrics: config.send_metrics,
 							});
 							logger.log(`✨ Success! Deleted secret ${args.key}`);
@@ -1078,7 +1078,7 @@ function createCLIParser(argv: string[]) {
 								: `/accounts/${accountId}/workers/services/${scriptName}/environments/${args.env}/secrets`;
 
 						logger.log(JSON.stringify(await fetchResult(url), null, "  "));
-						metrics.sendMetricsEvent("list encrypted variables", {
+						await metrics.sendMetricsEvent("list encrypted variables", {
 							sendMetrics: config.send_metrics,
 						});
 					}
@@ -1142,7 +1142,7 @@ function createCLIParser(argv: string[]) {
 
 						logger.log(`🌀 Creating namespace with title "${title}"`);
 						const namespaceId = await createKVNamespace(accountId, title);
-						metrics.sendMetricsEvent("create kv namespace", {
+						await metrics.sendMetricsEvent("create kv namespace", {
 							sendMetrics: config.send_metrics,
 						});
 
@@ -1173,7 +1173,7 @@ function createCLIParser(argv: string[]) {
 						logger.log(
 							JSON.stringify(await listKVNamespaces(accountId), null, "  ")
 						);
-						metrics.sendMetricsEvent("list kv namespaces", {
+						await metrics.sendMetricsEvent("list kv namespaces", {
 							sendMetrics: config.send_metrics,
 						});
 					}
@@ -1221,7 +1221,7 @@ function createCLIParser(argv: string[]) {
 						const accountId = await requireAuth(config);
 
 						await deleteKVNamespace(accountId, id);
-						metrics.sendMetricsEvent("delete kv namespace", {
+						await metrics.sendMetricsEvent("delete kv namespace", {
 							sendMetrics: config.send_metrics,
 						});
 
@@ -1347,7 +1347,7 @@ function createCLIParser(argv: string[]) {
 							expiration_ttl: ttl,
 							metadata: metadata as KeyValue["metadata"],
 						});
-						metrics.sendMetricsEvent("write kv key-value", {
+						await metrics.sendMetricsEvent("write kv key-value", {
 							sendMetrics: config.send_metrics,
 						});
 					}
@@ -1399,7 +1399,7 @@ function createCLIParser(argv: string[]) {
 							prefix
 						);
 						logger.log(JSON.stringify(results, undefined, 2));
-						metrics.sendMetricsEvent("list kv keys", {
+						await metrics.sendMetricsEvent("list kv keys", {
 							sendMetrics: config.send_metrics,
 						});
 					}
@@ -1462,7 +1462,7 @@ function createCLIParser(argv: string[]) {
 						} else {
 							process.stdout.write(bufferKVValue);
 						}
-						metrics.sendMetricsEvent("read kv value", {
+						await metrics.sendMetricsEvent("read kv value", {
 							sendMetrics: config.send_metrics,
 						});
 					}
@@ -1511,7 +1511,7 @@ function createCLIParser(argv: string[]) {
 						const accountId = await requireAuth(config);
 
 						await deleteKVKeyValue(accountId, namespaceId, key);
-						metrics.sendMetricsEvent("delete kv key-value", {
+						await metrics.sendMetricsEvent("delete kv key-value", {
 							sendMetrics: config.send_metrics,
 						});
 					}
@@ -1618,7 +1618,7 @@ function createCLIParser(argv: string[]) {
 
 						const accountId = await requireAuth(config);
 						await putKVBulkKeyValue(accountId, namespaceId, content);
-						metrics.sendMetricsEvent("write kv key-values (bulk)", {
+						await metrics.sendMetricsEvent("write kv key-values (bulk)", {
 							sendMetrics: config.send_metrics,
 						});
 
@@ -1711,7 +1711,7 @@ function createCLIParser(argv: string[]) {
 						const accountId = await requireAuth(config);
 
 						await deleteKVBulkKeyValue(accountId, namespaceId, content);
-						metrics.sendMetricsEvent("delete kv key-values (bulk)", {
+						await metrics.sendMetricsEvent("delete kv key-values (bulk)", {
 							sendMetrics: config.send_metrics,
 						});
 
@@ -1753,7 +1753,7 @@ function createCLIParser(argv: string[]) {
 						logger.log(`Creating bucket ${args.name}.`);
 						await createR2Bucket(accountId, args.name);
 						logger.log(`Created bucket ${args.name}.`);
-						metrics.sendMetricsEvent("create r2 bucket", {
+						await metrics.sendMetricsEvent("create r2 bucket", {
 							sendMetrics: config.send_metrics,
 						});
 					}
@@ -1765,7 +1765,7 @@ function createCLIParser(argv: string[]) {
 					const accountId = await requireAuth(config);
 
 					logger.log(JSON.stringify(await listR2Buckets(accountId), null, 2));
-					metrics.sendMetricsEvent("list r2 buckets", {
+					await metrics.sendMetricsEvent("list r2 buckets", {
 						sendMetrics: config.send_metrics,
 					});
 				});
@@ -1790,7 +1790,7 @@ function createCLIParser(argv: string[]) {
 						logger.log(`Deleting bucket ${args.name}.`);
 						await deleteR2Bucket(accountId, args.name);
 						logger.log(`Deleted bucket ${args.name}.`);
-						metrics.sendMetricsEvent("delete r2 bucket", {
+						await metrics.sendMetricsEvent("delete r2 bucket", {
 							sendMetrics: config.send_metrics,
 						});
 					}
@@ -1862,7 +1862,7 @@ function createCLIParser(argv: string[]) {
 			}
 			await login();
 			const config = readConfig(args.config as ConfigPath, args);
-			metrics.sendMetricsEvent("login user", {
+			await metrics.sendMetricsEvent("login user", {
 				sendMetrics: config.send_metrics,
 			});
 
@@ -1882,7 +1882,7 @@ function createCLIParser(argv: string[]) {
 			await printWranglerBanner();
 			await logout();
 			const config = readConfig(undefined, {});
-			metrics.sendMetricsEvent("logout user", {
+			await metrics.sendMetricsEvent("logout user", {
 				sendMetrics: config.send_metrics,
 			});
 		}
@@ -1897,7 +1897,7 @@ function createCLIParser(argv: string[]) {
 			await printWranglerBanner();
 			await whoami();
 			const config = readConfig(undefined, {});
-			metrics.sendMetricsEvent("view accounts", {
+			await metrics.sendMetricsEvent("view accounts", {
 				sendMetrics: config.send_metrics,
 			});
 		}

--- a/packages/wrangler/src/pages/build.tsx
+++ b/packages/wrangler/src/pages/build.tsx
@@ -121,7 +121,7 @@ export const Handler = async ({
 		buildOutputDirectory,
 		nodeCompat,
 	});
-	metrics.sendMetricsEvent("build pages functions");
+	await metrics.sendMetricsEvent("build pages functions");
 };
 
 export async function buildFunctions({

--- a/packages/wrangler/src/pages/deployments.tsx
+++ b/packages/wrangler/src/pages/deployments.tsx
@@ -98,6 +98,9 @@ export async function ListHandler({
 		account_id: accountId,
 	});
 
-	render(<Table data={data}></Table>, { patchConsole: false });
-	metrics.sendMetricsEvent("list pages projects deployments");
+	const { unmount } = render(<Table data={data}></Table>, {
+		patchConsole: false,
+	});
+	unmount();
+	await metrics.sendMetricsEvent("list pages projects deployments");
 }

--- a/packages/wrangler/src/pages/dev.tsx
+++ b/packages/wrangler/src/pages/dev.tsx
@@ -173,7 +173,7 @@ export const Handler = async ({
 				buildOutputDirectory: directory,
 				nodeCompat,
 			});
-			metrics.sendMetricsEvent("build pages functions");
+			await metrics.sendMetricsEvent("build pages functions");
 		} catch {}
 
 		watch([functionsDirectory], {
@@ -189,7 +189,7 @@ export const Handler = async ({
 				buildOutputDirectory: directory,
 				nodeCompat,
 			});
-			metrics.sendMetricsEvent("build pages functions");
+			await metrics.sendMetricsEvent("build pages functions");
 		});
 
 		miniflareArgs = {
@@ -321,7 +321,7 @@ export const Handler = async ({
 		// `startServer` might throw if user code contains errors
 		const server = await miniflare.startServer();
 		logger.log(`Serving at http://localhost:${port}/`);
-		metrics.sendMetricsEvent("run pages dev");
+		await metrics.sendMetricsEvent("run pages dev");
 
 		if (process.env.BROWSER !== "none") {
 			await openInBrowser(`http://localhost:${port}/`);

--- a/packages/wrangler/src/pages/projects.tsx
+++ b/packages/wrangler/src/pages/projects.tsx
@@ -44,8 +44,11 @@ export async function ListHandler() {
 		account_id: accountId,
 	});
 
-	render(<Table data={data}></Table>, { patchConsole: false });
-	metrics.sendMetricsEvent("list pages projects");
+	const { unmount } = render(<Table data={data}></Table>, {
+		patchConsole: false,
+	});
+	unmount();
+	await metrics.sendMetricsEvent("list pages projects");
 }
 
 export const listProjects = async ({
@@ -156,5 +159,5 @@ export async function CreateHandler({
 	logger.log(
 		`To deploy a folder of assets, run 'wrangler pages publish [directory]'.`
 	);
-	metrics.sendMetricsEvent("create pages project");
+	await metrics.sendMetricsEvent("create pages project");
 }

--- a/packages/wrangler/src/pages/publish.tsx
+++ b/packages/wrangler/src/pages/publish.tsx
@@ -194,7 +194,7 @@ export const Handler = async ({
 				});
 
 				logger.log(`✨ Successfully created the '${projectName}' project.`);
-				metrics.sendMetricsEvent("create pages project");
+				await metrics.sendMetricsEvent("create pages project");
 				break;
 			}
 		}
@@ -334,5 +334,5 @@ export const Handler = async ({
 	logger.log(
 		`✨ Deployment complete! Take a peek over at ${deploymentResponse.url}`
 	);
-	metrics.sendMetricsEvent("deploy pages project");
+	await metrics.sendMetricsEvent("deploy pages project");
 };

--- a/packages/wrangler/src/pubsub/pubsub-commands.tsx
+++ b/packages/wrangler/src/pubsub/pubsub-commands.tsx
@@ -51,7 +51,7 @@ export function pubSubCommands(
 							logger.log(`Creating Pub/SubNamespace ${args.name}...`);
 							await pubsub.createPubSubNamespace(accountId, namespace);
 							logger.log(`Success! Created Pub/Sub Namespace ${args.name}`);
-							metrics.sendMetricsEvent("create pubsub namespace", {
+							await metrics.sendMetricsEvent("create pubsub namespace", {
 								sendMetrics: config.send_metrics,
 							});
 						}
@@ -67,7 +67,7 @@ export function pubSubCommands(
 							const accountId = await requireAuth(config);
 
 							logger.log(await pubsub.listPubSubNamespaces(accountId));
-							metrics.sendMetricsEvent("list pubsub namespaces", {
+							await metrics.sendMetricsEvent("list pubsub namespaces", {
 								sendMetrics: config.send_metrics,
 							});
 						}
@@ -96,7 +96,7 @@ export function pubSubCommands(
 								logger.log(`Deleting namespace ${args.name}...`);
 								await pubsub.deletePubSubNamespace(accountId, args.name);
 								logger.log(`Deleted namespace ${args.name}.`);
-								metrics.sendMetricsEvent("delete pubsub namespace", {
+								await metrics.sendMetricsEvent("delete pubsub namespace", {
 									sendMetrics: config.send_metrics,
 								});
 							}
@@ -121,7 +121,7 @@ export function pubSubCommands(
 							logger.log(
 								await pubsub.describePubSubNamespace(accountId, args.name)
 							);
-							metrics.sendMetricsEvent("view pubsub namespace", {
+							await metrics.sendMetricsEvent("view pubsub namespace", {
 								sendMetrics: config.send_metrics,
 							});
 						}
@@ -191,7 +191,7 @@ export function pubSubCommands(
 					logger.log(
 						await pubsub.createPubSubBroker(accountId, args.namespace, broker)
 					);
-					metrics.sendMetricsEvent("create pubsub broker", {
+					await metrics.sendMetricsEvent("create pubsub broker", {
 						sendMetrics: config.send_metrics,
 					});
 				}
@@ -263,7 +263,7 @@ export function pubSubCommands(
 						)
 					);
 					logger.log(`Successfully updated Pub/Sub Broker ${args.name}`);
-					metrics.sendMetricsEvent("update pubsub broker", {
+					await metrics.sendMetricsEvent("update pubsub broker", {
 						sendMetrics: config.send_metrics,
 					});
 				}
@@ -287,7 +287,7 @@ export function pubSubCommands(
 					const accountId = await requireAuth(config);
 
 					logger.log(await pubsub.listPubSubBrokers(accountId, args.namespace));
-					metrics.sendMetricsEvent("list pubsub brokers", {
+					await metrics.sendMetricsEvent("list pubsub brokers", {
 						sendMetrics: config.send_metrics,
 					});
 				}
@@ -328,7 +328,7 @@ export function pubSubCommands(
 								args.name
 							);
 							logger.log(`Deleted Pub/Sub Broker ${args.name}.`);
-							metrics.sendMetricsEvent("delete pubsub broker", {
+							await metrics.sendMetricsEvent("delete pubsub broker", {
 								sendMetrics: config.send_metrics,
 							});
 						}
@@ -363,7 +363,7 @@ export function pubSubCommands(
 								args.name
 							)
 						);
-						metrics.sendMetricsEvent("view pubsub broker", {
+						await metrics.sendMetricsEvent("view pubsub broker", {
 							sendMetrics: config.send_metrics,
 						});
 					}
@@ -441,7 +441,7 @@ export function pubSubCommands(
 							parsedExpiration
 						)
 					);
-					metrics.sendMetricsEvent("issue pubsub broker credentials", {
+					await metrics.sendMetricsEvent("issue pubsub broker credentials", {
 						sendMetrics: config.send_metrics,
 					});
 				}
@@ -489,7 +489,7 @@ export function pubSubCommands(
 					);
 
 					logger.log(`Revoked ${args.jti.length} credential(s).`);
-					metrics.sendMetricsEvent("revoke pubsub broker credentials", {
+					await metrics.sendMetricsEvent("revoke pubsub broker credentials", {
 						sendMetrics: config.send_metrics,
 					});
 				}
@@ -536,7 +536,7 @@ export function pubSubCommands(
 					);
 
 					logger.log(`Unrevoked ${numTokens} credential(s)`);
-					metrics.sendMetricsEvent("unrevoke pubsub broker credentials", {
+					await metrics.sendMetricsEvent("unrevoke pubsub broker credentials", {
 						sendMetrics: config.send_metrics,
 					});
 				}
@@ -572,9 +572,12 @@ export function pubSubCommands(
 							args.name
 						)
 					);
-					metrics.sendMetricsEvent("list pubsub broker revoked credentials", {
-						sendMetrics: config.send_metrics,
-					});
+					await metrics.sendMetricsEvent(
+						"list pubsub broker revoked credentials",
+						{
+							sendMetrics: config.send_metrics,
+						}
+					);
 				}
 			);
 
@@ -607,7 +610,7 @@ export function pubSubCommands(
 							args.name
 						)
 					);
-					metrics.sendMetricsEvent("list pubsub broker public-keys", {
+					await metrics.sendMetricsEvent("list pubsub broker public-keys", {
 						sendMetrics: config.send_metrics,
 					});
 				}

--- a/packages/wrangler/src/user/user.tsx
+++ b/packages/wrangler/src/user/user.tsx
@@ -1058,7 +1058,8 @@ export function listScopes(message = "💁 Available scopes:"): void {
 		Scope: scope,
 		Description: Scopes[scope],
 	}));
-	render(<Table data={data} />);
+	const { unmount } = render(<Table data={data} />);
+	unmount();
 	// TODO: maybe a good idea to show usage here
 }
 

--- a/packages/wrangler/src/whoami.tsx
+++ b/packages/wrangler/src/whoami.tsx
@@ -8,7 +8,8 @@ import { getAPIToken, getAuthFromEnv } from "./user";
 export async function whoami() {
 	logger.log("Getting User settings...");
 	const user = await getUserInfo();
-	render(<WhoAmI user={user}></WhoAmI>);
+	const { unmount } = render(<WhoAmI user={user}></WhoAmI>);
+	unmount();
 }
 
 export function WhoAmI({ user }: { user: UserInfo | undefined }) {

--- a/packages/wrangler/src/worker-namespace.ts
+++ b/packages/wrangler/src/worker-namespace.ts
@@ -114,7 +114,7 @@ export function workerNamespaceCommands(
 			const config = readConfig(args.config as ConfigPath, args);
 			const accountId = await requireAuth(config);
 			await listWorkerNamespaces(accountId);
-			metrics.sendMetricsEvent("list worker namespaces", {
+			await metrics.sendMetricsEvent("list worker namespaces", {
 				sendMetrics: config.send_metrics,
 			});
 		})
@@ -132,7 +132,7 @@ export function workerNamespaceCommands(
 				const config = readConfig(args.config as ConfigPath, args);
 				const accountId = await requireAuth(config);
 				await getWorkerNamespaceInfo(accountId, args.name);
-				metrics.sendMetricsEvent("view worker namespace", {
+				await metrics.sendMetricsEvent("view worker namespace", {
 					sendMetrics: config.send_metrics,
 				});
 			}
@@ -152,7 +152,7 @@ export function workerNamespaceCommands(
 				const config = readConfig(args.config as ConfigPath, args);
 				const accountId = await requireAuth(config);
 				await createWorkerNamespace(accountId, args.name);
-				metrics.sendMetricsEvent("create worker namespace", {
+				await metrics.sendMetricsEvent("create worker namespace", {
 					sendMetrics: config.send_metrics,
 				});
 			}
@@ -172,7 +172,7 @@ export function workerNamespaceCommands(
 				const config = readConfig(args.config as ConfigPath, args);
 				const accountId = await requireAuth(config);
 				await deleteWorkerNamespace(accountId, args.name);
-				metrics.sendMetricsEvent("delete worker namespace", {
+				await metrics.sendMetricsEvent("delete worker namespace", {
 					sendMetrics: config.send_metrics,
 				});
 			}
@@ -198,7 +198,7 @@ export function workerNamespaceCommands(
 				const config = readConfig(args.config as ConfigPath, args);
 				const accountId = await requireAuth(config);
 				await renameWorkerNamespace(accountId, args.oldName, args.newName);
-				metrics.sendMetricsEvent("rename worker namespace", {
+				await metrics.sendMetricsEvent("rename worker namespace", {
 					sendMetrics: config.send_metrics,
 				});
 			}


### PR DESCRIPTION
The new metrics usage capture may interact with the user if they have not yet set their metrics permission.
Sending metrics was being done concurrently with other commands, so there was a chance that the metrics UI broke the other command's UI.
Now we ensure that metrics UI will happen synchronously.