### PR TITLE
patch: Consolidate redundant routes when generating _routes.generated.json

### DIFF
--- a/.changeset/four-bags-train.md
+++ b/.changeset/four-bags-train.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+patch: Consolidate redundant routes when generating \_routes.generated.json
+
+Example: `["/foo/:name", "/foo/bar"] => ["/foo/*"]`

--- a/packages/wrangler/src/pages/build.tsx
+++ b/packages/wrangler/src/pages/build.tsx
@@ -172,9 +172,11 @@ export async function buildFunctions({
 
 	if (config.routes) {
 		if (!directory) {
-			logger.warn(
-				"Cannot write generated routes file _routes.generated.json. Output directory is undefined."
-			);
+			if (!isInPagesCI) {
+				logger.warn(
+					"Cannot write generated routes file _routes.generated.json. Output directory is undefined."
+				);
+			}
 		} else if (existsSync(join(directory, "_routes.json"))) {
 			logger.log(
 				"Found _routes.json file. Skipping automatic routes generation."

--- a/packages/wrangler/src/pages/constants.ts
+++ b/packages/wrangler/src/pages/constants.ts
@@ -6,3 +6,5 @@ export const MAX_UPLOAD_ATTEMPTS = 5;
 export const MAX_CHECK_MISSING_ATTEMPTS = 5;
 export const SECONDS_TO_WAIT_FOR_PROXY = 5;
 export const isInPagesCI = !!process.env.CF_PAGES;
+/** The max number of rules in _routes.json / _routes.generated.json */
+export const MAX_FUNCTIONS_ROUTES_RULES = 100;

--- a/packages/wrangler/src/pages/dev.tsx
+++ b/packages/wrangler/src/pages/dev.tsx
@@ -188,6 +188,7 @@ export const Handler = async ({
 				onEnd: () => scriptReadyResolve(),
 				buildOutputDirectory: directory,
 				nodeCompat,
+				directory,
 			});
 			await metrics.sendMetricsEvent("build pages functions");
 		} catch {}
@@ -204,6 +205,7 @@ export const Handler = async ({
 				onEnd: () => scriptReadyResolve(),
 				buildOutputDirectory: directory,
 				nodeCompat,
+				directory,
 			});
 			await metrics.sendMetricsEvent("build pages functions");
 		});

--- a/packages/wrangler/src/pages/functions/routes-consolidation.test.ts
+++ b/packages/wrangler/src/pages/functions/routes-consolidation.test.ts
@@ -1,0 +1,66 @@
+import { consolidateRoutes } from "./routes-consolidation";
+
+describe("route-consolidation", () => {
+	describe("consolidateRoutes()", () => {
+		it("should consolidate redundant routes", () => {
+			expect(consolidateRoutes(["/api/foo", "/api/*"])).toEqual(["/api/*"]);
+			expect(
+				consolidateRoutes([
+					"/api/foo",
+					"/api/foo/*",
+					"/api/bar/*",
+					"/api/*",
+					"/foo",
+					"/foo/bar",
+					"/bar/*",
+					"/bar/baz/*",
+					"/bar/baz/hello",
+				])
+			).toEqual(["/api/*", "/foo", "/foo/bar", "/bar/*"]);
+		});
+		it("should consolidate thousands of redundant routes", () => {
+			// Test to make sure the consolidator isn't horribly slow
+			const routes: string[] = [];
+			const limit = 1000;
+			for (let i = 0; i < limit; i++) {
+				// Add 3 routes per id
+				const id = `some-id-${i}`;
+				routes.push(`/${id}/*`, `/${id}/foo`, `/${id}/bar/*`);
+			}
+			const consolidated = consolidateRoutes(routes);
+			expect(consolidated.length).toEqual(limit);
+			// Should be all unique
+			expect(Array.from(new Set(consolidated)).length).toEqual(limit);
+			// Should all have pattern `/$id/*`
+			expect(
+				consolidated.every((route) => route.match(/\/[a-z0-9-]+\/\*/) !== null)
+			).toEqual(true);
+		});
+
+		it("should consolidate many redundant sub-routes", () => {
+			const routes: string[] = [];
+			const limit = 15;
+
+			// Create $limit of top-level catch-all routes, with a lot of sub-routes
+			for (let i = 0; i < limit; i++) {
+				routes.push(`/foo-${i}/*`);
+				for (let j = 0; j < limit; j++) {
+					routes.push(`/foo-${i}/bar-${j}/hello`);
+					for (let k = 0; k < limit; k++) {
+						routes.push(`/foo-${i}/bar-${j}/baz-${k}/*`);
+						routes.push(`/foo-${i}/bar-${j}/baz-${k}/profile`);
+					}
+				}
+			}
+
+			const consolidated = consolidateRoutes(routes);
+			expect(consolidated.length).toEqual(limit);
+			// Should be all unique
+			expect(Array.from(new Set(consolidated)).length).toEqual(limit);
+			// Should all have pattern `/$id/*`
+			expect(
+				consolidated.every((route) => route.match(/\/[a-z0-9-]+\/\*/) !== null)
+			).toEqual(true);
+		});
+	});
+});

--- a/packages/wrangler/src/pages/functions/routes-consolidation.ts
+++ b/packages/wrangler/src/pages/functions/routes-consolidation.ts
@@ -1,0 +1,29 @@
+/**
+ * consolidateRoutes consolidates redundant routes - eg. ["/api/*"", "/api/foo"] -> ["/api/*""]
+ * @param routes If this is the same order as Functions routes (with most-specific first),
+ *   it will be more efficient to reverse it first. Should be in the format: /api/foo, /api/*
+ * @returns Non-redundant list of routes
+ */
+export function consolidateRoutes(routes: string[]): string[] {
+	// create a map of the routes
+	const routesMap = new Map<string, boolean>();
+	for (const route of routes) {
+		routesMap.set(route, true);
+	}
+	// Find routes that might render other routes redundant
+	for (const route of routes.filter((r) => r.endsWith("/*"))) {
+		// Make sure the route still exists in the map
+		if (routesMap.has(route)) {
+			// Remove splat at the end, leaving the /
+			// eg. /api/* -> /api/
+			const routeTrimmed = route.substring(0, route.length - 1);
+			for (const nextRoute of routesMap.keys()) {
+				// Delete any route that has the wildcard route as a prefix
+				if (nextRoute !== route && nextRoute.startsWith(routeTrimmed)) {
+					routesMap.delete(nextRoute);
+				}
+			}
+		}
+	}
+	return Array.from(routesMap.keys());
+}

--- a/packages/wrangler/src/pages/functions/routes-transformation.ts
+++ b/packages/wrangler/src/pages/functions/routes-transformation.ts
@@ -1,7 +1,10 @@
 import { join as pathJoin } from "node:path";
 import { toUrlPath } from "../../paths";
+import { MAX_FUNCTIONS_ROUTES_RULES } from "../constants";
+import { consolidateRoutes } from "./routes-consolidation";
 import type { RouteConfig } from "./routes";
 
+/** Interface for _routes.json and _routes.generated.json */
 interface RoutesJSONSpec {
 	version: 1;
 	include: string[];
@@ -36,12 +39,61 @@ export function convertRoutesToGlobPatterns(
 	return Array.from(new Set(convertedRoutes));
 }
 
+/**
+ * Converts Functions routes like /foo/:bar to a Routing object that's used
+ * to determine if a request should run in the Functions user-worker.
+ * Also consolidates redundant routes such as [/foo/bar, /foo/:bar] -> /foo/*
+ *
+ * @returns RotuesJSONSpec to be written to _routes.generated.json
+ */
 export function convertRoutesToRoutesJSONSpec(
 	routes: RoutesJSONRouteInput
 ): RoutesJSONSpec {
+	// The initial routes coming in are sorted most-specific to least-specific.
+	// The order doesn't have any affect on the output of this function, but
+	// it should speed up route consolidation with less-specific routes being first.
+	routes.reverse();
+	const convertedRoutes = convertRoutesToGlobPatterns(routes);
+	let consolidatedRoutes = consolidateRoutes(convertedRoutes);
+	if (consolidatedRoutes.length > MAX_FUNCTIONS_ROUTES_RULES) {
+		consolidatedRoutes = ["/*"];
+	}
+	// Sort so that least-specific routes are first
+	consolidatedRoutes.sort((a, b) => compareRoutes(b, a));
 	return {
 		version: 1,
-		include: convertRoutesToGlobPatterns(routes),
+		include: consolidatedRoutes,
 		exclude: [],
 	};
+}
+
+/**
+ * Simplified routes comparison (copied from the one in filepath-routing.)
+ * This version will sort most-specific to least-specific, but the input is simplified
+ * routes like /foo/*, /foo, etc
+ */
+export function compareRoutes(routeA: string, routeB: string) {
+	function parseRoutePath(routePath: string): string[] {
+		return routePath.slice(1).split("/").filter(Boolean);
+	}
+
+	const segmentsA = parseRoutePath(routeA);
+	const segmentsB = parseRoutePath(routeB);
+
+	// sort routes with fewer segments after those with more segments
+	if (segmentsA.length !== segmentsB.length) {
+		return segmentsB.length - segmentsA.length;
+	}
+
+	for (let i = 0; i < segmentsA.length; i++) {
+		const isWildcardA = segmentsA[i].includes("*");
+		const isWildcardB = segmentsB[i].includes("*");
+
+		// sort wildcard segments after non-wildcard segments
+		if (isWildcardA && !isWildcardB) return 1;
+		if (!isWildcardA && isWildcardB) return -1;
+	}
+
+	// all else equal, just sort the paths lexicographically
+	return routeA.localeCompare(routeB);
 }

--- a/packages/wrangler/src/pages/functions/routes-transformation.ts
+++ b/packages/wrangler/src/pages/functions/routes-transformation.ts
@@ -52,8 +52,8 @@ export function convertRoutesToRoutesJSONSpec(
 	// The initial routes coming in are sorted most-specific to least-specific.
 	// The order doesn't have any affect on the output of this function, but
 	// it should speed up route consolidation with less-specific routes being first.
-	routes.reverse();
-	const convertedRoutes = convertRoutesToGlobPatterns(routes);
+	const reversedRoutes = [...routes].reverse();
+	const convertedRoutes = convertRoutesToGlobPatterns(reversedRoutes);
 	let consolidatedRoutes = consolidateRoutes(convertedRoutes);
 	if (consolidatedRoutes.length > MAX_FUNCTIONS_ROUTES_RULES) {
 		consolidatedRoutes = ["/*"];


### PR DESCRIPTION
Example: `["/foo/:name", "/foo/bar"] => ["/foo/*"]`

Also fixed buildFunctions in a few places where we weren't passing `directory`