### PR TITLE
Add output-routes-path to functions build

### DIFF
--- a/.changeset/nine-ladybugs-confess.md
+++ b/.changeset/nine-ladybugs-confess.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+feat: Add output-routes-path to functions build
+
+This controls the output path of the \_routes.json file. Also moves \_routes.json generation to tmp directory during functions build + publish

--- a/.prettierignore
+++ b/.prettierignore
@@ -13,6 +13,5 @@ packages/jest-environment-wrangler/dist/
 packages/wranglerjs-compat-webpack-plugin/lib
 packages/wrangler-devtools/built-devtools
 fixtures/pages-plugin-example/index.js
-_routes.generated.json
 fixtures/remix-pages-app/build/
 fixtures/remix-pages-app/public/build/

--- a/fixtures/pages-functions-app/.gitignore
+++ b/fixtures/pages-functions-app/.gitignore
@@ -1,2 +1,1 @@
 cdn-cgi/
-public/_routes.generated.json

--- a/fixtures/remix-pages-app/.gitignore
+++ b/fixtures/remix-pages-app/.gitignore
@@ -3,4 +3,3 @@ node_modules
 /.cache
 /build
 /public/build
-/public/_routes.generated.json

--- a/packages/wrangler/src/pages/build.tsx
+++ b/packages/wrangler/src/pages/build.tsx
@@ -12,12 +12,10 @@ import { writeRoutesModule } from "./functions/routes";
 import { convertRoutesToRoutesJSONSpec } from "./functions/routes-transformation";
 import { pagesBetaWarning, RUNNING_BUILDERS } from "./utils";
 import type { Config } from "./functions/routes";
-import type { ArgumentsCamelCase, Argv } from "yargs";
+import type { YargsOptionsToInterface } from "./types";
+import type { Argv } from "yargs";
 
-type YargsArgsType<T extends Argv> = T extends Argv<infer P> ? P : never;
-type PagesBuildArgs = ArgumentsCamelCase<
-	YargsArgsType<ReturnType<typeof Options>>
->;
+type PagesBuildArgs = YargsOptionsToInterface<typeof Options>;
 
 export function Options(yargs: Argv) {
 	return yargs

--- a/packages/wrangler/src/pages/constants.ts
+++ b/packages/wrangler/src/pages/constants.ts
@@ -6,5 +6,6 @@ export const MAX_UPLOAD_ATTEMPTS = 5;
 export const MAX_CHECK_MISSING_ATTEMPTS = 5;
 export const SECONDS_TO_WAIT_FOR_PROXY = 5;
 export const isInPagesCI = !!process.env.CF_PAGES;
-/** The max number of rules in _routes.json / _routes.generated.json */
+/** The max number of rules in _routes.json */
 export const MAX_FUNCTIONS_ROUTES_RULES = 100;
+export const ROUTES_SPEC_VERSION = 1;

--- a/packages/wrangler/src/pages/deployments.tsx
+++ b/packages/wrangler/src/pages/deployments.tsx
@@ -11,14 +11,16 @@ import { requireAuth } from "../user";
 import { PAGES_CONFIG_CACHE_FILENAME } from "./constants";
 import { listProjects } from "./projects";
 import { pagesBetaWarning } from "./utils";
-import type { Deployment, PagesConfigCache } from "./types";
-import type { ArgumentsCamelCase, Argv } from "yargs";
+import type {
+	Deployment,
+	PagesConfigCache,
+	YargsOptionsToInterface,
+} from "./types";
+import type { Argv } from "yargs";
 
-type ListArgs = {
-	"project-name"?: string;
-};
+type ListArgs = YargsOptionsToInterface<typeof ListOptions>;
 
-export function ListOptions(yargs: Argv): Argv<ListArgs> {
+export function ListOptions(yargs: Argv) {
 	return yargs
 		.options({
 			"project-name": {
@@ -30,9 +32,7 @@ export function ListOptions(yargs: Argv): Argv<ListArgs> {
 		.epilogue(pagesBetaWarning);
 }
 
-export async function ListHandler({
-	projectName,
-}: ArgumentsCamelCase<ListArgs>) {
+export async function ListHandler({ projectName }: ListArgs) {
 	const config = getConfigCache<PagesConfigCache>(PAGES_CONFIG_CACHE_FILENAME);
 	const accountId = await requireAuth(config);
 

--- a/packages/wrangler/src/pages/dev.tsx
+++ b/packages/wrangler/src/pages/dev.tsx
@@ -12,33 +12,17 @@ import { buildFunctions } from "./build";
 import { SECONDS_TO_WAIT_FOR_PROXY } from "./constants";
 import { CLEANUP, CLEANUP_CALLBACKS, pagesBetaWarning } from "./utils";
 import type { AdditionalDevProps } from "../dev";
+import type { YargsOptionsToInterface } from "./types";
 import type { Plugin } from "esbuild";
-import type { ArgumentsCamelCase, Argv } from "yargs";
+import type { Argv } from "yargs";
 
 const DURABLE_OBJECTS_BINDING_REGEXP = new RegExp(
 	/^(?<binding>[^=]+)=(?<className>[^@\s]+)(@(?<scriptName>.*)$)?$/
 );
 
-type PagesDevArgs = {
-	directory?: string;
-	command?: string;
-	local: boolean;
-	ip: string;
-	port: number;
-	"inspector-port"?: number;
-	proxy?: number;
-	"script-path": string;
-	binding?: (string | number)[];
-	kv?: (string | number)[];
-	do?: (string | number)[];
-	r2?: (string | number)[];
-	"live-reload": boolean;
-	"local-protocol"?: "https" | "http";
-	"experimental-enable-local-persistence": boolean;
-	"node-compat": boolean;
-};
+type PagesDevArgs = YargsOptionsToInterface<typeof Options>;
 
-export function Options(yargs: Argv): Argv<PagesDevArgs> {
+export function Options(yargs: Argv) {
 	return yargs
 		.positional("directory", {
 			type: "string",
@@ -146,7 +130,7 @@ export const Handler = async ({
 	"node-compat": nodeCompat,
 	config: config,
 	_: [_pages, _dev, ...remaining],
-}: ArgumentsCamelCase<PagesDevArgs>) => {
+}: PagesDevArgs) => {
 	// Beta message for `wrangler pages <commands>` usage
 	logger.log(pagesBetaWarning);
 
@@ -208,7 +192,6 @@ export const Handler = async ({
 				onEnd: () => scriptReadyResolve(),
 				buildOutputDirectory: directory,
 				nodeCompat,
-				directory,
 			});
 			await metrics.sendMetricsEvent("build pages functions");
 		} catch {}
@@ -225,7 +208,6 @@ export const Handler = async ({
 				onEnd: () => scriptReadyResolve(),
 				buildOutputDirectory: directory,
 				nodeCompat,
-				directory,
 			});
 			await metrics.sendMetricsEvent("build pages functions");
 		});

--- a/packages/wrangler/src/pages/functions/routes-transformation.ts
+++ b/packages/wrangler/src/pages/functions/routes-transformation.ts
@@ -117,7 +117,7 @@ export function isRoutesJSONSpec(data: unknown): data is RoutesJSONSpec {
 			data &&
 			"version" in data &&
 			typeof (data as RoutesJSONSpec).version === "number" &&
-			(data as RoutesJSONSpec).version === 1 &&
+			(data as RoutesJSONSpec).version === ROUTES_SPEC_VERSION &&
 			Array.isArray((data as RoutesJSONSpec).include) &&
 			Array.isArray((data as RoutesJSONSpec).exclude)) ||
 		false

--- a/packages/wrangler/src/pages/publish.tsx
+++ b/packages/wrangler/src/pages/publish.tsx
@@ -16,6 +16,11 @@ import * as metrics from "../metrics";
 import { requireAuth } from "../user";
 import { buildFunctions } from "./build";
 import { PAGES_CONFIG_CACHE_FILENAME } from "./constants";
+import { consolidateRoutes } from "./functions/routes-consolidation";
+import {
+	isRoutesJSONSpec,
+	optimizeRoutesJSONSpec,
+} from "./functions/routes-transformation";
 import { listProjects } from "./projects";
 import { upload } from "./upload";
 import { pagesBetaWarning } from "./utils";
@@ -251,6 +256,7 @@ export const Handler = async ({
 
 	let builtFunctions: string | undefined = undefined;
 	const functionsDirectory = join(cwd(), "functions");
+	const routesOutputPath = join(tmpdir(), `_routes-${Math.random()}.json`);
 	if (existsSync(functionsDirectory)) {
 		const outfile = join(tmpdir(), `./functionsWorker-${Math.random()}.js`);
 
@@ -260,7 +266,7 @@ export const Handler = async ({
 				functionsDirectory,
 				onEnd: () => resolve(null),
 				buildOutputDirectory: dirname(outfile),
-				directory,
+				routesOutputPath,
 			})
 		);
 
@@ -303,18 +309,8 @@ export const Handler = async ({
 	} catch {}
 
 	try {
-		_routes = readFileSync(join(directory, "_routes.json"), "utf-8");
-		logger.warn(
-			`🚨 _routes.json is an experimental feature and is subject to change. Don't use unless you really must!`
-		);
-	} catch {
-		try {
-			_routes = readFileSync(
-				join(directory, "_routes.generated.json"),
-				"utf-8"
-			);
-		} catch {}
-	}
+		_routes = readFileSync(routesOutputPath, "utf-8");
+	} catch {}
 
 	try {
 		_workerJS = readFileSync(join(directory, "_worker.js"), "utf-8");
@@ -335,7 +331,37 @@ export const Handler = async ({
 	if (builtFunctions) {
 		formData.append("_worker.js", new File([builtFunctions], "_worker.js"));
 	} else if (_workerJS) {
+		// Advanced Mode
+		// https://developers.cloudflare.com/pages/platform/functions/#advanced-mode
 		formData.append("_worker.js", new File([_workerJS], "_worker.js"));
+
+		try {
+			// In advanced mode, developers can specify a custom _routes.json
+			// file. In which case, we need to run it through optimization
+			// to potentially reduce the overall worker pipeline size
+			const routesPath = join(directory, "_routes.json");
+			const advancedModeRoutesString = readFileSync(routesPath, "utf-8");
+			const advancedModeRoutes = JSON.parse(advancedModeRoutesString);
+
+			if (!isRoutesJSONSpec(advancedModeRoutes)) {
+				throw new FatalError(
+					"Invalid _routes.json file found at:" + routesPath,
+					1
+				);
+			}
+
+			_routes = JSON.stringify(optimizeRoutesJSONSpec(advancedModeRoutes));
+
+			logger.warn(
+				`🚨 _routes.json is an experimental feature and is subject to change. Don't use unless you really must!`
+			);
+		} catch (e) {
+			// Ignore file not existing errors for _routes.json but forward the potential
+			// FatalError from an invalid spec
+			if (e instanceof FatalError) {
+				throw e;
+			}
+		}
 	}
 	const deploymentResponse = await fetchResult<Deployment>(
 		`/accounts/${accountId}/pages/projects/${projectName}/deployments`,

--- a/packages/wrangler/src/pages/publish.tsx
+++ b/packages/wrangler/src/pages/publish.tsx
@@ -16,7 +16,6 @@ import * as metrics from "../metrics";
 import { requireAuth } from "../user";
 import { buildFunctions } from "./build";
 import { PAGES_CONFIG_CACHE_FILENAME } from "./constants";
-import { consolidateRoutes } from "./functions/routes-consolidation";
 import {
 	isRoutesJSONSpec,
 	optimizeRoutesJSONSpec,
@@ -24,19 +23,17 @@ import {
 import { listProjects } from "./projects";
 import { upload } from "./upload";
 import { pagesBetaWarning } from "./utils";
-import type { Deployment, PagesConfigCache, Project } from "./types";
-import type { ArgumentsCamelCase, Argv } from "yargs";
+import type {
+	Deployment,
+	PagesConfigCache,
+	Project,
+	YargsOptionsToInterface,
+} from "./types";
+import type { Argv } from "yargs";
 
-type PublishArgs = {
-	directory: string;
-	"project-name"?: string;
-	branch?: string;
-	"commit-hash"?: string;
-	"commit-message"?: string;
-	"commit-dirty"?: boolean;
-};
+type PublishArgs = YargsOptionsToInterface<typeof Options>;
 
-export function Options(yargs: Argv): Argv<PublishArgs> {
+export function Options(yargs: Argv) {
 	return yargs
 		.positional("directory", {
 			type: "string",
@@ -82,7 +79,7 @@ export const Handler = async ({
 	commitMessage,
 	commitDirty,
 	config: wranglerConfig,
-}: ArgumentsCamelCase<PublishArgs>) => {
+}: PublishArgs) => {
 	if (wranglerConfig) {
 		throw new FatalError("Pages does not support wrangler.toml", 1);
 	}

--- a/packages/wrangler/src/pages/types.ts
+++ b/packages/wrangler/src/pages/types.ts
@@ -1,3 +1,12 @@
+import type { ArgumentsCamelCase, Argv } from "yargs";
+
+/**
+ * Given some Yargs Options function factory, extract the interface
+ * that corresponds to the yargs arguments
+ */
+export type YargsOptionsToInterface<T extends (yargs: Argv) => Argv> =
+	T extends (yargs: Argv) => Argv<infer P> ? ArgumentsCamelCase<P> : never;
+
 export type Project = {
 	name: string;
 	subdomain: string;

--- a/packages/wrangler/src/pages/upload.tsx
+++ b/packages/wrangler/src/pages/upload.tsx
@@ -107,7 +107,6 @@ export const upload = async (
 		"_redirects",
 		"_headers",
 		"_routes.json",
-		"_routes.generated.json",
 		".DS_Store",
 		"node_modules",
 		".git",

--- a/packages/wrangler/src/pages/upload.tsx
+++ b/packages/wrangler/src/pages/upload.tsx
@@ -26,15 +26,12 @@ import {
 	MAX_UPLOAD_ATTEMPTS,
 } from "./constants";
 import { pagesBetaWarning } from "./utils";
-import type { UploadPayloadFile } from "./types";
-import type { ArgumentsCamelCase, Argv } from "yargs";
+import type { UploadPayloadFile, YargsOptionsToInterface } from "./types";
+import type { Argv } from "yargs";
 
-type UploadArgs = {
-	directory: string;
-	"output-manifest-path"?: string;
-};
+type UploadArgs = YargsOptionsToInterface<typeof Options>;
 
-export function Options(yargs: Argv): Argv<UploadArgs> {
+export function Options(yargs: Argv) {
 	return yargs
 		.positional("directory", {
 			type: "string",
@@ -53,7 +50,7 @@ export function Options(yargs: Argv): Argv<UploadArgs> {
 export const Handler = async ({
 	directory,
 	outputManifestPath,
-}: ArgumentsCamelCase<UploadArgs>) => {
+}: UploadArgs) => {
 	if (!directory) {
 		throw new FatalError("Must specify a directory.", 1);
 	}


### PR DESCRIPTION
This controls the output path of the _routes.json file. Also moves _routes.json generation to tmp directory during functions build + publish

Also removes the concept of `_routes.generated.json` and instead moves the generated routes to a temporary file