### PR TITLE
fix: rerun useEffect when we detect error code 10049

### DIFF
--- a/.changeset/mean-actors-beam.md
+++ b/.changeset/mean-actors-beam.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: refresh token when we detect that the preview session has expired (error code 10049)
+
+When running `wrangler dev`, from time to time the preview session token would expire, and the dev server would need to be manually restarted. This fixes this, by refreshing the token when it expires.
+
+Closes #1446

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -383,7 +383,9 @@ export function useWorker(props: {
 				} else if (err.code === 10049) {
 					logger.log("Preview token expired, fetching a new one");
 					// code 10049 happens when the preview token expires
-					// since we want a new preview token when this happens
+					// since we want a new preview token when this happens,
+					// lets increment the counter, and trigger a rerun of
+					// the useEffect above
 					setRestartCounter((prevCount) => prevCount + 1);
 				} else {
 					logger.error("Error on remote worker:", err);

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -182,7 +182,7 @@ export function useWorker(props: {
 	} = props;
 	const [session, setSession] = useState<CfPreviewSession | undefined>();
 	const [token, setToken] = useState<CfPreviewToken | undefined>();
-
+	const [restartCounter, setRestartCounter] = useState<number>(0);
 	// This is the most reliable way to detect whether
 	// something's "happened" in our system; We make a ref and
 	// mark it once we log our initial message. Refs are vars!
@@ -237,6 +237,7 @@ export function useWorker(props: {
 		props.routes,
 		props.zone,
 		props.sendMetrics,
+		restartCounter,
 	]);
 
 	// This effect uses the session to upload the worker and create a preview
@@ -379,6 +380,11 @@ export function useWorker(props: {
 					logger.error(
 						`${errorMessage}\n${solutionMessage}\n${onboardingLink}`
 					);
+				} else if (err.code === 10049) {
+					logger.log("Preview token expired, fetching a new one");
+					// code 10049 happens when the preview token expires
+					// since we want a new preview token when this happens
+					setRestartCounter((prevCount) => prevCount + 1);
 				} else {
 					logger.error("Error on remote worker:", err);
 				}


### PR DESCRIPTION
What it looks like when this kicks in:
```
⎔ Detected changes, restarted server.
Total Upload: 0.19 KiB / gzip: 0.16 KiB
Preview token expired, fetching a new one
⎔ Detected changes, restarted server.
Total Upload: 0.19 KiB / gzip: 0.16 KiB
Script modified; context reset.
16:29:38 GET / 200
16:29:38 GET /favicon.ico 200
```

Closes #1446