### PR TITLE
fix: Consolidate routes that are over the limit to prevent failed deployments

### DIFF
--- a/.changeset/heavy-timers-matter.md
+++ b/.changeset/heavy-timers-matter.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: Consolidate routes that are over the limit to prevent failed deployments
+
+Rather than failing a deployment because a route is too long (>100 characters), it will now be shortened to the next available level. Eg. `/foo/aaaaaaa...` -> `/foo/*`

--- a/packages/wrangler/src/pages/constants.ts
+++ b/packages/wrangler/src/pages/constants.ts
@@ -8,4 +8,5 @@ export const SECONDS_TO_WAIT_FOR_PROXY = 5;
 export const isInPagesCI = !!process.env.CF_PAGES;
 /** The max number of rules in _routes.json */
 export const MAX_FUNCTIONS_ROUTES_RULES = 100;
+export const MAX_FUNCTIONS_ROUTES_RULE_LENGTH = 100;
 export const ROUTES_SPEC_VERSION = 1;

--- a/packages/wrangler/src/pages/functions/routes-consolidation.test.ts
+++ b/packages/wrangler/src/pages/functions/routes-consolidation.test.ts
@@ -233,9 +233,10 @@ describe("route-consolidation", () => {
 					const segment = "/" + "a".repeat(i);
 					// make sure the segment isn't too long since we are testing not resulting to /*
 					expect(segment.length).toBeLessThanOrEqual(maxRuleLength);
-
 					const route =
 						segment.repeat((maxRuleLength / segment.length) * 2) + suffix;
+					// Make sure we made the rule too long
+					expect(route.length).toBeGreaterThan(maxRuleLength);
 					const short = shortenRoute(route);
 
 					// Make sure it's not over the limit

--- a/packages/wrangler/src/pages/functions/routes-consolidation.test.ts
+++ b/packages/wrangler/src/pages/functions/routes-consolidation.test.ts
@@ -1,6 +1,7 @@
-import { consolidateRoutes } from "./routes-consolidation";
+import { consolidateRoutes, shortenRoute } from "./routes-consolidation";
 
 describe("route-consolidation", () => {
+	const maxRuleLength = 100; // from constants.MAX_FUNCTIONS_ROUTES_RULE_LENGTH
 	describe("consolidateRoutes()", () => {
 		it("should consolidate redundant routes", () => {
 			expect(consolidateRoutes(["/api/foo", "/api/*"])).toEqual(["/api/*"]);
@@ -62,5 +63,189 @@ describe("route-consolidation", () => {
 				consolidated.every((route) => route.match(/\/[a-z0-9-]+\/\*/) !== null)
 			).toEqual(true);
 		});
+
+		it("should truncate long single-level path into catch-all path, removing other paths", () => {
+			expect(
+				consolidateRoutes([
+					// [/aaaaaaa, /foo] -> [/*]
+					"/" + "a".repeat(maxRuleLength * 2),
+					"/foo",
+					"/bar/*",
+					"/baz/bagel/coffee",
+				])
+			).toEqual(["/*"]);
+		});
+
+		it("should truncate long nested path, removing other paths", () => {
+			expect(
+				consolidateRoutes([
+					// [/aaaaaaa, /foo] -> [/*]
+					"/foo/" + "a".repeat(maxRuleLength * 2),
+					"/foo/bar",
+				])
+			).toEqual(["/foo/*"]);
+		});
+	});
+
+	// Try all tests for different rule limits to make sure we don't
+	// have weird off-by-some errors
+	describe(`shortenRoute()`, () => {
+		it("should allow max length path", () => {
+			const route = "/" + "a".repeat(maxRuleLength - 1);
+			// Make sure we don't have an off-by-one error, that'd be embarrassing...
+			expect(route.length).toEqual(maxRuleLength);
+			expect(
+				// Should stay the same
+				shortenRoute(route)
+			).toEqual(route);
+		});
+
+		it("should allow max length path (with slash)", () => {
+			const route = "/" + "a".repeat(maxRuleLength - 2) + "/";
+			expect(route.length).toEqual(maxRuleLength);
+			expect(
+				// Should stay the same
+				shortenRoute(route)
+			).toEqual(route);
+		});
+
+		it("should allow max length wildcard path", () => {
+			const route = "/" + "a".repeat(maxRuleLength - 3) + "/*";
+			expect(route.length).toEqual(maxRuleLength);
+			expect(
+				// Should stay the same
+				shortenRoute(route)
+			).toEqual(route);
+		});
+
+		it("should truncate long specific path to shorter wildcard path", () => {
+			const short = shortenRoute(
+				// /aaa/bbb -> /aaa/*
+				"/" +
+					"a".repeat(maxRuleLength * 0.6) +
+					"/" +
+					"b".repeat(maxRuleLength * 0.6)
+			);
+			expect(short).toEqual("/" + "a".repeat(maxRuleLength * 0.6) + "/*");
+			expect(short.length).toBeLessThanOrEqual(maxRuleLength);
+		});
+
+		it("should truncate long specific path (with slash) to shorter wildcard path", () => {
+			const short = shortenRoute(
+				// /aaa/bbb/ -> /aaa/*
+				"/" +
+					"a".repeat(maxRuleLength * 0.6) +
+					"/" +
+					"b".repeat(maxRuleLength * 0.6) +
+					"/"
+			);
+			expect(short).toEqual("/" + "a".repeat(maxRuleLength * 0.6) + "/*");
+			expect(short.length).toBeLessThanOrEqual(maxRuleLength);
+		});
+
+		it("should truncate long wildcard path to shorter wildcard path", () => {
+			const short = shortenRoute(
+				// /aaa/bbb/* -> /aaa/*
+				"/" +
+					"a".repeat(maxRuleLength * 0.6) +
+					"/" +
+					"b".repeat(maxRuleLength * 0.6) +
+					"/*"
+			);
+			expect(short).toEqual("/" + "a".repeat(maxRuleLength * 0.6) + "/*");
+			expect(short.length).toBeLessThanOrEqual(maxRuleLength);
+		});
+
+		it("should truncate long single-level specific path to catch-all path", () => {
+			expect(
+				shortenRoute(
+					// /aaa -> /*
+					"/" + "a".repeat(maxRuleLength * 2)
+				)
+			).toEqual("/*");
+		});
+
+		it("should truncate long single-level specific path (with slash) to catch-all path", () => {
+			expect(
+				shortenRoute(
+					// /aaa/ -> /*
+					"/" + "a".repeat(maxRuleLength * 2) + "/"
+				)
+			).toEqual("/*");
+		});
+
+		it("should truncate long single-level wildcard path to catch-all path", () => {
+			expect(
+				shortenRoute(
+					// /aaa/* -> /*
+					"/" + "a".repeat(maxRuleLength * 2) + "/*"
+				)
+			).toEqual("/*");
+		});
+
+		it("should truncate many single-character segements", () => {
+			const short = shortenRoute(
+				// /a/a/a -> /a/a/*
+				"/a".repeat(maxRuleLength) // 2x limit
+			);
+			expect(short).toEqual("/a".repeat(maxRuleLength / 2 - 1) + "/*");
+			// Should be the exact max length
+			expect(short.length).toEqual(maxRuleLength);
+		});
+
+		it("should truncate many double-character segements", () => {
+			// === odd ===
+			const short = shortenRoute(
+				// /aa/aa/aa -> /aa/aa/*
+				"/aa".repeat(maxRuleLength) // 3x limit
+			);
+			expect(short).toEqual("/aa".repeat(maxRuleLength / 3 - 1) + "/*");
+			// Should be the exact max length
+			expect(short.length).toEqual(maxRuleLength - 2); // -2 because of the odd number
+		});
+
+		it("should truncate many single-character segements with wildcard", () => {
+			const short = shortenRoute(
+				// /a/a/a -> /a/a/*
+				"/a".repeat(maxRuleLength) + "/*" // 2x limit
+			);
+			expect(short).toEqual("/a".repeat(maxRuleLength / 2 - 1) + "/*");
+			// Should be the exact max length
+			expect(short.length).toEqual(maxRuleLength);
+		});
+
+		it("should truncate many double-character segements with wildcard", () => {
+			const short = shortenRoute(
+				// /aa/aa/aa -> /aa/*
+				"/aa".repeat(maxRuleLength) + "/*" // 2x limit
+			);
+			expect(short).toEqual("/aa".repeat(maxRuleLength / 3 - 1) + "/*");
+			// Should be the exact max length
+			expect(short.length).toEqual(maxRuleLength - 2); // -2 because of the odd number
+		});
+
+		// This is probably the best test here - tests variable-length segments, up until the max.
+		// This ensures that it's always able to shorten rules, without failing and returning "/*"
+		// The other tests are great for ensuring exact sequences instead of only asserting length, though.
+		for (const suffix of ["", "/", "/*"]) {
+			// Test each type of path: /a, /a/a, /a/*
+			it(`should truncate many variable-character segements (suffix="${suffix}") without truncating to /*`, () => {
+				// "/" + 97 chars + "/*" === 100
+				for (let i = 1; i < maxRuleLength - 2; i++) {
+					const segment = "/" + "a".repeat(i);
+					// make sure the segment isn't too long since we are testing not resulting to /*
+					expect(segment.length).toBeLessThanOrEqual(maxRuleLength);
+
+					const route =
+						segment.repeat((maxRuleLength / segment.length) * 2) + suffix;
+					const short = shortenRoute(route);
+
+					// Make sure it's not over the limit
+					expect(short.length).toBeLessThanOrEqual(maxRuleLength);
+					// It should never have to fall back to /*
+					expect(short).not.toEqual("/*");
+				}
+			});
+		}
 	});
 });

--- a/packages/wrangler/src/pages/functions/routes-consolidation.test.ts
+++ b/packages/wrangler/src/pages/functions/routes-consolidation.test.ts
@@ -87,8 +87,6 @@ describe("route-consolidation", () => {
 		});
 	});
 
-	// Try all tests for different rule limits to make sure we don't
-	// have weird off-by-some errors
 	describe(`shortenRoute()`, () => {
 		it("should allow max length path", () => {
 			const route = "/" + "a".repeat(maxRuleLength - 1);

--- a/packages/wrangler/src/pages/functions/routes-consolidation.ts
+++ b/packages/wrangler/src/pages/functions/routes-consolidation.ts
@@ -51,9 +51,9 @@ export function shortenRoute(
 	}
 
 	let route = routeToShorten;
-	// Shorten to the first slash within the limit
+	// May have to try multiple times for longer segments
 	for (let i = 0; i < routeToShorten.length; i++) {
-		// May have to try multiple times for longer segments
+		// Shorten to the first slash within the limit
 		for (let j = maxLength - 1 - i; j > 0; j--) {
 			if (route[j] === "/") {
 				route = route.slice(0, j) + "/*";


### PR DESCRIPTION
Rather than failing a deployment because a route is too long (>100 characters), it will now be shortened to the next available level. Eg. `/foo/aaaaaaa...` -> `/foo/*`