### PR TITLE
Support passing routes as well as worker names to `wrangler tail`

### DIFF
--- a/.changeset/ninety-books-hope.md
+++ b/.changeset/ninety-books-hope.md
@@ -3,3 +3,5 @@
 ---
 
 Closes [#1505](https://github.com/cloudflare/wrangler2/issues/1505) by extending `wrangler tail` to allow for passing worker routes as well as worker script names.
+
+For example, if you have a worker `example-worker` assigned to the route `example.com/*`, you can retrieve it's logs by running either `wrangler tail example.com/*` or `wrangler tail example-worker`—previously only `wrangler tail example-worker` was supported.

--- a/.changeset/ninety-books-hope.md
+++ b/.changeset/ninety-books-hope.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Closes [#1505](https://github.com/cloudflare/wrangler2/issues/1505) by extending `wrangler tail` to allow for passing worker routes as well as worker script names.

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -34,7 +34,7 @@ describe("wrangler", () => {
 			  wrangler init [name]       📥 Create a wrangler.toml configuration file
 			  wrangler dev [script]      👂 Start a local server for developing your worker
 			  wrangler publish [script]  🆙 Publish your Worker to Cloudflare.
-			  wrangler tail [name]       🦚 Starts a log tailing session for a published Worker.
+			  wrangler tail [worker]     🦚 Starts a log tailing session for a published Worker.
 			  wrangler secret            🤫 Generate a secret that can be referenced in a Worker
 			  wrangler kv:namespace      🗂️  Interact with your Workers KV Namespaces
 			  wrangler kv:key            🔑 Individually manage Workers KV key-value pairs
@@ -73,7 +73,7 @@ describe("wrangler", () => {
 			  wrangler init [name]       📥 Create a wrangler.toml configuration file
 			  wrangler dev [script]      👂 Start a local server for developing your worker
 			  wrangler publish [script]  🆙 Publish your Worker to Cloudflare.
-			  wrangler tail [name]       🦚 Starts a log tailing session for a published Worker.
+			  wrangler tail [worker]     🦚 Starts a log tailing session for a published Worker.
 			  wrangler secret            🤫 Generate a secret that can be referenced in a Worker
 			  wrangler kv:namespace      🗂️  Interact with your Workers KV Namespaces
 			  wrangler kv:key            🔑 Individually manage Workers KV key-value pairs

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -6622,16 +6622,16 @@ function mockUnauthorizedPublishRoutesRequest({
 	);
 }
 
-function mockCollectKnownRoutesRequest(
+export function mockCollectKnownRoutesRequest(
 	routes: { pattern: string; script: string }[]
 ) {
 	setMockResponse(`/zones/:zoneId/workers/routes`, "GET", () => routes);
 }
 
-function mockGetZoneFromHostRequest(host: string, zone: string) {
+export function mockGetZoneFromHostRequest(host: string, zone?: string) {
 	setMockResponse("/zones", (_uri, _init, queryParams) => {
 		expect(queryParams.get("name")).toEqual(host);
-		return [{ id: zone }];
+		return zone ? [{ id: zone }] : [];
 	});
 }
 

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -13,6 +13,10 @@ import type {
 	AlarmEvent,
 } from "../tail";
 import type WebSocket from "ws";
+import {
+	mockCollectKnownRoutesRequest,
+	mockGetZoneFromHostRequest,
+} from "./publish.test";
 
 describe("tail", () => {
 	runInTempDir();
@@ -52,6 +56,38 @@ describe("tail", () => {
 
 			api.ws.close();
 			expect(api.requests.deletion.count).toStrictEqual(1);
+		});
+		it("should connect to the worker assigned to a given route", async () => {
+			const api = mockWebsocketAPIs();
+			expect(api.requests.creation.count).toStrictEqual(0);
+
+			mockGetZoneFromHostRequest("example.com", "test-zone");
+			mockCollectKnownRoutesRequest([
+				{
+					pattern: "example.com/*",
+					script: "test-worker",
+				},
+			]);
+			await runWrangler("tail example.com/*");
+
+			await expect(api.ws.connected).resolves.toBeTruthy();
+			expect(api.requests.creation.count).toStrictEqual(1);
+			expect(api.requests.deletion.count).toStrictEqual(0);
+
+			api.ws.close();
+			expect(api.requests.deletion.count).toStrictEqual(1);
+		});
+
+		it("should error if a given route is not assigned to the user's zone", async () => {
+			mockGetZoneFromHostRequest("example.com", "test-zone");
+			mockCollectKnownRoutesRequest([]);
+
+			await expect(runWrangler("tail example.com/*")).rejects.toThrow();
+		});
+		it("should error if a given route is not within the user's zone", async () => {
+			mockGetZoneFromHostRequest("example.com");
+
+			await expect(runWrangler("tail example.com/*")).rejects.toThrow();
 		});
 
 		it("creates and then delete tails: legacy envs", async () => {

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -6,6 +6,10 @@ import { mockConsoleMethods } from "./helpers/mock-console";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
+import {
+	mockCollectKnownRoutesRequest,
+	mockGetZoneFromHostRequest,
+} from "./publish.test";
 import type {
 	TailEventMessage,
 	RequestEvent,
@@ -13,10 +17,6 @@ import type {
 	AlarmEvent,
 } from "../tail";
 import type WebSocket from "ws";
-import {
-	mockCollectKnownRoutesRequest,
-	mockGetZoneFromHostRequest,
-} from "./publish.test";
 
 describe("tail", () => {
 	runInTempDir();

--- a/packages/wrangler/src/zones.ts
+++ b/packages/wrangler/src/zones.ts
@@ -74,3 +74,16 @@ export async function getZoneIdFromHost(host: string): Promise<string> {
 
 	throw new Error(`Could not find zone for ${host}`);
 }
+
+interface WorkerRoute {
+	id: string;
+	pattern: string;
+	script: string;
+}
+
+export async function getRoutesForZone(zone: string): Promise<WorkerRoute[]> {
+	const routes = await fetchListResult<WorkerRoute>(
+		`/zones/${zone}/workers/routes`
+	);
+	return routes;
+}

--- a/packages/wrangler/src/zones.ts
+++ b/packages/wrangler/src/zones.ts
@@ -122,7 +122,7 @@ function distanceBetween(a: string, b: string, cache = new Map()): number {
 }
 
 /**
- * Given a route which isn't valid, sort the valid routes by closeness (levenstein distance)
+ * Given an invalid route, sort the valid routes by closeness to the invalid route (levenstein distance)
  */
 export function findClosestRoute(
 	providedRoute: string,


### PR DESCRIPTION
An initial stab at https://github.com/cloudflare/wrangler2/issues/492, following the approach outlined there:
> 1. Checking if the positional argument passed to wrangler tail <url | name> resembles a URL
> 1. Determining the zone ID from the URL (e.g. via [getZoneForRoute](https://github.com/cloudflare/wrangler2/blob/main/packages/wrangler/src/zones.ts#L29))
> 1. Calling [GET zone/:zone_id/workers/routes](https://api.cloudflare.com/#worker-routes-list-routes)
> 1. Finding the given URL in the returned routes
> 1. Using the worker name associated with that route to plug in to the existing tail infrastructure

Some notes:
- Distinguishing between a route and a worker name is done by checking for the presence of a `.` character, following confirmation that that will suffice.
- I've defined a new type for responses from the route list endpoint. I couldn't find anything similar, but I may have missed an existing type that should be used instead:
```
interface WorkerRoute {
	id: string;
	pattern: string;
	script: string;
}
```
- I've tested this on a worker in my CF account, but I'm unsure as to how to go about adding automated tests for the new functionality—some pointers here would be really helpful!

This PR covers exact route matching, whereas the linked issue asks for flexible route matching. Some thoughts on that:
- **Precedence** For instance, if two routes were defined (`www.example.com` and `*.example.com`), and the logs for `www.example.com` were requested, Wrangler would have to figure out that the worker on the `www.example.com` route would have served those requests, even though the `*.example.com` route would also match. This is obviously implemented somewhere, and so the precedence algorithm could be reimplemented in Wrangler to allow for this (maybe it's already implemented somewhere in Wrangler?)
- **Matching rules** The matching rules for worker routes are [documented](https://developers.cloudflare.com/workers/platform/routing/routes/#matching-behavior) so they could be implemented in Wrangler. This would be for e.g. `wrangler tail example.com/foo` to find a worker deployed on the `example.com/*` route. 
- **Filtering** A related concern is filtering URL patterns. Currently, the logs backend only supports filtering based on IP, header etc... and not on URL path. That filtering could either be done within Wrangler, or added as a filter to the logs backend, to make sure that e.g. `wrangler tail example.com/foo`, matching a worker deployed on the route `example.com/*`, only showed the logs from requests to `example.com/foo`, and not requests to `example.com/baz` (which would be handled by the same worker).