### PR TITLE
fix: apply multiworker dev facade only when required

### DIFF
--- a/.changeset/serious-deers-applaud.md
+++ b/.changeset/serious-deers-applaud.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: apply multiworker dev facade only when required
+
+This fix makes sure the multiworker dev facade is applied to the input worker only where there are other wrangler dev instances running that are bound to the input worker. We also make sure we don't apply it when we already have a binding (like in remote mode).

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -156,7 +156,9 @@ export async function bundleWorker(
 			}),
 		// bind to other dev instances/service bindings
 		workerDefinitions &&
+			Object.keys(workerDefinitions).length > 0 &&
 			services &&
+			services.length > 0 &&
 			((currentEntry: Entry) => {
 				return applyMultiWorkerDevFacade(
 					currentEntry,

--- a/packages/wrangler/templates/service-bindings-module-facade.js
+++ b/packages/wrangler/templates/service-bindings-module-facade.js
@@ -34,9 +34,9 @@ export default {
 					},
 				};
 			} else {
-				// This means it's a local mode binding
-				// but hasn't started up locally yet.
-				facadeEnv[name] = {
+				// This means there's no dev binding available.
+				// Let's use whatever's available, or put a shim with a message.
+				facadeEnv[name] = facadeEnv[name] || {
 					async fetch() {
 						return new Response(
 							`You should start up wrangler dev --local on the ${name} worker`,


### PR DESCRIPTION
This fix makes sure the multiworker dev facade is applied to the input worker only where there are other wrangler dev instances running that are bound to the input worker. We also make sure we don't apply it when we already have a binding (like in remote mode).