### PR TITLE
feat: describe current permissions in `wrangler whoami`

### DIFF
--- a/.changeset/four-onions-divide.md
+++ b/.changeset/four-onions-divide.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+---
+
+feat: describe current permissions in `wrangler whoami`
+
+Often users experience issues due to tokens not having the correct permissions associated with them (often due to new scopes being created for new products). With this, we print out a list of permissions associated with OAuth tokens with the `wrangler whoami` command to help them debug for OAuth tokens. We cannot access the permissions on an API key, so we direct the user to the location in the dashboard to achieve this.
+We also cache the scopes of OAuth tokens alongside the access and refresh tokens in the .wrangler/config file to achieve this.
+
+Currently unable to implement https://github.com/cloudflare/wrangler2/issues/1371 - instead directs the user to the dashboard.
+Resolves https://github.com/cloudflare/wrangler2/issues/1540

--- a/packages/wrangler/src/__tests__/user.test.ts
+++ b/packages/wrangler/src/__tests__/user.test.ts
@@ -56,6 +56,7 @@ describe("User", () => {
 				oauth_token: "test-access-token",
 				refresh_token: "test-refresh-token",
 				expiration_time: expect.any(String),
+				scopes: ["account:read"],
 			});
 		});
 	});

--- a/packages/wrangler/src/__tests__/whoami.test.tsx
+++ b/packages/wrangler/src/__tests__/whoami.test.tsx
@@ -185,14 +185,14 @@ describe("getUserInfo()", () => {
 		});
 		await getUserInfo();
 		expect(std.warn).toMatchInlineSnapshot(`
-      "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mIt looks like you have used Wrangler 1's \`config\` command to login with an API token.[0m
+		      "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mIt looks like you have used Wrangler 1's \`config\` command to login with an API token.[0m
 
-        This is no longer supported in the current version of Wrangler.
-        If you wish to authenticate via an API token then please set the \`CLOUDFLARE_API_TOKEN\`
-        environment variable.
+		        This is no longer supported in the current version of Wrangler.
+		        If you wish to authenticate via an API token then please set the \`CLOUDFLARE_API_TOKEN\`
+		        environment variable.
 
-      "
-    `);
+		      "
+	    `);
 	});
 });
 
@@ -219,20 +219,23 @@ describe("WhoAmI component", () => {
 		};
 
 		const { lastFrame } = render(<WhoAmI user={user}></WhoAmI>);
-
-		expect(lastFrame()).toContain(
-			"You are logged in with an OAuth Token, associated with the email 'user@example.com'!"
-		);
-		expect(lastFrame()).toMatch(/Account Name .+ Account ID/);
-		expect(lastFrame()).toMatch(/Account One .+ account-1/);
-		expect(lastFrame()).toMatch(/Account Two .+ account-2/);
-		expect(lastFrame()).toMatch(/Account Three .+ account-3/);
-		expect(lastFrame()).toContain(
-			"Token Permissions: If scopes are missing, you may need to logout and re-login."
-		);
-		expect(lastFrame()).toContain("- scope1 (read)");
-		expect(lastFrame()).toContain("- scope2 (write)");
-		expect(lastFrame()).toContain("- scope3");
+		expect(lastFrame()).toMatchInlineSnapshot(`
+		"👋 You are logged in with an OAuth Token, associated with the email 'user@example.com'!
+		[1m┌[22m[1m───────────────[22m[1m┬[22m[1m────────────[22m[1m┐[22m
+		[1m│[22m[1m[34m Account Name  [22m[39m[1m│[22m[1m[34m Account ID [22m[39m[1m│[22m
+		[1m├[22m[1m───────────────[22m[1m┼[22m[1m────────────[22m[1m┤[22m
+		[1m│[22m Account One   [1m│[22m account-1  [1m│[22m
+		[1m├[22m[1m───────────────[22m[1m┼[22m[1m────────────[22m[1m┤[22m
+		[1m│[22m Account Two   [1m│[22m account-2  [1m│[22m
+		[1m├[22m[1m───────────────[22m[1m┼[22m[1m────────────[22m[1m┤[22m
+		[1m│[22m Account Three [1m│[22m account-3  [1m│[22m
+		[1m└[22m[1m───────────────[22m[1m┴[22m[1m────────────[22m[1m┘[22m
+		🔓 Token Permissions: If scopes are missing, you may need to logout and re-login.
+		Scope (Access)
+		- scope1 (read)
+		- scope2 (write)
+		- scope3"
+	`);
 	});
 
 	// For the case where the cache hasn't updated to include the scopes array
@@ -251,13 +254,18 @@ describe("WhoAmI component", () => {
 
 		const { lastFrame } = render(<WhoAmI user={user}></WhoAmI>);
 
-		expect(lastFrame()).toContain(
-			"You are logged in with an OAuth Token, associated with the email 'user@example.com'!"
-		);
-		expect(lastFrame()).toMatch(/Account Name .+ Account ID/);
-		expect(lastFrame()).toMatch(/Account One .+ account-1/);
-		expect(lastFrame()).toMatch(/Account Two .+ account-2/);
-		expect(lastFrame()).toMatch(/Account Three .+ account-3/);
+		expect(lastFrame()).toMatchInlineSnapshot(`
+		"👋 You are logged in with an OAuth Token, associated with the email 'user@example.com'!
+		[1m┌[22m[1m───────────────[22m[1m┬[22m[1m────────────[22m[1m┐[22m
+		[1m│[22m[1m[34m Account Name  [22m[39m[1m│[22m[1m[34m Account ID [22m[39m[1m│[22m
+		[1m├[22m[1m───────────────[22m[1m┼[22m[1m────────────[22m[1m┤[22m
+		[1m│[22m Account One   [1m│[22m account-1  [1m│[22m
+		[1m├[22m[1m───────────────[22m[1m┼[22m[1m────────────[22m[1m┤[22m
+		[1m│[22m Account Two   [1m│[22m account-2  [1m│[22m
+		[1m├[22m[1m───────────────[22m[1m┼[22m[1m────────────[22m[1m┤[22m
+		[1m│[22m Account Three [1m│[22m account-3  [1m│[22m
+		[1m└[22m[1m───────────────[22m[1m┴[22m[1m────────────[22m[1m┘[22m"
+	`);
 	});
 
 	it("should display the user's email, accounts and link to view token permissions for non-OAuth tokens", async () => {
@@ -274,16 +282,18 @@ describe("WhoAmI component", () => {
 		};
 
 		const { lastFrame } = render(<WhoAmI user={user}></WhoAmI>);
-
-		expect(lastFrame()).toContain(
-			"You are logged in with an API Token, associated with the email 'user@example.com'!"
-		);
-		expect(lastFrame()).toMatch(/Account Name .+ Account ID/);
-		expect(lastFrame()).toMatch(/Account One .+ account-1/);
-		expect(lastFrame()).toMatch(/Account Two .+ account-2/);
-		expect(lastFrame()).toMatch(/Account Three .+ account-3/);
-		expect(lastFrame()).toContain(
-			"To see token permissions visit https://dash.cloudflare.com/profile/api-tokens"
-		);
+		expect(lastFrame()).toMatchInlineSnapshot(`
+		"👋 You are logged in with an API Token, associated with the email 'user@example.com'!
+		[1m┌[22m[1m───────────────[22m[1m┬[22m[1m────────────[22m[1m┐[22m
+		[1m│[22m[1m[34m Account Name  [22m[39m[1m│[22m[1m[34m Account ID [22m[39m[1m│[22m
+		[1m├[22m[1m───────────────[22m[1m┼[22m[1m────────────[22m[1m┤[22m
+		[1m│[22m Account One   [1m│[22m account-1  [1m│[22m
+		[1m├[22m[1m───────────────[22m[1m┼[22m[1m────────────[22m[1m┤[22m
+		[1m│[22m Account Two   [1m│[22m account-2  [1m│[22m
+		[1m├[22m[1m───────────────[22m[1m┼[22m[1m────────────[22m[1m┤[22m
+		[1m│[22m Account Three [1m│[22m account-3  [1m│[22m
+		[1m└[22m[1m───────────────[22m[1m┴[22m[1m────────────[22m[1m┘[22m
+		🔓 To see token permissions visit https://dash.cloudflare.com/profile/api-tokens"
+	`);
 	});
 });

--- a/packages/wrangler/src/user/user.tsx
+++ b/packages/wrangler/src/user/user.tsx
@@ -262,6 +262,7 @@ interface State extends AuthTokens {
 interface AuthTokens {
 	accessToken?: AccessToken;
 	refreshToken?: RefreshToken;
+	scopes?: Scope[];
 	/** @deprecated - this field was only provided by the deprecated `wrangler1 config` command. */
 	apiToken?: string;
 }
@@ -279,6 +280,7 @@ export interface UserAuthConfig {
 	oauth_token?: string;
 	refresh_token?: string;
 	expiration_time?: string;
+	scopes?: string[];
 	/** @deprecated - this field was only provided by the deprecated `wrangler1 config` command. */
 	api_token?: string;
 }
@@ -355,7 +357,7 @@ function getAuthTokens(config?: UserAuthConfig): AuthTokens | undefined {
 		if (getAuthFromEnv()) return;
 
 		// otherwise try loading from the user auth config file.
-		const { oauth_token, refresh_token, expiration_time, api_token } =
+		const { oauth_token, refresh_token, expiration_time, scopes, api_token } =
 			config || readAuthConfigFile();
 
 		if (oauth_token) {
@@ -366,6 +368,7 @@ function getAuthTokens(config?: UserAuthConfig): AuthTokens | undefined {
 					expiry: expiration_time ?? "2000-01-01:00:00:00+00:00",
 				},
 				refreshToken: { value: refresh_token ?? "" },
+				scopes: scopes as Scope[],
 			};
 		} else if (api_token) {
 			logger.warn(
@@ -783,6 +786,8 @@ async function exchangeAuthCodeForAccessToken(): Promise<AccessContext> {
 		};
 	}
 
+	console.log("SCOPE", scope);
+
 	if (scope) {
 		// Multiple scopes are passed and delimited by spaces,
 		// despite using the singular name "scope".
@@ -959,6 +964,7 @@ export async function login(props?: LoginProps): Promise<boolean> {
 							oauth_token: exchange.token?.value ?? "",
 							expiration_time: exchange.token?.expiry,
 							refresh_token: exchange.refreshToken?.value,
+							scopes: exchange.scopes,
 						});
 						res.writeHead(307, {
 							Location:
@@ -1003,8 +1009,14 @@ async function refreshToken(): Promise<boolean> {
 				expiry: "",
 			},
 			refreshToken: { value: refresh_token } = {},
+			scopes,
 		} = await exchangeRefreshTokenForAccessToken();
-		writeAuthConfigFile({ oauth_token, expiration_time, refresh_token });
+		writeAuthConfigFile({
+			oauth_token,
+			expiration_time,
+			refresh_token,
+			scopes,
+		});
 		return true;
 	} catch (err) {
 		return false;
@@ -1168,4 +1180,12 @@ export function getAccountFromCache():
 	return getConfigCache<{ account: { id: string; name: string } }>(
 		"wrangler-account.json"
 	).account;
+}
+
+/**
+ * Get the scopes of the following token, will only return scopes
+ * if the token is an OAuth token.
+ */
+export function getScopes(): Scope[] | undefined {
+	return LocalState.scopes;
 }

--- a/packages/wrangler/src/user/user.tsx
+++ b/packages/wrangler/src/user/user.tsx
@@ -786,8 +786,6 @@ async function exchangeAuthCodeForAccessToken(): Promise<AccessContext> {
 		};
 	}
 
-	console.log("SCOPE", scope);
-
 	if (scope) {
 		// Multiple scopes are passed and delimited by spaces,
 		// despite using the singular name "scope".


### PR DESCRIPTION
Often users experience issues due to tokens not having the correct permissions associated with them (often due to new scopes being created for new products). With this, we print out a list of permissions associated with OAuth tokens with the `wrangler whoami` command to help them debug for OAuth tokens. We cannot access the permissions on an API key, so we direct the user to the location in the dashboard to achieve this.
We also cache the scopes of OAuth tokens alongside the access and refresh tokens in the .wrangler/config file to achieve this.

Currently unable to implement https://github.com/cloudflare/wrangler2/issues/1371 - instead directs the user to the dashboard.
Resolves https://github.com/cloudflare/wrangler2/issues/1540
