### PR TITLE
feat: cloudflare workers repl

### DIFF
--- a/.changeset/silly-years-tan.md
+++ b/.changeset/silly-years-tan.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+feat: cloudflare workers repl
+
+Introduces a repl stype interface for cloudflare workers, running locally through miniflare.
+
+Closes https://github.com/cloudflare/wrangler2/issues/1263

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -46,6 +46,7 @@ describe("wrangler", () => {
 			  wrangler login             🔓 Login to Cloudflare
 			  wrangler logout            🚪 Logout from Cloudflare
 			  wrangler whoami            🕵️  Retrieve your user info and test your auth config
+			  wrangler repl              💬 Start an interactive REPL session
 
 			Flags:
 			  -c, --config   Path to .toml configuration file  [string]
@@ -85,6 +86,7 @@ describe("wrangler", () => {
 			  wrangler login             🔓 Login to Cloudflare
 			  wrangler logout            🚪 Logout from Cloudflare
 			  wrangler whoami            🕵️  Retrieve your user info and test your auth config
+			  wrangler repl              💬 Start an interactive REPL session
 
 			Flags:
 			  -c, --config   Path to .toml configuration file  [string]

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -56,6 +56,7 @@ import {
 	listR2Buckets,
 	putR2Object,
 } from "./r2";
+import { repl } from "./repl";
 import { getAssetPaths, getSiteAssetPaths } from "./sites";
 import {
 	createTail,
@@ -2122,6 +2123,19 @@ function createCLIParser(argv: string[]) {
 			await metrics.sendMetricsEvent("view accounts", {
 				sendMetrics: config.send_metrics,
 			});
+		}
+	);
+
+	// repl
+	wrangler.command(
+		"repl",
+		"💬 Start an interactive REPL session",
+		() => {},
+		async () => {
+			await printWranglerBanner();
+			await repl();
+			const config = readConfig(undefined, {});
+			// TODO: set up metrics event for repl
 		}
 	);
 

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -2134,8 +2134,11 @@ function createCLIParser(argv: string[]) {
 		async () => {
 			await printWranglerBanner();
 			await repl();
-			const config = readConfig(undefined, {});
 			// TODO: set up metrics event for repl
+			// const config = readConfig(undefined, {});
+			// await metrics.sendMetricsEvent("repl", {
+			// 	sendMetrics: config.send_metrics,
+			// });
 		}
 	);
 

--- a/packages/wrangler/src/repl.ts
+++ b/packages/wrangler/src/repl.ts
@@ -1,7 +1,9 @@
-import { Miniflare } from "miniflare";
 import { logger } from "./logger";
 
 export async function repl() {
+	// Dynamically imported for speed
+	const { Miniflare } = await import("miniflare");
+
 	logger.log("Interactive REPL session started though Miniflare");
 	const mf = new Miniflare({
 		// Allow REPL to be started without a script

--- a/packages/wrangler/src/repl.ts
+++ b/packages/wrangler/src/repl.ts
@@ -1,0 +1,18 @@
+import { Miniflare } from "miniflare";
+import { logger } from "./logger";
+
+export async function repl() {
+	logger.log("Interactive REPL session started though Miniflare");
+	const mf = new Miniflare({
+		// Allow REPL to be started without a script
+		scriptRequired: false,
+		// Disable file watching in REPL
+		watch: false,
+		// Allow async I/O in REPL without request context
+		globalAsyncIO: true,
+		globalTimers: true,
+		globalRandom: true,
+	});
+
+	await mf.startREPL();
+}


### PR DESCRIPTION
Introduces a repl style interface for cloudflare workers, running locally through miniflare. I think it is important that we let people know that this is running through miniflare; in this I have printed out `Interactive REPL session started though Miniflare` at the start of the session. Other suggestions on how to best inform people would be appreciated. 

Closes https://github.com/cloudflare/wrangler2/issues/1263