### PR TITLE
fix: Warn when Pages Functions have no routes

### DIFF
--- a/.changeset/shaggy-spies-scream.md
+++ b/.changeset/shaggy-spies-scream.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: Throw error when Pages Functions have no routes
+
+Building pages functions with no valid handlers would result in a Functions script containing no routes, often because the user is using the functions directory for something unrelated.

--- a/.changeset/shaggy-spies-scream.md
+++ b/.changeset/shaggy-spies-scream.md
@@ -2,6 +2,6 @@
 "wrangler": patch
 ---
 
-fix: Throw error when Pages Functions have no routes
+fix: Warn when Pages Functions have no routes
 
-Building pages functions with no valid handlers would result in a Functions script containing no routes, often because the user is using the functions directory for something unrelated.
+Building/publishing pages functions with no valid handlers would result in a Functions script containing no routes, often because the user is using the functions directory for something unrelated. This will no longer add an empty Functions script to the deployment, needlessly consuming Functions quota.

--- a/packages/wrangler/src/pages/build.tsx
+++ b/packages/wrangler/src/pages/build.tsx
@@ -1,6 +1,7 @@
 import { writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { FatalError } from "../errors";
 import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { toUrlPath } from "../paths";
@@ -14,7 +15,6 @@ import { pagesBetaWarning, RUNNING_BUILDERS } from "./utils";
 import type { Config } from "./functions/routes";
 import type { YargsOptionsToInterface } from "./types";
 import type { Argv } from "yargs";
-import { FatalError } from "../errors";
 
 type PagesBuildArgs = YargsOptionsToInterface<typeof Options>;
 

--- a/packages/wrangler/src/pages/build.tsx
+++ b/packages/wrangler/src/pages/build.tsx
@@ -1,6 +1,7 @@
 import { writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { FatalError } from "../errors";
 import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { toUrlPath } from "../paths";
@@ -19,7 +20,6 @@ import { pagesBetaWarning, RUNNING_BUILDERS } from "./utils";
 import type { Config } from "./functions/routes";
 import type { YargsOptionsToInterface } from "./types";
 import type { Argv } from "yargs";
-import { FatalError } from "../errors";
 
 type PagesBuildArgs = YargsOptionsToInterface<typeof Options>;
 

--- a/packages/wrangler/src/pages/build.tsx
+++ b/packages/wrangler/src/pages/build.tsx
@@ -14,6 +14,7 @@ import { pagesBetaWarning, RUNNING_BUILDERS } from "./utils";
 import type { Config } from "./functions/routes";
 import type { YargsOptionsToInterface } from "./types";
 import type { Argv } from "yargs";
+import { FatalError } from "../errors";
 
 type PagesBuildArgs = YargsOptionsToInterface<typeof Options>;
 
@@ -164,7 +165,14 @@ export async function buildFunctions({
 		baseURL,
 	});
 
-	if (config.routes && routesOutputPath) {
+	if (!config.routes || config.routes.length === 0) {
+		throw new FatalError(
+			`Failed to find any routes while compiling Functions in ${functionsDirectory}`,
+			1
+		);
+	}
+
+	if (routesOutputPath) {
 		const routesJSON = convertRoutesToRoutesJSONSpec(config.routes);
 		writeFileSync(routesOutputPath, JSON.stringify(routesJSON, null, 2));
 	}

--- a/packages/wrangler/src/pages/build.tsx
+++ b/packages/wrangler/src/pages/build.tsx
@@ -186,7 +186,7 @@ export async function buildFunctions({
 
 	if (!config.routes || config.routes.length === 0) {
 		throw new FunctionsNoRoutesError(
-			`Failed to find any routes while compiling Functions in ${functionsDirectory}`
+			`Failed to find any routes while compiling Functions in: ${functionsDirectory}`
 		);
 	}
 

--- a/packages/wrangler/src/pages/dev.tsx
+++ b/packages/wrangler/src/pages/dev.tsx
@@ -208,7 +208,7 @@ export const Handler = async ({
 						functionsDirectory,
 						sourcemap: true,
 						watch: true,
-						onEnd: () => scriptReadyResolve(),
+						onEnd,
 						buildOutputDirectory: directory,
 						nodeCompat,
 					});

--- a/packages/wrangler/src/pages/dev.tsx
+++ b/packages/wrangler/src/pages/dev.tsx
@@ -215,7 +215,9 @@ export const Handler = async ({
 					await metrics.sendMetricsEvent("build pages functions");
 				} catch (e) {
 					if (e instanceof FunctionsNoRoutesError) {
-						logger.warn(getFunctionsNoRoutesWarning(functionsDirectory));
+						logger.warn(
+							getFunctionsNoRoutesWarning(functionsDirectory, "skipping")
+						);
 					} else {
 						throw e;
 					}
@@ -224,7 +226,9 @@ export const Handler = async ({
 		} catch (e) {
 			// If there are no Functions, then Pages will only serve assets.
 			if (e instanceof FunctionsNoRoutesError) {
-				logger.warn(getFunctionsNoRoutesWarning(functionsDirectory));
+				logger.warn(
+					getFunctionsNoRoutesWarning(functionsDirectory, "skipping")
+				);
 				// Resolve anyway and run without Functions
 				onEnd();
 				// Turn off Functions

--- a/packages/wrangler/src/pages/dev.tsx
+++ b/packages/wrangler/src/pages/dev.tsx
@@ -191,7 +191,7 @@ export const Handler = async ({
 				functionsDirectory,
 				sourcemap: true,
 				watch: true,
-				onEnd: onEnd,
+				onEnd,
 				buildOutputDirectory: directory,
 				nodeCompat,
 			});

--- a/packages/wrangler/src/pages/errors.ts
+++ b/packages/wrangler/src/pages/errors.ts
@@ -13,6 +13,11 @@ export class FunctionsNoRoutesError extends Error {
 export const EXIT_CODE_FUNCTIONS_NO_ROUTES_ERROR = 3;
 
 /** Warning message for when buildFunctions throws FunctionsNoRoutesError */
-export function getFunctionsNoRoutesWarning(functionsDirectory: string) {
-	return `No routes found when building Functions directory: ${functionsDirectory} - Skipping Functions in deployment.`;
+export function getFunctionsNoRoutesWarning(
+	functionsDirectory: string,
+	suffix?: string
+) {
+	return `No routes found when building Functions directory: ${functionsDirectory}${
+		suffix ? " - " + suffix : ""
+	}`;
 }

--- a/packages/wrangler/src/pages/errors.ts
+++ b/packages/wrangler/src/pages/errors.ts
@@ -1,0 +1,18 @@
+/**
+ * Pages error when no routes are found in the functions directory
+ */
+export class FunctionsNoRoutesError extends Error {
+	constructor(message: string) {
+		super(message);
+	}
+}
+/**
+ * Exit code for `pages functions build` when no routes are found.
+ * This is a safe exit code to use: https://tldp.org/LDP/abs/html/exitcodes.html
+ */
+export const EXIT_CODE_FUNCTIONS_NO_ROUTES_ERROR = 3;
+
+/** Warning message for when buildFunctions throws FunctionsNoRoutesError */
+export function getFunctionsNoRoutesWarning(functionsDirectory: string) {
+	return `No routes found when building Functions directory: ${functionsDirectory} - Skipping Functions in deployment.`;
+}

--- a/packages/wrangler/src/pages/errors.ts
+++ b/packages/wrangler/src/pages/errors.ts
@@ -8,9 +8,8 @@ export class FunctionsNoRoutesError extends Error {
 }
 /**
  * Exit code for `pages functions build` when no routes are found.
- * This is a safe exit code to use: https://tldp.org/LDP/abs/html/exitcodes.html
  */
-export const EXIT_CODE_FUNCTIONS_NO_ROUTES_ERROR = 3;
+export const EXIT_CODE_FUNCTIONS_NO_ROUTES_ERROR = 156;
 
 /** Warning message for when buildFunctions throws FunctionsNoRoutesError */
 export function getFunctionsNoRoutesWarning(

--- a/packages/wrangler/src/pages/publish.tsx
+++ b/packages/wrangler/src/pages/publish.tsx
@@ -268,7 +268,9 @@ export const Handler = async ({
 			builtFunctions = readFileSync(outfile, "utf-8");
 		} catch (e) {
 			if (e instanceof FunctionsNoRoutesError) {
-				logger.warn(getFunctionsNoRoutesWarning(functionsDirectory));
+				logger.warn(
+					getFunctionsNoRoutesWarning(functionsDirectory, "skipping")
+				);
 			} else {
 				throw e;
 			}


### PR DESCRIPTION
Building pages functions with no valid handlers would result in a Functions script containing no routes, often because the user is using the functions directory for something unrelated.

This will now warn when no routes are found, and skip adding an empty Functions worker to the deployment.

Internal-use only: `pages functions build` will exit with code `156` if no routes are found.

**Example** with `wrangler pages dev` with empty `functions` dir:
![Screen Shot 2022-08-11 at 4 56 54 PM](https://user-images.githubusercontent.com/10719325/184249504-9ddec257-694d-4bd4-8f1c-bc8575f1fb1c.png)

**Example** with `wrangler pages publish` with empty `functions` dir:
![Screen Shot 2022-08-11 at 4 58 08 PM](https://user-images.githubusercontent.com/10719325/184249606-ef1dca17-2611-4dc5-8b32-7c4d64b29059.png)

