### PR TITLE
feat: add --ip argument for `wrangler pages dev` & set default IP to `0.0.0.0`

### DIFF
--- a/.changeset/witty-planets-refuse.md
+++ b/.changeset/witty-planets-refuse.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+refactor: add --ip argument for `wrangler pages dev` & defaults IP to `0.0.0.0`
+
+Add new argument `--ip` for the command `wrangler pages dev`, defaults to `0.0.0.0`. The command `wrangler dev` is also defaulting to `0.0.0.0` instead of `localhost`.

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -26,7 +26,7 @@ describe("normalizeAndValidateConfig()", () => {
 			compatibility_flags: [],
 			configPath: undefined,
 			dev: {
-				ip: "localhost",
+				ip: "0.0.0.0",
 				local_protocol: "http",
 				port: undefined, // the default of 8787 is set at runtime
 				upstream_protocol: "https",

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -630,13 +630,13 @@ describe("wrangler dev", () => {
 	});
 
 	describe("ip", () => {
-		it("should default ip to localhost", async () => {
+		it("should default ip to 0.0.0.0", async () => {
 			writeWranglerToml({
 				main: "index.js",
 			});
 			fs.writeFileSync("index.js", `export default {};`);
 			await runWrangler("dev");
-			expect((Dev as jest.Mock).mock.calls[0][0].ip).toEqual("localhost");
+			expect((Dev as jest.Mock).mock.calls[0][0].ip).toEqual("0.0.0.0");
 			expect(std.out).toMatchInlineSnapshot(`""`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 			expect(std.err).toMatchInlineSnapshot(`""`);
@@ -849,7 +849,7 @@ describe("wrangler dev", () => {
 			});
 			fs.writeFileSync("index.js", `export default {};`);
 			await runWrangler("dev");
-			expect((Dev as jest.Mock).mock.calls[0][0].ip).toEqual("localhost");
+			expect((Dev as jest.Mock).mock.calls[0][0].ip).toEqual("0.0.0.0");
 			expect(std.out).toMatchInlineSnapshot(`
 			        "Your worker has access to the following bindings:
 			        - Durable Objects:
@@ -983,7 +983,7 @@ describe("wrangler dev", () => {
 			      --compatibility-date                         Date to use for compatibility checks  [string]
 			      --compatibility-flags, --compatibility-flag  Flags to use for compatibility checks  [array]
 			      --latest                                     Use the latest version of the worker runtime  [boolean] [default: true]
-			      --ip                                         IP address to listen on, defaults to \`localhost\`  [string]
+			      --ip                                         IP address to listen on  [string] [default: \\"0.0.0.0\\"]
 			      --port                                       Port to listen on  [number]
 			      --inspector-port                             Port for devtools to connect to  [number]
 			      --routes, --route                            Routes to upload  [array]

--- a/packages/wrangler/src/config/config.ts
+++ b/packages/wrangler/src/config/config.ts
@@ -174,7 +174,7 @@ export interface DevConfig {
 	/**
 	 * IP address for the local dev server to listen on,
 	 *
-	 * @default `localhost`
+	 * @default `0.0.0.0`
 	 */
 	ip: string;
 

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -357,7 +357,7 @@ function normalizeAndValidateDev(
 	rawDev: RawDevConfig
 ): DevConfig {
 	const {
-		ip = "localhost",
+		ip = "0.0.0.0",
 		port,
 		inspector_port,
 		local_protocol = "http",

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -127,9 +127,9 @@ export function devOptions(yargs: Argv): Argv<DevArgs> {
 				default: true,
 			})
 			.option("ip", {
-				describe: "IP address to listen on, defaults to `localhost`",
+				describe: "IP address to listen on",
 				type: "string",
-				requiresArg: true,
+				default: "0.0.0.0",
 			})
 			.option("port", {
 				describe: "Port to listen on",

--- a/packages/wrangler/src/pages/dev.tsx
+++ b/packages/wrangler/src/pages/dev.tsx
@@ -16,6 +16,7 @@ type PagesDevArgs = {
 	directory?: string;
 	command?: string;
 	local: boolean;
+	ip: string;
 	port: number;
 	proxy?: number;
 	"script-path": string;
@@ -45,6 +46,11 @@ export function Options(yargs: Argv): Argv<PagesDevArgs> {
 				type: "boolean",
 				default: true,
 				description: "Run on my machine",
+			},
+			ip: {
+				type: "string",
+				default: "0.0.0.0",
+				description: "The IP address to listen on",
 			},
 			port: {
 				type: "number",
@@ -108,6 +114,7 @@ export function Options(yargs: Argv): Argv<PagesDevArgs> {
 export const Handler = async ({
 	local,
 	directory,
+	ip,
 	port,
 	proxy: requestedProxyPort,
 	"script-path": singleWorkerScriptPath,
@@ -221,6 +228,7 @@ export const Handler = async ({
 	const { stop, waitUntilExit } = await unstable_dev(
 		scriptPath,
 		{
+			ip,
 			port,
 			watch: true,
 			localProtocol,


### PR DESCRIPTION
## What does this PR do

- Add a new argument `--ip` for `wrangler pages dev`, defaults to `0.0.0.0`
- Change default IP of `wrangler dev` to `0.0.0.0` instead of `localhost`

```
> wrangler pages dev --help
wrangler pages dev [directory] [-- command..]

Develop your full-stack Pages application locally

Positionals:
  directory  The directory of static assets to serve  [string]
  command    The proxy command to run  [string]

Flags:
  -h, --help     Show help  [boolean]
  -v, --version  Show version number  [boolean]

Options:
      --local                                  Run on my machine  [boolean] [default: true]
      --ip                                     The IP address to listen on  [string] [default: "0.0.0.0"]
      --port                                   The port to listen on (serve from)  [number] [default: 8788]
      --proxy                                  The port to proxy (where the static assets are served)  [number]
      --script-path                            The location of the single Worker script if not using functions  [string] [default: "_worker.js"]
  -b, --binding                                Bind variable/secret (KEY=VALUE)  [array]
  -k, --kv                                     KV namespace to bind  [array]
  -o, --do                                     Durable Object to bind (NAME=CLASS)  [array]
      --live-reload                            Auto reload HTML pages when change is detected  [boolean] [default: false]
      --local-protocol                         Protocol to listen to requests on, defaults to http.  [choices: "http", "https"]
      --experimental-enable-local-persistence  Enable persistence for this session (only for local mode)  [boolean] [default: false]
```
