### PR TITLE
fix: use `config.dev.ip` when provided

### DIFF
--- a/.changeset/late-laws-applaud.md
+++ b/.changeset/late-laws-applaud.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: use `config.dev.ip` when provided
+
+Because we'd used a default for 0.0.0.0 for the `--ip` flag, `wrangler dev` was overriding the value specified in `wrangler.toml` under `dev.ip`. This fix removes the default value (since it's being set when normalising config anyway).
+
+Fixes https://github.com/cloudflare/wrangler2/issues/1714

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -668,12 +668,12 @@ describe("wrangler dev", () => {
 			writeWranglerToml({
 				main: "index.js",
 				dev: {
-					ip: "0.0.0.0",
+					ip: "1.2.3.4",
 				},
 			});
 			fs.writeFileSync("index.js", `export default {};`);
 			await runWrangler("dev");
-			expect((Dev as jest.Mock).mock.calls[0][0].ip).toEqual("0.0.0.0");
+			expect((Dev as jest.Mock).mock.calls[0][0].ip).toEqual("1.2.3.4");
 			expect(std.out).toMatchInlineSnapshot(`""`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 			expect(std.err).toMatchInlineSnapshot(`""`);
@@ -683,12 +683,12 @@ describe("wrangler dev", () => {
 			writeWranglerToml({
 				main: "index.js",
 				dev: {
-					ip: "1.1.1.1",
+					ip: "1.2.3.4",
 				},
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev --ip=0.0.0.0");
-			expect((Dev as jest.Mock).mock.calls[0][0].ip).toEqual("0.0.0.0");
+			await runWrangler("dev --ip=5.6.7.8");
+			expect((Dev as jest.Mock).mock.calls[0][0].ip).toEqual("5.6.7.8");
 			expect(std.out).toMatchInlineSnapshot(`""`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 			expect(std.err).toMatchInlineSnapshot(`""`);
@@ -1005,7 +1005,7 @@ describe("wrangler dev", () => {
 			      --compatibility-date                         Date to use for compatibility checks  [string]
 			      --compatibility-flags, --compatibility-flag  Flags to use for compatibility checks  [array]
 			      --latest                                     Use the latest version of the worker runtime  [boolean] [default: true]
-			      --ip                                         IP address to listen on  [string] [default: \\"0.0.0.0\\"]
+			      --ip                                         IP address to listen on  [string]
 			      --port                                       Port to listen on  [number]
 			      --inspector-port                             Port for devtools to connect to  [number]
 			      --routes, --route                            Routes to upload  [array]

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -129,7 +129,6 @@ export function devOptions(yargs: Argv): Argv<DevArgs> {
 			.option("ip", {
 				describe: "IP address to listen on",
 				type: "string",
-				default: "0.0.0.0",
 			})
 			.option("port", {
 				describe: "Port to listen on",


### PR DESCRIPTION
Because we'd used a default for 0.0.0.0 for the `--ip` flag, `wrangler dev` was overriding the value specified in `wrangler.toml` under `dev.ip`. This fix removes the default value (since it's being set when normalising config anyway).

Fixes https://github.com/cloudflare/wrangler2/issues/1714