### PR TITLE
fix: export durable object bindings when using service bindings in dev

### DIFF
--- a/.changeset/thin-avocados-trade.md
+++ b/.changeset/thin-avocados-trade.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: export durable object bindings when using service bindings in dev
+
+A similar fix to https://github.com/cloudflare/wrangler2/pull/1539, this exports correctly when using service bindings in dev.

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -138,10 +138,12 @@ export async function bundleWorker(
 
 	type MiddlewareFn = (arg0: Entry) => Promise<Entry>;
 	const middleware: (false | undefined | MiddlewareFn)[] = [
+		// serve static assets
 		serveAssetsFromWorker &&
 			((currentEntry: Entry) => {
 				return applyStaticAssetFacade(currentEntry, tmpDir.path, assets);
 			}),
+		// format errors nicely
 		// We use an env var here because we don't actually
 		// want to expose this to the user. It's only used internally to
 		// experiment with middleware as a teaching exercise.
@@ -149,10 +151,11 @@ export async function bundleWorker(
 			((currentEntry: Entry) => {
 				return applyFormatDevErrorsFacade(currentEntry, tmpDir.path);
 			}),
+		// bind to other dev instances/service bindings
 		workerDefinitions &&
 			services &&
 			((currentEntry: Entry) => {
-				return applyMultiWorkerFacade(
+				return applyMultiWorkerDevFacade(
 					currentEntry,
 					tmpDir.path,
 					services,
@@ -348,7 +351,12 @@ async function applyStaticAssetFacade(
 	};
 }
 
-async function applyMultiWorkerFacade(
+/**
+ * A middleware that enables service bindings to be used in dev,
+ * binding to other love wrangler dev instances
+ */
+
+async function applyMultiWorkerDevFacade(
 	entry: Entry,
 	tmpDirPath: string,
 	services: Config["services"],

--- a/packages/wrangler/templates/service-bindings-module-facade.js
+++ b/packages/wrangler/templates/service-bindings-module-facade.js
@@ -1,6 +1,8 @@
 import worker from "__ENTRY_POINT__";
 const Workers = __WORKERS__;
 
+export * from "__ENTRY_POINT__";
+
 export default {
 	async fetch(req, env, ctx) {
 		const facadeEnv = { ...env };


### PR DESCRIPTION
A similar fix to https://github.com/cloudflare/wrangler2/pull/1539, this exports correctly when using service bindings in dev.