### PR TITLE
Fix multiworker and assets bug

### DIFF
--- a/.changeset/hungry-lemons-exercise.md
+++ b/.changeset/hungry-lemons-exercise.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: Multiworker and static asset dev bug preventing both from being used
+
+There was previously a collision on the generated filenames which resulted in the generated scripts looping and crashing in Miniflare with error code 7. By renaming one of the generated files, this is avoided.

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -380,7 +380,7 @@ async function applyMultiWorkerDevFacade(
 	services: Config["services"],
 	workerDefinitions: WorkerRegistry
 ) {
-	const targetPath = path.join(tmpDirPath, "serve-static-assets.entry.js");
+	const targetPath = path.join(tmpDirPath, "multiworker-dev-facade.entry.js");
 	const serviceMap = Object.fromEntries(
 		(services || []).map((serviceBinding) => [
 			serviceBinding.binding,


### PR DESCRIPTION
Thanks Dario for the report!

---

fix: Multiworker and static asset dev bug preventing both from being used

There was previously a collision on the generated filenames which resulted in the generated scripts looping and crashing in Miniflare with error code 7. By renaming one of the generated files, this is avoided.