### PR TITLE
fix: export durable objects correctly when using `--assets`

### DIFF
--- a/.changeset/new-poems-tan.md
+++ b/.changeset/new-poems-tan.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: export durable objects correctly when using `--assets`
+
+The facade for static assets doesn't export any exports from the entry point, meaning Durable Objects will fail. This fix adds all exports to the facade's exports.

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -210,7 +210,7 @@ function getEntryPoint(
 						"utf8"
 					)
 					// on windows, escape backslashes in the path (`\`)
-					.replace("__ENTRY_POINT__", entryFile.replaceAll("\\", "\\\\"))
+					.replaceAll("__ENTRY_POINT__", entryFile.replaceAll("\\", "\\\\"))
 					.replace(
 						"__KV_ASSET_HANDLER__",
 						path

--- a/packages/wrangler/templates/static-asset-facade.js
+++ b/packages/wrangler/templates/static-asset-facade.js
@@ -8,6 +8,8 @@ import {
 import manifest from "__STATIC_CONTENT_MANIFEST";
 const ASSET_MANIFEST = JSON.parse(manifest);
 
+export * from "__ENTRY_POINT__";
+
 export default {
 	async fetch(request, env, ctx) {
 		let options = {


### PR DESCRIPTION
The facade for static assets doesn't export any exports from the entry point, meaning Durable Objects will fail. This fix adds all exports to the facade's exports.