### PR TITLE
Set `sourceRoot` to `destination` in local dev mode

### DIFF
--- a/.changeset/beige-mirrors-clap.md
+++ b/.changeset/beige-mirrors-clap.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: Resolve source maps correctly in local dev mode
+
+Resolves https://github.com/cloudflare/wrangler2/issues/1614

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -192,8 +192,9 @@ export async function bundleWorker(
 		format: entry.format === "modules" ? "esm" : "iife",
 		target: "es2020",
 		sourcemap: true,
-		// The root included, as the sources are relative paths to tmpDir
-		sourceRoot: entryDirectory,
+		// Include a reference to the output folder in the sourcemap.
+		// This is omitted by default, but we need it to properly resolve source paths in error output.
+		sourceRoot: destination,
 		minify,
 		metafile: true,
 		conditions: ["worker", "browser"],

--- a/packages/wrangler/src/inspect.ts
+++ b/packages/wrangler/src/inspect.ts
@@ -320,10 +320,7 @@ export default function useInspector(props: InspectorProps) {
 														const convertedFnName =
 															pos.name || functionName || "";
 														exceptionLines.push(
-															`    at ${convertedFnName} (${pos.source?.replace(
-																`${mapContent.sourceRoot}/`,
-																""
-															)}:${pos.line}:${pos.column})`
+															`    at ${convertedFnName} (${pos.source}:${pos.line}:${pos.column})`
 														);
 													}
 												}


### PR DESCRIPTION
Passing `sourceRoot` as `entryDirectory` allows us to reference the original directory when outputting errors in remote dev mode, but unfortunately it breaks source resolution when using a debugger in local mode, since the `source` paths are resolved relative to `sourceRoot`—but `source` paths are set relative to the temporary directory we build in, not the original source root.

We can fix the latter without breaking the former by setting `sourceRoot` to `destination` (the temporary build directory). When logging errors, we rely on `source-map` to properly resolve the source file’s absolute path, rather than trying to rebuild the pathname ourselves by removing `sourceRoot` from `source`, which maintains the original desired behaviour.

I tested this locally with the following file:

```js
addEventListener('fetch', event => {
  throw new Error("Error");
})
```

In remote dev, visiting localhost produces:

```
✘ [ERROR] Uncaught Error: Error

  throw new Error("Error");
        ^
      at  (/<path-to-src>/index.js:2:8)


✘ [ERROR] Uncaught (in response) Error: fucked it
```

In local dev, adding a breakpoint in VS Code on line 2 correctly resolves & stops (previously, it did not).

Fixes #1614