### PR TITLE
Add support for Alarm Events in `wrangler tail`

### DIFF
--- a/.changeset/lovely-pets-tie.md
+++ b/.changeset/lovely-pets-tie.md
@@ -7,3 +7,5 @@ Add support for Alarm Events in `wrangler tail`
 `wrangler tail --format pretty` now supports receiving events from [Durable Object Alarms](https://developers.cloudflare.com/workers/learning/using-durable-objects/#alarms-in-durable-objects), and will display the time the alarm was triggered.
 
 Additionally, any future unknown events will simply print "Unkonwn Event" instead of crashing the `wrangler` process.
+
+Closes #1519

--- a/.changeset/lovely-pets-tie.md
+++ b/.changeset/lovely-pets-tie.md
@@ -6,6 +6,6 @@ Add support for Alarm Events in `wrangler tail`
 
 `wrangler tail --format pretty` now supports receiving events from [Durable Object Alarms](https://developers.cloudflare.com/workers/learning/using-durable-objects/#alarms-in-durable-objects), and will display the time the alarm was triggered.
 
-Additionally, any future unknown events will simply print "Unkonwn Event" instead of crashing the `wrangler` process.
+Additionally, any future unknown events will simply print "Unknown Event" instead of crashing the `wrangler` process.
 
 Closes #1519

--- a/.changeset/lovely-pets-tie.md
+++ b/.changeset/lovely-pets-tie.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Add support for Alarm Events in `wrangler tail`
+
+`wrangler tail --format pretty` now supports receiving events from [Durable Object Alarms](https://developers.cloudflare.com/workers/learning/using-durable-objects/#alarms-in-durable-objects), and will display the time the alarm was triggered.
+
+Additionally, any future unknown events will simply print "Unkonwn Event" instead of crashing the `wrangler` process.

--- a/packages/wrangler/src/tail/index.ts
+++ b/packages/wrangler/src/tail/index.ts
@@ -174,12 +174,12 @@ export type TailEventMessage = {
 	/**
 	 * The event that triggered the worker. In the case of an HTTP request,
 	 * this will be a RequestEvent. If it's a cron trigger, it'll be a
-	 * ScheduledEvent.
+	 * ScheduledEvent. If it's a durable object alarm, it's an AlarmEvent.
 	 *
 	 * Until workers-types exposes individual types for export, we'll have
 	 * to just re-define these types ourselves.
 	 */
-	event: RequestEvent | ScheduledEvent | undefined | null;
+	event: RequestEvent | ScheduledEvent | AlarmEvent | undefined | null;
 };
 
 /**
@@ -296,4 +296,17 @@ export type ScheduledEvent = {
 	 * do it directly as a Date. So parse it later on your own.
 	 */
 	scheduledTime: number;
+};
+
+/**
+ * A event that was triggered from a durable object alarm
+ */
+export type AlarmEvent = {
+	/**
+	 * The datetime the alarm was scheduled for.
+	 *
+	 * This is sent as an ISO timestamp string (different than ScheduledEvent.scheduledTime),
+	 * you should parse it later on on your own.
+	 */
+	scheduledTime: string;
 };

--- a/packages/wrangler/src/tail/printing.ts
+++ b/packages/wrangler/src/tail/printing.ts
@@ -4,7 +4,7 @@ import type {
 	RequestEvent,
 	ScheduledEvent,
 	TailEventMessage,
-} from ".";
+} from "./index";
 import type { Outcome } from "./filters";
 import type WebSocket from "ws";
 

--- a/packages/wrangler/src/tail/printing.ts
+++ b/packages/wrangler/src/tail/printing.ts
@@ -1,11 +1,11 @@
 import { logger } from "../logger";
+import type { Outcome } from "./filters";
 import type {
 	AlarmEvent,
 	RequestEvent,
 	ScheduledEvent,
 	TailEventMessage,
 } from "./index";
-import type { Outcome } from "./filters";
 import type WebSocket from "ws";
 
 export function prettyPrintLogs(data: WebSocket.RawData): void {

--- a/packages/wrangler/src/tail/printing.ts
+++ b/packages/wrangler/src/tail/printing.ts
@@ -77,17 +77,15 @@ function isScheduledEvent(
 /**
  * Check to see if an event sent from a worker is an AlarmEvent.
  *
- * CAUTION: Because the only property on `AlarmEvent` is "scheduledTime", which it
- * shares with `ScheduledEvent`, `isAlarmEvent` cannot differentiate between
- * `ScheduledEvent`s and `AlarmEvent`s.
+ * Because the only property on `AlarmEvent` is "scheduledTime", which it
+ * shares with `ScheduledEvent`, `isAlarmEvent` checks if there's _not_
+ * a "cron" property in `event` to confirm it's an alarm event.
  *
  * @param event An event
  * @returns true if the event is an AlarmEvent
  */
-function isAlarmEvent(
-	event: Exclude<TailEventMessage["event"], ScheduledEvent>
-): event is AlarmEvent {
-	return Boolean(event && "scheduledTime" in event);
+function isAlarmEvent(event: TailEventMessage["event"]): event is AlarmEvent {
+	return Boolean(event && "scheduledTime" in event && !("cron" in event));
 }
 
 function prettifyOutcome(outcome: Outcome): string {

--- a/packages/wrangler/src/tail/printing.ts
+++ b/packages/wrangler/src/tail/printing.ts
@@ -77,7 +77,9 @@ function isScheduledEvent(
 /**
  * Check to see if an event sent from a worker is an AlarmEvent.
  *
- * CAUTION: Because the only property on `AlarmEvent` is "scheduled"
+ * CAUTION: Because the only property on `AlarmEvent` is "scheduledTime", which it
+ * shares with `ScheduledEvent`, `isAlarmEvent` cannot differentiate between
+ * `ScheduledEvent`s and `AlarmEvent`s.
  *
  * @param event An event
  * @returns true if the event is an AlarmEvent

--- a/packages/wrangler/src/tail/printing.ts
+++ b/packages/wrangler/src/tail/printing.ts
@@ -1,5 +1,10 @@
 import { logger } from "../logger";
-import type { RequestEvent, ScheduledEvent, TailEventMessage } from ".";
+import type {
+	AlarmEvent,
+	RequestEvent,
+	ScheduledEvent,
+	TailEventMessage,
+} from ".";
 import type { Outcome } from "./filters";
 import type WebSocket from "ws";
 
@@ -14,7 +19,7 @@ export function prettyPrintLogs(data: WebSocket.RawData): void {
 		const outcome = prettifyOutcome(eventMessage.outcome);
 
 		logger.log(`"${cronPattern}" @ ${datetime} - ${outcome}`);
-	} else {
+	} else if (isRequestEvent(eventMessage.event)) {
 		const requestMethod = eventMessage.event?.request.method.toUpperCase();
 		const url = eventMessage.event?.request.url;
 		const outcome = prettifyOutcome(eventMessage.outcome);
@@ -25,6 +30,19 @@ export function prettyPrintLogs(data: WebSocket.RawData): void {
 				? `${requestMethod} ${url} - ${outcome} @ ${datetime}`
 				: `[missing request] - ${outcome} @ ${datetime}`
 		);
+	} else if (isAlarmEvent(eventMessage.event)) {
+		const outcome = prettifyOutcome(eventMessage.outcome);
+		const datetime = new Date(
+			eventMessage.event.scheduledTime
+		).toLocaleString();
+
+		logger.log(`Alarm @ ${datetime} - ${outcome}`);
+	} else {
+		// Unknown event type
+		const outcome = prettifyOutcome(eventMessage.outcome);
+		const datetime = new Date(eventMessage.eventTimestamp).toLocaleString();
+
+		logger.log(`Unknown Event - ${outcome} @ ${datetime}`);
 	}
 
 	if (eventMessage.logs.length > 0) {
@@ -44,10 +62,30 @@ export function jsonPrintLogs(data: WebSocket.RawData): void {
 	console.log(JSON.stringify(JSON.parse(data.toString()), null, 2));
 }
 
+function isRequestEvent(
+	event: TailEventMessage["event"]
+): event is RequestEvent {
+	return Boolean(event && "request" in event);
+}
+
 function isScheduledEvent(
-	event: RequestEvent | ScheduledEvent | undefined | null
+	event: TailEventMessage["event"]
 ): event is ScheduledEvent {
 	return Boolean(event && "cron" in event);
+}
+
+/**
+ * Check to see if an event sent from a worker is an AlarmEvent.
+ *
+ * CAUTION: Because the only property on `AlarmEvent` is "scheduled"
+ *
+ * @param event An event
+ * @returns true if the event is an AlarmEvent
+ */
+function isAlarmEvent(
+	event: Exclude<TailEventMessage["event"], ScheduledEvent>
+): event is AlarmEvent {
+	return Boolean(event && "scheduledTime" in event);
 }
 
 function prettifyOutcome(outcome: Outcome): string {


### PR DESCRIPTION
`wrangler tail --format pretty` now supports receiving events from [Durable Object Alarms](https://developers.cloudflare.com/workers/learning/using-durable-objects/#alarms-in-durable-objects), and will display the time the alarm was triggered.

Additionally, any future unknown events will simply print "Unknown Event" instead of crashing the `wrangler` process.

Closes #1519 