### PR TITLE
fix: prevent local mode restart

### DIFF
--- a/.changeset/good-clouds-help.md
+++ b/.changeset/good-clouds-help.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: prevent local mode restart
+
+In dev, we inject a patch for `fetch()` to detect bad usages. This patch is copied into the destination directory before it's used. esbuild appears to have a bug where it thinks a dependency has changed so it restarts once in local mode. The fix here is to copy the file to inject into a separate temporary dir.
+
+Fixes https://github.com/cloudflare/wrangler2/issues/1515

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 import * as fs from "node:fs";
 import { builtinModules } from "node:module";
+import * as os from "node:os";
 import * as path from "node:path";
 import NodeGlobalsPolyfills from "@esbuild-plugins/node-globals-polyfill";
 import NodeModulesPolyfills from "@esbuild-plugins/node-modules-polyfill";
@@ -97,14 +98,15 @@ export async function bundleWorker(
 	// `checked-fetch.js` to do so. However, with yarn 3 style pnp,
 	// we need to extract that file to an accessible place before injecting
 	// it in, hence this code here.
+	const osTempDir = os.tmpdir();
 	const checkedFetchFileToInject = path.join(
-		destination,
+		osTempDir,
 		"--temp-wrangler-files--",
 		"checked-fetch.js"
 	);
 
-	if (checkFetch) {
-		fs.mkdirSync(path.join(destination, "--temp-wrangler-files--"), {
+	if (checkFetch && !fs.existsSync(checkedFetchFileToInject)) {
+		fs.mkdirSync(path.join(osTempDir, "--temp-wrangler-files--"), {
 			recursive: true,
 		});
 		fs.writeFileSync(


### PR DESCRIPTION
In dev, we inject a patch for `fetch()` to detect bad usages. This patch is copied into the destination directory before it's used. esbuild appears to have a bug where it thinks a dependency has changed so it restarts once in local mode. The fix here is to copy the file to inject into a separate temporary dir.

Fixes https://github.com/cloudflare/wrangler2/issues/1515