### PR TITLE
Durable Object multi-worker bindings

### DIFF
--- a/.changeset/olive-needles-whisper.md
+++ b/.changeset/olive-needles-whisper.md
@@ -1,0 +1,31 @@
+---
+"wrangler": patch
+---
+
+feat: Durable Object multi-worker bindings in local dev.
+
+Building on [the recent work for multi-worker Service bindings in local dev](https://github.com/cloudflare/wrangler2/pull/1503), this now adds support for direct Durable Object namespace bindings.
+
+A parent (calling) Worker will look for child Workers (where the Durable Object has been defined) by matching the `script_name` configuration option with the child's Service name. For example, if you have a Worker A which defines a Durable Object, `MyDurableObject`, and Worker B which references A's Durable Object:
+
+```toml
+name = "A"
+
+[durable_objects]
+bindings = [
+	{ name = "MY_DO", class_name = "MyDurableObject" }
+]
+```
+
+```toml
+name = "B"
+
+[durable_objects]
+bindings = [
+	{ name = "REFERENCED_DO", class_name = "MyDurableObject", script_name = "A" }
+]
+```
+
+`MY_DO` will work as normal in Worker A. `REFERENCED_DO` in Worker B will point at A's Durable Object.
+
+Note: this only works in local mode (`wrangler dev --local`) at present.

--- a/fixtures/external-durable-objects-app/a/index.ts
+++ b/fixtures/external-durable-objects-app/a/index.ts
@@ -1,0 +1,18 @@
+export default {
+	fetch(request: Request, env: { MY_DO: DurableObjectNamespace }) {
+		const { pathname } = new URL(request.url);
+		const id = env.MY_DO.idFromName(pathname);
+		const stub = env.MY_DO.get(id);
+		return stub.fetch(request);
+	},
+};
+
+export class MyDurableObject implements DurableObject {
+	constructor(public state: DurableObjectState) {}
+
+	async fetch() {
+		let count: number = (await this.state.storage.get("count")) || 0;
+		await this.state.storage.put("count", ++count);
+		return Response.json({ count, id: this.state.id.toString() });
+	}
+}

--- a/fixtures/external-durable-objects-app/a/wrangler.toml
+++ b/fixtures/external-durable-objects-app/a/wrangler.toml
@@ -1,0 +1,6 @@
+name = "a"
+
+[durable_objects]
+bindings = [
+	{ name = "MY_DO", class_name = "MyDurableObject" }
+]

--- a/fixtures/external-durable-objects-app/b/index.ts
+++ b/fixtures/external-durable-objects-app/b/index.ts
@@ -1,0 +1,8 @@
+export default {
+	fetch(request: Request, env: { REFERENCED_DO: DurableObjectNamespace }) {
+		const { pathname } = new URL(request.url);
+		const id = env.REFERENCED_DO.idFromName(pathname);
+		const stub = env.REFERENCED_DO.get(id);
+		return stub.fetch(request);
+	},
+};

--- a/fixtures/external-durable-objects-app/b/wrangler.toml
+++ b/fixtures/external-durable-objects-app/b/wrangler.toml
@@ -1,0 +1,6 @@
+name = "b"
+
+[durable_objects]
+bindings = [
+	{ name = "REFERENCED_DO", class_name = "MyDurableObject", script_name = "a" }
+]

--- a/fixtures/external-durable-objects-app/c/index.ts
+++ b/fixtures/external-durable-objects-app/c/index.ts
@@ -1,0 +1,8 @@
+declare const SW_REFERENCED_DO: DurableObjectNamespace;
+
+addEventListener("fetch", (event) => {
+	const { pathname } = new URL(event.request.url);
+	const id = SW_REFERENCED_DO.idFromName(pathname);
+	const stub = SW_REFERENCED_DO.get(id);
+	event.respondWith(stub.fetch(event.request));
+});

--- a/fixtures/external-durable-objects-app/c/wrangler.toml
+++ b/fixtures/external-durable-objects-app/c/wrangler.toml
@@ -1,0 +1,6 @@
+name = "c"
+
+[durable_objects]
+bindings = [
+	{ name = "SW_REFERENCED_DO", class_name = "MyDurableObject", script_name = "a" }
+]

--- a/fixtures/external-durable-objects-app/package.json
+++ b/fixtures/external-durable-objects-app/package.json
@@ -1,0 +1,29 @@
+{
+	"name": "external-durable-objects-app",
+	"private": true,
+	"description": "A test for external durable objects",
+	"scripts": {
+		"dev": "npx concurrently -s first -k \"wrangler dev a/index.ts --local --port 8400\" \"wrangler dev b/index.ts --local --port 8401\" \"npx wrangler dev c/index.ts --local --port 8402\"",
+		"test": "npx jest --forceExit",
+		"test:ci": "npx jest --forceExit"
+	},
+	"jest": {
+		"restoreMocks": true,
+		"testRegex": ".*.(test|spec)\\.[jt]sx?$",
+		"testTimeout": 30000,
+		"transform": {
+			"^.+\\.c?(t|j)sx?$": [
+				"esbuild-jest",
+				{
+					"sourcemap": true
+				}
+			]
+		},
+		"transformIgnorePatterns": [
+			"node_modules/(?!find-up|locate-path|p-locate|p-limit|yocto-queue|path-exists|execa|strip-final-newline|npm-run-path|path-key|onetime|mimic-fn|human-signals|is-stream)"
+		]
+	},
+	"devDependencies": {
+		"@cloudflare/workers-types": "^3.14.1"
+	}
+}

--- a/fixtures/external-durable-objects-app/tests/index.test.ts
+++ b/fixtures/external-durable-objects-app/tests/index.test.ts
@@ -1,0 +1,70 @@
+import { spawn } from "child_process";
+import * as path from "path";
+import { fetch } from "undici";
+import type { ChildProcess } from "child_process";
+import type { Response } from "undici";
+
+const waitUntilReady = async (url: string): Promise<Response> => {
+	let response: Response | undefined = undefined;
+
+	while (response === undefined) {
+		await new Promise((resolvePromise) => setTimeout(resolvePromise, 500));
+
+		try {
+			response = await fetch(url);
+		} catch {}
+	}
+
+	return response as Response;
+};
+
+const isWindows = process.platform === "win32";
+
+describe("Pages Functions", () => {
+	let wranglerProcess: ChildProcess;
+
+	beforeEach(() => {
+		wranglerProcess = spawn("npm", ["run", "dev"], {
+			shell: isWindows,
+			cwd: path.resolve(__dirname, "../"),
+			env: { BROWSER: "none", ...process.env },
+		});
+		wranglerProcess.stdout?.on("data", (chunk) => {
+			console.log(chunk.toString());
+		});
+		wranglerProcess.stderr?.on("data", (chunk) => {
+			console.log(chunk.toString());
+		});
+	});
+
+	afterEach(async () => {
+		await new Promise((resolve, reject) => {
+			wranglerProcess.once("exit", (code) => {
+				if (!code) {
+					resolve(code);
+				} else {
+					reject(code);
+				}
+			});
+			wranglerProcess.kill("SIGTERM");
+		});
+	});
+
+	it("connects up Durable Objects and keeps state across wrangler instances", async () => {
+		const responseA = await waitUntilReady("http://localhost:8400/");
+		const dataA = (await responseA.json()) as { count: number; id: string };
+		expect(dataA.count).toEqual(1);
+		const responseB = await waitUntilReady("http://localhost:8401/");
+		const dataB = (await responseB.json()) as { count: number; id: string };
+		expect(dataB.count).toEqual(2);
+		const responseC = await waitUntilReady("http://localhost:8402/");
+		const dataC = (await responseC.json()) as { count: number; id: string };
+		expect(dataC.count).toEqual(3);
+		const responseA2 = await waitUntilReady("http://localhost:8400/");
+		const dataA2 = (await responseA2.json()) as { count: number; id: string };
+		expect(dataA2.count).toEqual(4);
+		expect(dataA.id).toEqual(dataB.id);
+		expect(dataA.id).toEqual(dataC.id);
+		expect(dataA.id).toEqual(dataA2.id);
+	});
+});

--- a/fixtures/external-durable-objects-app/tsconfig.json
+++ b/fixtures/external-durable-objects-app/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"include": ["a", "b", "c"],
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "CommonJS",
+		"lib": ["ES2020"],
+		"types": ["@cloudflare/workers-types"]
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,11 @@
 				"node": ">=16.7.0"
 			}
 		},
+		"fixtures/external-durable-objects-app": {
+			"devDependencies": {
+				"@cloudflare/workers-types": "^3.14.1"
+			}
+		},
 		"fixtures/legacy-site-app": {
 			"version": "0.0.0",
 			"license": "ISC"
@@ -867,9 +872,9 @@
 			"link": true
 		},
 		"node_modules/@cloudflare/workers-types": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.10.0.tgz",
-			"integrity": "sha512-gn+H5Ps9yV1VYz8FJ08bMfXLW8ubNblRF9Z+m+0ctNMyl3CdoZmUfH1pMTxYE8SMUJbLxuNvpdlZhwLDoGFXaw=="
+			"version": "3.14.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.14.1.tgz",
+			"integrity": "sha512-B1/plF62pt+H2IJHvApK8fdOJAVsvojvacuac8x8s+JIyqbropMyqNqHTKLm3YD8ZFLGwYeFTudU+PQ7vGvBdA=="
 		},
 		"node_modules/@cloudflare/wrangler-devtools": {
 			"resolved": "packages/wrangler-devtools",
@@ -8553,6 +8558,10 @@
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
 			"integrity": "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg=="
+		},
+		"node_modules/external-durable-objects-app": {
+			"resolved": "fixtures/external-durable-objects-app",
+			"link": true
 		},
 		"node_modules/external-editor": {
 			"version": "3.1.0",
@@ -21880,9 +21889,9 @@
 			}
 		},
 		"@cloudflare/workers-types": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.10.0.tgz",
-			"integrity": "sha512-gn+H5Ps9yV1VYz8FJ08bMfXLW8ubNblRF9Z+m+0ctNMyl3CdoZmUfH1pMTxYE8SMUJbLxuNvpdlZhwLDoGFXaw=="
+			"version": "3.14.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.14.1.tgz",
+			"integrity": "sha512-B1/plF62pt+H2IJHvApK8fdOJAVsvojvacuac8x8s+JIyqbropMyqNqHTKLm3YD8ZFLGwYeFTudU+PQ7vGvBdA=="
 		},
 		"@cloudflare/wrangler-devtools": {
 			"version": "file:packages/wrangler-devtools",
@@ -27424,6 +27433,12 @@
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
 			"integrity": "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg=="
+		},
+		"external-durable-objects-app": {
+			"version": "file:fixtures/external-durable-objects-app",
+			"requires": {
+				"@cloudflare/workers-types": "*"
+			}
 		},
 		"external-editor": {
 			"version": "3.1.0",

--- a/packages/wrangler/scripts/deps.ts
+++ b/packages/wrangler/scripts/deps.ts
@@ -11,6 +11,7 @@ export const EXTERNAL_DEPENDENCIES = [
 	"blake3-wasm",
 	"miniflare",
 	"@miniflare/core",
+	"@miniflare/durable-objects",
 	// todo - bundle miniflare too
 	"selfsigned",
 	"source-map",

--- a/packages/wrangler/src/dev-registry.tsx
+++ b/packages/wrangler/src/dev-registry.tsx
@@ -22,6 +22,8 @@ type WorkerDefinition = {
 	host: string | undefined;
 	mode: "local" | "remote";
 	headers?: Record<string, string>;
+	durableObjects?: string[];
+	durableObjectsPort?: number;
 };
 
 /**

--- a/packages/wrangler/src/dev-registry.tsx
+++ b/packages/wrangler/src/dev-registry.tsx
@@ -22,7 +22,8 @@ type WorkerDefinition = {
 	host: string | undefined;
 	mode: "local" | "remote";
 	headers?: Record<string, string>;
-	durableObjects?: string[];
+	durableObjects: { name: string; className: string }[];
+	durableObjectsHost?: string;
 	durableObjectsPort?: number;
 };
 

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -278,8 +278,9 @@ function useLocalWorker({
 				stdio: "pipe",
 			}));
 
-			child.on("message", async (message) => {
-				if (message === "ready") {
+			child.on("message", async (messageString) => {
+				const message = JSON.parse(messageString as string);
+				if (message.ready) {
 					// Let's register our presence in the dev registry
 					if (workerName) {
 						await registerWorker(workerName, {
@@ -287,6 +288,8 @@ function useLocalWorker({
 							mode: "local",
 							port,
 							host: ip,
+							durableObjects: message.durableObjectClassNames,
+							durableObjectsPort: message.durableObjectsPort,
 						});
 					}
 					onReady?.();

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -10,6 +10,7 @@ import { logger } from "../logger";
 import { DEFAULT_MODULE_RULES } from "../module-collection";
 import { waitForPortToBeAvailable } from "../proxy";
 import type { Config } from "../config";
+import type { WorkerRegistry } from "../dev-registry";
 import type { EnablePagesAssetsServiceBindingOptions } from "../miniflare-cli";
 import type { AssetPaths } from "../sites";
 import type { CfWorkerInit, CfScriptFormat } from "../worker";
@@ -24,6 +25,7 @@ interface LocalProps {
 	compatibilityFlags: string[] | undefined;
 	usageModel: "bundled" | "unbound" | undefined;
 	bindings: CfWorkerInit["bindings"];
+	workerDefinitions: WorkerRegistry;
 	assetPaths: AssetPaths | undefined;
 	port: number;
 	ip: string;
@@ -59,6 +61,7 @@ function useLocalWorker({
 	compatibilityFlags,
 	usageModel,
 	bindings,
+	workerDefinitions,
 	assetPaths,
 	port,
 	inspectorPort,
@@ -97,6 +100,18 @@ function useLocalWorker({
 			);
 		}
 	}, [bindings.services]);
+
+	useEffect(() => {
+		const externalDurableObjects = (
+			bindings.durable_objects?.bindings || []
+		).filter((binding) => binding.script_name);
+
+		if (externalDurableObjects.length > 0) {
+			logger.warn(
+				"⎔ Support for external Durable Objects in local mode is experimental and may change."
+			);
+		}
+	}, [bindings.durable_objects?.bindings]);
 
 	useEffect(() => {
 		const abortController = new AbortController();
@@ -182,6 +197,15 @@ function useLocalWorker({
 					? `${localProtocol}://${localUpstream}`
 					: undefined;
 
+			const internalDurableObjects = (
+				bindings.durable_objects?.bindings || []
+			).filter((binding) => !binding.script_name);
+			const externalDurableObjects = (
+				bindings.durable_objects?.bindings || []
+			).filter((binding) => binding.script_name);
+
+			// TODO: This was already messy with the custom `disableLogs` and `logOptions`.
+			// It's now getting _really_ messy now with Pages ASSETS binding outside and the external Durable Objects inside.
 			const options: MiniflareOptions = {
 				name: workerName,
 				port,
@@ -202,9 +226,33 @@ function useLocalWorker({
 				kvNamespaces: bindings.kv_namespaces?.map((kv) => kv.binding),
 				r2Buckets: bindings.r2_buckets?.map((r2) => r2.binding),
 				durableObjects: Object.fromEntries(
-					(bindings.durable_objects?.bindings ?? []).map<[string, string]>(
-						(value) => [value.name, value.class_name]
-					)
+					internalDurableObjects.map((binding) => [
+						binding.name,
+						binding.class_name,
+					])
+				),
+				externalDurableObjects: Object.fromEntries(
+					externalDurableObjects
+						.map((binding) => {
+							const service = workerDefinitions[binding.script_name as string];
+							if (!service) return [binding.name, undefined];
+
+							const name = service.durableObjects.find(
+								(durableObject) =>
+									durableObject.className === binding.class_name
+							)?.name;
+							if (!name) return [binding.name, undefined];
+
+							return [
+								binding.name,
+								{
+									name,
+									host: service.durableObjectsHost,
+									port: service.durableObjectsPort,
+								},
+							];
+						})
+						.filter(([_, details]) => !!details)
 				),
 				...(localPersistencePath
 					? {
@@ -288,8 +336,16 @@ function useLocalWorker({
 							mode: "local",
 							port,
 							host: ip,
-							durableObjects: message.durableObjectClassNames,
-							durableObjectsPort: message.durableObjectsPort,
+							durableObjects: internalDurableObjects.map((binding) => ({
+								name: binding.name,
+								className: binding.class_name,
+							})),
+							...(message.durableObjectsPort
+								? {
+										durableObjectsHost: ip,
+										durableObjectsPort: message.durableObjectsPort,
+								  }
+								: {}),
 						});
 					}
 					onReady?.();
@@ -369,6 +425,7 @@ function useLocalWorker({
 		bindings.r2_buckets,
 		bindings.vars,
 		bindings.services,
+		workerDefinitions,
 		compatibilityDate,
 		compatibilityFlags,
 		usageModel,

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -34,6 +34,7 @@ export function useEsbuild({
 	noBundle,
 	workerDefinitions,
 	services,
+	durableObjects,
 	firstPartyWorkerDevFacade,
 }: {
 	entry: Entry;
@@ -50,6 +51,7 @@ export function useEsbuild({
 	nodeCompat: boolean | undefined;
 	noBundle: boolean;
 	workerDefinitions: WorkerRegistry;
+	durableObjects: Config["durable_objects"];
 	firstPartyWorkerDevFacade: boolean | undefined;
 }): EsbuildBundle | undefined {
 	const [bundle, setBundle] = useState<EsbuildBundle>();
@@ -168,6 +170,7 @@ export function useEsbuild({
 		define,
 		assets,
 		services,
+		durableObjects,
 		workerDefinitions,
 		firstPartyWorkerDevFacade,
 	]);

--- a/packages/wrangler/src/miniflare-cli/index.ts
+++ b/packages/wrangler/src/miniflare-cli/index.ts
@@ -1,3 +1,8 @@
+import { fetch } from "@miniflare/core";
+import {
+	DurableObjectNamespace,
+	DurableObjectStub,
+} from "@miniflare/durable-objects";
 import {
 	Log,
 	LogLevel,
@@ -7,6 +12,7 @@ import {
 } from "miniflare";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
+import { FatalError } from "../errors";
 import generateASSETSBinding from "./assets";
 import { enumKeys } from "./enum-keys";
 import { getRequestContextCheckOptions } from "./request-context";
@@ -51,6 +57,42 @@ async function main() {
 		console.log("OPTIONS:\n", JSON.stringify(config, null, 2));
 	}
 
+	config.bindings = {
+		...config.bindings,
+		...Object.fromEntries(
+			Object.entries(
+				config.externalDurableObjects as Record<
+					string,
+					{ name: string; host: string; port: number }
+				>
+			).map(([binding, { name, host, port }]) => {
+				const factory = () => {
+					throw new FatalError(
+						"An external Durable Object instance's state has somehow been attempted to be accessed.",
+						1
+					);
+				};
+				const namespace = new DurableObjectNamespace(name as string, factory);
+				namespace.get = (id) => {
+					const stub = new DurableObjectStub(factory, id);
+					stub.fetch = (...reqArgs) => {
+						const url = `http://${host}${port ? `:${port}` : ""}`;
+						const request = new MiniflareRequest(
+							url,
+							new MiniflareRequest(...reqArgs)
+						);
+						request.headers.set("x-miniflare-durable-object-name", name);
+						request.headers.set("x-miniflare-durable-object-id", id.toString());
+
+						return fetch(request);
+					};
+					return stub;
+				};
+				return [binding, namespace];
+			})
+		),
+	};
+
 	let mf: Miniflare | undefined;
 	let durableObjectsMf: Miniflare | undefined = undefined;
 	let durableObjectsMfPort: number | undefined = undefined;
@@ -83,13 +125,14 @@ async function main() {
 		await mf.startServer();
 		await mf.startScheduler();
 
-		const durableObjectClassNames = Object.values(
+		const internalDurableObjectClassNames = Object.values(
 			config.durableObjects as Record<string, string>
 		);
 
-		if (durableObjectClassNames.length > 0) {
+		if (internalDurableObjectClassNames.length > 0) {
 			durableObjectsMf = new Miniflare({
 				host: config.host,
+				port: 0,
 				script: `
 				export default {
 					fetch(request, env) {
@@ -100,29 +143,26 @@ async function main() {
 					DO: async (request: MiniflareRequest) => {
 						request = new MiniflareRequest(request);
 
-						const className = request.headers.get(
-							"x-miniflare-durable-object-class-name"
-						);
+						const name = request.headers.get("x-miniflare-durable-object-name");
 						const idString = request.headers.get(
 							"x-miniflare-durable-object-id"
 						);
-						request.headers.delete("x-miniflare-durable-object-class-name");
+						request.headers.delete("x-miniflare-durable-object-name");
 						request.headers.delete("x-miniflare-durable-object-id");
-						// TODO: Host/URL
 
-						if (!className || !idString) {
+						if (!name || !idString) {
 							return new MiniflareResponse(
-								"[durable-object-proxy-err] Missing `x-miniflare-durable-object-class-name` or `x-miniflare-durable-object-id` headers.",
+								"[durable-object-proxy-err] Missing `x-miniflare-durable-object-name` or `x-miniflare-durable-object-id` headers.",
 								{ status: 400 }
 							);
 						}
 
-						const namespace = await mf?.getDurableObjectNamespace(className);
+						const namespace = await mf?.getDurableObjectNamespace(name);
 						const id = namespace?.idFromString(idString);
 
 						if (!id) {
 							return new MiniflareResponse(
-								"[durable-object-proxy-err] Could not generate an ID. Possibly due to a mismatched DO class name and ID?",
+								"[durable-object-proxy-err] Could not generate an ID. Possibly due to a mismatched DO name and ID?",
 								{ status: 500 }
 							);
 						}
@@ -131,7 +171,7 @@ async function main() {
 
 						if (!stub) {
 							return new MiniflareResponse(
-								"[durable-object-proxy-err] Could not generate a stub. Possibly due to a mismatched DO class name and ID?",
+								"[durable-object-proxy-err] Could not generate a stub. Possibly due to a mismatched DO name and ID?",
 								{ status: 500 }
 							);
 						}
@@ -149,7 +189,6 @@ async function main() {
 			process.send(
 				JSON.stringify({
 					ready: true,
-					durableObjectClassNames,
 					durableObjectsPort: durableObjectsMfPort,
 				})
 			);


### PR DESCRIPTION
feat: Durable Object multi-worker bindings in local dev.

Building on [the recent work for multi-worker Service bindings in local dev](https://github.com/cloudflare/wrangler2/pull/1503), this now adds support for direct Durable Object namespace bindings.

A parent (calling) Worker will look for child Workers (where the Durable Object has been defined) by matching the `script_name` configuration option with the child's Service name. For example, if you have a Worker A which defines a Durable Object, `MyDurableObject`, and Worker B which references A's Durable Object:

```toml
name = "A"

[durable_objects]
bindings = [
	{ name = "MY_DO", class_name = "MyDurableObject" }
]
```

```toml
name = "B"

[durable_objects]
bindings = [
	{ name = "REFERENCED_DO", class_name = "MyDurableObject", script_name = "A" }
]
```

`MY_DO` will work as normal in Worker A. `REFERENCED_DO` in Worker B will point at A's Durable Object.

Note: this only works in local mode (`wrangler dev --local`) at present.

---

I tried several approaches with this. Ultimately, this felt like the best way. Considerations:

- the ID generation needs to happen sync, which couldn't easily be done directly inside a Worker script (whereas Node.js has sync bindings that Miniflare already uses);
- Miniflare scopes ID generation by the _binding_ name rather than the class name, so the owner needs to announce how it has bound the class;
- everything pipes through a single Miniflare instance responsible for all Durable Objects because Miniflare servers aren't super cheap, so rather that than one for each Durable Object;
- redeclaring Durable Objects directly inside the calling scripts wasn't always possible because those might be service worker scripts.

cc @mrbbot — thanks for thinking it all through with me!

Limitations: 

This doesn't work with environments just yet because local service registry doesn't support them at the moment