### PR TITLE
[pages] Fix encoded uri file routing

### DIFF
--- a/.changeset/thin-drinks-mix.md
+++ b/.changeset/thin-drinks-mix.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix routing for URI encoded static requests

--- a/packages/wrangler/src/miniflare-cli/assets.ts
+++ b/packages/wrangler/src/miniflare-cli/assets.ts
@@ -335,6 +335,9 @@ async function generateAssetsFetch(
 
 	const generateResponse = (request: MiniflareRequest) => {
 		const url = new URL(request.url);
+		try {
+			url.pathname = decodeURIComponent(url.pathname);
+		} catch {}
 
 		const deconstructedResponse: {
 			status: number;


### PR DESCRIPTION
Aims to resolve #1437, where wrangler was trying to locate the static asset of `%5Bid%5D.js` rather than `[id].js`