### PR TITLE
chore: disabling a flaky test

### DIFF
--- a/fixtures/node-app-pages/tests/index.test.ts
+++ b/fixtures/node-app-pages/tests/index.test.ts
@@ -46,7 +46,7 @@ describe("Pages Dev", () => {
 		});
 	});
 
-	it("should work with `--node-compat` when running code requiring polyfills", async () => {
+	it.skip("should work with `--node-compat` when running code requiring polyfills", async () => {
 		const response = await waitUntilReady("http://localhost:12345/stripe");
 
 		await expect(response.text()).resolves.toContain(


### PR DESCRIPTION
We have a test that flakes a lot, so I'm disabling it. Filed https://github.com/cloudflare/wrangler2/issues/1571 for fixing/re-enabling it