### PR TITLE
chore: don't kill `npm run dev` if any subtask fails

### DIFF
--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -53,7 +53,7 @@
 		"bundle": "node -r esbuild-register scripts/bundle.ts",
 		"check:type": "tsc",
 		"clean": "rm -rf wrangler-dist miniflare-dist emitted-types",
-		"dev": "npm run clean && concurrently -c black,blue 'npm run bundle -- --watch' 'npm run check:type -- --watch --preserveWatchOutput'",
+		"dev": "npm run clean && concurrently -c black,blue --kill-others-on-fail false 'npm run bundle -- --watch' 'npm run check:type -- --watch --preserveWatchOutput'",
 		"emit-types": "tsc -p tsconfig.emit.json && node -r esbuild-register scripts/emit-types.ts",
 		"prepublishOnly": "SOURCEMAPS=false npm run build",
 		"start": "npm run bundle && NODE_OPTIONS=--enable-source-maps ./bin/wrangler.js",


### PR DESCRIPTION
We use `npm run dev` inside `packages/wrangler` to continuously build wrangler on any code change. This is useful when we're testing wrangler in any of the fixtures. However, it ends whenever we make a type error, which is common when experimenting, and interrupts the flow. It's better instead to log the error and carry on building as usual. This fix adds the flag to the concurrently task runner that enables this behaviour.