### PR TITLE
feat: legacy kv-namespace not supported

### DIFF
--- a/.changeset/green-queens-fry.md
+++ b/.changeset/green-queens-fry.md
@@ -1,0 +1,10 @@
+---
+"wrangler": patch
+---
+
+feat: legacy "kv-namespace" not supported
+In previous Wrangler 1, there was a legacy configuration that was considered a "bug" and removed.
+Before it was removed, tutorials, templates, blogs, etc... had utlized that configuration property
+to handle this in Wrangler 2 we will throw a blocking error that tell the user to utilize "kv_namespaces"
+
+resolves #1421

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -3735,6 +3735,7 @@ describe("normalizeAndValidateConfig()", () => {
 			it("should remove and warn about deprecated properties", () => {
 				const environment: RawEnvironment = {
 					zone_id: "ZONE_ID",
+					"kv-namespaces": "BAD_KV_NAMESPACE",
 					experimental_services: [
 						{
 							name: "mock-name",
@@ -3760,14 +3761,16 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(false);
 				expect(diagnostics.hasWarnings()).toBe(true);
 				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
-			          "Processing wrangler configuration:
+			"Processing wrangler configuration:
 
-			            - \\"env.ENV1\\" environment configuration
-			              - [1mDeprecation[0m: \\"zone_id\\":
-			                This is unnecessary since we can deduce this from routes directly.
-			              - [1mDeprecation[0m: \\"experimental_services\\":
-			                The \\"experimental_services\\" field is no longer supported. Simply rename the [experimental_services] field to [services]."
-		        `);
+			  - \\"env.ENV1\\" environment configuration
+			    - [1mDeprecation[0m: \\"kv-namespaces\\":
+			      The \\"kv-namespaces\\" field is no longer supported, please rename to \\"kv_namespaces\\"
+			    - [1mDeprecation[0m: \\"zone_id\\":
+			      This is unnecessary since we can deduce this from routes directly.
+			    - [1mDeprecation[0m: \\"experimental_services\\":
+			      The \\"experimental_services\\" field is no longer supported. Simply rename the [experimental_services] field to [services]."
+		`);
 			});
 		});
 

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -383,6 +383,13 @@ interface EnvironmentDeprecated {
 	zone_id?: string;
 
 	/**
+	 * Legacy way of defining KVNamespaces that is no longer supported.
+	 *
+	 * @deprecated DO NOT USE. This was a legacy bug from wrangler 1, that we do not want to support.
+	 */
+	"kv-namespaces"?: string;
+
+	/**
 	 * A list of services that your worker should be bound to.
 	 *
 	 * @default `[]`

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -876,6 +876,13 @@ function normalizeAndValidateEnvironment(
 	deprecated(
 		diagnostics,
 		rawEnv,
+		"kv-namespaces",
+		`The "kv-namespaces" field is no longer supported, please rename to "kv_namespaces"`,
+		true
+	);
+	deprecated(
+		diagnostics,
+		rawEnv,
 		"zone_id",
 		"This is unnecessary since we can deduce this from routes directly.",
 		false // We need to leave this in-place for the moment since `route` commands might use it.


### PR DESCRIPTION
In previous Wrangler 1, there was a legacy configuration that was considered a bug and removed.
Before it was removed, tutorials, templates, blogs, etc... had utlized that configuration property
to handle this in Wrangler 2 we will throw a blocking error that tell the user to utilize kv_namespaces

resolves #1421