### PR TITLE
fix: no feedback on `wrangler kv:namespace delete`

### DIFF
--- a/.changeset/lucky-poems-smile.md
+++ b/.changeset/lucky-poems-smile.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: no feedback on `wrangler kv:namespace delete`

--- a/packages/wrangler/src/__tests__/kv.test.ts
+++ b/packages/wrangler/src/__tests__/kv.test.ts
@@ -299,7 +299,10 @@ describe("wrangler", () => {
 					"kv:namespace delete --binding someBinding --env some-environment --preview false"
 				);
 
-				expect(std.out).toMatchInlineSnapshot(`""`);
+				expect(std.out).toMatchInlineSnapshot(`
+					"Deleting KV namespace env-bound-id.
+					Deleted KV namespace env-bound-id."
+				`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(requests.count).toEqual(1);
 			});

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -1220,7 +1220,9 @@ function createCLIParser(argv: string[]) {
 
 						const accountId = await requireAuth(config);
 
+						logger.log(`Deleting KV namespace ${id}.`);
 						await deleteKVNamespace(accountId, id);
+						logger.log(`Deleted KV namespace ${id}.`);
 						await metrics.sendMetricsEvent("delete kv namespace", {
 							sendMetrics: config.send_metrics,
 						});


### PR DESCRIPTION
Fixes https://github.com/cloudflare/wrangler2/issues/1494

Implemented feedback similar to `wrangler r2 bucket create`