### PR TITLE
fix: Retry check-missing call to make wrangler pages publish more reliable

### DIFF
--- a/.changeset/soft-seahorses-cough.md
+++ b/.changeset/soft-seahorses-cough.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: Retry check-missing call to make wrangler pages publish more reliable
+
+Before uploading files in wrangler pages publish, we make a network call to check what files need to be uploaded. This call could sometimes fail, causing the publish to fail. This change will retry that network call.

--- a/packages/wrangler/src/pages/constants.ts
+++ b/packages/wrangler/src/pages/constants.ts
@@ -3,5 +3,6 @@ export const MAX_BUCKET_SIZE = 50 * 1024 * 1024;
 export const MAX_BUCKET_FILE_COUNT = 5000;
 export const BULK_UPLOAD_CONCURRENCY = 3;
 export const MAX_UPLOAD_ATTEMPTS = 5;
+export const MAX_CHECK_MISSING_ATTEMPTS = 5;
 export const SECONDS_TO_WAIT_FOR_PROXY = 5;
 export const isInPagesCI = !!process.env.CF_PAGES;


### PR DESCRIPTION
`wrangler pages publish` sometimes fails because /check-missing fails (usually with 5XX errors.)
This will retry it with the same logic as upload calls do.