### PR TITLE
chore: make prettify also fix changesets

### DIFF
--- a/.changeset/old-jobs-drum.md
+++ b/.changeset/old-jobs-drum.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+chore: make prettier also fix changesets, as it causes checks to fail if they're not formatted

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"check:lint": "eslint \"packages/**/*.[tj]s?(x)\" --cache --cache-strategy content --max-warnings=0",
 		"check:type": "npm run check:type --workspaces --if-present",
 		"fix": "npm run prettify && npm run check:lint -- --fix",
-		"prettify": "prettier packages/** --write --ignore-unknown",
+		"prettify": "prettier packages/** .changeset --write --ignore-unknown",
 		"test": "npm run test --workspaces --if-present",
 		"test:ci": "npm run test:ci --workspaces --if-present"
 	},


### PR DESCRIPTION
Currently, on a pull request, prettier will test changesets, and ensure they match the desired formatting. It will not, however, fix these changesets when you run `prettify`. This PR now includes changesets in the prettify command to ensure that they are correct

This issue can be seen in PRs like [#2649](https://github.com/cloudflare/wrangler2/pull/2649) , where checks failed based on the changeset file