### PR TITLE
chore: upgrade `miniflare` to `2.7.1`

### DIFF
--- a/.changeset/spicy-icons-eat.md
+++ b/.changeset/spicy-icons-eat.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Upgrade `miniflare` to [`2.7.1`](https://github.com/cloudflare/miniflare/releases/tag/v2.7.1) incorporating changes from [`2.7.0`](https://github.com/cloudflare/miniflare/releases/tag/v2.7.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2599,12 +2599,12 @@
 			}
 		},
 		"node_modules/@miniflare/cache": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.7.0.tgz",
-			"integrity": "sha512-npxhXcA4cKt+zFXlKdMM1TDEOaVmu75AyV/RqtKykOWS/WOzLkjYHx5pCZ7P4QyOgaTpJAoz+avAx0VNNBxI8A==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.7.1.tgz",
+			"integrity": "sha512-QxN4yp8+cIlggbjIVP17xbSOjjJMco4coW5mXNPcTXazvqnbslwie9GDWmt4BkRvP77uwomf2CDUqEgxZC0frw==",
 			"dependencies": {
-				"@miniflare/core": "2.7.0",
-				"@miniflare/shared": "2.7.0",
+				"@miniflare/core": "2.7.1",
+				"@miniflare/shared": "2.7.1",
 				"http-cache-semantics": "^4.1.0",
 				"undici": "5.9.1"
 			},
@@ -2613,11 +2613,11 @@
 			}
 		},
 		"node_modules/@miniflare/cli-parser": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.7.0.tgz",
-			"integrity": "sha512-pZZAQPvs7Nb8ob8600n1kEZpiZqEdGcAMZqKdpC4OtJuBFEqmtJvmJj9LKLnv0VsmG+LxwInueqiOt8+UqjTag==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.7.1.tgz",
+			"integrity": "sha512-kuY6sWClFBQoc22g7P7gR3fv5dXDI8ezvPvNX6tHXPLiPxiYCoz8XTRUqG5CW12zTxrI3yPjEaTQoFlHzdnQkg==",
 			"dependencies": {
-				"@miniflare/shared": "2.7.0",
+				"@miniflare/shared": "2.7.1",
 				"kleur": "^4.1.4"
 			},
 			"engines": {
@@ -2625,13 +2625,13 @@
 			}
 		},
 		"node_modules/@miniflare/core": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.7.0.tgz",
-			"integrity": "sha512-NmxXi/2zJIXmJSYjR6BTc7tmpjcx5dIO+LPg9Hmw5aLrLD29a745gHcNSPWPrd8ZG76x3PJPMJncYnQMcZwsBA==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.7.1.tgz",
+			"integrity": "sha512-Pdq5+FPSg0L0/eUOKrEfGFowcmbcEXKCIJa8iYz1iA35koSytgTN+6zeuuGPGVXQbGGEPhNugWlOz4u70FJ1GA==",
 			"dependencies": {
 				"@iarna/toml": "^2.2.5",
-				"@miniflare/shared": "2.7.0",
-				"@miniflare/watcher": "2.7.0",
+				"@miniflare/shared": "2.7.1",
+				"@miniflare/watcher": "2.7.1",
 				"busboy": "^1.6.0",
 				"dotenv": "^10.0.0",
 				"kleur": "^4.1.4",
@@ -2652,13 +2652,13 @@
 			}
 		},
 		"node_modules/@miniflare/durable-objects": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.7.0.tgz",
-			"integrity": "sha512-6rZuxrdalLpOaE0+YxVHZOwxoHSJNdO41ZmKEPbZB3vWRE2zDonz7UMwyTgQJVC1PDw6bvTzzsTo84pa7kgpFg==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.7.1.tgz",
+			"integrity": "sha512-bzTzhu9KgtBZ3itR/u/izBHBzQnxhfOt1IQcJNCM/TBwSf8wr6ztDdsTDFE0j9/oQYj4umbGynzZvYYUm/SniQ==",
 			"dependencies": {
-				"@miniflare/core": "2.7.0",
-				"@miniflare/shared": "2.7.0",
-				"@miniflare/storage-memory": "2.7.0",
+				"@miniflare/core": "2.7.1",
+				"@miniflare/shared": "2.7.1",
+				"@miniflare/storage-memory": "2.7.1",
 				"undici": "5.9.1"
 			},
 			"engines": {
@@ -2666,12 +2666,12 @@
 			}
 		},
 		"node_modules/@miniflare/html-rewriter": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.7.0.tgz",
-			"integrity": "sha512-+lgpDydSOJqIdhscwWlnU5CtmWahuhITGs6K7Mv2XRju/EYAXR9NMRLFU/X0OekQm9GhjCW20DITyZukXd2Mnw==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.7.1.tgz",
+			"integrity": "sha512-7088TlpQBXdKX1OPOL+34xKSF5IjiHyjggM7HizJG14IIw1kSiJYojqaOi5f/DxstTUJJCOIxHn3zKf6QSpukA==",
 			"dependencies": {
-				"@miniflare/core": "2.7.0",
-				"@miniflare/shared": "2.7.0",
+				"@miniflare/core": "2.7.1",
+				"@miniflare/shared": "2.7.1",
 				"html-rewriter-wasm": "^0.4.1",
 				"undici": "5.9.1"
 			},
@@ -2680,13 +2680,13 @@
 			}
 		},
 		"node_modules/@miniflare/http-server": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.7.0.tgz",
-			"integrity": "sha512-M1fJgc8GGQJLPyviGKYEOOK5+yOYqntqpWqR/h5zW/Z8CihZFEUQ4YSlcxsFfCeDH+2BbF45oGTMqyCv9FOTYw==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.7.1.tgz",
+			"integrity": "sha512-fcLrEVxtwMhj3qO5Wg5844s6WNTiixRjGEV/Top2TjP3CM6DtIc5l6zca4vozaTba39So627NDalLZQaCAcSBQ==",
 			"dependencies": {
-				"@miniflare/core": "2.7.0",
-				"@miniflare/shared": "2.7.0",
-				"@miniflare/web-sockets": "2.7.0",
+				"@miniflare/core": "2.7.1",
+				"@miniflare/shared": "2.7.1",
+				"@miniflare/web-sockets": "2.7.1",
 				"kleur": "^4.1.4",
 				"selfsigned": "^2.0.0",
 				"undici": "5.9.1",
@@ -2718,22 +2718,22 @@
 			}
 		},
 		"node_modules/@miniflare/kv": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.7.0.tgz",
-			"integrity": "sha512-EorfVnCWTvZf/Oc0/cVrwVFCpQg4Nyiaj3/DsEi1KZ+2D7Oxp30q4hxXYLBngOrTRh/2E/vPI5S5x6yPKftFtA==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.7.1.tgz",
+			"integrity": "sha512-p3BUSgp2BK2l7GxM9wVnaXTM8/thzCzAITDbeyZLevtd8r3Vl1rE8W9Q+qrUbX454+zvHfG71O+BdtfFchgWkA==",
 			"dependencies": {
-				"@miniflare/shared": "2.7.0"
+				"@miniflare/shared": "2.7.1"
 			},
 			"engines": {
 				"node": ">=16.13"
 			}
 		},
 		"node_modules/@miniflare/r2": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.7.0.tgz",
-			"integrity": "sha512-Q9lY4uKOHGss3UVq9v/fbvIdOsJpJG8FbqYs8ICNjnxtgwuFpVXLa2Z1x58DZiSdwFDpoB8MRBlCxzP7O9iiNg==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.7.1.tgz",
+			"integrity": "sha512-UFqU2y4Qccto4PilHEn8JpTKi+lPZ61eV0G50Nnfnwa19yDKf0Wu6rYXecLTPetln10v6pCLvRvk4O93d99A6Q==",
 			"dependencies": {
-				"@miniflare/shared": "2.7.0",
+				"@miniflare/shared": "2.7.1",
 				"undici": "5.9.1"
 			},
 			"engines": {
@@ -2741,23 +2741,23 @@
 			}
 		},
 		"node_modules/@miniflare/runner-vm": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.7.0.tgz",
-			"integrity": "sha512-U5urPJkTIyUf44VArJmO0rPmIQjW2Zw39S+3CkWEkERdgqi3ShIzWnX1AM94BYKh9WvweTKW9BWQi2ZQJisXOQ==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.7.1.tgz",
+			"integrity": "sha512-kcntTSq38Jk81EQbEYs1wSrcziz/KO1JD1DyyDSw1C9pDSFmhusgObDW0VxaGgEVyh92No8l5CNlTjY7kjiMHw==",
 			"dependencies": {
-				"@miniflare/shared": "2.7.0"
+				"@miniflare/shared": "2.7.1"
 			},
 			"engines": {
 				"node": ">=16.13"
 			}
 		},
 		"node_modules/@miniflare/scheduler": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.7.0.tgz",
-			"integrity": "sha512-TvfRV1hOjuDkbPz62Q1K+yWAg50NQ3vspgZRHXBUVwcPTLP0HcWdHli855qNvtf7yCsD4Rzc2QZ2vOJTKZpypg==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.7.1.tgz",
+			"integrity": "sha512-00DCtvSi0/Kamo1OLtvfG+zxAS9VqrFO8Q1Wg7yEJpJBUlnUn+oOXKT//aCpZuVBJLSf7tXxzRXJYNPpu09fwg==",
 			"dependencies": {
-				"@miniflare/core": "2.7.0",
-				"@miniflare/shared": "2.7.0",
+				"@miniflare/core": "2.7.1",
+				"@miniflare/shared": "2.7.1",
 				"cron-schedule": "^3.0.4"
 			},
 			"engines": {
@@ -2765,9 +2765,9 @@
 			}
 		},
 		"node_modules/@miniflare/shared": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.7.0.tgz",
-			"integrity": "sha512-d2kQ0WcQAANqCwbCsuzGU3C3H1p5J4QhcRF9yX7CLVduHaBnu6lHo7+MBjU7AP1R/oXtlhAdpgo0+iYMKaCo8g==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.7.1.tgz",
+			"integrity": "sha512-hQsx/mt5N/zBxJ3DyAJyGMtdT07WeuU+nYiWjkIwQOkPgH/p72Xu0tdi2kO/KQogtxeT2B+eTMVXlE0JqZOyhA==",
 			"dependencies": {
 				"kleur": "^4.1.4",
 				"picomatch": "^2.3.1"
@@ -2777,59 +2777,59 @@
 			}
 		},
 		"node_modules/@miniflare/sites": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.7.0.tgz",
-			"integrity": "sha512-mp4n6aDgLK2B01borEyZ543KDbq9a5/liuJE2Fz0uWZfGBOaEP1CQzxFheIU9xQIu74TNgOODH7NSKV9wIfIvg==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.7.1.tgz",
+			"integrity": "sha512-b5pgVx5qifb9YejBfWjh5lnphc7wTX41CvBxssmCdQCxvQ+C5LgNelccNUvIBIMC+N5Ids+Fbd+Hx8MNGjp3iw==",
 			"dependencies": {
-				"@miniflare/kv": "2.7.0",
-				"@miniflare/shared": "2.7.0",
-				"@miniflare/storage-file": "2.7.0"
+				"@miniflare/kv": "2.7.1",
+				"@miniflare/shared": "2.7.1",
+				"@miniflare/storage-file": "2.7.1"
 			},
 			"engines": {
 				"node": ">=16.13"
 			}
 		},
 		"node_modules/@miniflare/storage-file": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.7.0.tgz",
-			"integrity": "sha512-mwSHZys9h6bi227tAff3TTb0bONXQWkU+rBsAf4J8SOqfOjqGbU+71Q8hNwr2pQqrY+16NnG/iVqY4sNHjSg/w==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.7.1.tgz",
+			"integrity": "sha512-6WiLGCeE1jIDJ3pp2ff1vFWCH1uf9BNWRkF3FpK7LyINzdDUlV56RtchPTBgk61oE8NYjlTqoYd4+KUvBul3/w==",
 			"dependencies": {
-				"@miniflare/shared": "2.7.0",
-				"@miniflare/storage-memory": "2.7.0"
+				"@miniflare/shared": "2.7.1",
+				"@miniflare/storage-memory": "2.7.1"
 			},
 			"engines": {
 				"node": ">=16.13"
 			}
 		},
 		"node_modules/@miniflare/storage-memory": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.7.0.tgz",
-			"integrity": "sha512-YBPMTJmw8LPFE7n3fuM7Tp7PEj9X2he2vvjninpkuxj0CFnNkgyayuU2hnQJl4epa8IDurcba4ytC5dL3+MZzw==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.7.1.tgz",
+			"integrity": "sha512-/YD6PshGEQneLmPC/FO+TnhN2STXT4oTuPxVo81fZ+q/XKglTA8iULtcgmF025lZ8S871ZANfmBtUzlxZJmW8Q==",
 			"dependencies": {
-				"@miniflare/shared": "2.7.0"
+				"@miniflare/shared": "2.7.1"
 			},
 			"engines": {
 				"node": ">=16.13"
 			}
 		},
 		"node_modules/@miniflare/watcher": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.7.0.tgz",
-			"integrity": "sha512-jerNvZDtT+DHedEJXh9dLjlkqvrb/jU+e0GOt8acax6EzIlFPPQRRr19/k3gk4daQmibZJFyIAu48O/MaThjUQ==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.7.1.tgz",
+			"integrity": "sha512-0P0jG2IoMIQtX2JHTABY13Yq3Fs2w5gs6f/LG/X0O9pBCN3SxeQXt0bp3ELkEHjNANQWLMUs6aohb7yZ6ZTfHg==",
 			"dependencies": {
-				"@miniflare/shared": "2.7.0"
+				"@miniflare/shared": "2.7.1"
 			},
 			"engines": {
 				"node": ">=16.13"
 			}
 		},
 		"node_modules/@miniflare/web-sockets": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.7.0.tgz",
-			"integrity": "sha512-uD4PAQCXm5jpClb2zu2MA8LwG20Jm8aqELu2kfV324vFNoc5fW/fxVzPu4UMpjZEEAgJqNN0hkUHz4V8wnEf1w==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.7.1.tgz",
+			"integrity": "sha512-VO0BhkYDn82LTRhvK1vJA1/PA9GXMJGlkt2wYomdQFOz4Rmybau4sgVyAdKWTTYV7XexEVAVRl8BDUM97Pdxvw==",
 			"dependencies": {
-				"@miniflare/core": "2.7.0",
-				"@miniflare/shared": "2.7.0",
+				"@miniflare/core": "2.7.1",
+				"@miniflare/shared": "2.7.1",
 				"undici": "5.9.1",
 				"ws": "^8.2.2"
 			},
@@ -16164,25 +16164,25 @@
 			}
 		},
 		"node_modules/miniflare": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.7.0.tgz",
-			"integrity": "sha512-C/qITsBoJUcZFSUi/4yl/cI+rlxuBxTdRGzMTBwR8e7bGnRG6dcu0485vNpddGLY9ZQt938TJUr3vJVKX15l8g==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.7.1.tgz",
+			"integrity": "sha512-O9kjSORazNCAGVkS0bRHhKGH1LcFOJZyBD0TchB02TalnQ3W21+QWO5PAXDGz/IATO8C8iXrPnN2XKDdDav2CA==",
 			"dependencies": {
-				"@miniflare/cache": "2.7.0",
-				"@miniflare/cli-parser": "2.7.0",
-				"@miniflare/core": "2.7.0",
-				"@miniflare/durable-objects": "2.7.0",
-				"@miniflare/html-rewriter": "2.7.0",
-				"@miniflare/http-server": "2.7.0",
-				"@miniflare/kv": "2.7.0",
-				"@miniflare/r2": "2.7.0",
-				"@miniflare/runner-vm": "2.7.0",
-				"@miniflare/scheduler": "2.7.0",
-				"@miniflare/shared": "2.7.0",
-				"@miniflare/sites": "2.7.0",
-				"@miniflare/storage-file": "2.7.0",
-				"@miniflare/storage-memory": "2.7.0",
-				"@miniflare/web-sockets": "2.7.0",
+				"@miniflare/cache": "2.7.1",
+				"@miniflare/cli-parser": "2.7.1",
+				"@miniflare/core": "2.7.1",
+				"@miniflare/durable-objects": "2.7.1",
+				"@miniflare/html-rewriter": "2.7.1",
+				"@miniflare/http-server": "2.7.1",
+				"@miniflare/kv": "2.7.1",
+				"@miniflare/r2": "2.7.1",
+				"@miniflare/runner-vm": "2.7.1",
+				"@miniflare/scheduler": "2.7.1",
+				"@miniflare/shared": "2.7.1",
+				"@miniflare/sites": "2.7.1",
+				"@miniflare/storage-file": "2.7.1",
+				"@miniflare/storage-memory": "2.7.1",
+				"@miniflare/web-sockets": "2.7.1",
 				"kleur": "^4.1.4",
 				"semiver": "^1.1.0",
 				"source-map-support": "^0.5.20",
@@ -16195,7 +16195,7 @@
 				"node": ">=16.13"
 			},
 			"peerDependencies": {
-				"@miniflare/storage-redis": "2.7.0",
+				"@miniflare/storage-redis": "2.7.1",
 				"cron-schedule": "^3.0.4",
 				"ioredis": "^4.27.9"
 			},
@@ -22164,7 +22164,7 @@
 				"blake3-wasm": "^2.1.5",
 				"chokidar": "^3.5.3",
 				"esbuild": "0.14.51",
-				"miniflare": "^2.7.0",
+				"miniflare": "^2.7.1",
 				"nanoid": "^3.3.3",
 				"path-to-regexp": "^6.2.0",
 				"selfsigned": "^2.0.1",
@@ -25418,33 +25418,33 @@
 			}
 		},
 		"@miniflare/cache": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.7.0.tgz",
-			"integrity": "sha512-npxhXcA4cKt+zFXlKdMM1TDEOaVmu75AyV/RqtKykOWS/WOzLkjYHx5pCZ7P4QyOgaTpJAoz+avAx0VNNBxI8A==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.7.1.tgz",
+			"integrity": "sha512-QxN4yp8+cIlggbjIVP17xbSOjjJMco4coW5mXNPcTXazvqnbslwie9GDWmt4BkRvP77uwomf2CDUqEgxZC0frw==",
 			"requires": {
-				"@miniflare/core": "2.7.0",
-				"@miniflare/shared": "2.7.0",
+				"@miniflare/core": "2.7.1",
+				"@miniflare/shared": "2.7.1",
 				"http-cache-semantics": "^4.1.0",
 				"undici": "5.9.1"
 			}
 		},
 		"@miniflare/cli-parser": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.7.0.tgz",
-			"integrity": "sha512-pZZAQPvs7Nb8ob8600n1kEZpiZqEdGcAMZqKdpC4OtJuBFEqmtJvmJj9LKLnv0VsmG+LxwInueqiOt8+UqjTag==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.7.1.tgz",
+			"integrity": "sha512-kuY6sWClFBQoc22g7P7gR3fv5dXDI8ezvPvNX6tHXPLiPxiYCoz8XTRUqG5CW12zTxrI3yPjEaTQoFlHzdnQkg==",
 			"requires": {
-				"@miniflare/shared": "2.7.0",
+				"@miniflare/shared": "2.7.1",
 				"kleur": "^4.1.4"
 			}
 		},
 		"@miniflare/core": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.7.0.tgz",
-			"integrity": "sha512-NmxXi/2zJIXmJSYjR6BTc7tmpjcx5dIO+LPg9Hmw5aLrLD29a745gHcNSPWPrd8ZG76x3PJPMJncYnQMcZwsBA==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.7.1.tgz",
+			"integrity": "sha512-Pdq5+FPSg0L0/eUOKrEfGFowcmbcEXKCIJa8iYz1iA35koSytgTN+6zeuuGPGVXQbGGEPhNugWlOz4u70FJ1GA==",
 			"requires": {
 				"@iarna/toml": "^2.2.5",
-				"@miniflare/shared": "2.7.0",
-				"@miniflare/watcher": "2.7.0",
+				"@miniflare/shared": "2.7.1",
+				"@miniflare/watcher": "2.7.1",
 				"busboy": "^1.6.0",
 				"dotenv": "^10.0.0",
 				"kleur": "^4.1.4",
@@ -25461,35 +25461,35 @@
 			}
 		},
 		"@miniflare/durable-objects": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.7.0.tgz",
-			"integrity": "sha512-6rZuxrdalLpOaE0+YxVHZOwxoHSJNdO41ZmKEPbZB3vWRE2zDonz7UMwyTgQJVC1PDw6bvTzzsTo84pa7kgpFg==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.7.1.tgz",
+			"integrity": "sha512-bzTzhu9KgtBZ3itR/u/izBHBzQnxhfOt1IQcJNCM/TBwSf8wr6ztDdsTDFE0j9/oQYj4umbGynzZvYYUm/SniQ==",
 			"requires": {
-				"@miniflare/core": "2.7.0",
-				"@miniflare/shared": "2.7.0",
-				"@miniflare/storage-memory": "2.7.0",
+				"@miniflare/core": "2.7.1",
+				"@miniflare/shared": "2.7.1",
+				"@miniflare/storage-memory": "2.7.1",
 				"undici": "5.9.1"
 			}
 		},
 		"@miniflare/html-rewriter": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.7.0.tgz",
-			"integrity": "sha512-+lgpDydSOJqIdhscwWlnU5CtmWahuhITGs6K7Mv2XRju/EYAXR9NMRLFU/X0OekQm9GhjCW20DITyZukXd2Mnw==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.7.1.tgz",
+			"integrity": "sha512-7088TlpQBXdKX1OPOL+34xKSF5IjiHyjggM7HizJG14IIw1kSiJYojqaOi5f/DxstTUJJCOIxHn3zKf6QSpukA==",
 			"requires": {
-				"@miniflare/core": "2.7.0",
-				"@miniflare/shared": "2.7.0",
+				"@miniflare/core": "2.7.1",
+				"@miniflare/shared": "2.7.1",
 				"html-rewriter-wasm": "^0.4.1",
 				"undici": "5.9.1"
 			}
 		},
 		"@miniflare/http-server": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.7.0.tgz",
-			"integrity": "sha512-M1fJgc8GGQJLPyviGKYEOOK5+yOYqntqpWqR/h5zW/Z8CihZFEUQ4YSlcxsFfCeDH+2BbF45oGTMqyCv9FOTYw==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.7.1.tgz",
+			"integrity": "sha512-fcLrEVxtwMhj3qO5Wg5844s6WNTiixRjGEV/Top2TjP3CM6DtIc5l6zca4vozaTba39So627NDalLZQaCAcSBQ==",
 			"requires": {
-				"@miniflare/core": "2.7.0",
-				"@miniflare/shared": "2.7.0",
-				"@miniflare/web-sockets": "2.7.0",
+				"@miniflare/core": "2.7.1",
+				"@miniflare/shared": "2.7.1",
+				"@miniflare/web-sockets": "2.7.1",
 				"kleur": "^4.1.4",
 				"selfsigned": "^2.0.0",
 				"undici": "5.9.1",
@@ -25506,91 +25506,91 @@
 			}
 		},
 		"@miniflare/kv": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.7.0.tgz",
-			"integrity": "sha512-EorfVnCWTvZf/Oc0/cVrwVFCpQg4Nyiaj3/DsEi1KZ+2D7Oxp30q4hxXYLBngOrTRh/2E/vPI5S5x6yPKftFtA==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.7.1.tgz",
+			"integrity": "sha512-p3BUSgp2BK2l7GxM9wVnaXTM8/thzCzAITDbeyZLevtd8r3Vl1rE8W9Q+qrUbX454+zvHfG71O+BdtfFchgWkA==",
 			"requires": {
-				"@miniflare/shared": "2.7.0"
+				"@miniflare/shared": "2.7.1"
 			}
 		},
 		"@miniflare/r2": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.7.0.tgz",
-			"integrity": "sha512-Q9lY4uKOHGss3UVq9v/fbvIdOsJpJG8FbqYs8ICNjnxtgwuFpVXLa2Z1x58DZiSdwFDpoB8MRBlCxzP7O9iiNg==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.7.1.tgz",
+			"integrity": "sha512-UFqU2y4Qccto4PilHEn8JpTKi+lPZ61eV0G50Nnfnwa19yDKf0Wu6rYXecLTPetln10v6pCLvRvk4O93d99A6Q==",
 			"requires": {
-				"@miniflare/shared": "2.7.0",
+				"@miniflare/shared": "2.7.1",
 				"undici": "5.9.1"
 			}
 		},
 		"@miniflare/runner-vm": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.7.0.tgz",
-			"integrity": "sha512-U5urPJkTIyUf44VArJmO0rPmIQjW2Zw39S+3CkWEkERdgqi3ShIzWnX1AM94BYKh9WvweTKW9BWQi2ZQJisXOQ==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.7.1.tgz",
+			"integrity": "sha512-kcntTSq38Jk81EQbEYs1wSrcziz/KO1JD1DyyDSw1C9pDSFmhusgObDW0VxaGgEVyh92No8l5CNlTjY7kjiMHw==",
 			"requires": {
-				"@miniflare/shared": "2.7.0"
+				"@miniflare/shared": "2.7.1"
 			}
 		},
 		"@miniflare/scheduler": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.7.0.tgz",
-			"integrity": "sha512-TvfRV1hOjuDkbPz62Q1K+yWAg50NQ3vspgZRHXBUVwcPTLP0HcWdHli855qNvtf7yCsD4Rzc2QZ2vOJTKZpypg==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.7.1.tgz",
+			"integrity": "sha512-00DCtvSi0/Kamo1OLtvfG+zxAS9VqrFO8Q1Wg7yEJpJBUlnUn+oOXKT//aCpZuVBJLSf7tXxzRXJYNPpu09fwg==",
 			"requires": {
-				"@miniflare/core": "2.7.0",
-				"@miniflare/shared": "2.7.0",
+				"@miniflare/core": "2.7.1",
+				"@miniflare/shared": "2.7.1",
 				"cron-schedule": "^3.0.4"
 			}
 		},
 		"@miniflare/shared": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.7.0.tgz",
-			"integrity": "sha512-d2kQ0WcQAANqCwbCsuzGU3C3H1p5J4QhcRF9yX7CLVduHaBnu6lHo7+MBjU7AP1R/oXtlhAdpgo0+iYMKaCo8g==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.7.1.tgz",
+			"integrity": "sha512-hQsx/mt5N/zBxJ3DyAJyGMtdT07WeuU+nYiWjkIwQOkPgH/p72Xu0tdi2kO/KQogtxeT2B+eTMVXlE0JqZOyhA==",
 			"requires": {
 				"kleur": "^4.1.4",
 				"picomatch": "^2.3.1"
 			}
 		},
 		"@miniflare/sites": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.7.0.tgz",
-			"integrity": "sha512-mp4n6aDgLK2B01borEyZ543KDbq9a5/liuJE2Fz0uWZfGBOaEP1CQzxFheIU9xQIu74TNgOODH7NSKV9wIfIvg==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.7.1.tgz",
+			"integrity": "sha512-b5pgVx5qifb9YejBfWjh5lnphc7wTX41CvBxssmCdQCxvQ+C5LgNelccNUvIBIMC+N5Ids+Fbd+Hx8MNGjp3iw==",
 			"requires": {
-				"@miniflare/kv": "2.7.0",
-				"@miniflare/shared": "2.7.0",
-				"@miniflare/storage-file": "2.7.0"
+				"@miniflare/kv": "2.7.1",
+				"@miniflare/shared": "2.7.1",
+				"@miniflare/storage-file": "2.7.1"
 			}
 		},
 		"@miniflare/storage-file": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.7.0.tgz",
-			"integrity": "sha512-mwSHZys9h6bi227tAff3TTb0bONXQWkU+rBsAf4J8SOqfOjqGbU+71Q8hNwr2pQqrY+16NnG/iVqY4sNHjSg/w==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.7.1.tgz",
+			"integrity": "sha512-6WiLGCeE1jIDJ3pp2ff1vFWCH1uf9BNWRkF3FpK7LyINzdDUlV56RtchPTBgk61oE8NYjlTqoYd4+KUvBul3/w==",
 			"requires": {
-				"@miniflare/shared": "2.7.0",
-				"@miniflare/storage-memory": "2.7.0"
+				"@miniflare/shared": "2.7.1",
+				"@miniflare/storage-memory": "2.7.1"
 			}
 		},
 		"@miniflare/storage-memory": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.7.0.tgz",
-			"integrity": "sha512-YBPMTJmw8LPFE7n3fuM7Tp7PEj9X2he2vvjninpkuxj0CFnNkgyayuU2hnQJl4epa8IDurcba4ytC5dL3+MZzw==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.7.1.tgz",
+			"integrity": "sha512-/YD6PshGEQneLmPC/FO+TnhN2STXT4oTuPxVo81fZ+q/XKglTA8iULtcgmF025lZ8S871ZANfmBtUzlxZJmW8Q==",
 			"requires": {
-				"@miniflare/shared": "2.7.0"
+				"@miniflare/shared": "2.7.1"
 			}
 		},
 		"@miniflare/watcher": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.7.0.tgz",
-			"integrity": "sha512-jerNvZDtT+DHedEJXh9dLjlkqvrb/jU+e0GOt8acax6EzIlFPPQRRr19/k3gk4daQmibZJFyIAu48O/MaThjUQ==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.7.1.tgz",
+			"integrity": "sha512-0P0jG2IoMIQtX2JHTABY13Yq3Fs2w5gs6f/LG/X0O9pBCN3SxeQXt0bp3ELkEHjNANQWLMUs6aohb7yZ6ZTfHg==",
 			"requires": {
-				"@miniflare/shared": "2.7.0"
+				"@miniflare/shared": "2.7.1"
 			}
 		},
 		"@miniflare/web-sockets": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.7.0.tgz",
-			"integrity": "sha512-uD4PAQCXm5jpClb2zu2MA8LwG20Jm8aqELu2kfV324vFNoc5fW/fxVzPu4UMpjZEEAgJqNN0hkUHz4V8wnEf1w==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.7.1.tgz",
+			"integrity": "sha512-VO0BhkYDn82LTRhvK1vJA1/PA9GXMJGlkt2wYomdQFOz4Rmybau4sgVyAdKWTTYV7XexEVAVRl8BDUM97Pdxvw==",
 			"requires": {
-				"@miniflare/core": "2.7.0",
-				"@miniflare/shared": "2.7.0",
+				"@miniflare/core": "2.7.1",
+				"@miniflare/shared": "2.7.1",
 				"undici": "5.9.1",
 				"ws": "^8.2.2"
 			},
@@ -34927,25 +34927,25 @@
 			"version": "1.0.1"
 		},
 		"miniflare": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.7.0.tgz",
-			"integrity": "sha512-C/qITsBoJUcZFSUi/4yl/cI+rlxuBxTdRGzMTBwR8e7bGnRG6dcu0485vNpddGLY9ZQt938TJUr3vJVKX15l8g==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.7.1.tgz",
+			"integrity": "sha512-O9kjSORazNCAGVkS0bRHhKGH1LcFOJZyBD0TchB02TalnQ3W21+QWO5PAXDGz/IATO8C8iXrPnN2XKDdDav2CA==",
 			"requires": {
-				"@miniflare/cache": "2.7.0",
-				"@miniflare/cli-parser": "2.7.0",
-				"@miniflare/core": "2.7.0",
-				"@miniflare/durable-objects": "2.7.0",
-				"@miniflare/html-rewriter": "2.7.0",
-				"@miniflare/http-server": "2.7.0",
-				"@miniflare/kv": "2.7.0",
-				"@miniflare/r2": "2.7.0",
-				"@miniflare/runner-vm": "2.7.0",
-				"@miniflare/scheduler": "2.7.0",
-				"@miniflare/shared": "2.7.0",
-				"@miniflare/sites": "2.7.0",
-				"@miniflare/storage-file": "2.7.0",
-				"@miniflare/storage-memory": "2.7.0",
-				"@miniflare/web-sockets": "2.7.0",
+				"@miniflare/cache": "2.7.1",
+				"@miniflare/cli-parser": "2.7.1",
+				"@miniflare/core": "2.7.1",
+				"@miniflare/durable-objects": "2.7.1",
+				"@miniflare/html-rewriter": "2.7.1",
+				"@miniflare/http-server": "2.7.1",
+				"@miniflare/kv": "2.7.1",
+				"@miniflare/r2": "2.7.1",
+				"@miniflare/runner-vm": "2.7.1",
+				"@miniflare/scheduler": "2.7.1",
+				"@miniflare/shared": "2.7.1",
+				"@miniflare/sites": "2.7.1",
+				"@miniflare/storage-file": "2.7.1",
+				"@miniflare/storage-memory": "2.7.1",
+				"@miniflare/web-sockets": "2.7.1",
 				"kleur": "^4.1.4",
 				"semiver": "^1.1.0",
 				"source-map-support": "^0.5.20",
@@ -39123,7 +39123,7 @@
 				"jest-fetch-mock": "^3.0.3",
 				"jest-websocket-mock": "^2.3.0",
 				"mime": "^3.0.0",
-				"miniflare": "^2.7.0",
+				"miniflare": "^2.7.1",
 				"nanoid": "^3.3.3",
 				"open": "^8.4.0",
 				"p-queue": "^7.2.0",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -97,7 +97,7 @@
 		"blake3-wasm": "^2.1.5",
 		"chokidar": "^3.5.3",
 		"esbuild": "0.14.51",
-		"miniflare": "^2.7.0",
+		"miniflare": "^2.7.1",
 		"nanoid": "^3.3.3",
 		"path-to-regexp": "^6.2.0",
 		"selfsigned": "^2.0.1",


### PR DESCRIPTION
Hey! 👋 This PR upgrades `miniflare` to version `2.7.1`, fixing a couple issues @vlovich found. See the [changelog here](https://github.com/cloudflare/miniflare/releases/tag/v2.7.1). The changeset also mentions the [upgrade to `2.7.0`](https://github.com/cloudflare/miniflare/releases/tag/v2.7.0) merged in as part of #1691.