### PR TITLE
chore: dedupe running publish.test tests twice

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -13,6 +13,4 @@ fixtures/pages-plugin-example/index.js
 fixtures/remix-pages-app/build/
 fixtures/remix-pages-app/public/build/
 fixtures/worker-app/dist/
-fixtures/remix-pages-app/build
-fixtures/remix-pages-app/public/
-fixtures/pages-functions-app/public/
+fixtures/pages-functions-app/public/cdn-cgi/

--- a/packages/wrangler/src/__tests__/helpers/mock-get-zone-from-host.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-get-zone-from-host.ts
@@ -1,0 +1,8 @@
+import { setMockResponse } from "./mock-cfetch";
+
+export function mockGetZoneFromHostRequest(host: string, zone?: string) {
+	setMockResponse("/zones", (_uri, _init, queryParams) => {
+		expect(queryParams.get("name")).toEqual(host);
+		return zone ? [{ id: zone }] : [];
+	});
+}

--- a/packages/wrangler/src/__tests__/helpers/mock-known-routes.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-known-routes.ts
@@ -1,0 +1,7 @@
+import { setMockResponse } from "./mock-cfetch";
+
+export function mockCollectKnownRoutesRequest(
+	routes: { pattern: string; script: string }[]
+) {
+	setMockResponse(`/zones/:zoneId/workers/routes`, "GET", () => routes);
+}

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -13,7 +13,9 @@ import {
 } from "./helpers/mock-cfetch";
 import { mockConsoleMethods, normalizeSlashes } from "./helpers/mock-console";
 import { mockConfirm } from "./helpers/mock-dialogs";
+import { mockGetZoneFromHostRequest } from "./helpers/mock-get-zone-from-host";
 import { useMockIsTTY } from "./helpers/mock-istty";
+import { mockCollectKnownRoutesRequest } from "./helpers/mock-known-routes";
 import { mockKeyListRequest } from "./helpers/mock-kv";
 import { mockGetMemberships, mockOAuthFlow } from "./helpers/mock-oauth-flow";
 import { runInTempDir } from "./helpers/run-in-tmp";
@@ -6620,19 +6622,6 @@ function mockUnauthorizedPublishRoutesRequest({
 				{ message: "Authentication error", code: 10000 },
 			])
 	);
-}
-
-export function mockCollectKnownRoutesRequest(
-	routes: { pattern: string; script: string }[]
-) {
-	setMockResponse(`/zones/:zoneId/workers/routes`, "GET", () => routes);
-}
-
-export function mockGetZoneFromHostRequest(host: string, zone?: string) {
-	setMockResponse("/zones", (_uri, _init, queryParams) => {
-		expect(queryParams.get("name")).toEqual(host);
-		return zone ? [{ id: zone }] : [];
-	});
 }
 
 function mockPublishRoutesFallbackRequest(route: {

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -3,13 +3,11 @@ import { Headers, Request } from "undici";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { setMockResponse, unsetAllMocks } from "./helpers/mock-cfetch";
 import { mockConsoleMethods } from "./helpers/mock-console";
+import { mockGetZoneFromHostRequest } from "./helpers/mock-get-zone-from-host";
 import { useMockIsTTY } from "./helpers/mock-istty";
+import { mockCollectKnownRoutesRequest } from "./helpers/mock-known-routes";
 import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
-import {
-	mockCollectKnownRoutesRequest,
-	mockGetZoneFromHostRequest,
-} from "./publish.test";
 import type {
 	TailEventMessage,
 	RequestEvent,


### PR DESCRIPTION
The tail.test suite was importing a helper from publish.test, which was also declaring all the tests in that suite. This fix extracts those helpers so they can be imported and used cleanly. Shaves a few seconds off when running all tests too.

--- 

No changeset here because it doesn't affect any code. 