### PR TITLE
fix: pages dev process exit when proxied process exits

### DIFF
--- a/.changeset/nasty-apricots-wash.md
+++ b/.changeset/nasty-apricots-wash.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: pages dev process exit when proxied process exits
+
+Currently, if the process pages dev is proxying exists or crashes, pages dev does not clean it up, and attempts to continue proxying requests to it, resulting in it throwing 502 errors. This fixes that behaviour to make wrangler exit with the code the child_process exits with.

--- a/packages/wrangler/src/pages/dev.tsx
+++ b/packages/wrangler/src/pages/dev.tsx
@@ -395,7 +395,7 @@ async function spawnProxyProcess({
 	proxy.on("close", (code) => {
 		logger.error(`Proxy exited with status ${code}.`);
 		CLEANUP();
-		process.exit(code ?? 0);
+		process.exitCode = code ?? 0;
 	});
 
 	// Wait for proxy process to start...

--- a/packages/wrangler/src/pages/dev.tsx
+++ b/packages/wrangler/src/pages/dev.tsx
@@ -279,24 +279,16 @@ export const Handler = async ({
 	);
 	await metrics.sendMetricsEvent("run pages dev");
 
+	CLEANUP_CALLBACKS.push(stop);
+
 	waitUntilExit().then(() => {
 		CLEANUP();
-		stop();
 		process.exit(0);
 	});
 
-	process.on("exit", () => {
-		CLEANUP();
-		stop();
-	});
-	process.on("SIGINT", () => {
-		CLEANUP();
-		stop();
-	});
-	process.on("SIGTERM", () => {
-		CLEANUP();
-		stop();
-	});
+	process.on("exit", CLEANUP);
+	process.on("SIGINT", CLEANUP);
+	process.on("SIGTERM", CLEANUP);
 };
 
 function isWindows() {
@@ -402,6 +394,8 @@ async function spawnProxyProcess({
 
 	proxy.on("close", (code) => {
 		logger.error(`Proxy exited with status ${code}.`);
+		CLEANUP();
+		process.exit(code ?? 0);
 	});
 
 	// Wait for proxy process to start...


### PR DESCRIPTION
Currently, if the process pages dev is proxying exists or crashes, pages dev does not clean it up, and attempts to continue proxying requests to it, resulting in it throwing 502 errors. This fixes that behaviour to make wrangler exit with the code the child_process exits with.

Possibly actually fixes #1544 