### PR TITLE
Sparrow events extras

### DIFF
--- a/.changeset/flat-foxes-dress.md
+++ b/.changeset/flat-foxes-dress.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+feat: add platform/os to usage metrics events

--- a/.changeset/flat-keys-teach.md
+++ b/.changeset/flat-keys-teach.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: rename pages metrics events to align better with the dashboard

--- a/.changeset/shy-walls-sparkle.md
+++ b/.changeset/shy-walls-sparkle.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+feat: add metricsEnabled header to CF API calls when developing or deploying a worker
+
+This allows us to estimate from API requests what proportion of Wrangler
+instances have enabled usage tracking, without breaking the agreement not
+to send data for those who have not opted in.

--- a/.changeset/tricky-rules-thank.md
+++ b/.changeset/tricky-rules-thank.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+feat: send whether a Worker is using TypeScript or not in usage events

--- a/packages/wrangler/src/__tests__/jest.setup.ts
+++ b/packages/wrangler/src/__tests__/jest.setup.ts
@@ -126,3 +126,25 @@ jest.mock("xdg-app-paths", () => {
 });
 
 jest.mock("create-cloudflare");
+
+jest.mock("../metrics/metrics-config", () => {
+	const realModule = jest.requireActual("../metrics/metrics-config");
+	const fakeModule = {
+		...realModule,
+		// Although we mock out the getMetricsConfig() function in most tests,
+		// we need a way to reinstate it for the metrics specific tests.
+		// This is what `useOriginal` is for.
+		useOriginal: false,
+		getMetricsConfig: (...args: unknown[]) =>
+			fakeModule.useOriginal
+				? realModule.getMetricsConfig(...args)
+				: async () => {
+						return {
+							enabled: false,
+							deviceId: "mock-device",
+							userId: undefined,
+						};
+				  },
+	};
+	return fakeModule;
+});

--- a/packages/wrangler/src/__tests__/metrics.test.ts
+++ b/packages/wrangler/src/__tests__/metrics.test.ts
@@ -65,6 +65,7 @@ describe("metrics", () => {
 						properties: {
 							category: "Workers",
 							wranglerVersion,
+							os: process.platform + ":" + process.arch,
 							a: 1,
 							b: 2,
 						},
@@ -139,6 +140,7 @@ describe("metrics", () => {
 						properties: {
 							category: "Workers",
 							wranglerVersion,
+							os: process.platform + ":" + process.arch,
 							a: 1,
 							b: 2,
 						},

--- a/packages/wrangler/src/__tests__/metrics.test.ts
+++ b/packages/wrangler/src/__tests__/metrics.test.ts
@@ -26,6 +26,9 @@ describe("metrics", () => {
 	runInTempDir();
 
 	beforeEach(() => {
+		// Tell jest to use the original version of the `getMetricsConfig()` function in these tests.
+		const mockMetricsConfig = jest.requireMock("../metrics/metrics-config");
+		mockMetricsConfig.useOriginal = true;
 		global.SPARROW_SOURCE_KEY = "MOCK_KEY";
 		logger.loggerLevel = "debug";
 		// Create a node_modules directory to store config-cache files

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -299,11 +299,6 @@ export async function startDev(args: StartDevOptions) {
 			((args.script &&
 				findWranglerToml(path.dirname(args.script))) as ConfigPath);
 		let config = readConfig(configPath, args);
-		await metrics.sendMetricsEvent(
-			"run dev",
-			{ local: args.local },
-			{ sendMetrics: config.send_metrics, offline: args.local }
-		);
 
 		if (config.configPath) {
 			watcher = watch(config.configPath, {
@@ -323,6 +318,15 @@ export async function startDev(args: StartDevOptions) {
 			{ assets: args.assets, script: args.script },
 			config,
 			"dev"
+		);
+
+		await metrics.sendMetricsEvent(
+			"run dev",
+			{
+				local: args.local,
+				usesTypeScript: /\.tsx?$/.test(entry.file),
+			},
+			{ sendMetrics: config.send_metrics, offline: args.local }
 		);
 
 		if (config.services && config.services.length > 0) {

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -512,6 +512,7 @@ export async function startDev(args: StartDevOptions) {
 					forceLocal={args.forceLocal}
 					enablePagesAssetsServiceBinding={args.enablePagesAssetsServiceBinding}
 					firstPartyWorker={config.first_party_worker}
+					sendMetrics={config.send_metrics}
 				/>
 			);
 		}

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -157,6 +157,7 @@ export type DevProps = {
 	forceLocal: boolean | undefined;
 	enablePagesAssetsServiceBinding?: EnablePagesAssetsServiceBindingOptions;
 	firstPartyWorker: boolean | undefined;
+	sendMetrics: boolean | undefined;
 };
 
 export function DevImplementation(props: DevProps): JSX.Element {
@@ -300,6 +301,7 @@ function DevSession(props: DevSessionProps) {
 			routes={props.routes}
 			onReady={props.onReady}
 			sourceMapPath={bundle?.sourceMapPath}
+			sendMetrics={props.sendMetrics}
 		/>
 	);
 }

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -56,6 +56,7 @@ export function Remote(props: {
 	routes: Route[] | undefined;
 	onReady?: (() => void) | undefined;
 	sourceMapPath: string | undefined;
+	sendMetrics: boolean | undefined;
 }) {
 	const [accountId, setAccountId] = useState(props.accountId);
 	const accountChoicesRef = useRef<Promise<ChooseAccountItem[]>>();
@@ -79,6 +80,7 @@ export function Remote(props: {
 		host: props.host,
 		routes: props.routes,
 		onReady: props.onReady,
+		sendMetrics: props.sendMetrics,
 	});
 
 	usePreviewServer({
@@ -163,6 +165,7 @@ export function useWorker(props: {
 	host: string | undefined;
 	routes: Route[] | undefined;
 	onReady: (() => void) | undefined;
+	sendMetrics: boolean | undefined;
 }): CfPreviewToken | undefined {
 	const {
 		name,
@@ -204,6 +207,7 @@ export function useWorker(props: {
 				zone: props.zone,
 				host: props.host,
 				routes: props.routes,
+				sendMetrics: props.sendMetrics,
 			};
 
 			setSession(
@@ -232,6 +236,7 @@ export function useWorker(props: {
 		props.legacyEnv,
 		props.routes,
 		props.zone,
+		props.sendMetrics,
 	]);
 
 	// This effect uses the session to upload the worker and create a preview
@@ -322,6 +327,7 @@ export function useWorker(props: {
 				zone: props.zone,
 				host: props.host,
 				routes: props.routes,
+				sendMetrics: props.sendMetrics,
 			};
 
 			const workerPreviewToken = await createWorkerPreview(
@@ -401,6 +407,7 @@ export function useWorker(props: {
 		props.routes,
 		session,
 		onReady,
+		props.sendMetrics,
 	]);
 	return token;
 }

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -523,10 +523,16 @@ function createCLIParser(argv: string[]) {
 				(args.config as ConfigPath) ||
 				(args.script && findWranglerToml(path.dirname(args.script)));
 			const config = readConfig(configPath, args);
-			await metrics.sendMetricsEvent("deploy worker script", {
-				sendMetrics: config.send_metrics,
-			});
 			const entry = await getEntry(args, config, "publish");
+			await metrics.sendMetricsEvent(
+				"deploy worker script",
+				{
+					usesTypeScript: /\.tsx?$/.test(entry.file),
+				},
+				{
+					sendMetrics: config.send_metrics,
+				}
+			);
 
 			if (args.public) {
 				throw new Error("The --public field has been renamed to --assets");

--- a/packages/wrangler/src/metrics/index.ts
+++ b/packages/wrangler/src/metrics/index.ts
@@ -2,3 +2,4 @@ export { getMetricsDispatcher } from "./metrics-dispatcher";
 export type { Properties } from "./metrics-dispatcher";
 export { getMetricsConfig } from "./metrics-config";
 export * from "./send-event";
+export { getMetricsUsageHeaders } from "./metrics-usage-headers";

--- a/packages/wrangler/src/metrics/metrics-dispatcher.ts
+++ b/packages/wrangler/src/metrics/metrics-dispatcher.ts
@@ -67,6 +67,7 @@ export async function getMetricsDispatcher(options: MetricsConfigOptions) {
 			properties: {
 				category: "Workers",
 				wranglerVersion,
+				os: process.platform + ":" + process.arch,
 				...event.properties,
 			},
 		});

--- a/packages/wrangler/src/metrics/metrics-usage-headers.ts
+++ b/packages/wrangler/src/metrics/metrics-usage-headers.ts
@@ -1,0 +1,24 @@
+import { getMetricsConfig } from "./metrics-config";
+
+/**
+ * Add an additional header to publish requests if the user has opted into sending usage metrics.
+ *
+ * This allows us to estimate the number of instances of Wrangler that have opted-in
+ * without breaking our agreement not to send stuff if you have not opted-in.
+ */
+export async function getMetricsUsageHeaders(
+	sendMetrics: boolean | undefined
+): Promise<Record<string, string> | undefined> {
+	const metricsEnabled = (
+		await getMetricsConfig({
+			sendMetrics,
+		})
+	).enabled;
+	if (metricsEnabled) {
+		return {
+			metricsEnabled: "true",
+		};
+	} else {
+		return undefined;
+	}
+}

--- a/packages/wrangler/src/metrics/send-event.ts
+++ b/packages/wrangler/src/metrics/send-event.ts
@@ -47,8 +47,8 @@ export type EventNames =
 	| "rename worker namespace"
 	| "create pages project"
 	| "list pages projects"
-	| "deploy pages project"
-	| "list pages projects deployments"
+	| "create pages deployment"
+	| "list pages deployments"
 	| "build pages functions"
 	| "run dev"
 	| "run pages dev";

--- a/packages/wrangler/src/pages/deployments.tsx
+++ b/packages/wrangler/src/pages/deployments.tsx
@@ -102,5 +102,5 @@ export async function ListHandler({
 		patchConsole: false,
 	});
 	unmount();
-	await metrics.sendMetricsEvent("list pages projects deployments");
+	await metrics.sendMetricsEvent("list pages deployments");
 }

--- a/packages/wrangler/src/pages/publish.tsx
+++ b/packages/wrangler/src/pages/publish.tsx
@@ -334,5 +334,5 @@ export const Handler = async ({
 	logger.log(
 		`✨ Deployment complete! Take a peek over at ${deploymentResponse.url}`
 	);
-	await metrics.sendMetricsEvent("deploy pages project");
+	await metrics.sendMetricsEvent("create pages deployment");
 };

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -11,6 +11,7 @@ import { createWorkerUploadForm } from "./create-worker-upload-form";
 import { confirm } from "./dialogs";
 import { getMigrationsToUpload } from "./durable";
 import { logger } from "./logger";
+import { getMetricsUsageHeaders } from "./metrics";
 import { ParseError } from "./parse";
 import { syncAssets } from "./sites";
 import { getZoneForRoute } from "./zones";
@@ -496,6 +497,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 				{
 					method: "PUT",
 					body: createWorkerUploadForm(worker),
+					headers: await getMetricsUsageHeaders(config.send_metrics),
 				},
 				new URLSearchParams({
 					include_subdomain_availability: "true",

--- a/packages/wrangler/src/worker.ts
+++ b/packages/wrangler/src/worker.ts
@@ -199,4 +199,5 @@ export interface CfWorkerContext {
 	zone: string | undefined;
 	host: string | undefined;
 	routes: Route[] | undefined;
+	sendMetrics: boolean | undefined;
 }


### PR DESCRIPTION
- feat: add platform/os to usage metrics events
- feat: send whether a Worker is using TypeScript or not in usage events
- fix: rename pages metrics events to align better with the dashboard
- feat: add metricsEnabled header when deploying a worker
