### PR TITLE
fix: don't log version spam in tests

### DIFF
--- a/.changeset/cuddly-rocks-pump.md
+++ b/.changeset/cuddly-rocks-pump.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: don't log version spam in tests
+
+Currently in tests, we see a bunch of logspam from yargs about "version" being a reserved word, this patch removes that spam.

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -1916,6 +1916,9 @@ function createCLIParser(argv: string[]) {
 		}
 	);
 
+	// This set to false to allow overwrite of default behaviour
+	wrangler.version(false);
+
 	// version
 	wrangler.command(
 		"version",
@@ -1935,9 +1938,6 @@ function createCLIParser(argv: string[]) {
 		alias: "version",
 		type: "boolean",
 	});
-
-	// This set to false to allow overwrite of default behaviour
-	wrangler.version(false);
 
 	wrangler.option("config", {
 		alias: "c",


### PR DESCRIPTION
Currently in tests, we see a bunch of logspam from yargs about "version" being a reserved word, this patch removes that spam.