### PR TITLE
`wrangler pages dev` compat date and flags

### DIFF
--- a/.changeset/spicy-candles-warn.md
+++ b/.changeset/spicy-candles-warn.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+feat: Adds `--compatibility-date` and `--compatibility-flags` to `wrangler pages dev`
+
+Soon to follow in production.

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -16,6 +16,7 @@ interface DevOptions {
 	siteExclude?: string[];
 	nodeCompat?: boolean;
 	compatibilityDate?: string;
+	compatibilityFlags?: string[];
 	experimentalEnableLocalPersistence?: boolean;
 	liveReload?: boolean;
 	watch?: boolean;

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -502,10 +502,10 @@ export async function startDev(args: StartDevOptions) {
 					isWorkersSite={Boolean(args.site || config.site)}
 					compatibilityDate={getDevCompatibilityDate(
 						config,
-						args["compatibility-date"]
+						args.compatibilityDate
 					)}
 					compatibilityFlags={
-						args["compatibility-flags"] || config.compatibility_flags
+						args.compatibilityFlags || config.compatibility_flags
 					}
 					usageModel={config.usage_model}
 					bindings={bindings}

--- a/packages/wrangler/src/pages/dev.tsx
+++ b/packages/wrangler/src/pages/dev.tsx
@@ -40,6 +40,27 @@ export function Options(yargs: Argv) {
 				default: true,
 				description: "Run on my machine",
 			},
+			"compatibility-date": {
+				describe: "Date to use for compatibility checks",
+				type: "string",
+			},
+			"compatibility-flags": {
+				describe: "Flags to use for compatibility checks",
+				alias: "compatibility-flag",
+				type: "string",
+				array: true,
+			},
+
+			// TODO
+			// For now, all Pages projects are set to 2021-11-02. We're adding compat date soon, and we can then adopt `wrangler dev`'s `default: true`.
+			// However, it looks like it isn't actually connected up properly in `wrangler dev` at the moment, hence commenting this out for now.
+
+			// latest: {
+			// 	describe: "Use the latest version of the worker runtime",
+			// 	type: "boolean",
+			// 	default: false,
+			// },
+
 			ip: {
 				type: "string",
 				default: "0.0.0.0",
@@ -115,6 +136,8 @@ export function Options(yargs: Argv) {
 export const Handler = async ({
 	local,
 	directory,
+	"compatibility-date": compatibilityDate = "2021-11-02",
+	"compatibility-flags": compatibilityFlags,
 	ip,
 	port,
 	"inspector-port": inspectorPort,
@@ -254,8 +277,8 @@ export const Handler = async ({
 			watch: true,
 			localProtocol,
 			liveReload,
-
-			compatibilityDate: "2021-11-02",
+			compatibilityDate,
+			compatibilityFlags,
 			nodeCompat,
 			vars: Object.fromEntries(
 				bindings


### PR DESCRIPTION
Fixes #495

---

feat: Adds `--compatibility-date` and `--compatibility-flags` to `wrangler pages dev`

Soon to follow in production.