### PR TITLE
feat: `config.first_party_worker` + dev facade

### DIFF
--- a/.changeset/sixty-pots-heal.md
+++ b/.changeset/sixty-pots-heal.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+feat: `config.first_party_worker` + dev facade
+
+This introduces configuration for marking a worker as a "first party" worker, to be used inside cloudflare to develop workers. It also adds a facade that's applied for first party workers in dev.

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -68,6 +68,7 @@ describe("normalizeAndValidateConfig()", () => {
 			no_bundle: undefined,
 			minify: undefined,
 			node_compat: undefined,
+			first_party_worker: undefined,
 		});
 		expect(diagnostics.hasErrors()).toBe(false);
 		expect(diagnostics.hasWarnings()).toBe(false);
@@ -914,6 +915,7 @@ describe("normalizeAndValidateConfig()", () => {
 				no_bundle: true,
 				minify: true,
 				node_compat: true,
+				first_party_worker: true,
 			};
 
 			const { config, diagnostics } = normalizeAndValidateConfig(
@@ -987,6 +989,7 @@ describe("normalizeAndValidateConfig()", () => {
 				no_bundle: "INVALID",
 				minify: "INVALID",
 				node_compat: "INVALID",
+				first_party_worker: "INVALID",
 			} as unknown as RawEnvironment;
 
 			const { config, diagnostics } = normalizeAndValidateConfig(
@@ -1053,7 +1056,8 @@ describe("normalizeAndValidateConfig()", () => {
 			  - The field \\"define.DEF1\\" should be a string but got 1777.
 			  - Expected \\"no_bundle\\" to be of type boolean but got \\"INVALID\\".
 			  - Expected \\"minify\\" to be of type boolean but got \\"INVALID\\".
-			  - Expected \\"node_compat\\" to be of type boolean but got \\"INVALID\\"."
+			  - Expected \\"node_compat\\" to be of type boolean but got \\"INVALID\\".
+			  - Expected \\"first_party_worker\\" to be of type boolean but got \\"INVALID\\"."
 		`);
 		});
 
@@ -2367,6 +2371,7 @@ describe("normalizeAndValidateConfig()", () => {
 				no_bundle: true,
 				minify: true,
 				node_compat: true,
+				first_party_worker: true,
 			};
 
 			const { config, diagnostics } = normalizeAndValidateConfig(
@@ -2410,6 +2415,7 @@ describe("normalizeAndValidateConfig()", () => {
 				no_bundle: false,
 				minify: false,
 				node_compat: false,
+				first_party_worker: false,
 			};
 			const rawConfig: RawConfig = {
 				name: "mock-name",
@@ -2432,6 +2438,7 @@ describe("normalizeAndValidateConfig()", () => {
 				no_bundle: true,
 				minify: true,
 				node_compat: true,
+				first_party_worker: true,
 				env: {
 					ENV1: rawEnv,
 				},
@@ -2693,6 +2700,7 @@ describe("normalizeAndValidateConfig()", () => {
 				no_bundle: "INVALID",
 				minify: "INVALID",
 				node_compat: "INVALID",
+				first_party_worker: "INVALID",
 			} as unknown as RawEnvironment;
 
 			const { config, diagnostics } = normalizeAndValidateConfig(
@@ -2728,7 +2736,8 @@ describe("normalizeAndValidateConfig()", () => {
 			    - Expected \\"usage_model\\" field to be one of [\\"bundled\\",\\"unbound\\"] but got \\"INVALID\\".
 			    - Expected \\"no_bundle\\" to be of type boolean but got \\"INVALID\\".
 			    - Expected \\"minify\\" to be of type boolean but got \\"INVALID\\".
-			    - Expected \\"node_compat\\" to be of type boolean but got \\"INVALID\\"."
+			    - Expected \\"node_compat\\" to be of type boolean but got \\"INVALID\\".
+			    - Expected \\"first_party_worker\\" to be of type boolean but got \\"INVALID\\"."
 		`);
 		});
 

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -55,9 +55,18 @@ describe("publish", () => {
 	describe("output additional script information", () => {
 		mockApiToken();
 
-		it("should print worker information at log level", async () => {
+		it("for first party workers, it should print worker information at log level", async () => {
 			setIsTTY(false);
-			writeWranglerToml();
+			fs.writeFileSync(
+				"./wrangler.toml",
+				TOML.stringify({
+					compatibility_date: "2022-01-12",
+					name: "test-name",
+					first_party_worker: true,
+				}),
+
+				"utf-8"
+			);
 			writeWorkerSource();
 			mockSubDomainRequest();
 			mockUploadWorkerRequest({ expectedType: "esm", sendScriptIds: true });

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -218,6 +218,11 @@ interface EnvironmentInheritable {
 	}[];
 
 	/**
+	 *	Designates this worker as an internal-only "first-party" worker.
+	 */
+	first_party_worker: boolean | undefined;
+
+	/**
 	 * TODO: remove this as it has been deprecated.
 	 *
 	 * This is just here for now because the `route` commands use it.

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -1125,6 +1125,14 @@ function normalizeAndValidateEnvironment(
 			isBoolean,
 			undefined
 		),
+		first_party_worker: inheritable(
+			diagnostics,
+			topLevelEnv,
+			rawEnv,
+			"first_party_worker",
+			isBoolean,
+			undefined
+		),
 	};
 
 	return environment;

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -507,6 +507,7 @@ export async function startDev(args: StartDevOptions) {
 					showInteractiveDevSession={args.showInteractiveDevSession}
 					forceLocal={args.forceLocal}
 					enablePagesAssetsServiceBinding={args.enablePagesAssetsServiceBinding}
+					firstPartyWorker={config.first_party_worker}
 				/>
 			);
 		}

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -156,6 +156,7 @@ export type DevProps = {
 	showInteractiveDevSession: boolean | undefined;
 	forceLocal: boolean | undefined;
 	enablePagesAssetsServiceBinding?: EnablePagesAssetsServiceBindingOptions;
+	firstPartyWorker: boolean | undefined;
 };
 
 export function DevImplementation(props: DevProps): JSX.Element {
@@ -246,6 +247,7 @@ function DevSession(props: DevSessionProps) {
 		assets: props.assetsConfig,
 		workerDefinitions,
 		services: props.bindings.services,
+		firstPartyWorkerDevFacade: props.firstPartyWorker,
 	});
 
 	return props.local ? (

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -34,6 +34,7 @@ export function useEsbuild({
 	noBundle,
 	workerDefinitions,
 	services,
+	firstPartyWorkerDevFacade,
 }: {
 	entry: Entry;
 	destination: string | undefined;
@@ -49,6 +50,7 @@ export function useEsbuild({
 	nodeCompat: boolean | undefined;
 	noBundle: boolean;
 	workerDefinitions: WorkerRegistry;
+	firstPartyWorkerDevFacade: boolean | undefined;
 }): EsbuildBundle | undefined {
 	const [bundle, setBundle] = useState<EsbuildBundle>();
 	const { exit } = useApp();
@@ -111,6 +113,7 @@ export function useEsbuild({
 						},
 						workerDefinitions,
 						services,
+						firstPartyWorkerDevFacade,
 				  });
 
 			// Capture the `stop()` method to use as the `useEffect()` destructor.
@@ -166,6 +169,7 @@ export function useEsbuild({
 		assets,
 		services,
 		workerDefinitions,
+		firstPartyWorkerDevFacade,
 	]);
 	return bundle;
 }

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -393,6 +393,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 						// because we don't want to apply the dev-time
 						// facades on top of it
 						workerDefinitions: undefined,
+						firstPartyWorkerDevFacade: false,
 					}
 			  );
 
@@ -505,13 +506,15 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 
 			available_on_subdomain = result.available_on_subdomain;
 
-			// Print some useful information returned after publishing
-			// Not all fields will be populated for every worker
-			// These fields are likely to be scraped by tools, so do not rename
-			if (result.id) logger.log("Worker ID: ", result.id);
-			if (result.etag) logger.log("Worker ETag: ", result.etag);
-			if (result.pipeline_hash)
-				logger.log("Worker PipelineHash: ", result.pipeline_hash);
+			if (config.first_party_worker) {
+				// Print some useful information returned after publishing
+				// Not all fields will be populated for every worker
+				// These fields are likely to be scraped by tools, so do not rename
+				if (result.id) logger.log("Worker ID: ", result.id);
+				if (result.etag) logger.log("Worker ETag: ", result.etag);
+				if (result.pipeline_hash)
+					logger.log("Worker PipelineHash: ", result.pipeline_hash);
+			}
 		}
 	} finally {
 		if (typeof destination !== "string") {

--- a/packages/wrangler/templates/first-party-worker-module-facade.ts
+++ b/packages/wrangler/templates/first-party-worker-module-facade.ts
@@ -1,0 +1,18 @@
+// @ts-ignore entry point will get replaced
+import worker from "__ENTRY_POINT__";
+// @ts-ignore entry point will get replaced
+export * from "__ENTRY_POINT__";
+
+type Env = {
+	// TODO: type this
+};
+
+/**
+ * Setup globals/vars as required
+ */
+
+export default {
+	async fetch(request: Request, env: Env, ctx: ExecutionContext) {
+		return worker.fetch(request, env, ctx);
+	},
+};


### PR DESCRIPTION
This introduces configuration for marking a worker as a "first party" worker, to be used inside cloudflare to develop workers. It also adds a facade that's applied for first party workers in dev.