### PR TITLE
refactor: break fetchInternal out

### DIFF
--- a/packages/wrangler/src/__tests__/jest.setup.ts
+++ b/packages/wrangler/src/__tests__/jest.setup.ts
@@ -1,11 +1,16 @@
 import fetchMock from "jest-fetch-mock";
 import {
 	fetchInternal,
+	fetchInternalResponse,
 	fetchKVGetValue,
 	getCloudflareAPIBaseURL,
 } from "../cfetch/internal";
 import { confirm, prompt } from "../dialogs";
-import { mockFetchInternal, mockFetchKVGetValue } from "./helpers/mock-cfetch";
+import {
+	mockFetchInternal,
+	mockFetchInternalResponse,
+	mockFetchKVGetValue,
+} from "./helpers/mock-cfetch";
 import { MockWebSocket } from "./helpers/mock-web-socket";
 
 // Mock out getPort since we don't actually care about what ports are open in unit tests.
@@ -39,6 +44,9 @@ jest.mock("../package-manager");
 
 jest.mock("../cfetch/internal");
 (fetchInternal as jest.Mock).mockImplementation(mockFetchInternal);
+(fetchInternalResponse as jest.Mock).mockImplementation(
+	mockFetchInternalResponse
+);
 (fetchKVGetValue as jest.Mock).mockImplementation(mockFetchKVGetValue);
 (getCloudflareAPIBaseURL as jest.Mock).mockReturnValue(
 	"https://api.cloudflare.com/client/v4"

--- a/packages/wrangler/src/cfetch/index.ts
+++ b/packages/wrangler/src/cfetch/index.ts
@@ -1,7 +1,11 @@
 import { URLSearchParams } from "node:url";
 import { ParseError } from "../parse";
-import { fetchInternal } from "./internal";
-import type { RequestInit } from "undici";
+import {
+	fetchInternal,
+	fetchInternalResponse,
+	handleResponseAsJSON,
+} from "./internal";
+import type { RequestInit, Response } from "undici";
 
 // Check out https://api.cloudflare.com/ for API docs.
 
@@ -45,6 +49,31 @@ export async function fetchResult<ResponseType>(
 }
 
 /**
+ * Like fetchResult, but for cases where you want to handle the response body yourself.
+ */
+export async function fetchRawResult<ResponseType>(
+	resource: string,
+	init: RequestInit = {},
+	queryParams?: URLSearchParams,
+	abortSignal?: AbortSignal
+): Promise<Response> {
+	const response = await fetchInternalResponse(
+		resource,
+		init,
+		queryParams,
+		abortSignal
+	);
+	if (!response.ok) {
+		const json = await handleResponseAsJSON<FetchResult<ResponseType>>(
+			resource,
+			init,
+			response
+		);
+		throwFetchError(resource, json);
+	}
+	return response;
+}
+/**
  * Make a fetch request for a list of values,
  * extracting the `result` from the JSON response,
  * and repeating the request if the results are paginated.
@@ -81,7 +110,7 @@ export async function fetchListResult<ResponseType>(
 	return results;
 }
 
-function throwFetchError(
+export function throwFetchError(
 	resource: string,
 	response: FetchResult<unknown>
 ): never {


### PR DESCRIPTION
Fetch internal function was bothing making the fetch then handling the unwrapping as JSON.
Certain features will need access to the raw response, this disconnects the unpacking and internal fetching from
each other.