### PR TITLE
chore: CodeCov non-blocking

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,9 @@
-if_ci_failed: ignore # ignore, fail, pass
-informational: true
+coverage:
+  status:
+    project:
+      default:
+        informational: true # https://docs.codecov.com/docs/commit-status#informational
+
 comment:
   layout: "reach, diff, flags, files"
   behavior: default


### PR DESCRIPTION
moved informational "true"  into the coverage context of config for codecov.
This according to their docs should be non-blocking
See: https://docs.codecov.com/docs/commit-status\#informational

Tested this on a fork, branch context was strange with using a PR from the original repo. Seemed to have resolved the issue. 