### PR TITLE
chore: fix "selfsigned" generate type

### DIFF
--- a/packages/wrangler/src/https-options.ts
+++ b/packages/wrangler/src/https-options.ts
@@ -70,11 +70,7 @@ function hasCertificateExpired(keyPath: string, certPath: string): boolean {
 async function generateCertificate() {
 	// `selfsigned` imports `node-forge`, which is a pretty big library.
 	// To reduce startup time, only load this dynamically when needed.
-	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-	const generate: typeof import("selfsigned").generate = promisify(
-		// eslint-disable-next-line @typescript-eslint/no-var-requires
-		require("selfsigned").generate
-	);
+	const generate = promisify((await import("selfsigned")).generate);
 
 	const certAttrs: Attributes = [{ name: "commonName", value: "localhost" }];
 


### PR DESCRIPTION
Previously the type was being assigned by `typeof` the import, then assigned `promisify` version of `required("selfsigned").generate()` which was awaited later down the function and did not have a promise 
signature causing TS to complain about an unnecessary `await`.