### PR TITLE
chore: test coverage

### DIFF
--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -62,7 +62,7 @@ jobs:
           NODE_ENV: "production"
 
       - name: Run tests & collect coverage
-        run: npm run test
+        run: npm run test:ci
 
       - name: Report Code Coverage
         uses: codecov/codecov-action@v3

--- a/fixtures/local-mode-tests/package.json
+++ b/fixtures/local-mode-tests/package.json
@@ -9,7 +9,8 @@
 	"main": "index.js",
 	"scripts": {
 		"check:type": "tsc",
-		"test": "cross-env NODE_ENV=local-testing npx jest --forceExit"
+		"test": "cross-env NODE_ENV=local-testing npx jest --forceExit",
+		"test:ci": "cross-env NODE_ENV=local-testing npx jest --forceExit"
 	},
 	"jest": {
 		"restoreMocks": true,

--- a/fixtures/node-app-pages/package.json
+++ b/fixtures/node-app-pages/package.json
@@ -1,36 +1,37 @@
 {
-  "name": "node-app-pages",
-  "version": "0.0.0",
-  "private": true,
-  "main": "dist/worker.js",
-  "engines": {
-    "node": ">=14"
-  },
-  "scripts": {
-    "dev": "npx wrangler pages dev public --port 12345 --node-compat",
-    "test": "npx jest --forceExit"
-  },
-  "dependencies": {
-    "stripe": "^9.1.0"
-  },
-  "devDependencies": {
-    "@cloudflare/workers-types": "^3.10.0",
-    "@types/node": "^17.0.33",
-    "undici": "^5.5.1"
-  },
-  "sideEffects": false,
-  "jest": {
-    "testRegex": ".*.(test|spec)\\.[jt]sx?$",
-    "transformIgnorePatterns": [
-      "node_modules/(?!find-up|locate-path|p-locate|p-limit|yocto-queue|path-exists|execa|strip-final-newline|npm-run-path|path-key|onetime|mimic-fn|human-signals|is-stream)"
-    ],
-    "transform": {
-      "^.+\\.c?(t|j)sx?$": [
-        "esbuild-jest",
-        {
-          "sourcemap": true
-        }
-      ]
-    }
-  }
+	"name": "node-app-pages",
+	"version": "0.0.0",
+	"private": true,
+	"sideEffects": false,
+	"main": "dist/worker.js",
+	"scripts": {
+		"dev": "npx wrangler pages dev public --port 12345 --node-compat",
+		"test": "npx jest --forceExit",
+		"test:ci": "npx jest --forceExit"
+	},
+	"jest": {
+		"testRegex": ".*.(test|spec)\\.[jt]sx?$",
+		"transform": {
+			"^.+\\.c?(t|j)sx?$": [
+				"esbuild-jest",
+				{
+					"sourcemap": true
+				}
+			]
+		},
+		"transformIgnorePatterns": [
+			"node_modules/(?!find-up|locate-path|p-locate|p-limit|yocto-queue|path-exists|execa|strip-final-newline|npm-run-path|path-key|onetime|mimic-fn|human-signals|is-stream)"
+		]
+	},
+	"dependencies": {
+		"stripe": "^9.1.0"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-types": "^3.10.0",
+		"@types/node": "^17.0.33",
+		"undici": "^5.5.1"
+	},
+	"engines": {
+		"node": ">=14"
+	}
 }

--- a/fixtures/pages-functions-app/package.json
+++ b/fixtures/pages-functions-app/package.json
@@ -6,7 +6,8 @@
 	"main": "dist/worker.js",
 	"scripts": {
 		"dev": "npx wrangler pages dev public  --binding=NAME=VALUE --binding=OTHER_NAME=THING=WITH=EQUALS  --port 8789",
-		"test": "npx jest --forceExit"
+		"test": "npx jest --forceExit",
+		"test:ci": "npx jest --forceExit"
 	},
 	"jest": {
 		"restoreMocks": true,

--- a/fixtures/remix-pages-app/package.json
+++ b/fixtures/remix-pages-app/package.json
@@ -13,7 +13,8 @@
 		"dev:remix": "remix watch",
 		"dev:wrangler": "wrangler pages dev ./public",
 		"start": "npm run dev:wrangler",
-		"test": "npx jest --forceExit"
+		"test": "npx jest --forceExit",
+		"test:ci": "npx jest --forceExit"
 	},
 	"jest": {
 		"restoreMocks": true,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
 		"check:type": "npm run check:type --workspaces --if-present",
 		"fix": "npm run prettify && npm run check:lint -- --fix",
 		"prettify": "prettier packages/** --write --ignore-unknown",
-		"test": "npm run test --workspaces --if-present"
+		"test": "npm run test --workspaces --if-present",
+		"test:ci": "npm run test:ci --workspaces --if-present"
 	},
 	"eslintConfig": {
 		"parser": "@typescript-eslint/parser",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -58,10 +58,10 @@
 		"prepublishOnly": "SOURCEMAPS=false npm run build",
 		"start": "npm run bundle && NODE_OPTIONS=--enable-source-maps ./bin/wrangler.js",
 		"test": "jest --silent=false --verbose=true",
-		"test-watch": "npm run test -- --runInBand --testTimeout=50000 --watch"
+		"test-watch": "npm run test -- --runInBand --testTimeout=50000 --watch",
+		"test:ci": "npm run test -- --verbose=true --coverage"
 	},
 	"jest": {
-		"collectCoverage": true,
 		"coverageReporters": [
 			"json",
 			"html",


### PR DESCRIPTION
Test coverage was setup in the package manifest which caused it to run anytime Jest ran
inside of that workspace. The config is now removed and replaced with a custom script "test:ci" that is
also checked for at the monorepo package manifest level.