### PR TITLE
fix: enable debugger in local mode

### DIFF
--- a/.changeset/giant-roses-tan.md
+++ b/.changeset/giant-roses-tan.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: enable debugger in local mode
+
+During a refactor, we missed enabling the inspector by default in local mode. We also broke the logic that detects the inspector url exposed by the local server. This patch passes the argument correctly, fixes the detection logic. Further, it also lets you disable the inspector altogether with `--inspect false`, if required (for both remote and local mode).
+
+Fixes https://github.com/cloudflare/wrangler2/issues/1436

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -1049,6 +1049,50 @@ describe("wrangler dev", () => {
 			        }
 		      `);
 		});
+
+		it("should default to true, without a warning", async () => {
+			fs.writeFileSync("index.js", `export default {};`);
+			await runWrangler("dev index.js");
+			expect((Dev as jest.Mock).mock.calls[0][0].inspect).toEqual(true);
+			expect(std).toMatchInlineSnapshot(`
+			Object {
+			  "debug": "",
+			  "err": "",
+			  "out": "",
+			  "warn": "",
+			}
+		`);
+		});
+
+		it("should pass true, with a warning", async () => {
+			fs.writeFileSync("index.js", `export default {};`);
+			await runWrangler("dev index.js --inspect");
+			expect((Dev as jest.Mock).mock.calls[0][0].inspect).toEqual(true);
+			expect(std).toMatchInlineSnapshot(`
+			Object {
+			  "debug": "",
+			  "err": "",
+			  "out": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mPassing --inspect is unnecessary, now you can always connect to devtools.[0m
+
+			",
+			}
+		`);
+		});
+
+		it("should pass false, without a warning", async () => {
+			fs.writeFileSync("index.js", `export default {};`);
+			await runWrangler("dev index.js --inspect false");
+			expect((Dev as jest.Mock).mock.calls[0][0].inspect).toEqual(false);
+			expect(std).toMatchInlineSnapshot(`
+			Object {
+			  "debug": "",
+			  "err": "",
+			  "out": "",
+			  "warn": "",
+			}
+		`);
+		});
 	});
 
 	describe("service bindings", () => {

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -506,7 +506,7 @@ export async function startDev(args: ArgumentsCamelCase<DevArgs>) {
 					crons={config.triggers.crons}
 					logLevel={args.logLevel}
 					onReady={args.onReady}
-					inspect={args.inspect}
+					inspect={args.inspect ?? true}
 					showInteractiveDevSession={args.showInteractiveDevSession}
 				/>
 			);

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -31,7 +31,7 @@ interface LocalProps {
 	crons: Config["triggers"]["crons"];
 	localProtocol: "http" | "https";
 	localUpstream: string | undefined;
-	inspect: boolean | undefined;
+	inspect: boolean;
 	onReady: (() => void) | undefined;
 	logLevel: "none" | "error" | "log" | "warn" | "debug" | undefined;
 }
@@ -256,6 +256,7 @@ function useLocalWorker({
 				{
 					cwd: path.dirname(scriptPath),
 					execArgv: nodeOptions,
+					stdio: "pipe",
 				}
 			));
 			child.on("message", (message) => {

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -42,6 +42,7 @@ export function Remote(props: {
 	port: number;
 	ip: string;
 	localProtocol: "https" | "http";
+	inspect: boolean;
 	inspectorPort: number;
 	accountId: string | undefined;
 	bindings: CfWorkerInit["bindings"];
@@ -91,7 +92,10 @@ export function Remote(props: {
 	});
 
 	useInspector({
-		inspectorUrl: previewToken ? previewToken.inspectorUrl.href : undefined,
+		inspectorUrl:
+			props.inspect && previewToken
+				? previewToken.inspectorUrl.href
+				: undefined,
 		port: props.inspectorPort,
 		logToTerminal: true,
 	});


### PR DESCRIPTION
During a refactor, we missed enabling the inspector by default in local mode. We also broke the logic that detects the inspector url exposed by the local server. This patch passes the argument correctly, fixes the detection logic. Further, it also lets you disable the inspector altogether with `--inspect false`, if required (for both remote and local mode).

Fixes https://github.com/cloudflare/wrangler2/issues/1436