### PR TITLE
polish: don't log an error message if wrangler dev startup is interrupted

### DIFF
--- a/.changeset/shy-tips-decide.md
+++ b/.changeset/shy-tips-decide.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+polish: don't log an error message if wrangler dev startup is interrupted.
+
+When we quit wrangler dev, any inflight requests are cancelled. Any error handlers for those requests are ignored if the request was cancelled purposely. The check for this was missing for the prewarm request for a dev session, and this patch adds it so it dorsn't get logged to the terminal.

--- a/packages/wrangler/src/create-worker-preview.ts
+++ b/packages/wrangler/src/create-worker-preview.ts
@@ -247,7 +247,9 @@ export async function createWorkerPreview(
 			}
 		},
 		(err) => {
-			logger.warn("worker failed to prewarm: ", err);
+			if ((err as { code: string }).code !== "ABORT_ERR") {
+				logger.warn("worker failed to prewarm: ", err);
+			}
 		}
 	);
 


### PR DESCRIPTION
When we quit wrangler dev, any inflight requests are cancelled. Any error handlers for those requests are ignored if the request was cancelled purposely. The check for this was missing for the prewarm request for a dev session, and this patch adds it so it dorsn't get logged to the terminal.