### PR TITLE
chore: remove unused var

### DIFF
--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -182,7 +182,6 @@ function DevSession(props: DevSessionProps) {
 			compatibilityFlags={props.compatibilityFlags}
 			bindings={props.bindings}
 			assetPaths={props.assetPaths}
-			isWorkersSite={props.isWorkersSite}
 			port={props.port}
 			ip={props.ip}
 			rules={props.rules}

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -23,7 +23,6 @@ interface LocalProps {
 	compatibilityFlags: string[] | undefined;
 	bindings: CfWorkerInit["bindings"];
 	assetPaths: AssetPaths | undefined;
-	isWorkersSite: boolean;
 	port: number;
 	ip: string;
 	rules: Config["rules"];
@@ -58,7 +57,6 @@ function useLocalWorker({
 	compatibilityFlags,
 	bindings,
 	assetPaths,
-	isWorkersSite,
 	port,
 	inspectorPort,
 	rules,
@@ -357,7 +355,6 @@ function useLocalWorker({
 		localPersistencePath,
 		liveReload,
 		assetPaths,
-		isWorkersSite,
 		rules,
 		bindings.wasm_modules,
 		bindings.text_blobs,


### PR DESCRIPTION
I noticed this is unused locally, only used in remote.tsx