### PR TITLE
fix: escape function path regex chars

### DIFF
--- a/.changeset/cool-peaches-boil.md
+++ b/.changeset/cool-peaches-boil.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: pages dev correctly escapes regex characters in function paths (fixes #1685)

--- a/fixtures/pages-functions-app/functions/regex_chars/my-file.ts
+++ b/fixtures/pages-functions-app/functions/regex_chars/my-file.ts
@@ -1,0 +1,1 @@
+export const onRequestGet = () => new Response("My file with regex chars");

--- a/fixtures/pages-functions-app/tests/index.test.ts
+++ b/fixtures/pages-functions-app/tests/index.test.ts
@@ -73,6 +73,14 @@ describe("Pages Functions", () => {
 		expect(text).toContain("// test script");
 	});
 
+	it("parses URLs with regex chars", async () => {
+		const response = await waitUntilReady(
+			"http://localhost:8789/regex_chars/my-file"
+		);
+		const text = await response.text();
+		expect(text).toEqual("My file with regex chars");
+	});
+
 	it("passes environment variables", async () => {
 		const response = await waitUntilReady("http://localhost:8789/variables");
 		const env = await response.json();

--- a/packages/wrangler/templates/pages-template-plugin.ts
+++ b/packages/wrangler/templates/pages-template-plugin.ts
@@ -1,5 +1,8 @@
 import { match } from "path-to-regexp";
 
+//note: this explicitly does not include the * character, as pages requires this
+const escapeRegex = /[.+?^${}()|[\]\\]/g;
+
 type HTTPMethod =
 	| "HEAD"
 	| "OPTIONS"
@@ -67,8 +70,13 @@ function* executeRequest(request: Request, relativePathname: string) {
 			continue;
 		}
 
-		const routeMatcher = match(route.routePath, { end: false });
-		const mountMatcher = match(route.mountPath, { end: false });
+		// replaces with "\\$&", this prepends a backslash to the matched string, e.g. "[" becomes "\["
+		const routeMatcher = match(route.routePath.replace(escapeRegex, "\\$&"), {
+			end: false,
+		});
+		const mountMatcher = match(route.mountPath.replace(escapeRegex, "\\$&"), {
+			end: false,
+		});
 		const matchResult = routeMatcher(relativePathname);
 		const mountMatchResult = mountMatcher(relativePathname);
 		if (matchResult && mountMatchResult) {
@@ -88,8 +96,12 @@ function* executeRequest(request: Request, relativePathname: string) {
 			continue;
 		}
 
-		const routeMatcher = match(route.routePath, { end: true });
-		const mountMatcher = match(route.mountPath, { end: false });
+		const routeMatcher = match(route.routePath.replace(escapeRegex, "\\$&"), {
+			end: true,
+		});
+		const mountMatcher = match(route.mountPath.replace(escapeRegex, "\\$&"), {
+			end: false,
+		});
 		const matchResult = routeMatcher(relativePathname);
 		const mountMatchResult = mountMatcher(relativePathname);
 		if (matchResult && mountMatchResult && route.modules.length) {

--- a/packages/wrangler/templates/pages-template-worker.ts
+++ b/packages/wrangler/templates/pages-template-worker.ts
@@ -1,5 +1,8 @@
 import { match } from "path-to-regexp";
 
+//note: this explicitly does not include the * character, as pages requires this
+const escapeRegex = /[.+?^${}()|[\]\\]/g;
+
 type HTTPMethod =
 	| "HEAD"
 	| "OPTIONS"
@@ -61,8 +64,12 @@ function* executeRequest(request: Request) {
 			continue;
 		}
 
-		const routeMatcher = match(route.routePath, { end: false });
-		const mountMatcher = match(route.mountPath, { end: false });
+		const routeMatcher = match(route.routePath.replace(escapeRegex, "\\$&"), {
+			end: false,
+		});
+		const mountMatcher = match(route.mountPath.replace(escapeRegex, "\\$&"), {
+			end: false,
+		});
 		const matchResult = routeMatcher(requestPath);
 		const mountMatchResult = mountMatcher(requestPath);
 		if (matchResult && mountMatchResult) {
@@ -81,9 +88,12 @@ function* executeRequest(request: Request) {
 		if (route.method && route.method !== request.method) {
 			continue;
 		}
-
-		const routeMatcher = match(route.routePath, { end: true });
-		const mountMatcher = match(route.mountPath, { end: false });
+		const routeMatcher = match(route.routePath.replace(escapeRegex, "\\$&"), {
+			end: true,
+		});
+		const mountMatcher = match(route.mountPath.replace(escapeRegex, "\\$&"), {
+			end: false,
+		});
 		const matchResult = routeMatcher(requestPath);
 		const mountMatchResult = mountMatcher(requestPath);
 		if (matchResult && mountMatchResult && route.modules.length) {

--- a/packages/wrangler/templates/pages-template-worker.ts
+++ b/packages/wrangler/templates/pages-template-worker.ts
@@ -64,6 +64,7 @@ function* executeRequest(request: Request) {
 			continue;
 		}
 
+		// replaces with "\\$&", this prepends a backslash to the matched string, e.g. "[" becomes "\["
 		const routeMatcher = match(route.routePath.replace(escapeRegex, "\\$&"), {
 			end: false,
 		});


### PR DESCRIPTION
Closes #1685

Currently, if you have a file such as `functions/*.ts`, pages attempts to run path-to-regex on this, and this will fail, as it assumes it's a regex character (it shouldn't be). This results in an `Unexpected MODIFIER at 1, expected END.` error. This PR correctly escapes these characters to solve the issue (confirmed fix from Alastair)