### PR TITLE
fix: service bindings + wrangler dev ignores pathname when making a request

### DIFF
--- a/.changeset/curly-eagles-vanish.md
+++ b/.changeset/curly-eagles-vanish.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: Added pathname to the constructed URL service bindings + wrangler dev ignores pathname when making a request.
+
+resolves #1598


### PR DESCRIPTION
Added pathname to the constructed URL.

resolves #1598