### PR TITLE
internal: middleware for modifying worker behaviour

### DIFF
--- a/.changeset/loud-shoes-heal.md
+++ b/.changeset/loud-shoes-heal.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+internal: middleware for modifying worker behaviour
+
+This adds an internal mechanism for applying multiple "middleware"/facades on to workers. This lets us add functionality during dev and/or publish, where we can modify requests or env, or other ideas. (See https://github.com/cloudflare/wrangler2/issues/1466 for actual usecases)
+
+As part of this, I implemented a simple facade that formats errors in dev. To enable it you need to set an environment variable `FORMAT_WRANGLER_ERRORS=true`. This _isn't_ a new feature we're shipping with wrangler, it's simply to demonstrate how to write middleware. We'll probably remove it in the future.

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -1438,7 +1438,9 @@ addEventListener('fetch', event => {});`
 				id: "__test-name-workers_sites_assets-id",
 			};
 			writeAssets(assets);
-			mockUploadWorkerRequest({ expectedMainModule: "stdin.js" });
+			mockUploadWorkerRequest({
+				expectedMainModule: "serve-static-assets.entry.js",
+			});
 			mockSubDomainRequest();
 			mockListKVNamespacesRequest(kvNamespace);
 			mockKeyListRequest(kvNamespace.id, []);
@@ -1526,7 +1528,7 @@ addEventListener('fetch', event => {});`
 			writeWorkerSource();
 			writeAssets(assets);
 			mockUploadWorkerRequest({
-				expectedMainModule: "stdin.js",
+				expectedMainModule: "serve-static-assets.entry.js",
 			});
 			mockSubDomainRequest();
 			mockListKVNamespacesRequest(kvNamespace);
@@ -1708,7 +1710,7 @@ addEventListener('fetch', event => {});`
 			writeWorkerSource();
 			writeAssets(assets);
 			mockUploadWorkerRequest({
-				expectedMainModule: "stdin.js",
+				expectedMainModule: "serve-static-assets.entry.js",
 			});
 			mockSubDomainRequest();
 			mockListKVNamespacesRequest(kvNamespace);
@@ -1753,7 +1755,7 @@ addEventListener('fetch', event => {});`
 			writeWorkerSource();
 			writeAssets(assets);
 			mockUploadWorkerRequest({
-				expectedMainModule: "stdin.js",
+				expectedMainModule: "serve-static-assets.entry.js",
 			});
 			mockSubDomainRequest();
 			mockListKVNamespacesRequest(kvNamespace);
@@ -2777,7 +2779,7 @@ addEventListener('fetch', event => {});`
 			writeWorkerSource();
 			writeAssets(assets, "my-assets");
 			mockUploadWorkerRequest({
-				expectedMainModule: "stdin.js",
+				expectedMainModule: "serve-static-assets.entry.js",
 			});
 			mockSubDomainRequest();
 			mockListKVNamespacesRequest(kvNamespace);

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -1,11 +1,11 @@
 import assert from "node:assert";
 import * as fs from "node:fs";
 import { builtinModules } from "node:module";
-import * as os from "node:os";
 import * as path from "node:path";
 import NodeGlobalsPolyfills from "@esbuild-plugins/node-globals-polyfill";
 import NodeModulesPolyfills from "@esbuild-plugins/node-modules-polyfill";
 import * as esbuild from "esbuild";
+import tmp from "tmp-promise";
 import createModuleCollector from "./module-collection";
 import type { Config } from "./config";
 import type { Entry } from "./entry";
@@ -75,6 +75,12 @@ export async function bundleWorker(
 		nodeCompat,
 		checkFetch,
 	} = options;
+
+	// We create a temporary directory for any oneoff files we
+	// need to create. This is separate from the main build
+	// directory (`destination`).
+	const tmpDir = await tmp.dir({ unsafeCleanup: true });
+
 	const entryDirectory = path.dirname(entry.file);
 	const moduleCollector = createModuleCollector({
 		wrangler1xlegacyModuleReferences: {
@@ -98,15 +104,11 @@ export async function bundleWorker(
 	// `checked-fetch.js` to do so. However, with yarn 3 style pnp,
 	// we need to extract that file to an accessible place before injecting
 	// it in, hence this code here.
-	const osTempDir = os.tmpdir();
-	const checkedFetchFileToInject = path.join(
-		osTempDir,
-		"--temp-wrangler-files--",
-		"checked-fetch.js"
-	);
+
+	const checkedFetchFileToInject = path.join(tmpDir.path, "checked-fetch.js");
 
 	if (checkFetch && !fs.existsSync(checkedFetchFileToInject)) {
-		fs.mkdirSync(path.join(osTempDir, "--temp-wrangler-files--"), {
+		fs.mkdirSync(tmpDir.path, {
 			recursive: true,
 		});
 		fs.writeFileSync(
@@ -114,12 +116,38 @@ export async function bundleWorker(
 			fs.readFileSync(path.resolve(__dirname, "../templates/checked-fetch.js"))
 		);
 	}
-	// TODO: we need to have similar logic like above for other files
-	// like the static asset facade, and other middleware that we
-	// plan on injecting/referencing.
+
+	// At this point, we take the opportunity to "wrap" any input workers
+	// with any extra functionality we may want to add. This is done by
+	// passing the entry point through a pipeline of functions that return
+	// a new entry point, that we call "middleware" or "facades".
+	// Look at implementations of these functions to learn more.
+
+	type MiddlewareFn = (arg0: Entry) => Promise<Entry>;
+	const middleware: (false | MiddlewareFn)[] = [
+		serveAssetsFromWorker &&
+			((currentEntry: Entry) => {
+				return applyStaticAssetFacade(currentEntry, tmpDir.path);
+			}),
+		// We use an env var here because we don't actually
+		// want to expose this to the user. It's only used internally to
+		// experiment with middleware as a teaching exercise.
+		process.env.FORMAT_WRANGLER_ERRORS === "true" &&
+			((currentEntry: Entry) => {
+				return applyFormatDevErrorsFacade(currentEntry, tmpDir.path);
+			}),
+	].filter((x) => x !== false);
+
+	let inputEntry = entry;
+
+	for (const middlewareFn of middleware as MiddlewareFn[]) {
+		inputEntry = await middlewareFn(inputEntry);
+	}
+
+	// At this point, inputEntry points to the entry point we want to build.
 
 	const result = await esbuild.build({
-		...getEntryPoint(entry.file, serveAssetsFromWorker),
+		entryPoints: [inputEntry.file],
 		bundle: true,
 		absWorkingDir: entry.directory,
 		outdir: destination,
@@ -188,42 +216,98 @@ export async function bundleWorker(
 	};
 }
 
-type EntryPoint = { stdin: esbuild.StdinOptions } | { entryPoints: string[] };
+/**
+ * A simple plugin to alias modules and mark them as external
+ */
+function esbuildAliasExternalPlugin(
+	aliases: Record<string, string>
+): esbuild.Plugin {
+	return {
+		name: "alias",
+		setup(build) {
+			build.onResolve({ filter: /.*/g }, (args) => {
+				// If it's the entrypoint, let it be as is
+				if (args.kind === "entry-point") {
+					return {
+						path: args.path,
+					};
+				}
+				// If it's not a recognised alias, then throw an error
+				if (!Object.keys(aliases).includes(args.path)) {
+					throw new Error("unrecognized module: " + args.path);
+				}
+
+				// Otherwise, return the alias
+				return {
+					path: aliases[args.path as keyof typeof aliases],
+					external: true,
+				};
+			});
+		},
+	};
+}
 
 /**
- * Create an object that describes the entry point for esbuild.
- *
- * If we are using the experimental asset handling, then the entry point is
- * actually a shim worker that will either return an asset from a KV store,
- * or delegate to the actual worker.
+ * A middleware that catches any thrown errors, and instead formats
+ * them to be rendered in a browser. This middleware is for demonstration
+ * purposes only, and is not intended to be used in production (or even dev!)
  */
-function getEntryPoint(
-	entryFile: string,
-	serveAssetsFromWorker: boolean
-): EntryPoint {
-	if (serveAssetsFromWorker) {
-		return {
-			stdin: {
-				contents: fs
-					.readFileSync(
-						path.join(__dirname, "../templates/static-asset-facade.js"),
-						"utf8"
-					)
-					// on windows, escape backslashes in the path (`\`)
-					.replaceAll("__ENTRY_POINT__", entryFile.replaceAll("\\", "\\\\"))
-					.replace(
-						"__KV_ASSET_HANDLER__",
-						path
-							.join(__dirname, "../kv-asset-handler.js")
-							.replaceAll("\\", "\\\\")
-					),
-				sourcefile: "static-asset-facade.js",
-				resolveDir: path.dirname(entryFile),
-			},
-		};
-	} else {
-		return { entryPoints: [entryFile] };
-	}
+async function applyFormatDevErrorsFacade(
+	entry: Entry,
+	tmpDirPath: string
+): Promise<Entry> {
+	const targetPath = path.join(tmpDirPath, "format-dev-errors.entry.js");
+	await esbuild.build({
+		entryPoints: [path.resolve(__dirname, "../templates/format-dev-errors.ts")],
+		bundle: true,
+		sourcemap: true,
+		format: "esm",
+		plugins: [
+			esbuildAliasExternalPlugin({
+				__ENTRY_POINT__: entry.file,
+			}),
+		],
+		outfile: targetPath,
+	});
+
+	return {
+		...entry,
+		file: targetPath,
+	};
+}
+
+/**
+ * A middleware that serves static assets from a worker.
+ * This powers --assets / config.assets
+ */
+
+async function applyStaticAssetFacade(
+	entry: Entry,
+	tmpDirPath: string
+): Promise<Entry> {
+	const targetPath = path.join(tmpDirPath, "serve-static-assets.entry.js");
+
+	await esbuild.build({
+		entryPoints: [
+			path.resolve(__dirname, "../templates/serve-static-assets.ts"),
+		],
+		bundle: true,
+		format: "esm",
+		sourcemap: true,
+		plugins: [
+			esbuildAliasExternalPlugin({
+				__ENTRY_POINT__: entry.file,
+				__KV_ASSET_HANDLER__: path.join(__dirname, "../kv-asset-handler.js"),
+				__STATIC_CONTENT_MANIFEST: "__STATIC_CONTENT_MANIFEST",
+			}),
+		],
+		outfile: targetPath,
+	});
+
+	return {
+		...entry,
+		file: targetPath,
+	};
 }
 
 /**

--- a/packages/wrangler/templates/format-dev-errors.ts
+++ b/packages/wrangler/templates/format-dev-errors.ts
@@ -1,0 +1,32 @@
+// @ts-expect-error We'll swap in the entry point during build
+import Worker from "__ENTRY_POINT__";
+
+// @ts-expect-error
+export * from "__ENTRY_POINT__";
+
+export default {
+	async fetch(req: Request, env: unknown, ctx: ExecutionContext) {
+		try {
+			return await Worker.fetch(req, env, ctx);
+		} catch (err) {
+			return new Response(
+				`<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<title>Error</title>
+	</head>
+	<body>
+		<pre>${(err as Error).stack}</pre>
+	</body>
+</html>`,
+				{
+					status: 500,
+					headers: {
+						"Content-Type": "text/html",
+					},
+				}
+			);
+		}
+	},
+};


### PR DESCRIPTION
This adds an internal mechanism for applying multiple "middleware"/facades on to workers. This lets us add functionality during dev and/or publish, where we can modify requests or env, or other ideas. (See https://github.com/cloudflare/wrangler2/issues/1466 for actual usecases)

As part of this, I implemented a simple facade that formats errors in dev. To enable it you need to set an environment variable `FORMAT_WRANGLER_ERRORS=true`. This _isn't_ a new feature we're shipping with wrangler, it's simply to demonstrate how to write middleware. We'll probably remove it in the future.