### PR TITLE
feat: add debug logging to CF API requests and remote dev worker requests

### DIFF
--- a/.changeset/sour-tables-lay.md
+++ b/.changeset/sour-tables-lay.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+feat: add debug logging to CF API requests and remote dev worker requests

--- a/packages/wrangler/src/cfetch/internal.ts
+++ b/packages/wrangler/src/cfetch/internal.ts
@@ -2,6 +2,7 @@ import assert from "node:assert";
 import { fetch, Headers } from "undici";
 import { version as wranglerVersion } from "../../package.json";
 import { getEnvironmentVariableFactory } from "../environment-variables";
+import { logger } from "../logger";
 import { ParseError, parseJSON } from "../parse";
 import { loginOrRefreshIfRequired, requireApiToken } from "../user";
 import type { ApiCredentials } from "../user";
@@ -44,6 +45,13 @@ export async function fetchInternal<ResponseType>(
 
 	const queryString = queryParams ? `?${queryParams.toString()}` : "";
 	const method = init.method ?? "GET";
+
+	logger.debug(
+		`-- START CF API REQUEST: ${method} ${getCloudflareAPIBaseURL()}${resource}${queryString}`
+	);
+	logger.debug("HEADERS:", JSON.stringify(headers, null, 2));
+	logger.debug("INIT:", JSON.stringify(init, null, 2));
+	logger.debug("-- END CF API REQUEST");
 	const response = await fetch(
 		`${getCloudflareAPIBaseURL()}${resource}${queryString}`,
 		{
@@ -54,6 +62,15 @@ export async function fetchInternal<ResponseType>(
 		}
 	);
 	const jsonText = await response.text();
+	logger.debug(
+		"-- START CF API RESPONSE:",
+		response.statusText,
+		response.status
+	);
+	logger.debug("HEADERS:", JSON.stringify(response.headers, null, 2));
+	logger.debug("RESPONSE:", jsonText);
+	logger.debug("-- END CF API RESPONSE");
+
 	try {
 		return parseJSON<ResponseType>(jsonText);
 	} catch (err) {

--- a/packages/wrangler/src/proxy.ts
+++ b/packages/wrangler/src/proxy.ts
@@ -177,6 +177,7 @@ export function usePreviewServer({
 		const cleanupListeners: (() => void)[] = [];
 
 		// create a ClientHttp2Session
+		logger.debug("PREVIEW URL:", `https://${previewToken.host}`);
 		const remote = connect(`https://${previewToken.host}`);
 		cleanupListeners.push(() => remote.destroy());
 
@@ -221,6 +222,15 @@ export function usePreviewServer({
 				}
 			}
 			const request = message.pipe(remote.request(headers));
+			logger.debug(
+				"WORKER REQUEST",
+				new Date().toLocaleTimeString(),
+				method,
+				url
+			);
+			logger.debug("HEADERS", JSON.stringify(headers, null, 2));
+			logger.debug("PREVIEW TOKEN", previewToken);
+
 			request.on("response", (responseHeaders) => {
 				const status = responseHeaders[":status"] ?? 500;
 


### PR DESCRIPTION
You can now see more detailed information about HTTP requests that Wrangler is making by setting the `WRANGLER_LOG` environment variable to `debug`. E.g. `WRANGLER_LOG=debug npx wrangler dev`.