### PR TITLE
chore: disable caching node_modules in github actions

### DIFF
--- a/.github/workflows/create-pullrequest-prerelease.yml
+++ b/.github/workflows/create-pullrequest-prerelease.yml
@@ -20,16 +20,7 @@ jobs:
           node-version: 16.7
           cache: "npm" # cache ~/.npm in case 'npm ci' needs to run
 
-      - uses: actions/cache@v3
-        id: node-modules-cache
-        with:
-          path: |
-            node_modules
-            */*/node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-
       - name: Install NPM Dependencies
-        if: steps.node-modules-cache.outputs.cache-hit != 'true' || runner.os == 'Windows'
         run: npm ci
 
       - name: Modify package.json version

--- a/.github/workflows/d1.yml
+++ b/.github/workflows/d1.yml
@@ -22,18 +22,7 @@ jobs:
           node-version: 16.7
           cache: "npm" # cache ~/.npm in case 'npm ci' needs to run
 
-      - uses: actions/cache@v3
-        id: node-modules-cache
-        with:
-          path: |
-            node_modules
-            */*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
       - name: Install NPM Dependencies
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Build

--- a/.github/workflows/experimental-wasm-release.yml
+++ b/.github/workflows/experimental-wasm-release.yml
@@ -21,16 +21,6 @@ jobs:
           node-version: 16.7
           cache: "npm" # cache ~/.npm in case 'npm ci' needs to run
 
-      - uses: actions/cache@v3
-        id: node-modules-cache
-        with:
-          path: |
-            node_modules
-            */*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
       - name: Install NPM Dependencies
         run: npm ci
 

--- a/.github/workflows/prereleases.yml
+++ b/.github/workflows/prereleases.yml
@@ -22,16 +22,7 @@ jobs:
           node-version: 16.7
           cache: "npm" # cache ~/.npm in case 'npm ci' needs to run
 
-      - uses: actions/cache@v3
-        id: node-modules-cache
-        with:
-          path: |
-            node_modules
-            */*/node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-
       - name: Install NPM Dependencies
-        if: steps.node-modules-cache.outputs.cache-hit != 'true' || runner.os == 'Windows'
         run: npm ci
 
       - name: Modify package.json version
@@ -70,16 +61,7 @@ jobs:
           node-version: 16.7
           cache: "npm" # cache ~/.npm in case 'npm ci' needs to run
 
-      - uses: actions/cache@v3
-        id: node-modules-cache
-        with:
-          path: |
-            node_modules
-            */*/node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-
       - name: Install NPM Dependencies
-        if: steps.node-modules-cache.outputs.cache-hit != 'true' || runner.os == 'Windows'
         run: npm ci
 
       - name: Build wrangler

--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -29,18 +29,7 @@ jobs:
             tsconfig.tsbuildinfo
           key: ${{ matrix.os }}-eslint-tsbuildinfo-${{ hashFiles('**/*.ts','**/*.js', 'package.json', 'tsconfig.json') }}
 
-      - uses: actions/cache@v3
-        id: node-modules-cache
-        with:
-          path: |
-            node_modules
-            */*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
       - name: Install NPM Dependencies
-        if: steps.node-modules-cache.outputs.cache-hit != 'true' || runner.os == 'Windows'
         run: npm ci
 
       - name: Check for errors
@@ -64,25 +53,7 @@ jobs:
           node-version: 16.7
           cache: "npm" # cache ~/.npm in case 'npm ci' needs to run
 
-      - name: Restore Wrangler 1 from Cache
-        uses: actions/cache@v3
-        id: wrangler-1-cache
-        with:
-          path: packages/wranglerjs-compat-webpack-plugin/src/__tests__/helpers/.wrangler-1-cache
-          key: ${{ matrix.os }}-wrangler-1-cache
-
-      - uses: actions/cache@v3
-        id: node-modules-cache
-        with:
-          path: |
-            node_modules
-            */*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
       - name: Install NPM Dependencies
-        if: steps.node-modules-cache.outputs.cache-hit != 'true' || runner.os == 'Windows'
         run: npm ci
 
       - name: Run builds

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,18 +22,7 @@ jobs:
           node-version: 16.7
           cache: "npm" # cache ~/.npm in case 'npm ci' needs to run
 
-      - uses: actions/cache@v3
-        id: node-modules-cache
-        with:
-          path: |
-            node_modules
-            */*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
       - name: Install NPM Dependencies
-        if: steps.node-modules-cache.outputs.cache-hit != 'true' || runner.os == 'Windows'
         run: npm ci
 
       - name: Check the build


### PR DESCRIPTION
We shouldn't restore an older cache if we don't find a matching one (for node_modules in github actions). We're also having issues with caches in general. Disabling all node_modules caching til lwe figure out a proper solution.