### PR TITLE
fix: Throw error if both `directory` and `command` are specified for `pages dev`

### DIFF
--- a/.changeset/slimy-yaks-think.md
+++ b/.changeset/slimy-yaks-think.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: Throw error if both `directory` and `command` is specified for `pages dev`
+
+The previous behavior was to silently ignore the `command` argument.

--- a/packages/wrangler/src/pages/dev.tsx
+++ b/packages/wrangler/src/pages/dev.tsx
@@ -139,7 +139,12 @@ export const Handler = async ({
 
 	let proxyPort: number | undefined;
 
-	if (directory === undefined) {
+	if (directory !== undefined && command.length) {
+		throw new FatalError(
+			"Specify either a directory OR a proxy command, not both.",
+			1
+		);
+	} else if (directory === undefined) {
 		proxyPort = await spawnProxyProcess({
 			port: requestedProxyPort,
 			command,

--- a/packages/wrangler/src/pages/dev.tsx
+++ b/packages/wrangler/src/pages/dev.tsx
@@ -139,7 +139,7 @@ export const Handler = async ({
 
 	let proxyPort: number | undefined;
 
-	if (directory !== undefined && command.length) {
+	if (directory !== undefined && command.length > 0) {
 		throw new FatalError(
 			"Specify either a directory OR a proxy command, not both.",
 			1


### PR DESCRIPTION
If both `directory` and `command` are specified for `wrangler
pages dev`, throw an error.

The previous behavior was to silently ignore the `command` argument.

Closes #1543.