### PR TITLE
feat: source-map function names in stack trace

### DIFF
--- a/.changeset/heavy-plants-jump.md
+++ b/.changeset/heavy-plants-jump.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+feat: source-map function names
+
+Following on from https://github.com/cloudflare/wrangler2/pull/1535, using new functionality from esbuild v0.14.50 of generation of `names` field in generated sourcemaps, we output the original function name in the stack trace.

--- a/packages/wrangler/src/inspect.ts
+++ b/packages/wrangler/src/inspect.ts
@@ -271,8 +271,6 @@ export default function useInspector(props: InspectorProps) {
 								await readFile(props.sourceMapPath, "utf-8")
 							);
 
-							console.log(props.sourceMapPath);
-
 							// Create the lines for the exception details log
 							const exceptionLines = [
 								params.exceptionDetails.exception?.description?.split("\n")[0],

--- a/packages/wrangler/src/inspect.ts
+++ b/packages/wrangler/src/inspect.ts
@@ -271,6 +271,8 @@ export default function useInspector(props: InspectorProps) {
 								await readFile(props.sourceMapPath, "utf-8")
 							);
 
+							console.log(props.sourceMapPath);
+
 							// Create the lines for the exception details log
 							const exceptionLines = [
 								params.exceptionDetails.exception?.description?.split("\n")[0],
@@ -283,51 +285,56 @@ export default function useInspector(props: InspectorProps) {
 									// Pass each of the callframes into the consumer, and format the error
 									const stack = params.exceptionDetails.stackTrace?.callFrames;
 
-									stack?.forEach(({ lineNumber, columnNumber }, i) => {
-										try {
-											if (lineNumber) {
-												// The line and column numbers in the stackTrace are zero indexed,
-												// whereas the sourcemap consumer indexes from one.
-												const pos = consumer.originalPositionFor({
-													line: lineNumber + 1,
-													column: columnNumber + 1,
-												});
+									stack?.forEach(
+										({ functionName, lineNumber, columnNumber }, i) => {
+											try {
+												if (lineNumber) {
+													// The line and column numbers in the stackTrace are zero indexed,
+													// whereas the sourcemap consumer indexes from one.
+													const pos = consumer.originalPositionFor({
+														line: lineNumber + 1,
+														column: columnNumber + 1,
+													});
 
-												// Print out line which caused error:
-												if (i === 0 && pos.source && pos.line) {
-													const fileSource = consumer.sourceContentFor(
-														pos.source
-													);
-													const fileSourceLine =
-														fileSource?.split("\n")[pos.line - 1] || "";
-													exceptionLines.push(fileSourceLine.trim());
+													// Print out line which caused error:
+													if (i === 0 && pos.source && pos.line) {
+														const fileSource = consumer.sourceContentFor(
+															pos.source
+														);
+														const fileSourceLine =
+															fileSource?.split("\n")[pos.line - 1] || "";
+														exceptionLines.push(fileSourceLine.trim());
 
-													// If we have a column, we can mark the position underneath
-													if (pos.column) {
+														// If we have a column, we can mark the position underneath
+														if (pos.column) {
+															exceptionLines.push(
+																`${" ".repeat(
+																	pos.column - fileSourceLine.search(/\S/)
+																)}^`
+															);
+														}
+													}
+
+													// From the way esbuild implements the "names" field:
+													// > To save space, the original name is only recorded when it's different from the final name.
+													// however, source-map consumer does not handle this
+													if (pos && pos.line != null) {
+														const convertedFnName =
+															pos.name || functionName || "";
 														exceptionLines.push(
-															`${" ".repeat(
-																pos.column - fileSourceLine.search(/\S/)
-															)}^`
+															`    at ${convertedFnName} (${pos.source?.replace(
+																`${mapContent.sourceRoot}/`,
+																""
+															)}:${pos.line}:${pos.column})`
 														);
 													}
 												}
-
-												// Unfortunately due to the way esbuild generates sourcemaps,
-												// we can't get the name of the function
-												if (pos && pos.line != null) {
-													exceptionLines.push(
-														`    at ${pos.source?.replace(
-															`${mapContent.sourceRoot}/`,
-															""
-														)}:${pos.line}:${pos.column}`
-													);
-												}
+											} catch {
+												// Line failed to parse through the sourcemap consumer
+												// We should handle this better
 											}
-										} catch {
-											// Line failed to parse through the sourcemap consumer
-											// We should handle this better
 										}
-									});
+									);
 								}
 							);
 


### PR DESCRIPTION
Following on from https://github.com/cloudflare/wrangler2/pull/1535, using new functionality from esbuild v0.14.50 of generation of `names` field in generated source maps, we output the original function name in the stack trace.
