### PR TITLE
feat: support source maps in wrangler dev remote mode

### DIFF
--- a/.changeset/young-buckets-provide.md
+++ b/.changeset/young-buckets-provide.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+feat: source maps support in `wrangler dev` remote mode
+
+Previously stack traces from runtime errors in `wrangler dev` remote mode, would give unhelpful stack traces from the bundled build that was sent to the server. Here, we use source maps generated as part of bundling to provide better stack traces for errors, referencing the unbundled files.
+
+Resolves https://github.com/cloudflare/wrangler2/issues/1509

--- a/package-lock.json
+++ b/package-lock.json
@@ -17968,8 +17968,9 @@
 			"dev": true
 		},
 		"node_modules/source-map": {
-			"version": "0.7.3",
-			"license": "BSD-3-Clause",
+			"version": "0.7.4",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+			"integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
 			"engines": {
 				"node": ">= 8"
 			}
@@ -20684,6 +20685,7 @@
 				"nanoid": "^3.3.3",
 				"path-to-regexp": "^6.2.0",
 				"selfsigned": "^2.0.1",
+				"source-map": "^0.7.4",
 				"xxhash-wasm": "^1.0.1"
 			},
 			"bin": {
@@ -33511,7 +33513,9 @@
 			"dev": true
 		},
 		"source-map": {
-			"version": "0.7.3"
+			"version": "0.7.4",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+			"integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA=="
 		},
 		"source-map-resolve": {
 			"version": "0.5.3",
@@ -35360,6 +35364,7 @@
 				"selfsigned": "^2.0.1",
 				"serve-static": "^1.15.0",
 				"signal-exit": "^3.0.7",
+				"source-map": "^0.7.4",
 				"supports-color": "^9.2.2",
 				"timeago.js": "^4.0.2",
 				"tmp-promise": "^3.0.3",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -101,6 +101,7 @@
 		"nanoid": "^3.3.3",
 		"path-to-regexp": "^6.2.0",
 		"selfsigned": "^2.0.1",
+		"source-map": "^0.7.4",
 		"xxhash-wasm": "^1.0.1"
 	},
 	"devDependencies": {

--- a/packages/wrangler/scripts/deps.ts
+++ b/packages/wrangler/scripts/deps.ts
@@ -13,6 +13,7 @@ export const EXTERNAL_DEPENDENCIES = [
 	"@miniflare/core",
 	// todo - bundle miniflare too
 	"selfsigned",
+	"source-map",
 	"@esbuild-plugins/node-globals-polyfill",
 	"@esbuild-plugins/node-modules-polyfill",
 	"chokidar",

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -16,6 +16,7 @@ type BundleResult = {
 	resolvedEntryPointPath: string;
 	bundleType: "esm" | "commonjs";
 	stop: (() => void) | undefined;
+	sourceMapPath: string | undefined;
 };
 
 /**
@@ -179,6 +180,10 @@ export async function bundleWorker(
 	const entryPointExports = entryPointOutputs[0][1].exports;
 	const bundleType = entryPointExports.length > 0 ? "esm" : "commonjs";
 
+	const sourceMapPath = Object.keys(result.metafile.outputs).filter((_path) =>
+		_path.includes(".map")
+	)[0];
+
 	return {
 		modules: moduleCollector.modules,
 		resolvedEntryPointPath: path.resolve(
@@ -187,6 +192,7 @@ export async function bundleWorker(
 		),
 		bundleType,
 		stop: result.stop,
+		sourceMapPath,
 	};
 }
 

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -128,6 +128,8 @@ export async function bundleWorker(
 		format: entry.format === "modules" ? "esm" : "iife",
 		target: "es2020",
 		sourcemap: true,
+		// The root included, as the sources are relative paths to tmpDir
+		sourceRoot: entryDirectory,
 		minify,
 		metafile: true,
 		conditions: ["worker", "browser"],

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -16,7 +16,7 @@ type BundleResult = {
 	resolvedEntryPointPath: string;
 	bundleType: "esm" | "commonjs";
 	stop: (() => void) | undefined;
-	sourceMapPath: string | undefined;
+	sourceMapPath?: string | undefined;
 };
 
 /**

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -223,7 +223,7 @@ function DevSession(props: DevSessionProps) {
 			host={props.host}
 			routes={props.routes}
 			onReady={props.onReady}
-			sourceMapPath={`${directory}/index.js.map`}
+			sourceMapPath={bundle?.sourceMapPath}
 		/>
 	);
 }

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -223,6 +223,7 @@ function DevSession(props: DevSessionProps) {
 			host={props.host}
 			routes={props.routes}
 			onReady={props.onReady}
+			sourceMapPath={`${directory}/index.js.map`}
 		/>
 	);
 }

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -55,6 +55,7 @@ export function Remote(props: {
 	host: string | undefined;
 	routes: Route[] | undefined;
 	onReady?: (() => void) | undefined;
+	sourceMapPath: string | undefined;
 }) {
 	const [accountId, setAccountId] = useState(props.accountId);
 	const accountChoicesRef = useRef<Promise<ChooseAccountItem[]>>();
@@ -97,6 +98,7 @@ export function Remote(props: {
 				: undefined,
 		port: props.inspectorPort,
 		logToTerminal: true,
+		sourceMapPath: props.sourceMapPath,
 	});
 
 	const errorHandler = useErrorHandler();

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -15,6 +15,7 @@ export type EsbuildBundle = {
 	entry: Entry;
 	type: "esm" | "commonjs";
 	modules: CfModule[];
+	sourceMapPath: string | undefined;
 };
 
 export function useEsbuild({
@@ -76,12 +77,14 @@ export function useEsbuild({
 				bundleType,
 				modules,
 				stop,
+				sourceMapPath,
 			}: Awaited<ReturnType<typeof bundleWorker>> = noBundle
 				? {
 						modules: [],
 						resolvedEntryPointPath: entry.file,
 						bundleType: entry.format === "modules" ? "esm" : "commonjs",
 						stop: undefined,
+						sourceMapPath: undefined,
 				  }
 				: await bundleWorker(entry, destination, {
 						serveAssetsFromWorker,
@@ -119,6 +122,7 @@ export function useEsbuild({
 				path: resolvedEntryPointPath,
 				type: bundleType,
 				modules,
+				sourceMapPath,
 			});
 		}
 


### PR DESCRIPTION
feat: source maps support in `wrangler dev` remote mode

Previously stack traces from runtime errors in `wrangler dev` remote mode, would give unhelpful stack traces from the bundled build that was sent to the server. Here, we use source maps generated as part of bundling to provide better stack traces for errors, referencing the unbundled files.

Resolves https://github.com/cloudflare/wrangler2/issues/1509