### PR TITLE
Support 'exceededMemory' error status

### DIFF
--- a/.changeset/thick-weeks-pump.md
+++ b/.changeset/thick-weeks-pump.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+---
+
+fix: support 'exceededMemory' error status in tail
+
+While the exception for 'Worker exceeded memory limits' gets logged
+correctly when tailing, the actual status wasn't being counted as an
+error, and was falling through a switch case to 'unknown'
+
+This ensures filtering and logging reflects that status correctly

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -118,7 +118,7 @@ describe("tail", () => {
 			const api = mockWebsocketAPIs();
 			await runWrangler("tail test-worker --status error");
 			await expect(api.nextMessageJson()).resolves.toHaveProperty("filters", [
-				{ outcome: ["exception", "exceededCpu", "unknown"] },
+				{ outcome: ["exception", "exceededCpu", "exceededMemory", "unknown"] },
 			]);
 		});
 
@@ -126,7 +126,15 @@ describe("tail", () => {
 			const api = mockWebsocketAPIs();
 			await runWrangler("tail test-worker --status error --status canceled");
 			await expect(api.nextMessageJson()).resolves.toHaveProperty("filters", [
-				{ outcome: ["exception", "exceededCpu", "unknown", "canceled"] },
+				{
+					outcome: [
+						"exception",
+						"exceededCpu",
+						"exceededMemory",
+						"unknown",
+						"canceled",
+					],
+				},
 			]);
 		});
 
@@ -213,7 +221,15 @@ describe("tail", () => {
 			const expectedWebsocketMessage = {
 				filters: [
 					{ sampling_rate },
-					{ outcome: ["ok", "exception", "exceededCpu", "unknown"] },
+					{
+						outcome: [
+							"ok",
+							"exception",
+							"exceededCpu",
+							"exceededMemory",
+							"unknown",
+						],
+					},
 					{ method },
 					{ header: { key: "X-HELLO", query: "world" } },
 					{ client_ip },

--- a/packages/wrangler/src/tail/filters.ts
+++ b/packages/wrangler/src/tail/filters.ts
@@ -58,13 +58,14 @@ type OutcomeFilter = {
 
 /**
  * There are five possible outcomes we can get, three of which
- * (exception, exceededCpu, and unknown) are considered errors
+ * (exception, exceededCpu, exceededMemory, and unknown) are considered errors
  */
 export type Outcome =
 	| "ok"
 	| "canceled"
 	| "exception"
 	| "exceededCpu"
+	| "exceededMemory"
 	| "unknown";
 
 /**
@@ -210,6 +211,7 @@ function parseOutcome(
 			case "error":
 				outcomes.add("exception");
 				outcomes.add("exceededCpu");
+				outcomes.add("exceededMemory");
 				outcomes.add("unknown");
 				break;
 

--- a/packages/wrangler/src/tail/printing.ts
+++ b/packages/wrangler/src/tail/printing.ts
@@ -96,6 +96,8 @@ function prettifyOutcome(outcome: Outcome): string {
 			return "Canceled";
 		case "exceededCpu":
 			return "Exceeded CPU Limit";
+		case "exceededMemory":
+			return "Exceeded Memory Limit";
 		case "exception":
 			return "Exception Thrown";
 		case "unknown":


### PR DESCRIPTION
While the exception for 'Worker exceeded memory limits' gets logged
correctly when tailing, the actual status wasn't being counted as an
error, and was falling through a switch case to 'unknown'

This ensures filtering and logging reflects that status correctly