### PR TITLE
'--experimental-enable-local-persistence' for 'wrangler pages dev'

### DIFF
--- a/.changeset/thick-pens-cheat.md
+++ b/.changeset/thick-pens-cheat.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+feat: Adds the `--experimental-enable-local-persistence` option to `wrangler pages dev`
+
+Previously, this was implicitly enabled and stored things in a `.mf` directory. Now we move to be in line with what `wrangler dev` does, defaults disabled, and stores in a `wrangler-local-state` directory.

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -532,7 +532,7 @@ export async function startDev(args: StartDevOptions) {
 					localProtocol={args.localProtocol || config.dev.local_protocol}
 					localUpstream={args["local-upstream"] || host}
 					enableLocalPersistence={
-						args["experimental-enable-local-persistence"] || false
+						args.experimentalEnableLocalPersistence || false
 					}
 					liveReload={args.liveReload || false}
 					accountId={config.account_id || getAccountFromCache()?.id}

--- a/packages/wrangler/src/pages/dev.tsx
+++ b/packages/wrangler/src/pages/dev.tsx
@@ -24,6 +24,7 @@ type PagesDevArgs = {
 	do?: (string | number)[];
 	"live-reload": boolean;
 	"local-protocol"?: "https" | "http";
+	"experimental-enable-local-persistence": boolean;
 	"node-compat": boolean;
 };
 
@@ -84,6 +85,11 @@ export function Options(yargs: Argv): Argv<PagesDevArgs> {
 				describe: "Protocol to listen to requests on, defaults to http.",
 				choices: ["http", "https"] as const,
 			},
+			"experimental-enable-local-persistence": {
+				type: "boolean",
+				default: false,
+				describe: "Enable persistence for this session (only for local mode)",
+			},
 			"node-compat": {
 				describe: "Enable node.js compatibility",
 				default: false,
@@ -110,6 +116,7 @@ export const Handler = async ({
 	do: durableObjects = [],
 	"live-reload": liveReload,
 	"local-protocol": localProtocol,
+	"experimental-enable-local-persistence": experimentalEnableLocalPersistence,
 	"node-compat": nodeCompat,
 	config: config,
 	_: [_pages, _dev, ...remaining],
@@ -238,6 +245,7 @@ export const Handler = async ({
 				directory,
 			},
 			forceLocal: true,
+			experimentalEnableLocalPersistence,
 			showInteractiveDevSession: undefined,
 			inspect: true,
 			logLevel: "error",


### PR DESCRIPTION
feat: Adds the `--experimental-enable-local-persistence` option to `wrangler pages dev`

Previously, this was implicitly enabled and stored things in a `.mf` directory. Now we move to be in line with what `wrangler dev` does, defaults disabled, and stores in a `wrangler-local-state` directory.
