### PR TITLE
fix: Invalid regular expression error

### DIFF
--- a/.changeset/fifty-schools-check.md
+++ b/.changeset/fifty-schools-check.md
@@ -2,4 +2,4 @@
 "wrangler": patch
 ---
 
-fix: createModuleCollector when tmp dir has a file with a '+'
+fix: invalid regular expression error (pages)

--- a/.changeset/fifty-schools-check.md
+++ b/.changeset/fifty-schools-check.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: createModuleCollector when tmp dir has a file with a '+'

--- a/packages/wrangler/src/module-collection.ts
+++ b/packages/wrangler/src/module-collection.ts
@@ -125,7 +125,7 @@ export default function createModuleCollector(props: {
 								"^(" +
 									[...props.wrangler1xlegacyModuleReferences.fileNames]
 										.join("|")
-										.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") +
+										.replace(/[*+?^${}()|[\]\\]/g, "\\$&") +
 									")$"
 							),
 						},

--- a/packages/wrangler/src/module-collection.ts
+++ b/packages/wrangler/src/module-collection.ts
@@ -124,8 +124,8 @@ export default function createModuleCollector(props: {
 							filter: new RegExp(
 								"^(" +
 									[...props.wrangler1xlegacyModuleReferences.fileNames]
-										.join("|")
-										.replace(/[*+?^${}()|[\]\\]/g, "\\$&") +
+										.map((name) => name.replace(/[*+?^${}()|[\]\\]/g, "\\$&"))
+										.join("|") +
 									")$"
 							),
 						},

--- a/packages/wrangler/src/module-collection.ts
+++ b/packages/wrangler/src/module-collection.ts
@@ -124,7 +124,7 @@ export default function createModuleCollector(props: {
 							filter: new RegExp(
 								"^(" +
 									[...props.wrangler1xlegacyModuleReferences.fileNames]
-										.map((name) => name.replace(/[*+?^${}()|[\]\\]/g, "\\$&"))
+										.map((name) => name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
 										.join("|") +
 									")$"
 							),

--- a/packages/wrangler/src/module-collection.ts
+++ b/packages/wrangler/src/module-collection.ts
@@ -123,9 +123,9 @@ export default function createModuleCollector(props: {
 						{
 							filter: new RegExp(
 								"^(" +
-									[...props.wrangler1xlegacyModuleReferences.fileNames].join(
-										"|"
-									) +
+									[...props.wrangler1xlegacyModuleReferences.fileNames]
+										.join("|")
+										.replace("+", "\\+") +
 									")$"
 							),
 						},

--- a/packages/wrangler/src/module-collection.ts
+++ b/packages/wrangler/src/module-collection.ts
@@ -125,7 +125,7 @@ export default function createModuleCollector(props: {
 								"^(" +
 									[...props.wrangler1xlegacyModuleReferences.fileNames]
 										.join("|")
-										.replace("+", "\\+") +
+										.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") +
 									")$"
 							),
 						},


### PR DESCRIPTION
Ref: https://github.com/cloudflare/wrangler2/issues/1504#issuecomment-1194301983

`wrangler pages dev` uses the tmp directory to build functions, which can contain files with a '+' character in their name, which is a key character in regular expressions. This issue was also reported in the cloudflare developers server, at [this message](https://discord.com/channels/595317990191398933/799437470004412476/1001176224443412600)

May be worth escaping all regex characters?