### PR TITLE
feat[pages]: Warn users when _routes.json is ignored

### DIFF
--- a/packages/wrangler/src/pages/publish.tsx
+++ b/packages/wrangler/src/pages/publish.tsx
@@ -370,7 +370,16 @@ export const Handler = async ({
 				throw e;
 			}
 		}
+	} else {
+		const routesPath = join(directory, "_routes.json");
+
+		if (existsSync(routesPath)) {
+			logger.warn(
+				`⚠️ Ignoring ${routesPath} because project is not in Advanced Mode. Only Advanced Mode projects can specify a custom _routes.json file.`
+			);
+		}
 	}
+
 	const deploymentResponse = await fetchResult<Deployment>(
 		`/accounts/${accountId}/pages/projects/${projectName}/deployments`,
 		{


### PR DESCRIPTION
A custom _routes.json file can be specified only by projects in Advanced
Mode. This commit ensures that if a user tries to publish a project,
not in Advanced Mode and with a custom _routes.json file, they will be
warned about the custom routes file being ignored.