### PR TITLE
Fix R2 create bucket endpoint

### DIFF
--- a/.changeset/twelve-peaches-punch.md
+++ b/.changeset/twelve-peaches-punch.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fixed R2 create bucket API endpoint. The `wrangler r2 bucket create` command should work again

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -82,10 +82,11 @@ describe("wrangler", () => {
 				function mockCreateRequest(expectedBucketName: string) {
 					const requests = { count: 0 };
 					setMockResponse(
-						"/accounts/:accountId/r2/buckets/:bucketName",
-						"PUT",
-						([_url, accountId, bucketName]) => {
+						"/accounts/:accountId/r2/buckets",
+						"POST",
+						([_url, accountId], { body }) => {
 							expect(accountId).toEqual("some-account-id");
+							const bucketName = JSON.parse(body as string).name;
 							expect(bucketName).toEqual(expectedBucketName);
 							requests.count += 1;
 						}

--- a/packages/wrangler/src/r2.ts
+++ b/packages/wrangler/src/r2.ts
@@ -33,13 +33,10 @@ export async function createR2Bucket(
 	accountId: string,
 	bucketName: string
 ): Promise<void> {
-	return await fetchResult<void>(
-		`/accounts/${accountId}/r2/buckets`,
-		{
-			method: "POST",
-			body: JSON.stringify({ name: bucketName })
-		}
-	);
+	return await fetchResult<void>(`/accounts/${accountId}/r2/buckets`, {
+		method: "POST",
+		body: JSON.stringify({ name: bucketName }),
+	});
 }
 
 /**

--- a/packages/wrangler/src/r2.ts
+++ b/packages/wrangler/src/r2.ts
@@ -34,8 +34,11 @@ export async function createR2Bucket(
 	bucketName: string
 ): Promise<void> {
 	return await fetchResult<void>(
-		`/accounts/${accountId}/r2/buckets/${bucketName}`,
-		{ method: "PUT" }
+		`/accounts/${accountId}/r2/buckets`,
+		{
+			method: "POST",
+			body: JSON.stringify({ name: bucketName })
+		}
 	);
 }
 


### PR DESCRIPTION
The old PUT endpoint was removed in favour of POST `{ "name": "<bucket>" }`
