### PR TITLE
feat: new internal middleware

### DIFF
--- a/.changeset/tough-beers-return.md
+++ b/.changeset/tough-beers-return.md
@@ -1,0 +1,10 @@
+---
+"wrangler": patch
+---
+
+feat: new internal middleware
+
+A new way of registering middleware that gets bundled and executed on the edge.
+
+- the same middleware functions can be used for both modules workers and service workers
+- only requires running esbuild a fixed number of times, rather than for each middleware added

--- a/packages/wrangler/src/__tests__/helpers/mock-console.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-console.ts
@@ -29,7 +29,9 @@ const std = {
 function normalizeOutput(spy: jest.SpyInstance): string {
 	return normalizeErrorMarkers(
 		replaceByte(
-			stripTrailingWhitespace(normalizeSlashes(stripTimings(captureCalls(spy))))
+			stripTrailingWhitespace(
+				normalizeSlashes(normalizeTempDirs(stripTimings(captureCalls(spy))))
+			)
 		)
 	);
 }
@@ -93,5 +95,12 @@ export function stripTrailingWhitespace(str: string): string {
  * variation causing every few tests the value to change by ± .01
  */
 function replaceByte(stdout: string): string {
-	return stdout.replaceAll(/.[0-9][0-9] KiB/g, "xx KiB");
+	return stdout.replaceAll(/\d+\.\d+ KiB/g, "xx KiB");
+}
+
+/**
+ * Temp directories are created with random names, so we replace all comments temp dirs in them
+ */
+export function normalizeTempDirs(stdout: string): string {
+	return stdout.replaceAll(/\/\/.+\/tmp.+/g, "//tmpdir");
 }

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -227,16 +227,16 @@ describe("wrangler", () => {
 		await runWrangler("build");
 		await endEventLoop();
 		expect(std.out).toMatchInlineSnapshot(`
-		      "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mDeprecation: \`wrangler build\` has been deprecated.[0m
+		"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mDeprecation: \`wrangler build\` has been deprecated.[0m
 
-		        Please refer to [4mhttps://developers.cloudflare.com/workers/wrangler/migration/deprecations/#build[0m
-		        for more information.
-		        Attempting to run \`wrangler publish --dry-run --outdir=dist\` for you instead:
+		  Please refer to [4mhttps://developers.cloudflare.com/workers/wrangler/migration/deprecations/#build[0m
+		  for more information.
+		  Attempting to run \`wrangler publish --dry-run --outdir=dist\` for you instead:
 
 
-		      --dry-run: exiting now.
-		      Total Upload: 0xx KiB / gzip: 0xx KiB"
-	    `);
+		Total Upload: xx KiB / gzip: xx KiB
+		--dry-run: exiting now."
+	`);
 	});
 });
 

--- a/packages/wrangler/src/__tests__/middleware.test.ts
+++ b/packages/wrangler/src/__tests__/middleware.test.ts
@@ -1,0 +1,675 @@
+import * as fs from "node:fs";
+import { unstable_dev } from "../api";
+import { unsetAllMocks } from "./helpers/mock-cfetch";
+import { useMockIsTTY } from "./helpers/mock-istty";
+import { runInTempDir } from "./helpers/run-in-tmp";
+
+jest.unmock("undici");
+
+describe("module workers change behaviour with middleware with wrangler dev", () => {
+	runInTempDir();
+	const { setIsTTY } = useMockIsTTY();
+
+	beforeEach(() => {
+		setIsTTY(true);
+	});
+
+	afterEach(() => {
+		unsetAllMocks();
+	});
+
+	process.env.EXPERIMENTAL_MIDDLEWARE = "true";
+
+	it("should register a middleware and intercept", async () => {
+		const scriptContent = `
+    const middleware = async (request, env, _ctx, middlewareCtx) => {
+      const response = await middlewareCtx.next(request, env);
+      const text = await response.text();
+      return new Response(text + ' world');
+    }
+
+    export default {
+      middleware: [middleware],
+      fetch(request, env, ctx) {
+        return new Response('Hello');
+      }
+    };
+    `;
+		fs.writeFileSync("index.js", scriptContent);
+
+		const worker = await unstable_dev(
+			"index.js",
+			{},
+			{ disableExperimentalWarning: true }
+		);
+
+		const resp = await worker.fetch();
+		let text;
+		if (resp) text = await resp.text();
+		expect(text).toMatchInlineSnapshot(`"Hello world"`);
+		await worker.stop();
+	});
+
+	it("should be able to access scheduled workers from middleware", async () => {
+		const scriptContent = `
+    const middleware = async (request, env, _ctx, middlewareCtx) => {
+      await middlewareCtx.dispatch("scheduled", { cron: "* * * * *" });
+      return new Response("OK");
+    }
+
+    export default {
+      middleware: [middleware],
+      scheduled(controller, env, ctx) {
+        console.log("Scheduled worker called");
+      }
+    }
+    `;
+
+		fs.writeFileSync("index.js", scriptContent);
+
+		const worker = await unstable_dev(
+			"index.js",
+			{},
+			{ disableExperimentalWarning: true }
+		);
+
+		const resp = await worker.fetch();
+		let text;
+		if (resp) text = await resp.text();
+		expect(text).toMatchInlineSnapshot(`"OK"`);
+		await worker.stop();
+	});
+
+	it("should trigger an error in a scheduled work from middleware", async () => {
+		const scriptContent = `
+    const middleware = async (request, env, _ctx, middlewareCtx) => {
+      try {
+        await middlewareCtx.dispatch("scheduled", { cron: "* * * * *" });
+      } catch (e) {
+        return new Response(e.message);
+      }
+    }
+
+    export default {
+      middleware: [middleware],
+      scheduled(controller, env, ctx) {
+        throw new Error("Error in scheduled worker");
+      }
+    }
+    `;
+
+		fs.writeFileSync("index.js", scriptContent);
+
+		const worker = await unstable_dev(
+			"index.js",
+			{},
+			{ disableExperimentalWarning: true }
+		);
+
+		const resp = await worker.fetch();
+		let text;
+		if (resp) text = await resp.text();
+		expect(text).toMatchInlineSnapshot(`"Error in scheduled worker"`);
+		await worker.stop();
+	});
+});
+
+describe("service workers change behaviour with middleware with wrangler dev", () => {
+	runInTempDir();
+	const { setIsTTY } = useMockIsTTY();
+
+	beforeEach(() => {
+		setIsTTY(true);
+	});
+
+	afterEach(() => {
+		unsetAllMocks();
+	});
+
+	process.env.EXPERIMENTAL_MIDDLEWARE = "true";
+
+	it("should register a middleware and intercept using addMiddleware", async () => {
+		const scriptContent = `
+    const middleware = async (request, env, _ctx, middlewareCtx) => {
+      const response = await middlewareCtx.next(request, env);
+      const text = await response.text();
+      return new Response(text + ' world');
+    }
+
+    addMiddleware(middleware);
+
+    addEventListener("fetch", (event) => {
+      event.respondWith(new Response('Hello'));
+    });
+    `;
+		fs.writeFileSync("index.js", scriptContent);
+
+		const worker = await unstable_dev(
+			"index.js",
+			{},
+			{ disableExperimentalWarning: true }
+		);
+
+		const resp = await worker.fetch();
+		let text;
+		if (resp) text = await resp.text();
+		expect(text).toMatchInlineSnapshot(`"Hello world"`);
+		await worker.stop();
+	});
+
+	it("should register a middleware and intercept using addMiddlewareInternal", async () => {
+		const scriptContent = `
+    const middleware = async (request, env, _ctx, middlewareCtx) => {
+      const response = await middlewareCtx.next(request, env);
+      const text = await response.text();
+      return new Response(text + ' world');
+    }
+
+    addMiddlewareInternal(middleware);
+
+    addEventListener("fetch", (event) => {
+      event.respondWith(new Response('Hello'));
+    });
+    `;
+		fs.writeFileSync("index.js", scriptContent);
+
+		const worker = await unstable_dev(
+			"index.js",
+			{},
+			{ disableExperimentalWarning: true }
+		);
+
+		const resp = await worker.fetch();
+		let text;
+		if (resp) text = await resp.text();
+		expect(text).toMatchInlineSnapshot(`"Hello world"`);
+		await worker.stop();
+	});
+
+	it("should be able to access scheduled workers from middleware", async () => {
+		const scriptContent = `
+    const middleware = async (request, env, _ctx, middlewareCtx) => {
+      await middlewareCtx.dispatch("scheduled", { cron: "* * * * *" });
+      return new Response("OK");
+    }
+
+    addMiddleware(middleware);
+
+    addEventListener("scheduled", (event) => {
+      console.log("Scheduled worker called");
+    });
+    `;
+
+		fs.writeFileSync("index.js", scriptContent);
+
+		const worker = await unstable_dev(
+			"index.js",
+			{},
+			{ disableExperimentalWarning: true }
+		);
+
+		const resp = await worker.fetch();
+		let text;
+		if (resp) text = await resp.text();
+		expect(text).toMatchInlineSnapshot(`"OK"`);
+		await worker.stop();
+	});
+
+	it("should trigger an error in a scheduled work from middleware", async () => {
+		const scriptContent = `
+    const middleware = async (request, env, _ctx, middlewareCtx) => {
+      try {
+        await middlewareCtx.dispatch("scheduled", { cron: "* * * * *" });
+      } catch (e) {
+        return new Response(e.message);
+      }
+    }
+
+    addMiddleware(middleware);
+
+    addEventListener("scheduled", (event) => {
+      throw new Error("Error in scheduled worker");
+    });
+    `;
+
+		fs.writeFileSync("index.js", scriptContent);
+
+		const worker = await unstable_dev(
+			"index.js",
+			{},
+			{ disableExperimentalWarning: true }
+		);
+
+		const resp = await worker.fetch();
+		let text;
+		if (resp) text = await resp.text();
+		expect(text).toMatchInlineSnapshot(`"Error in scheduled worker"`);
+		await worker.stop();
+	});
+});
+
+describe("unchanged functionality when wrapping with middleware (modules)", () => {
+	runInTempDir();
+	const { setIsTTY } = useMockIsTTY();
+
+	beforeEach(() => {
+		setIsTTY(true);
+	});
+
+	afterEach(() => {
+		unsetAllMocks();
+	});
+
+	process.env.EXPERIMENTAL_MIDDLEWARE = "true";
+
+	it("should return Hello World with no middleware export", async () => {
+		const scriptContent = `
+    export default {
+      fetch(request, env, ctx) {
+        return new Response("Hello world");
+      }
+    };
+    `;
+		fs.writeFileSync("index.js", scriptContent);
+
+		const worker = await unstable_dev(
+			"index.js",
+			{},
+			{ disableExperimentalWarning: true }
+		);
+
+		const resp = await worker.fetch();
+		if (resp) {
+			const text = await resp.text();
+			expect(text).toMatchInlineSnapshot(`"Hello world"`);
+		}
+		await worker.stop();
+	});
+
+	it("should return hello world with empty middleware array", async () => {
+		const scriptContent = `
+    export default {
+      middleware: [],
+      fetch() {
+        return new Response("Hello world");
+      }
+    }
+    `;
+		fs.writeFileSync("index.js", scriptContent);
+
+		const worker = await unstable_dev(
+			"index.js",
+			{},
+			{ disableExperimentalWarning: true }
+		);
+
+		const resp = await worker.fetch();
+		let text;
+		if (resp) text = await resp.text();
+		expect(text).toMatchInlineSnapshot(`"Hello world"`);
+		await worker.stop();
+	});
+
+	it("should return hello world passing through middleware", async () => {
+		const scriptContent = `
+    const middleware = async (request, env, _ctx, middlewareCtx) => {
+      return middlewareCtx.next(request, env);
+    }
+
+    export default {
+      middleware: [middleware],
+      fetch(request, env, ctx) {
+        return new Response("Hello world");
+      }
+    }
+    `;
+		fs.writeFileSync("index.js", scriptContent);
+
+		const worker = await unstable_dev(
+			"index.js",
+			{},
+			{ disableExperimentalWarning: true }
+		);
+
+		const resp = await worker.fetch();
+		if (resp) {
+			const text = await resp.text();
+			expect(text).toMatchInlineSnapshot(`"Hello world"`);
+		}
+		await worker.stop();
+	});
+
+	it("should return hello world with multiple middleware in array", async () => {
+		const scriptContent = `
+    const middleware = async (request, env, _ctx, middlewareCtx) => {
+      return middlewareCtx.next(request, env);
+    }
+    const middleware2 = async (request, env, _ctx, middlewareCtx) => {
+      return middlewareCtx.next(request, env);
+    }
+
+
+    export default {
+      middleware: [middleware, middleware2],
+      fetch() {
+        return new Response("Hello world");
+      }
+    }
+    `;
+		fs.writeFileSync("index.js", scriptContent);
+
+		const worker = await unstable_dev(
+			"index.js",
+			{},
+			{ disableExperimentalWarning: true }
+		);
+
+		const resp = await worker.fetch();
+		let text;
+		if (resp) text = await resp.text();
+		expect(text).toMatchInlineSnapshot(`"Hello world"`);
+		await worker.stop();
+	});
+
+	it("should leave response headers unchanged with middleware", async () => {
+		const scriptContent = `
+    const middleware = async (request, env, _ctx, middlewareCtx) => {
+      return middlewareCtx.next(request, env);
+    }
+
+    export default {
+      middleware: [middleware],
+      fetch() {
+        return new Response("Hello world", { status: 500, headers: { "x-test": "test" } });
+      }
+    }
+    `;
+		fs.writeFileSync("index.js", scriptContent);
+
+		const worker = await unstable_dev(
+			"index.js",
+			{},
+			{ disableExperimentalWarning: true }
+		);
+
+		const resp = await worker.fetch();
+		const status = resp?.status;
+		let text;
+		if (resp) text = await resp.text();
+		const testHeader = resp?.headers.get("x-test");
+		expect(status).toEqual(500);
+		expect(text).toMatchInlineSnapshot(`"Hello world"`);
+		expect(testHeader).toEqual("test");
+		await worker.stop();
+	});
+});
+
+describe("unchanged functionality when wrapping with middlware (service workers)", () => {
+	runInTempDir();
+	const { setIsTTY } = useMockIsTTY();
+
+	beforeEach(() => {
+		setIsTTY(true);
+	});
+
+	afterEach(() => {
+		unsetAllMocks();
+	});
+
+	process.env.EXPERIMENTAL_MIDDLEWARE = "true";
+
+	it("should return Hello World with no middleware export", async () => {
+		const scriptContent = `
+    addEventListener("fetch", (event) => {
+      event.respondWith(new Response("Hello world"));
+    });
+    `;
+		fs.writeFileSync("index.js", scriptContent);
+
+		const worker = await unstable_dev(
+			"index.js",
+			{},
+			{ disableExperimentalWarning: true }
+		);
+
+		const resp = await worker.fetch();
+		if (resp) {
+			const text = await resp.text();
+			expect(text).toMatchInlineSnapshot(`"Hello world"`);
+		}
+		await worker.stop();
+	});
+
+	it("should return hello world with empty middleware array", async () => {
+		const scriptContent = `
+    addMiddleware([]);
+
+    addEventListener("fetch", (event) => {
+      event.respondWith(new Response("Hello world"));
+    });
+    `;
+		fs.writeFileSync("index.js", scriptContent);
+
+		const worker = await unstable_dev(
+			"index.js",
+			{},
+			{ disableExperimentalWarning: true }
+		);
+
+		const resp = await worker.fetch();
+		let text;
+		if (resp) text = await resp.text();
+		expect(text).toMatchInlineSnapshot(`"Hello world"`);
+		await worker.stop();
+	});
+
+	it("should return hello world passing through middleware", async () => {
+		const scriptContent = `
+    const middleware = async (request, env, _ctx, middlewareCtx) => {
+      return middlewareCtx.next(request, env);
+    }
+
+    addMiddleware(middleware);
+
+    addEventListener("fetch", (event) => {
+      event.respondWith(new Response("Hello world"));
+    });
+    `;
+		fs.writeFileSync("index.js", scriptContent);
+
+		const worker = await unstable_dev(
+			"index.js",
+			{},
+			{ disableExperimentalWarning: true }
+		);
+
+		const resp = await worker.fetch();
+		if (resp) {
+			const text = await resp.text();
+			expect(text).toMatchInlineSnapshot(`"Hello world"`);
+		}
+		await worker.stop();
+	});
+
+	it("should return hello world with addMiddleware function called multiple times", async () => {
+		const scriptContent = `
+    const middleware = async (request, env, _ctx, middlewareCtx) => {
+      return middlewareCtx.next(request, env);
+    }
+    const middleware2 = async (request, env, _ctx, middlewareCtx) => {
+      return middlewareCtx.next(request, env);
+    }
+
+    addMiddleware(middleware);
+    addMiddleware(middleware2);
+
+    addEventListener("fetch", (event) => {
+      event.respondWith(new Response("Hello world"));
+    });
+    `;
+		fs.writeFileSync("index.js", scriptContent);
+
+		const worker = await unstable_dev(
+			"index.js",
+			{},
+			{ disableExperimentalWarning: true }
+		);
+
+		const resp = await worker.fetch();
+		let text;
+		if (resp) text = await resp.text();
+		expect(text).toMatchInlineSnapshot(`"Hello world"`);
+		await worker.stop();
+	});
+
+	it("should return hello world with addMiddleware function called with array of middleware", async () => {
+		const scriptContent = `
+    const middleware = async (request, env, _ctx, middlewareCtx) => {
+      return middlewareCtx.next(request, env);
+    }
+    const middleware2 = async (request, env, _ctx, middlewareCtx) => {
+      return middlewareCtx.next(request, env);
+    }
+
+    addMiddleware(middleware, middleware2);
+
+    addEventListener("fetch", (event) => {
+      event.respondWith(new Response("Hello world"));
+    });
+    `;
+		fs.writeFileSync("index.js", scriptContent);
+
+		const worker = await unstable_dev(
+			"index.js",
+			{},
+			{ disableExperimentalWarning: true }
+		);
+
+		const resp = await worker.fetch();
+		let text;
+		if (resp) text = await resp.text();
+		expect(text).toMatchInlineSnapshot(`"Hello world"`);
+		await worker.stop();
+	});
+
+	it("should return hello world with addMiddlewareInternal function called multiple times", async () => {
+		const scriptContent = `
+    const middleware = async (request, env, _ctx, middlewareCtx) => {
+      return middlewareCtx.next(request, env);
+    }
+    const middleware2 = async (request, env, _ctx, middlewareCtx) => {
+      return middlewareCtx.next(request, env);
+    }
+
+    addMiddlewareInternal(middleware);
+    addMiddlewareInternal(middleware2);
+
+    addEventListener("fetch", (event) => {
+      event.respondWith(new Response("Hello world"));
+    });
+    `;
+		fs.writeFileSync("index.js", scriptContent);
+
+		const worker = await unstable_dev(
+			"index.js",
+			{},
+			{ disableExperimentalWarning: true }
+		);
+
+		const resp = await worker.fetch();
+		let text;
+		if (resp) text = await resp.text();
+		expect(text).toMatchInlineSnapshot(`"Hello world"`);
+		await worker.stop();
+	});
+
+	it("should return hello world with addMiddlewareInternal function called with array of middleware", async () => {
+		const scriptContent = `
+    const middleware = async (request, env, _ctx, middlewareCtx) => {
+      return middlewareCtx.next(request, env);
+    }
+    const middleware2 = async (request, env, _ctx, middlewareCtx) => {
+      return middlewareCtx.next(request, env);
+    }
+
+    addMiddlewareInternal(middleware, middleware2);
+
+    addEventListener("fetch", (event) => {
+      event.respondWith(new Response("Hello world"));
+    });
+    `;
+		fs.writeFileSync("index.js", scriptContent);
+
+		const worker = await unstable_dev(
+			"index.js",
+			{},
+			{ disableExperimentalWarning: true }
+		);
+
+		const resp = await worker.fetch();
+		let text;
+		if (resp) text = await resp.text();
+		expect(text).toMatchInlineSnapshot(`"Hello world"`);
+		await worker.stop();
+	});
+
+	it("should return hello world with both addMiddleware and addMiddlewareInternal called", async () => {
+		const scriptContent = `
+    const middleware = async (request, env, _ctx, middlewareCtx) => {
+      return middlewareCtx.next(request, env);
+    }
+    const middleware2 = async (request, env, _ctx, middlewareCtx) => {
+      return middlewareCtx.next(request, env);
+    }
+
+    addMiddleware(middleware);
+    addMiddlewareInternal(middleware2);
+
+    addEventListener("fetch", (event) => {
+      event.respondWith(new Response("Hello world"));
+    });
+    `;
+		fs.writeFileSync("index.js", scriptContent);
+
+		const worker = await unstable_dev(
+			"index.js",
+			{},
+			{ disableExperimentalWarning: true }
+		);
+
+		const resp = await worker.fetch();
+		let text;
+		if (resp) text = await resp.text();
+		expect(text).toMatchInlineSnapshot(`"Hello world"`);
+		await worker.stop();
+	});
+
+	it("should leave response headers unchanged with middleware", async () => {
+		const scriptContent = `
+    const middleware = async (request, env, _ctx, middlewareCtx) => {
+      return middlewareCtx.next(request, env);
+    }
+
+    addEventListener("fetch", (event) => {
+      event.respondWith(new Response("Hello world", { status: 500, headers: { "x-test": "test" } }));
+    });
+    `;
+		fs.writeFileSync("index.js", scriptContent);
+
+		const worker = await unstable_dev(
+			"index.js",
+			{},
+			{ disableExperimentalWarning: true }
+		);
+
+		const resp = await worker.fetch();
+		const status = resp?.status;
+		let text;
+		if (resp) text = await resp.text();
+		const testHeader = resp?.headers.get("x-test");
+		expect(status).toEqual(500);
+		expect(text).toMatchInlineSnapshot(`"Hello world"`);
+		expect(testHeader).toEqual("test");
+		await worker.stop();
+	});
+});

--- a/packages/wrangler/src/__tests__/middleware.test.ts
+++ b/packages/wrangler/src/__tests__/middleware.test.ts
@@ -215,37 +215,37 @@ describe("service workers change behaviour with middleware with wrangler dev", (
 		await worker.stop();
 	});
 
-	// 	it("should trigger an error in a scheduled work from middleware", async () => {
-	// 		const scriptContent = `
-	//     const middleware = async (request, env, _ctx, middlewareCtx) => {
-	//       try {
-	//         await middlewareCtx.dispatch("scheduled", { cron: "* * * * *" });
-	//       } catch (e) {
-	//         return new Response(e.message);
-	//       }
-	//     }
+	it("should trigger an error in a scheduled work from middleware", async () => {
+		const scriptContent = `
+	    const middleware = async (request, env, _ctx, middlewareCtx) => {
+	      try {
+	        await middlewareCtx.dispatch("scheduled", { cron: "* * * * *" });
+	      } catch (e) {
+	        return new Response(e.message);
+	      }
+	    }
 
-	//     addMiddleware(middleware);
+	    addMiddleware(middleware);
 
-	//     addEventListener("scheduled", (event) => {
-	//       throw new Error("Error in scheduled worker");
-	//     });
-	//     `;
+	    addEventListener("scheduled", (event) => {
+	      throw new Error("Error in scheduled worker");
+	    });
+	    `;
 
-	// 		fs.writeFileSync("index.js", scriptContent);
+		fs.writeFileSync("index.js", scriptContent);
 
-	// 		const worker = await unstable_dev(
-	// 			"index.js",
-	// 			{},
-	// 			{ disableExperimentalWarning: true }
-	// 		);
+		const worker = await unstable_dev(
+			"index.js",
+			{},
+			{ disableExperimentalWarning: true }
+		);
 
-	// 		const resp = await worker.fetch();
-	// 		let text;
-	// 		if (resp) text = await resp.text();
-	// 		expect(text).toMatchInlineSnapshot(`"Error in scheduled worker"`);
-	// 		await worker.stop();
-	// 	});
+		const resp = await worker.fetch();
+		let text;
+		if (resp) text = await resp.text();
+		expect(text).toMatchInlineSnapshot(`"Error in scheduled worker"`);
+		await worker.stop();
+	});
 });
 
 describe("unchanged functionality when wrapping with middleware (modules)", () => {

--- a/packages/wrangler/src/__tests__/middleware.test.ts
+++ b/packages/wrangler/src/__tests__/middleware.test.ts
@@ -765,31 +765,4 @@ describe("unchanged functionality when wrapping with middlware (service workers)
 		expect(text).toMatchInlineSnapshot(`"Hello world0"`);
 		await worker.stop();
 	});
-
-	// it("should not allow multiple event listeners for scheduled", async () => {
-	// 	const scriptContent = `
-	//   addEventListener("scheduled", (event) => {
-	//     console.log(1);
-	//   });
-
-	//   addEventListener("scheduled", (event) => {
-	//     console.log(2);
-	//   });
-	//   `;
-	// 	fs.writeFileSync("index.js", scriptContent);
-
-	// 	await expect(
-	// 		unstable_dev("index.js", {}, { disableExperimentalWarning: true })
-	// 	).rejects.toThrowErrorMatchingInlineSnapshot(
-	// 		`"Multiple event listeners for scheduled are not allowed"`
-	// 	);
-	// });
-
-	// Add tests for:
-	// - addEventListener
-	// - removeEventListener
-	// wait until
-	// noRetry
-	// pass through on exception
-	//
 });

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -11,7 +11,11 @@ import {
 	unsetAllMocks,
 	unsetSpecialMockFns,
 } from "./helpers/mock-cfetch";
-import { mockConsoleMethods, normalizeSlashes } from "./helpers/mock-console";
+import {
+	mockConsoleMethods,
+	normalizeSlashes,
+	normalizeTempDirs,
+} from "./helpers/mock-console";
 import { mockConfirm } from "./helpers/mock-dialogs";
 import { mockGetZoneFromHostRequest } from "./helpers/mock-get-zone-from-host";
 import { useMockIsTTY } from "./helpers/mock-istty";
@@ -77,7 +81,7 @@ describe("publish", () => {
 			await runWrangler("publish ./index");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			"Total Upload: 0xx KiB / gzip: 0xx KiB
+			"Total Upload: xx KiB / gzip: xx KiB
 			Worker ID:  abc12345
 			Worker ETag:  etag98765
 			Worker PipelineHash:  hash9999
@@ -116,7 +120,7 @@ describe("publish", () => {
 			        "Attempting to login via OAuth...
 			        Opening a link in your default browser: https://dash.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20pages%3Awrite%20zone%3Aread%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
 			        Successfully logged in.
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
+			        Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -137,7 +141,7 @@ describe("publish", () => {
 			await expect(runWrangler("publish index.js")).resolves.toBeUndefined();
 
 			expect(std.out).toMatchInlineSnapshot(`
-			"Total Upload: 0xx KiB / gzip: 0xx KiB
+			"Total Upload: xx KiB / gzip: xx KiB
 			Uploaded test-name (TIMINGS)
 			Published test-name (TIMINGS)
 			  https://test-name.test-sub-domain.workers.dev"
@@ -177,7 +181,7 @@ describe("publish", () => {
 				await runWrangler("publish index.js");
 
 				expect(std.out).toMatchInlineSnapshot(`
-			          "Total Upload: 0xx KiB / gzip: 0xx KiB
+			          "Total Upload: xx KiB / gzip: xx KiB
 			          Uploaded test-name (TIMINGS)
 			          Published test-name (TIMINGS)
 			            https://test-name.test-sub-domain.workers.dev"
@@ -201,7 +205,7 @@ describe("publish", () => {
 				await runWrangler("publish index.js");
 
 				expect(std.out).toMatchInlineSnapshot(`
-			          "Total Upload: 0xx KiB / gzip: 0xx KiB
+			          "Total Upload: xx KiB / gzip: xx KiB
 			          Uploaded test-name (TIMINGS)
 			          Published test-name (TIMINGS)
 			            https://test-name.test-sub-domain.workers.dev"
@@ -303,7 +307,7 @@ describe("publish", () => {
 			});
 			await runWrangler("publish index.js --env some-env");
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name-some-env (TIMINGS)
 			        Published test-name-some-env (TIMINGS)
 			          https://test-name-some-env.test-sub-domain.workers.dev"
@@ -322,7 +326,7 @@ describe("publish", () => {
 				});
 				await runWrangler("publish index.js --legacy-env true");
 				expect(std.out).toMatchInlineSnapshot(`
-			          "Total Upload: 0xx KiB / gzip: 0xx KiB
+			          "Total Upload: xx KiB / gzip: xx KiB
 			          Uploaded test-name (TIMINGS)
 			          Published test-name (TIMINGS)
 			            https://test-name.test-sub-domain.workers.dev"
@@ -341,7 +345,7 @@ describe("publish", () => {
 				});
 				await runWrangler("publish index.js --env some-env --legacy-env true");
 				expect(std.out).toMatchInlineSnapshot(`
-			          "Total Upload: 0xx KiB / gzip: 0xx KiB
+			          "Total Upload: xx KiB / gzip: xx KiB
 			          Uploaded test-name-some-env (TIMINGS)
 			          Published test-name-some-env (TIMINGS)
 			            https://test-name-some-env.test-sub-domain.workers.dev"
@@ -360,7 +364,7 @@ describe("publish", () => {
 				});
 				await runWrangler("publish index.js --env some-env --legacy-env true");
 				expect(std.out).toMatchInlineSnapshot(`
-			          "Total Upload: 0xx KiB / gzip: 0xx KiB
+			          "Total Upload: xx KiB / gzip: xx KiB
 			          Uploaded test-name-some-env (TIMINGS)
 			          Published test-name-some-env (TIMINGS)
 			            https://test-name-some-env.test-sub-domain.workers.dev"
@@ -430,7 +434,7 @@ describe("publish", () => {
 				});
 				await runWrangler("publish index.js --legacy-env false");
 				expect(std.out).toMatchInlineSnapshot(`
-			          "Total Upload: 0xx KiB / gzip: 0xx KiB
+			          "Total Upload: xx KiB / gzip: xx KiB
 			          Uploaded test-name (TIMINGS)
 			          Published test-name (TIMINGS)
 			            https://test-name.test-sub-domain.workers.dev"
@@ -456,7 +460,7 @@ describe("publish", () => {
 				});
 				await runWrangler("publish index.js --env some-env --legacy-env false");
 				expect(std.out).toMatchInlineSnapshot(`
-			          "Total Upload: 0xx KiB / gzip: 0xx KiB
+			          "Total Upload: xx KiB / gzip: xx KiB
 			          Uploaded test-name (some-env) (TIMINGS)
 			          Published test-name (some-env) (TIMINGS)
 			            https://some-env.test-name.test-sub-domain.workers.dev"
@@ -499,14 +503,14 @@ describe("publish", () => {
 		mockSubDomainRequest();
 		await runWrangler("publish ./some-path/worker/index.js");
 		expect(std.out).toMatchInlineSnapshot(`
-		      "Your worker has access to the following bindings:
-		      - Vars:
-		        - xyz: \\"123\\"
-		      Total Upload: 0xx KiB / gzip: 0xx KiB
-		      Uploaded test-name (TIMINGS)
-		      Published test-name (TIMINGS)
-		        https://test-name.test-sub-domain.workers.dev"
-	    `);
+		"Total Upload: xx KiB / gzip: xx KiB
+		Your worker has access to the following bindings:
+		- Vars:
+		  - xyz: \\"123\\"
+		Uploaded test-name (TIMINGS)
+		Published test-name (TIMINGS)
+		  https://test-name.test-sub-domain.workers.dev"
+	`);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
@@ -536,7 +540,7 @@ describe("publish", () => {
 			Object {
 			  "debug": "",
 			  "err": "",
-			  "out": "Total Upload: 0xx KiB / gzip: 0xx KiB
+			  "out": "Total Upload: xx KiB / gzip: xx KiB
 			Uploaded test-name (TIMINGS)
 			Published test-name (TIMINGS)
 			  https://test-name.test-sub-domain.workers.dev",
@@ -583,7 +587,7 @@ describe("publish", () => {
 			        Object {
 			          "debug": "",
 			          "err": "",
-			          "out": "Total Upload: 0xx KiB / gzip: 0xx KiB
+			          "out": "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          some-example.com/some-route/*
@@ -644,7 +648,7 @@ describe("publish", () => {
 			        Object {
 			          "debug": "",
 			          "err": "",
-			          "out": "Total Upload: 0xx KiB / gzip: 0xx KiB
+			          "out": "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (staging) (TIMINGS)
 			        Published test-name (staging) (TIMINGS)
 			          some-example.com/some-route/*
@@ -750,7 +754,7 @@ describe("publish", () => {
 			        "
 		      `);
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          example.com/some-route/*"
@@ -1030,7 +1034,7 @@ Update them to point to this script instead?`,
 			await runWrangler("publish ./index");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -1047,7 +1051,7 @@ Update them to point to this script instead?`,
 			await runWrangler("publish ./index");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -1064,7 +1068,7 @@ Update them to point to this script instead?`,
 			await runWrangler("publish");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -1083,7 +1087,7 @@ Update them to point to this script instead?`,
 			await runWrangler("publish");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -1100,7 +1104,7 @@ Update them to point to this script instead?`,
 			await runWrangler("publish");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -1136,7 +1140,7 @@ Update them to point to this script instead?`,
 			await runWrangler("publish");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -1186,7 +1190,7 @@ Update them to point to this script instead?`,
 			await runWrangler("publish index.ts");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -1205,7 +1209,7 @@ Update them to point to this script instead?`,
 			await runWrangler("publish index.ts");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -1236,7 +1240,7 @@ export default{
 			mockSubDomainRequest();
 			await runWrangler("publish index.js");
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -1253,7 +1257,7 @@ export default{
 			await runWrangler("publish ./src/index.js");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -1290,14 +1294,14 @@ export default {};`
 		      `);
 
 			expect(std).toMatchInlineSnapshot(`
-			        Object {
-			          "debug": "",
-			          "err": "",
-			          "out": "--dry-run: exiting now.
-			        Total Upload: 0xx KiB / gzip: 0xx KiB",
-			          "warn": "",
-			        }
-		      `);
+			Object {
+			  "debug": "",
+			  "err": "",
+			  "out": "Total Upload: xx KiB / gzip: xx KiB
+			--dry-run: exiting now.",
+			  "warn": "",
+			}
+		`);
 		});
 
 		it("should not preserve exports on a service-worker format worker", async () => {
@@ -1323,16 +1327,16 @@ addEventListener('fetch', event => {});`
 			).toMatchInlineSnapshot(`Array []`);
 
 			expect(std).toMatchInlineSnapshot(`
-			        Object {
-			          "debug": "",
-			          "err": "",
-			          "out": "--dry-run: exiting now.
-			        Total Upload: 0xx KiB / gzip: 0xx KiB",
-			          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe entrypoint index.js has exports like an ES Module, but hasn't defined a default export like a module worker normally would. Building the worker using \\"service-worker\\" format...[0m
+			Object {
+			  "debug": "",
+			  "err": "",
+			  "out": "Total Upload: xx KiB / gzip: xx KiB
+			--dry-run: exiting now.",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe entrypoint index.js has exports like an ES Module, but hasn't defined a default export like a module worker normally would. Building the worker using \\"service-worker\\" format...[0m
 
-			        ",
-			        }
-		      `);
+			",
+			}
+		`);
 		});
 
 		it("should be able to transpile entry-points in sub-directories (sw)", async () => {
@@ -1347,7 +1351,7 @@ addEventListener('fetch', event => {});`
 			await runWrangler("publish ./src/index.js");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -1429,7 +1433,7 @@ addEventListener('fetch', event => {});`
 			        Reading file-2.txt...
 			        Uploading as file-2.5938485188.txt...
 			        ↗️  Done syncing assets
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
+			        Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev",
@@ -1481,7 +1485,7 @@ addEventListener('fetch', event => {});`
 			        Reading file-2.txt...
 			        Uploading as file-2.5938485188.txt...
 			        ↗️  Done syncing assets
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
+			        Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -1570,7 +1574,7 @@ addEventListener('fetch', event => {});`
 			Reading file-2.txt...
 			Uploading as file-2.5938485188.txt...
 			↗️  Done syncing assets
-			Total Upload: 52xx KiB / gzip: 14xx KiB
+			Total Upload: xx KiB / gzip: xx KiB
 			Uploaded test-name (TIMINGS)
 			Published test-name (TIMINGS)
 			  https://test-name.test-sub-domain.workers.dev",
@@ -1618,7 +1622,7 @@ addEventListener('fetch', event => {});`
 			        Reading file-2.txt...
 			        Uploading as file-2.5938485188.txt...
 			        ↗️  Done syncing assets
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
+			        Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -1658,7 +1662,7 @@ addEventListener('fetch', event => {});`
 			Reading file-2.txt...
 			Uploading as file-2.5938485188.txt...
 			↗️  Done syncing assets
-			Total Upload: 52xx KiB / gzip: 14xx KiB
+			Total Upload: xx KiB / gzip: xx KiB
 			Uploaded test-name (TIMINGS)
 			Published test-name (TIMINGS)
 			  https://test-name.test-sub-domain.workers.dev",
@@ -1842,7 +1846,7 @@ addEventListener('fetch', event => {});`
 			Reading subdir/file-2.txt...
 			Uploading as subdir/file-2.5938485188.txt...
 			↗️  Done syncing assets
-			Total Upload: 52xx KiB / gzip: 14xx KiB
+			Total Upload: xx KiB / gzip: xx KiB
 			Uploaded test-name (TIMINGS)
 			Published test-name (TIMINGS)
 			  https://test-name.test-sub-domain.workers.dev",
@@ -1888,7 +1892,7 @@ addEventListener('fetch', event => {});`
 			Reading subdir/file-2.txt...
 			Uploading as subdir/file-2.5938485188.txt...
 			↗️  Done syncing assets
-			Total Upload: 52xx KiB / gzip: 14xx KiB
+			Total Upload: xx KiB / gzip: xx KiB
 			Uploaded test-name (TIMINGS)
 			Published test-name (TIMINGS)
 			  https://test-name.test-sub-domain.workers.dev",
@@ -1944,7 +1948,7 @@ addEventListener('fetch', event => {});`
 			        Reading subdir/file-2.txt...
 			        Uploading as subdir/file-2.5938485188.txt...
 			        ↗️  Done syncing assets
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
+			        Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -2001,7 +2005,7 @@ addEventListener('fetch', event => {});`
 			        Reading file-2.txt...
 			        Uploading as file-2.5938485188.txt...
 			        ↗️  Done syncing assets
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
+			        Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -2052,7 +2056,7 @@ addEventListener('fetch', event => {});`
 			        Reading file-2.txt...
 			        Uploading as file-2.5938485188.txt...
 			        ↗️  Done syncing assets
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
+			        Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -2101,7 +2105,7 @@ addEventListener('fetch', event => {});`
 			        Reading file-2.txt...
 			        Uploading as file-2.5938485188.txt...
 			        ↗️  Done syncing assets
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
+			        Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (some-env) (TIMINGS)
 			        Published test-name (some-env) (TIMINGS)
 			          https://some-env.test-name.test-sub-domain.workers.dev"
@@ -2151,7 +2155,7 @@ addEventListener('fetch', event => {});`
 			        Reading file-2.txt...
 			        Uploading as file-2.5938485188.txt...
 			        ↗️  Done syncing assets
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
+			        Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name-some-env (TIMINGS)
 			        Published test-name-some-env (TIMINGS)
 			          https://test-name-some-env.test-sub-domain.workers.dev"
@@ -2194,7 +2198,7 @@ addEventListener('fetch', event => {});`
 			        Reading file-2.txt...
 			        Uploading as file-2.5938485188.txt...
 			        ↗️  Done syncing assets
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
+			        Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -2234,7 +2238,7 @@ addEventListener('fetch', event => {});`
 			        "Reading file-1.txt...
 			        Uploading as file-1.2ca234f380.txt...
 			        ↗️  Done syncing assets
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
+			        Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -2274,7 +2278,7 @@ addEventListener('fetch', event => {});`
 			        "Reading file-1.txt...
 			        Uploading as file-1.2ca234f380.txt...
 			        ↗️  Done syncing assets
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
+			        Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -2315,7 +2319,7 @@ addEventListener('fetch', event => {});`
 			        "Reading file-1.txt...
 			        Uploading as file-1.2ca234f380.txt...
 			        ↗️  Done syncing assets
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
+			        Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -2356,7 +2360,7 @@ addEventListener('fetch', event => {});`
 			        "Reading file-1.txt...
 			        Uploading as file-1.2ca234f380.txt...
 			        ↗️  Done syncing assets
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
+			        Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -2397,7 +2401,7 @@ addEventListener('fetch', event => {});`
 			        "Reading file-1.txt...
 			        Uploading as file-1.2ca234f380.txt...
 			        ↗️  Done syncing assets
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
+			        Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -2438,7 +2442,7 @@ addEventListener('fetch', event => {});`
 			        "Reading file-1.txt...
 			        Uploading as file-1.2ca234f380.txt...
 			        ↗️  Done syncing assets
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
+			        Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -2481,7 +2485,7 @@ addEventListener('fetch', event => {});`
 			        "Reading directory-1/file-1.txt...
 			        Uploading as directory-1/file-1.2ca234f380.txt...
 			        ↗️  Done syncing assets
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
+			        Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -2528,7 +2532,7 @@ addEventListener('fetch', event => {});`
 			        "Reading .well-known/file-2.txt...
 			        Uploading as .well-known/file-2.5938485188.txt...
 			        ↗️  Done syncing assets
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
+			        Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -2677,7 +2681,7 @@ addEventListener('fetch', event => {});`
 			        Reading file-19.txt...
 			        Uploading as file-19.f0d69f705d.txt...
 			        ↗️  Done syncing assets
-			        Total Upload: 1xx KiB / gzip: 0xx KiB
+			        Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev",
@@ -2776,7 +2780,7 @@ addEventListener('fetch', event => {});`
 			        Deleting file-3.somehash.txt from the asset store...
 			        Deleting file-4.anotherhash.txt from the asset store...
 			        ↗️  Done syncing assets
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
+			        Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -2830,7 +2834,7 @@ addEventListener('fetch', event => {});`
 			        Reading file-2.txt...
 			        Uploading as file-2.5938485188.txt...
 			        ↗️  Done syncing assets
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
+			        Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -2871,7 +2875,7 @@ addEventListener('fetch', event => {});`
 			        Reading file-2.txt...
 			        Uploading as file-2.5938485188.txt...
 			        ↗️  Done syncing assets
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
+			        Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev",
@@ -2913,7 +2917,7 @@ addEventListener('fetch', event => {});`
 			Reading file-2.txt...
 			Uploading as file-2.5938485188.txt...
 			↗️  Done syncing assets
-			Total Upload: 52xx KiB / gzip: 14xx KiB
+			Total Upload: xx KiB / gzip: xx KiB
 			Uploaded test-name (TIMINGS)
 			Published test-name (TIMINGS)
 			  https://test-name.test-sub-domain.workers.dev",
@@ -2935,7 +2939,7 @@ addEventListener('fetch', event => {});`
 			await runWrangler("publish ./index");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -2955,7 +2959,7 @@ addEventListener('fetch', event => {});`
 			await runWrangler("publish ./index");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -2974,7 +2978,7 @@ addEventListener('fetch', event => {});`
 			await runWrangler("publish ./index");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -2993,7 +2997,7 @@ addEventListener('fetch', event => {});`
 			await runWrangler("publish ./index");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        No publish targets for test-name (TIMINGS)"
 		      `);
@@ -3013,7 +3017,7 @@ addEventListener('fetch', event => {});`
 			await runWrangler("publish ./index");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        No publish targets for test-name (TIMINGS)"
 		      `);
@@ -3037,7 +3041,7 @@ addEventListener('fetch', event => {});`
 			await runWrangler("publish ./index --env dev --legacy-env false");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (dev) (TIMINGS)
 			        No publish targets for test-name (dev) (TIMINGS)"
 		      `);
@@ -3062,7 +3066,7 @@ addEventListener('fetch', event => {});`
 			await runWrangler("publish ./index --env dev --legacy-env false");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (dev) (TIMINGS)
 			        No publish targets for test-name (dev) (TIMINGS)"
 		      `);
@@ -3087,7 +3091,7 @@ addEventListener('fetch', event => {});`
 			await runWrangler("publish ./index --env dev --legacy-env false");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (dev) (TIMINGS)
 			        Published test-name (dev) (TIMINGS)
 			          https://dev.test-name.test-sub-domain.workers.dev"
@@ -3114,7 +3118,7 @@ addEventListener('fetch', event => {});`
 			await runWrangler("publish ./index --env dev --legacy-env false");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (dev) (TIMINGS)
 			        Published test-name (dev) (TIMINGS)
 			          https://dev.test-name.test-sub-domain.workers.dev"
@@ -3142,7 +3146,7 @@ addEventListener('fetch', event => {});`
 			await runWrangler("publish ./index --env dev --legacy-env false");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (dev) (TIMINGS)
 			        Published test-name (dev) (TIMINGS)
 			          https://dev.test-name.test-sub-domain.workers.dev"
@@ -3173,7 +3177,7 @@ addEventListener('fetch', event => {});`
 			await runWrangler("publish ./index --env dev --legacy-env false");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (dev) (TIMINGS)
 			        Published test-name (dev) (TIMINGS)
 			          https://dev.test-name.test-sub-domain.workers.dev"
@@ -3206,7 +3210,7 @@ addEventListener('fetch', event => {});`
 			);
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (dev) (TIMINGS)
 			        Published test-name (dev) (TIMINGS)
 			          https://dev.test-name.test-sub-domain.workers.dev"
@@ -3243,7 +3247,7 @@ addEventListener('fetch', event => {});`
 			await runWrangler("publish ./index");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -3261,7 +3265,7 @@ addEventListener('fetch', event => {});`
 			await runWrangler("publish ./index");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -3299,7 +3303,7 @@ addEventListener('fetch', event => {});`
 			await runWrangler("publish index.js");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          http://example.com/*"
@@ -3333,7 +3337,7 @@ addEventListener('fetch', event => {});`
 			await runWrangler("publish index.js --env production");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name-production (TIMINGS)
 			        Published test-name-production (TIMINGS)
 			          http://production.example.com/*"
@@ -3366,7 +3370,7 @@ addEventListener('fetch', event => {});`
 			await runWrangler("publish index.js --env production");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name-production (TIMINGS)
 			        Published test-name-production (TIMINGS)
 			          http://production.example.com/*"
@@ -3392,7 +3396,7 @@ addEventListener('fetch', event => {});`
 			await runWrangler("publish index.js");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev
@@ -3427,7 +3431,7 @@ addEventListener('fetch', event => {});`
 			await runWrangler("publish index.js --env production");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name-production (TIMINGS)
 			        Published test-name-production (TIMINGS)
 			          https://test-name-production.test-sub-domain.workers.dev
@@ -3462,7 +3466,7 @@ addEventListener('fetch', event => {});`
 			await runWrangler("publish index.js --env production");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name-production (TIMINGS)
 			        Published test-name-production (TIMINGS)
 			          https://test-name-production.test-sub-domain.workers.dev
@@ -3497,7 +3501,7 @@ addEventListener('fetch', event => {});`
 			await runWrangler("publish index.js --env production");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name-production (TIMINGS)
 			        Published test-name-production (TIMINGS)
 			          http://production.example.com/*"
@@ -3531,7 +3535,7 @@ addEventListener('fetch', event => {});`
 			await runWrangler("publish index.js --env production");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name-production (TIMINGS)
 			        Published test-name-production (TIMINGS)
 			          http://production.example.com/*"
@@ -3569,20 +3573,17 @@ addEventListener('fetch', event => {});`
 			mockSubDomainRequest();
 			mockUploadWorkerRequest();
 			await runWrangler("build");
-			expect(fs.readFileSync("dist/index.js", "utf-8")).toMatchInlineSnapshot(`
-			        "(() => {
-			          // index.js
-			          console.log(123);
-			          console.log(globalThis.abc);
-			          function foo() {
-			            const abc2 = \\"a string\\";
-			            console.log(abc2);
-			          }
-			          console.log(foo);
-			        })();
-			        //# sourceMappingURL=index.js.map
-			        "
-		      `);
+
+			const outFile = normalizeSlashes(
+				normalizeTempDirs(fs.readFileSync("dist/index.js", "utf-8"))
+			);
+
+			// We don't check against the whole file as there is middleware being injected
+			expect(outFile).toContain("console.log(123);");
+			expect(outFile).toContain("console.log(globalThis.abc);");
+			expect(outFile).toContain(`const abc2 = "a string";`);
+			expect(outFile).toContain("console.log(abc2);");
+			expect(outFile).toContain("console.log(foo);");
 		});
 
 		it("can be overriden in environments", async () => {
@@ -3608,14 +3609,13 @@ addEventListener('fetch', event => {});`
 			mockSubDomainRequest();
 			mockUploadWorkerRequest();
 			await runWrangler("build --env staging");
-			expect(fs.readFileSync("dist/index.js", "utf-8")).toMatchInlineSnapshot(`
-			        "(() => {
-			          // index.js
-			          console.log(456);
-			        })();
-			        //# sourceMappingURL=index.js.map
-			        "
-		      `);
+
+			const outFile = normalizeSlashes(
+				normalizeTempDirs(fs.readFileSync("dist/index.js", "utf-8"))
+			);
+
+			// We don't check against the whole file as there is middleware being injected
+			expect(outFile).toContain("console.log(456);");
 		});
 
 		it("can be overridden with cli args", async () => {
@@ -3665,12 +3665,36 @@ addEventListener('fetch', event => {});`
 
 			await runWrangler("publish index.js");
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Running custom build: node -e \\"console.log('custom build'); require('fs').writeFileSync('index.js', 'export default { fetch(){ return new Response(123) } }')\\"
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
-			        Uploaded test-name (TIMINGS)
-			        Published test-name (TIMINGS)
-			          https://test-name.test-sub-domain.workers.dev"
-		      `);
+			"Running custom build: node -e \\"console.log('custom build'); require('fs').writeFileSync('index.js', 'export default { fetch(){ return new Response(123) } }')\\"
+			Total Upload: xx KiB / gzip: xx KiB
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev"
+		`);
+			expect(std.err).toMatchInlineSnapshot(`""`);
+			expect(std.warn).toMatchInlineSnapshot(`""`);
+		});
+
+		it("should run a custom build before publishing 2", async () => {
+			writeWranglerToml({
+				build: {
+					command: `node -e "console.log('custom build'); require('fs').writeFileSync('index.js', 'export default { fetch(){ return new Response(123) } }')"`,
+				},
+			});
+
+			mockUploadWorkerRequest({
+				expectedEntry: "return new Response(123)",
+			});
+			mockSubDomainRequest();
+
+			await runWrangler("publish index.js");
+			expect(std.out).toMatchInlineSnapshot(`
+			"Running custom build: node -e \\"console.log('custom build'); require('fs').writeFileSync('index.js', 'export default { fetch(){ return new Response(123) } }')\\"
+			Total Upload: xx KiB / gzip: xx KiB
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev"
+		`);
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
@@ -3691,7 +3715,7 @@ addEventListener('fetch', event => {});`
 				await runWrangler("publish index.js");
 				expect(std.out).toMatchInlineSnapshot(`
 			          "Running custom build: echo \\"custom build\\" && echo \\"export default { fetch(){ return new Response(123) } }\\" > index.js
-			          Total Upload: 0xx KiB / gzip: 0xx KiB
+			          Total Upload: xx KiB / gzip: xx KiB
 			          Uploaded test-name (TIMINGS)
 			          Published test-name (TIMINGS)
 			            https://test-name.test-sub-domain.workers.dev"
@@ -3797,7 +3821,7 @@ addEventListener('fetch', event => {});`
 			mockSubDomainRequest();
 			await runWrangler("publish index.js --minify");
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -3836,7 +3860,7 @@ addEventListener('fetch', event => {});`
 			mockSubDomainRequest();
 			await runWrangler("publish -e testEnv index.js");
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (testEnv) (TIMINGS)
 			        Published test-name (testEnv) (TIMINGS)
 			          https://testEnv.test-name.test-sub-domain.workers.dev"
@@ -3860,14 +3884,14 @@ addEventListener('fetch', event => {});`
 			mockUploadWorkerRequest();
 			await runWrangler("publish index.js");
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Your worker has access to the following bindings:
-			        - Durable Objects:
-			          - SOMENAME: SomeClass
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
-			        Uploaded test-name (TIMINGS)
-			        Published test-name (TIMINGS)
-			          https://test-name.test-sub-domain.workers.dev"
-		      `);
+			"Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- Durable Objects:
+			  - SOMENAME: SomeClass
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev"
+		`);
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.warn).toMatchInlineSnapshot(`
 			        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
@@ -3910,14 +3934,14 @@ addEventListener('fetch', event => {});`
 			mockUploadWorkerRequest();
 			await runWrangler("publish index.js");
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Your worker has access to the following bindings:
-			        - Durable Objects:
-			          - SOMENAME: SomeClass (defined in some-script)
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
-			        Uploaded test-name (TIMINGS)
-			        Published test-name (TIMINGS)
-			          https://test-name.test-sub-domain.workers.dev"
-		      `);
+			"Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- Durable Objects:
+			  - SOMENAME: SomeClass (defined in some-script)
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev"
+		`);
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
@@ -3953,15 +3977,15 @@ addEventListener('fetch', event => {});`
 
 			await runWrangler("publish index.js");
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Your worker has access to the following bindings:
-			        - Durable Objects:
-			          - SOMENAME: SomeClass
-			          - SOMEOTHERNAME: SomeOtherClass
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
-			        Uploaded test-name (TIMINGS)
-			        Published test-name (TIMINGS)
-			          https://test-name.test-sub-domain.workers.dev"
-		      `);
+			"Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- Durable Objects:
+			  - SOMENAME: SomeClass
+			  - SOMEOTHERNAME: SomeOtherClass
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev"
+		`);
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
@@ -4001,20 +4025,20 @@ addEventListener('fetch', event => {});`
 
 			await runWrangler("publish index.js");
 			expect(std).toMatchInlineSnapshot(`
-			        Object {
-			          "debug": "",
-			          "err": "",
-			          "out": "Your worker has access to the following bindings:
-			        - Durable Objects:
-			          - SOMENAME: SomeClass
-			          - SOMEOTHERNAME: SomeOtherClass
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
-			        Uploaded test-name (TIMINGS)
-			        Published test-name (TIMINGS)
-			          https://test-name.test-sub-domain.workers.dev",
-			          "warn": "",
-			        }
-		      `);
+			Object {
+			  "debug": "",
+			  "err": "",
+			  "out": "Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- Durable Objects:
+			  - SOMENAME: SomeClass
+			  - SOMEOTHERNAME: SomeOtherClass
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev",
+			  "warn": "",
+			}
+		`);
 		});
 
 		it("should not send migrations if they've all already been sent", async () => {
@@ -4045,20 +4069,20 @@ addEventListener('fetch', event => {});`
 
 			await runWrangler("publish index.js");
 			expect(std).toMatchInlineSnapshot(`
-			        Object {
-			          "debug": "",
-			          "err": "",
-			          "out": "Your worker has access to the following bindings:
-			        - Durable Objects:
-			          - SOMENAME: SomeClass
-			          - SOMEOTHERNAME: SomeOtherClass
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
-			        Uploaded test-name (TIMINGS)
-			        Published test-name (TIMINGS)
-			          https://test-name.test-sub-domain.workers.dev",
-			          "warn": "",
-			        }
-		      `);
+			Object {
+			  "debug": "",
+			  "err": "",
+			  "out": "Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- Durable Objects:
+			  - SOMENAME: SomeClass
+			  - SOMEOTHERNAME: SomeOtherClass
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev",
+			  "warn": "",
+			}
+		`);
 		});
 
 		describe("service environments", () => {
@@ -4094,15 +4118,15 @@ addEventListener('fetch', event => {});`
 
 				await runWrangler("publish index.js --legacy-env false");
 				expect(std.out).toMatchInlineSnapshot(`
-			          "Your worker has access to the following bindings:
-			          - Durable Objects:
-			            - SOMENAME: SomeClass
-			            - SOMEOTHERNAME: SomeOtherClass
-			          Total Upload: 0xx KiB / gzip: 0xx KiB
-			          Uploaded test-name (TIMINGS)
-			          Published test-name (TIMINGS)
-			            https://test-name.test-sub-domain.workers.dev"
-		        `);
+			"Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- Durable Objects:
+			  - SOMENAME: SomeClass
+			  - SOMEOTHERNAME: SomeOtherClass
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`
 			          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
@@ -4157,15 +4181,15 @@ addEventListener('fetch', event => {});`
 
 				await runWrangler("publish index.js --legacy-env false --env xyz");
 				expect(std.out).toMatchInlineSnapshot(`
-			          "Your worker has access to the following bindings:
-			          - Durable Objects:
-			            - SOMENAME: SomeClass
-			            - SOMEOTHERNAME: SomeOtherClass
-			          Total Upload: 0xx KiB / gzip: 0xx KiB
-			          Uploaded test-name (xyz) (TIMINGS)
-			          Published test-name (xyz) (TIMINGS)
-			            https://xyz.test-name.test-sub-domain.workers.dev"
-		        `);
+			"Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- Durable Objects:
+			  - SOMENAME: SomeClass
+			  - SOMEOTHERNAME: SomeOtherClass
+			Uploaded test-name (xyz) (TIMINGS)
+			Published test-name (xyz) (TIMINGS)
+			  https://xyz.test-name.test-sub-domain.workers.dev"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`
 			          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
@@ -4213,25 +4237,25 @@ addEventListener('fetch', event => {});`
 
 				await runWrangler("publish index.js --legacy-env false");
 				expect(std).toMatchInlineSnapshot(`
-			          Object {
-			            "debug": "",
-			            "err": "",
-			            "out": "Your worker has access to the following bindings:
-			          - Durable Objects:
-			            - SOMENAME: SomeClass
-			            - SOMEOTHERNAME: SomeOtherClass
-			          Total Upload: 0xx KiB / gzip: 0xx KiB
-			          Uploaded test-name (TIMINGS)
-			          Published test-name (TIMINGS)
-			            https://test-name.test-sub-domain.workers.dev",
-			            "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+			Object {
+			  "debug": "",
+			  "err": "",
+			  "out": "Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- Durable Objects:
+			  - SOMENAME: SomeClass
+			  - SOMEOTHERNAME: SomeOtherClass
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
 
-			              - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in
-			            the future. DO NOT USE IN PRODUCTION.
+			    - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in
+			  the future. DO NOT USE IN PRODUCTION.
 
-			          ",
-			          }
-		        `);
+			",
+			}
+		`);
 			});
 
 			it("should use an environment's current migration tag when publishing migrations", async () => {
@@ -4282,25 +4306,25 @@ addEventListener('fetch', event => {});`
 
 				await runWrangler("publish index.js --legacy-env false --env xyz");
 				expect(std).toMatchInlineSnapshot(`
-			          Object {
-			            "debug": "",
-			            "err": "",
-			            "out": "Your worker has access to the following bindings:
-			          - Durable Objects:
-			            - SOMENAME: SomeClass
-			            - SOMEOTHERNAME: SomeOtherClass
-			          Total Upload: 0xx KiB / gzip: 0xx KiB
-			          Uploaded test-name (xyz) (TIMINGS)
-			          Published test-name (xyz) (TIMINGS)
-			            https://xyz.test-name.test-sub-domain.workers.dev",
-			            "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+			Object {
+			  "debug": "",
+			  "err": "",
+			  "out": "Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- Durable Objects:
+			  - SOMENAME: SomeClass
+			  - SOMEOTHERNAME: SomeOtherClass
+			Uploaded test-name (xyz) (TIMINGS)
+			Published test-name (xyz) (TIMINGS)
+			  https://xyz.test-name.test-sub-domain.workers.dev",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
 
-			              - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in
-			            the future. DO NOT USE IN PRODUCTION.
+			    - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in
+			  the future. DO NOT USE IN PRODUCTION.
 
-			          ",
-			          }
-		        `);
+			",
+			}
+		`);
 			});
 		});
 	});
@@ -4479,39 +4503,39 @@ addEventListener('fetch', event => {});`
 
 			await expect(runWrangler("publish index.js")).resolves.toBeUndefined();
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Your worker has access to the following bindings:
-			        - Data Blobs:
-			          - DATA_BLOB_ONE: some-data-blob.bin
-			          - DATA_BLOB_TWO: more-data-blob.bin
-			        - Durable Objects:
-			          - DURABLE_OBJECT_ONE: SomeDurableObject (defined in some-durable-object-worker)
-			          - DURABLE_OBJECT_TWO: AnotherDurableObject (defined in another-durable-object-worker) - staging
-			        - KV Namespaces:
-			          - KV_NAMESPACE_ONE: kv-ns-one-id
-			          - KV_NAMESPACE_TWO: kv-ns-two-id
-			        - R2 Buckets:
-			          - R2_BUCKET_ONE: r2-bucket-one-name
-			          - R2_BUCKET_TWO: r2-bucket-two-name
-			        - logfwdr:
-			          - httplogs: httplogs
-			          - trace: trace
-			        - Text Blobs:
-			          - TEXT_BLOB_ONE: my-entire-app-depends-on-this.cfg
-			          - TEXT_BLOB_TWO: the-entirety-of-human-knowledge.txt
-			        - Unsafe:
-			          - some unsafe thing: UNSAFE_BINDING_ONE
-			          - another unsafe thing: UNSAFE_BINDING_TWO
-			        - Vars:
-			          - ENV_VAR_ONE: \\"123\\"
-			          - ENV_VAR_TWO: \\"Hello, I'm an environment variable\\"
-			        - Wasm Modules:
-			          - WASM_MODULE_ONE: some_wasm.wasm
-			          - WASM_MODULE_TWO: more_wasm.wasm
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
-			        Uploaded test-name (TIMINGS)
-			        Published test-name (TIMINGS)
-			          https://test-name.test-sub-domain.workers.dev"
-		      `);
+			"Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- Data Blobs:
+			  - DATA_BLOB_ONE: some-data-blob.bin
+			  - DATA_BLOB_TWO: more-data-blob.bin
+			- Durable Objects:
+			  - DURABLE_OBJECT_ONE: SomeDurableObject (defined in some-durable-object-worker)
+			  - DURABLE_OBJECT_TWO: AnotherDurableObject (defined in another-durable-object-worker) - staging
+			- KV Namespaces:
+			  - KV_NAMESPACE_ONE: kv-ns-one-id
+			  - KV_NAMESPACE_TWO: kv-ns-two-id
+			- R2 Buckets:
+			  - R2_BUCKET_ONE: r2-bucket-one-name
+			  - R2_BUCKET_TWO: r2-bucket-two-name
+			- logfwdr:
+			  - httplogs: httplogs
+			  - trace: trace
+			- Text Blobs:
+			  - TEXT_BLOB_ONE: my-entire-app-depends-on-this.cfg
+			  - TEXT_BLOB_TWO: the-entirety-of-human-knowledge.txt
+			- Unsafe:
+			  - some unsafe thing: UNSAFE_BINDING_ONE
+			  - another unsafe thing: UNSAFE_BINDING_TWO
+			- Vars:
+			  - ENV_VAR_ONE: \\"123\\"
+			  - ENV_VAR_TWO: \\"Hello, I'm an environment variable\\"
+			- Wasm Modules:
+			  - WASM_MODULE_ONE: some_wasm.wasm
+			  - WASM_MODULE_TWO: more_wasm.wasm
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev"
+		`);
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.warn).toMatchInlineSnapshot(`
 			        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
@@ -4884,14 +4908,14 @@ addEventListener('fetch', event => {});`
 				mockSubDomainRequest();
 				await runWrangler("publish index.js");
 				expect(std.out).toMatchInlineSnapshot(`
-			          "Your worker has access to the following bindings:
-			          - Wasm Modules:
-			            - TESTWASMNAME: path/to/test.wasm
-			          Total Upload: 0xx KiB / gzip: 0xx KiB
-			          Uploaded test-name (TIMINGS)
-			          Published test-name (TIMINGS)
-			            https://test-name.test-sub-domain.workers.dev"
-		        `);
+			"Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- Wasm Modules:
+			  - TESTWASMNAME: path/to/test.wasm
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
@@ -4954,14 +4978,14 @@ addEventListener('fetch', event => {});`
 				mockSubDomainRequest();
 				await runWrangler("publish index.js --config ./path/to/wrangler.toml");
 				expect(std.out).toMatchInlineSnapshot(`
-			          "Your worker has access to the following bindings:
-			          - Wasm Modules:
-			            - TESTWASMNAME: path/to/and/the/path/to/test.wasm
-			          Total Upload: 0xx KiB / gzip: 0xx KiB
-			          Uploaded test-name (TIMINGS)
-			          Published test-name (TIMINGS)
-			            https://test-name.test-sub-domain.workers.dev"
-		        `);
+			"Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- Wasm Modules:
+			  - TESTWASMNAME: path/to/and/the/path/to/test.wasm
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
@@ -4990,7 +5014,7 @@ addEventListener('fetch', event => {});`
 				mockSubDomainRequest();
 				await runWrangler("publish index.js");
 				expect(std.out).toMatchInlineSnapshot(`
-			          "Total Upload: 0xx KiB / gzip: 0xx KiB
+			          "Total Upload: xx KiB / gzip: xx KiB
 			          Uploaded test-name (TIMINGS)
 			          Published test-name (TIMINGS)
 			            https://test-name.test-sub-domain.workers.dev"
@@ -5024,14 +5048,14 @@ addEventListener('fetch', event => {});`
 				mockSubDomainRequest();
 				await runWrangler("publish index.js");
 				expect(std.out).toMatchInlineSnapshot(`
-			          "Your worker has access to the following bindings:
-			          - Text Blobs:
-			            - TESTTEXTBLOBNAME: path/to/text.file
-			          Total Upload: 0xx KiB / gzip: 0xx KiB
-			          Uploaded test-name (TIMINGS)
-			          Published test-name (TIMINGS)
-			            https://test-name.test-sub-domain.workers.dev"
-		        `);
+			"Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- Text Blobs:
+			  - TESTTEXTBLOBNAME: path/to/text.file
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
@@ -5098,14 +5122,14 @@ addEventListener('fetch', event => {});`
 				mockSubDomainRequest();
 				await runWrangler("publish index.js --config ./path/to/wrangler.toml");
 				expect(std.out).toMatchInlineSnapshot(`
-			          "Your worker has access to the following bindings:
-			          - Text Blobs:
-			            - TESTTEXTBLOBNAME: path/to/and/the/path/to/text.file
-			          Total Upload: 0xx KiB / gzip: 0xx KiB
-			          Uploaded test-name (TIMINGS)
-			          Published test-name (TIMINGS)
-			            https://test-name.test-sub-domain.workers.dev"
-		        `);
+			"Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- Text Blobs:
+			  - TESTTEXTBLOBNAME: path/to/and/the/path/to/text.file
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
@@ -5135,14 +5159,14 @@ addEventListener('fetch', event => {});`
 				mockSubDomainRequest();
 				await runWrangler("publish index.js");
 				expect(std.out).toMatchInlineSnapshot(`
-			          "Your worker has access to the following bindings:
-			          - Data Blobs:
-			            - TESTDATABLOBNAME: path/to/data.bin
-			          Total Upload: 0xx KiB / gzip: 0xx KiB
-			          Uploaded test-name (TIMINGS)
-			          Published test-name (TIMINGS)
-			            https://test-name.test-sub-domain.workers.dev"
-		        `);
+			"Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- Data Blobs:
+			  - TESTDATABLOBNAME: path/to/data.bin
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
@@ -5209,14 +5233,14 @@ addEventListener('fetch', event => {});`
 				mockSubDomainRequest();
 				await runWrangler("publish index.js --config ./path/to/wrangler.toml");
 				expect(std.out).toMatchInlineSnapshot(`
-			          "Your worker has access to the following bindings:
-			          - Data Blobs:
-			            - TESTDATABLOBNAME: path/to/and/the/path/to/data.bin
-			          Total Upload: 0xx KiB / gzip: 0xx KiB
-			          Uploaded test-name (TIMINGS)
-			          Published test-name (TIMINGS)
-			            https://test-name.test-sub-domain.workers.dev"
-		        `);
+			"Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- Data Blobs:
+			  - TESTDATABLOBNAME: path/to/and/the/path/to/data.bin
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
@@ -5247,16 +5271,16 @@ addEventListener('fetch', event => {});`
 
 				await runWrangler("publish index.js");
 				expect(std.out).toMatchInlineSnapshot(`
-			          "Your worker has access to the following bindings:
-			          - Vars:
-			            - text: \\"plain ol' string\\"
-			            - count: \\"1\\"
-			            - complex: \\"[object Object]\\"
-			          Total Upload: 0xx KiB / gzip: 0xx KiB
-			          Uploaded test-name (TIMINGS)
-			          Published test-name (TIMINGS)
-			            https://test-name.test-sub-domain.workers.dev"
-		        `);
+			"Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- Vars:
+			  - text: \\"plain ol' string\\"
+			  - count: \\"1\\"
+			  - complex: \\"[object Object]\\"
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
@@ -5300,14 +5324,14 @@ addEventListener('fetch', event => {});`
 
 				await runWrangler("publish index.js");
 				expect(std.out).toMatchInlineSnapshot(`
-			          "Your worker has access to the following bindings:
-			          - R2 Buckets:
-			            - FOO: foo-bucket
-			          Total Upload: 0xx KiB / gzip: 0xx KiB
-			          Uploaded test-name (TIMINGS)
-			          Published test-name (TIMINGS)
-			            https://test-name.test-sub-domain.workers.dev"
-		        `);
+			"Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- R2 Buckets:
+			  - FOO: foo-bucket
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
@@ -5351,15 +5375,15 @@ addEventListener('fetch', event => {});`
 
 				await runWrangler("publish index.js");
 				expect(std.out).toMatchInlineSnapshot(`
-			          "Your worker has access to the following bindings:
-			          - logfwdr:
-			            - httplogs: httplogs
-			            - trace: trace
-			          Total Upload: 0xx KiB / gzip: 0xx KiB
-			          Uploaded test-name (TIMINGS)
-			          Published test-name (TIMINGS)
-			            https://test-name.test-sub-domain.workers.dev"
-		        `);
+			"Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- logfwdr:
+			  - httplogs: httplogs
+			  - trace: trace
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
@@ -5398,14 +5422,14 @@ addEventListener('fetch', event => {});`
 
 				await runWrangler("publish index.js");
 				expect(std.out).toMatchInlineSnapshot(`
-			          "Your worker has access to the following bindings:
-			          - Durable Objects:
-			            - EXAMPLE_DO_BINDING: ExampleDurableObject
-			          Total Upload: 0xx KiB / gzip: 0xx KiB
-			          Uploaded test-name (TIMINGS)
-			          Published test-name (TIMINGS)
-			            https://test-name.test-sub-domain.workers.dev"
-		        `);
+			"Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- Durable Objects:
+			  - EXAMPLE_DO_BINDING: ExampleDurableObject
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
@@ -5438,14 +5462,14 @@ addEventListener('fetch', event => {});`
 
 				await runWrangler("publish index.js");
 				expect(std.out).toMatchInlineSnapshot(`
-			          "Your worker has access to the following bindings:
-			          - Durable Objects:
-			            - EXAMPLE_DO_BINDING: ExampleDurableObject (defined in example-do-binding-worker)
-			          Total Upload: 0xx KiB / gzip: 0xx KiB
-			          Uploaded test-name (TIMINGS)
-			          Published test-name (TIMINGS)
-			            https://test-name.test-sub-domain.workers.dev"
-		        `);
+			"Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- Durable Objects:
+			  - EXAMPLE_DO_BINDING: ExampleDurableObject (defined in example-do-binding-worker)
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
@@ -5483,14 +5507,14 @@ addEventListener('fetch', event => {});`
 
 				await runWrangler("publish index.js");
 				expect(std.out).toMatchInlineSnapshot(`
-			          "Your worker has access to the following bindings:
-			          - Durable Objects:
-			            - EXAMPLE_DO_BINDING: ExampleDurableObject
-			          Total Upload: 0xx KiB / gzip: 0xx KiB
-			          Uploaded test-name (TIMINGS)
-			          Published test-name (TIMINGS)
-			            https://test-name.test-sub-domain.workers.dev"
-		        `);
+			"Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- Durable Objects:
+			  - EXAMPLE_DO_BINDING: ExampleDurableObject
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
@@ -5546,14 +5570,14 @@ addEventListener('fetch', event => {});`
 
 				await runWrangler("publish index.js");
 				expect(std.out).toMatchInlineSnapshot(`
-			          "Your worker has access to the following bindings:
-			          - Services:
-			            - FOO: foo-service - production
-			          Total Upload: 0xx KiB / gzip: 0xx KiB
-			          Uploaded test-name (TIMINGS)
-			          Published test-name (TIMINGS)
-			            https://test-name.test-sub-domain.workers.dev"
-		        `);
+			"Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- Services:
+			  - FOO: foo-service - production
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`
 			          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
@@ -5588,14 +5612,14 @@ addEventListener('fetch', event => {});`
 				});
 				await runWrangler("publish index.js");
 				expect(std.out).toMatchInlineSnapshot(`
-			          "Your worker has access to the following bindings:
-			          - dispatch namespaces:
-			            - foo: Foo
-			          Total Upload: 0xx KiB / gzip: 0xx KiB
-			          Uploaded test-name (TIMINGS)
-			          Published test-name (TIMINGS)
-			            https://test-name.test-sub-domain.workers.dev"
-		        `);
+			"Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- dispatch namespaces:
+			  - foo: Foo
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`
 			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
@@ -5634,14 +5658,14 @@ addEventListener('fetch', event => {});`
 
 				await runWrangler("publish index.js");
 				expect(std.out).toMatchInlineSnapshot(`
-			          "Your worker has access to the following bindings:
-			          - Unsafe:
-			            - binding-type: my-binding
-			          Total Upload: 0xx KiB / gzip: 0xx KiB
-			          Uploaded test-name (TIMINGS)
-			          Published test-name (TIMINGS)
-			            https://test-name.test-sub-domain.workers.dev"
-		        `);
+			"Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- Unsafe:
+			  - binding-type: my-binding
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`
 			          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
@@ -5677,14 +5701,14 @@ addEventListener('fetch', event => {});`
 
 				await runWrangler("publish index.js");
 				expect(std.out).toMatchInlineSnapshot(`
-			          "Your worker has access to the following bindings:
-			          - Unsafe:
-			            - plain_text: my-binding
-			          Total Upload: 0xx KiB / gzip: 0xx KiB
-			          Uploaded test-name (TIMINGS)
-			          Published test-name (TIMINGS)
-			            https://test-name.test-sub-domain.workers.dev"
-		        `);
+			"Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- Unsafe:
+			  - plain_text: my-binding
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`
 			          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
@@ -5726,7 +5750,7 @@ addEventListener('fetch', event => {});`
 			});
 			await runWrangler("publish index.js");
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -5755,7 +5779,7 @@ addEventListener('fetch', event => {});`
 			});
 			await runWrangler("publish index.js");
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -5788,7 +5812,7 @@ addEventListener('fetch', event => {});`
 			});
 			await runWrangler("publish index.js");
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -5837,7 +5861,7 @@ addEventListener('fetch', event => {});`
 			});
 			await runWrangler("publish index.js");
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -5934,7 +5958,7 @@ addEventListener('fetch', event => {});`
 				});
 				await runWrangler("publish index.js");
 				expect(std.out).toMatchInlineSnapshot(`
-			          "Total Upload: 0xx KiB / gzip: 0xx KiB
+			          "Total Upload: xx KiB / gzip: xx KiB
 			          Uploaded test-name (TIMINGS)
 			          Published test-name (TIMINGS)
 			            https://test-name.test-sub-domain.workers.dev"
@@ -5964,7 +5988,7 @@ addEventListener('fetch', event => {});`
 			});
 			await runWrangler("publish index.js");
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -5993,7 +6017,7 @@ addEventListener('fetch', event => {});`
 			});
 			await runWrangler("publish index.js");
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -6024,7 +6048,7 @@ addEventListener('fetch', event => {});`
 			});
 			await runWrangler("publish index.js");
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -6053,7 +6077,7 @@ addEventListener('fetch', event => {});`
 				"publish index.js --compatibility-date 2022-03-17 --name test-name"
 			);
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Total Upload: 0xx KiB / gzip: 0xx KiB
+			        "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev"
@@ -6094,7 +6118,7 @@ addEventListener('fetch', event => {});`
 			        Object {
 			          "debug": "",
 			          "err": "",
-			          "out": "Total Upload: 0xx KiB / gzip: 0xx KiB
+			          "out": "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev",
@@ -6124,7 +6148,7 @@ addEventListener('fetch', event => {});`
 			        Object {
 			          "debug": "",
 			          "err": "",
-			          "out": "Total Upload: 0xx KiB / gzip: 0xx KiB
+			          "out": "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev",
@@ -6147,7 +6171,7 @@ addEventListener('fetch', event => {});`
 			        Object {
 			          "debug": "",
 			          "err": "",
-			          "out": "Total Upload: 0xx KiB / gzip: 0xx KiB
+			          "out": "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev",
@@ -6171,17 +6195,17 @@ addEventListener('fetch', event => {});`
 			process.env.CLOUDFLARE_ACCOUNT_ID = "";
 			await runWrangler("publish index.js --dry-run");
 			expect(std).toMatchInlineSnapshot(`
-			        Object {
-			          "debug": "",
-			          "err": "",
-			          "out": "Your worker has access to the following bindings:
-			        - Durable Objects:
-			          - NAME: SomeClass
-			        Total Upload: 0xx KiB / gzip: 0xx KiB
-			        --dry-run: exiting now.",
-			          "warn": "",
-			        }
-		      `);
+			Object {
+			  "debug": "",
+			  "err": "",
+			  "out": "Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- Durable Objects:
+			  - NAME: SomeClass
+			--dry-run: exiting now.",
+			  "warn": "",
+			}
+		`);
 		});
 	});
 
@@ -6194,7 +6218,7 @@ addEventListener('fetch', event => {});`
 			        Object {
 			          "debug": "",
 			          "err": "",
-			          "out": "Total Upload: 0xx KiB / gzip: 0xx KiB
+			          "out": "Total Upload: xx KiB / gzip: xx KiB
 			        --dry-run: exiting now.",
 			          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mEnabling node.js compatibility mode for built-ins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details.[0m
 
@@ -6239,7 +6263,7 @@ addEventListener('fetch', event => {});`
 			        Object {
 			          "debug": "",
 			          "err": "",
-			          "out": "Total Upload: 4xx KiB / gzip: 1xx KiB
+			          "out": "Total Upload: xx KiB / gzip: xx KiB
 			        --dry-run: exiting now.",
 			          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mEnabling node.js compatibility mode for built-ins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details.[0m
 
@@ -6289,7 +6313,7 @@ addEventListener('fetch', event => {});`
 			        Object {
 			          "debug": "",
 			          "err": "",
-			          "out": "Total Upload: 4xx KiB / gzip: 0xx KiB
+			          "out": "Total Upload: xx KiB / gzip: xx KiB
 			        Uploaded test-name (TIMINGS)
 			        Published test-name (TIMINGS)
 			          https://test-name.test-sub-domain.workers.dev",
@@ -6344,7 +6368,7 @@ addEventListener('fetch', event => {});`
 			        Object {
 			          "debug": "",
 			          "err": "",
-			          "out": "Total Upload: 0xx KiB / gzip: 0xx KiB
+			          "out": "Total Upload: xx KiB / gzip: xx KiB
 
 			        [31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/some-account-id/workers/scripts/test-name) failed.[0m
 

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -3634,14 +3634,10 @@ addEventListener('fetch', event => {});`
 			mockSubDomainRequest();
 			mockUploadWorkerRequest();
 			await runWrangler("publish --dry-run --outdir dist --define abc:789");
-			expect(fs.readFileSync("dist/index.js", "utf-8")).toMatchInlineSnapshot(`
-			        "(() => {
-			          // index.js
-			          console.log(789);
-			        })();
-			        //# sourceMappingURL=index.js.map
-			        "
-		      `);
+
+			expect(fs.readFileSync("dist/index.js", "utf-8")).toContain(
+				`console.log(789);`
+			);
 		});
 	});
 
@@ -5271,11 +5267,11 @@ addEventListener('fetch', event => {});`
 			Object {
 			  "debug": "",
 			  "err": "",
-			  "out": "Your worker has access to the following bindings:
+			  "out": "Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
 			- Vars:
 			  - TEXT: \\"(hidden)\\"
 			  - COUNT: \\"(hidden)\\"
-			Total Upload: 0xx KiB / gzip: 0xx KiB
 			Uploaded test-name (TIMINGS)
 			Published test-name (TIMINGS)
 			  https://test-name.test-sub-domain.workers.dev",

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -3675,30 +3675,6 @@ addEventListener('fetch', event => {});`
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should run a custom build before publishing 2", async () => {
-			writeWranglerToml({
-				build: {
-					command: `node -e "console.log('custom build'); require('fs').writeFileSync('index.js', 'export default { fetch(){ return new Response(123) } }')"`,
-				},
-			});
-
-			mockUploadWorkerRequest({
-				expectedEntry: "return new Response(123)",
-			});
-			mockSubDomainRequest();
-
-			await runWrangler("publish index.js");
-			expect(std.out).toMatchInlineSnapshot(`
-			"Running custom build: node -e \\"console.log('custom build'); require('fs').writeFileSync('index.js', 'export default { fetch(){ return new Response(123) } }')\\"
-			Total Upload: xx KiB / gzip: xx KiB
-			Uploaded test-name (TIMINGS)
-			Published test-name (TIMINGS)
-			  https://test-name.test-sub-domain.workers.dev"
-		`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
-			expect(std.warn).toMatchInlineSnapshot(`""`);
-		});
-
 		if (process.platform !== "win32") {
 			it("should run a custom build of multiple steps combined by && before publishing", async () => {
 				writeWranglerToml({

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -493,7 +493,7 @@ async function applyMiddlewareLoaderFacade(
 			dynamicFacadePath,
 			`
 			${imports}
-			addMiddleware([${middlewareIdentifiers.join(",")}],true)
+			addMiddlewareInternal([${middlewareIdentifiers.join(",")}])
 		`
 		);
 	}
@@ -523,6 +523,7 @@ async function applyMiddlewareLoaderFacade(
 						removeEventListener: "__facade_removeEventListener__",
 						dispatchEvent: "__facade_dispatchEvent__",
 						addMiddleware: "__facade_register__",
+						addMiddlewareInternal: "__facade_registerInternal__",
 					},
 			  }
 			: {

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -447,6 +447,9 @@ async function applyMiddlewareLoaderFacade(
 			entryPoints: [entry.file],
 			bundle: true,
 			sourcemap: true,
+			define: {
+				"process.env.NODE_ENV": `"${process.env["NODE_ENV" + ""]}"`,
+			},
 			format: "esm",
 			outfile: targetPathInsertion,
 			plugins: [moduleCollectorPlugin],

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -195,11 +195,12 @@ export async function bundleWorker(
 		// As we are not yet supporting user created middlewares yet, if no wrangler applied middleware
 		// are found, we will not load any middleware. We also need to check if there are middlewares compatible with
 		// the target consumer (dev / publish).
-		middlewareToLoad.filter(
+		(middlewareToLoad.filter(
 			(m) =>
 				(m.publish && targetConsumer === "publish") ||
 				(m.dev !== false && targetConsumer === "dev")
-		).length > 0 &&
+		).length > 0 ||
+			process.env.EXPERIMENTAL_MIDDLEWARE === "true") &&
 			((currentEntry: Entry) => {
 				return applyMiddlewareLoaderFacade(
 					currentEntry,

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -434,7 +434,7 @@ async function applyMiddlewareLoaderFacade(
 		);
 
 		await esbuild.build({
-			entryPoints: [path.resolve(__dirname, dynamicFacadePath)],
+			entryPoints: [path.resolve(getBasePath(), dynamicFacadePath)],
 			bundle: true,
 			sourcemap: true,
 			format: "esm",
@@ -444,7 +444,7 @@ async function applyMiddlewareLoaderFacade(
 					...Object.fromEntries(
 						middleware.map((val, index) => [
 							middlewareIdentifiers[index],
-							path.resolve(__dirname, val.path),
+							path.resolve(getBasePath(), val.path),
 						])
 					),
 				}),
@@ -470,7 +470,10 @@ async function applyMiddlewareLoaderFacade(
 		const imports = middlewareIdentifiers
 			.map(
 				(m, i) =>
-					`import ${m} from "${path.resolve(__dirname, middleware[i].path)}";`
+					`import ${m} from "${path.resolve(
+						getBasePath(),
+						middleware[i].path
+					)}";`
 			)
 			.join("\n");
 
@@ -502,7 +505,7 @@ async function applyMiddlewareLoaderFacade(
 
 	const loaderPath =
 		entry.format === "modules"
-			? path.resolve(__dirname, "../templates/middleware/loader-modules.ts")
+			? path.resolve(getBasePath(), "../templates/middleware/loader-modules.ts")
 			: dynamicFacadePath;
 
 	await esbuild.build({
@@ -513,7 +516,7 @@ async function applyMiddlewareLoaderFacade(
 		...(entry.format === "service-worker"
 			? {
 					inject: [
-						path.resolve(__dirname, "../templates/middleware/loader-sw.ts"),
+						path.resolve(getBasePath(), "../templates/middleware/loader-sw.ts"),
 					],
 					define: {
 						addEventListener: "__facade_addEventListener__",
@@ -527,7 +530,7 @@ async function applyMiddlewareLoaderFacade(
 						esbuildAliasExternalPlugin({
 							__ENTRY_POINT__: targetPathInsertion,
 							"./common": path.resolve(
-								__dirname,
+								getBasePath(),
 								"../templates/middleware/common.ts"
 							),
 						}),

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -490,7 +490,7 @@ async function applyMiddlewareLoaderFacade(
 			dynamicFacadePath,
 			`
 			${imports}
-			addMiddlewareInternal([${middlewareIdentifiers.join(",")}])
+			addMiddleware([${middlewareIdentifiers.join(",")}],true)
 		`
 		);
 	}
@@ -520,7 +520,6 @@ async function applyMiddlewareLoaderFacade(
 						removeEventListener: "__facade_removeEventListener__",
 						dispatchEvent: "__facade_dispatchEvent__",
 						addMiddleware: "__facade_register__",
-						addMiddlewareInternal: "__facade_registerInternal__",
 					},
 			  }
 			: {

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -441,12 +441,11 @@ async function applyMiddlewareLoaderFacade(
 			plugins: [
 				esbuildAliasExternalPlugin({
 					__ENTRY_POINT__: entry.file,
-					...middleware.reduce(
-						(obj, val, index) => ({
-							...obj,
-							[middlewareIdentifiers[index]]: path.resolve(__dirname, val.path),
-						}),
-						{}
+					...Object.fromEntries(
+						middleware.map((val, index) => [
+							middlewareIdentifiers[index],
+							path.resolve(__dirname, val.path),
+						])
 					),
 				}),
 			],

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -193,8 +193,13 @@ export async function bundleWorker(
 		// Currently for demonstration purposes we have two example middlewares
 		// Middlewares are togglable by changing the `publish` (default=false) and `dev` (default=true) options
 		// As we are not yet supporting user created middlewares yet, if no wrangler applied middleware
-		// are found, we will not load any middleware.
-		middlewareToLoad.length > 0 &&
+		// are found, we will not load any middleware. We also need to check if there are middlewares compatible with
+		// the target consumer (dev / publish).
+		middlewareToLoad.filter(
+			(m) =>
+				(m.publish && targetConsumer === "publish") ||
+				(m.dev !== false && targetConsumer === "dev")
+		).length > 0 &&
 			((currentEntry: Entry) => {
 				return applyMiddlewareLoaderFacade(
 					currentEntry,

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -357,9 +357,8 @@ async function applyMiddlewareLoaderFacade(
 	// We need to import each of the middlewares, so we need to generate a
 	// random, unique identifier that we can use for the import.
 	// Middlewares are required to be default exports so we can import to any name.
-	const genID = new IdentifierGenerator();
 	const middlewareIdentifiers = middleware.map(
-		() => `__MIDDLEWARE_${genID.next()}__`
+		(_, index) => `__MIDDLEWARE_${index}__`
 	);
 
 	const dynamicFacadePath = path.join(
@@ -496,35 +495,6 @@ async function applyMiddlewareLoaderFacade(
 		...entry,
 		file: targetPathLoader,
 	};
-}
-
-/**
- * A simple way of generating unique alphabetical ids
- */
-class IdentifierGenerator {
-	_chars: string;
-	_nextId: number[];
-	constructor(chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ") {
-		this._chars = chars;
-		this._nextId = [0];
-	}
-	next() {
-		const r = [];
-		for (const char of this._nextId) r.unshift(this._chars[char]);
-		this._increment();
-		return r.join("");
-	}
-	_increment() {
-		for (let i = 0; i < this._nextId.length; i++) {
-			const val = ++this._nextId[i];
-			if (val >= this._chars.length) this._nextId[i] = 0;
-			else return;
-		}
-		this._nextId.push(0);
-	}
-	*[Symbol.iterator]() {
-		while (true) yield this.next();
-	}
 }
 
 /**

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -146,7 +146,7 @@ export async function bundleWorker(
 	// which is all loaded as one in a stack.
 	const middlewareToLoad: MiddlewareLoader[] = [
 		// {
-		// 	path: "../templates/middleware/middleware-pretty-error.ts",
+		// 	path: "templates/middleware/middleware-pretty-error.ts",
 		// 	publish: true,
 		// 	dev: false,
 		// },
@@ -505,7 +505,7 @@ async function applyMiddlewareLoaderFacade(
 
 	const loaderPath =
 		entry.format === "modules"
-			? path.resolve(getBasePath(), "../templates/middleware/loader-modules.ts")
+			? path.resolve(getBasePath(), "templates/middleware/loader-modules.ts")
 			: dynamicFacadePath;
 
 	await esbuild.build({
@@ -516,7 +516,7 @@ async function applyMiddlewareLoaderFacade(
 		...(entry.format === "service-worker"
 			? {
 					inject: [
-						path.resolve(getBasePath(), "../templates/middleware/loader-sw.ts"),
+						path.resolve(getBasePath(), "templates/middleware/loader-sw.ts"),
 					],
 					define: {
 						addEventListener: "__facade_addEventListener__",
@@ -531,7 +531,7 @@ async function applyMiddlewareLoaderFacade(
 							__ENTRY_POINT__: targetPathInsertion,
 							"./common": path.resolve(
 								getBasePath(),
-								"../templates/middleware/common.ts"
+								"templates/middleware/common.ts"
 							),
 						}),
 					],

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -400,10 +400,7 @@ async function applyMiddlewareLoaderFacade(
 					...middleware.reduce(
 						(obj, val, index) => ({
 							...obj,
-							[`__MIDDLEWARE_${middlewareIdentifiers[index]}__`]: path.resolve(
-								__dirname,
-								val
-							),
+							[middlewareIdentifiers[index]]: path.resolve(__dirname, val),
 						}),
 						{}
 					),

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -257,6 +257,8 @@ function DevSession(props: DevSessionProps) {
 		services: props.bindings.services,
 		durableObjects: props.bindings.durable_objects || { bindings: [] },
 		firstPartyWorkerDevFacade: props.firstPartyWorker,
+		// Enable the bundling to know whether we are using dev or publish
+		targetConsumer: "dev",
 	});
 
 	return props.local ? (

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -177,6 +177,7 @@ async function runEsbuild({
 				services: undefined,
 				workerDefinitions: undefined,
 				firstPartyWorkerDevFacade: undefined,
+				targetConsumer: "dev", // We are starting a dev server
 		  });
 
 	return {

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -176,6 +176,7 @@ export function useEsbuild({
 		durableObjects,
 		workerDefinitions,
 		firstPartyWorkerDevFacade,
+		targetConsumer,
 	]);
 	return bundle;
 }

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -36,6 +36,7 @@ export function useEsbuild({
 	services,
 	durableObjects,
 	firstPartyWorkerDevFacade,
+	targetConsumer,
 }: {
 	entry: Entry;
 	destination: string | undefined;
@@ -53,6 +54,7 @@ export function useEsbuild({
 	workerDefinitions: WorkerRegistry;
 	durableObjects: Config["durable_objects"];
 	firstPartyWorkerDevFacade: boolean | undefined;
+	targetConsumer: "dev" | "publish";
 }): EsbuildBundle | undefined {
 	const [bundle, setBundle] = useState<EsbuildBundle>();
 	const { exit } = useApp();
@@ -116,6 +118,7 @@ export function useEsbuild({
 						workerDefinitions,
 						services,
 						firstPartyWorkerDevFacade,
+						targetConsumer,
 				  });
 
 			// Capture the `stop()` method to use as the `useEffect()` destructor.

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -478,10 +478,18 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			keep_bindings: true,
 		};
 
-		void printBundleSize(
-			{ name: path.basename(resolvedEntryPointPath), content: content },
-			modules
-		);
+		// As this is not deterministic for testing, we detect if in a jest environment and run asynchronously
+		if (process.env.JEST_WORKER_ID !== undefined) {
+			await printBundleSize(
+				{ name: path.basename(resolvedEntryPointPath), content: content },
+				modules
+			);
+		} else {
+			void printBundleSize(
+				{ name: path.basename(resolvedEntryPointPath), content: content },
+				modules
+			);
+		}
 
 		const withoutStaticAssets = {
 			...bindings,

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -479,17 +479,13 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		};
 
 		// As this is not deterministic for testing, we detect if in a jest environment and run asynchronously
-		if (process.env.JEST_WORKER_ID !== undefined) {
-			await printBundleSize(
-				{ name: path.basename(resolvedEntryPointPath), content: content },
-				modules
-			);
-		} else {
-			void printBundleSize(
-				{ name: path.basename(resolvedEntryPointPath), content: content },
-				modules
-			);
-		}
+		// We do not care about the timing outside of testing
+		const bundleSizePromise = printBundleSize(
+			{ name: path.basename(resolvedEntryPointPath), content: content },
+			modules
+		);
+		if (process.env.JEST_WORKER_ID !== undefined) await bundleSizePromise;
+		else void bundleSizePromise;
 
 		const withoutStaticAssets = {
 			...bindings,

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -397,6 +397,9 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 						// facades on top of it
 						workerDefinitions: undefined,
 						firstPartyWorkerDevFacade: false,
+						// We want to know if the build is for development or publishing
+						// This could potentially cause issues as we no longer have identical behaviour between dev and publish?
+						targetConsumer: "publish",
 					}
 			  );
 

--- a/packages/wrangler/templates/middleware/common.ts
+++ b/packages/wrangler/templates/middleware/common.ts
@@ -19,14 +19,16 @@ export type Middleware = (
 
 const __facade_middleware__: Middleware[] = [];
 
-export function __facade_register__(
-	// If insertFront is true, we insert the middleware first (we do this with internal middleware)
-	middleware: Middleware | Middleware[],
-	insertFront = false
+// The register functions allow for the insertion of one or many middleware,
+// We register internal middleware first in the stack, but have no way of controlling
+// the order that addMiddleware is run in service workers so need an internal function.
+export function __facade_register__(...args: (Middleware | Middleware[])[]) {
+	__facade_middleware__.push(...args.flat());
+}
+export function __facade_registerInternal__(
+	...args: (Middleware | Middleware[])[]
 ) {
-	// This function allows for registering of one or many middleware
-	if (insertFront) __facade_middleware__.unshift(...[middleware].flat());
-	else __facade_middleware__.push(...[middleware].flat());
+	__facade_middleware__.unshift(...args.flat());
 }
 
 function __facade_invokeChain__(

--- a/packages/wrangler/templates/middleware/common.ts
+++ b/packages/wrangler/templates/middleware/common.ts
@@ -21,15 +21,7 @@ const __facade_middleware__: Middleware[] = [];
 
 export function __facade_register__(...args: (Middleware | Middleware[])[]) {
 	// This function allows for registering of one or many middleware
-	for (const arg of arguments) {
-		if (Array.isArray(arg)) {
-			for (const middleware of arg) {
-				__facade_middleware__.push(middleware);
-			}
-		} else {
-			__facade_middleware__.push(arg);
-		}
-	}
+	__facade_middleware__.push(...args.flat());
 }
 
 export function __facade_registerInternal__(
@@ -38,15 +30,7 @@ export function __facade_registerInternal__(
 	// This function allows for registering of one or many middleware
 	// For internal middleware we want to push to the start of the stack
 	// We reverse the ordering of the arrays such that they get inserted in the right order
-	for (const arg of Array.from(arguments).reverse()) {
-		if (Array.isArray(arg)) {
-			for (const middleware of arg.reverse()) {
-				__facade_middleware__.unshift(middleware);
-			}
-		} else {
-			__facade_middleware__.unshift(arg);
-		}
-	}
+	__facade_middleware__.unshift(...args.flat());
 }
 
 function __facade_invokeChain__(

--- a/packages/wrangler/templates/middleware/common.ts
+++ b/packages/wrangler/templates/middleware/common.ts
@@ -1,0 +1,80 @@
+export type Awaitable<T> = T | Promise<T>;
+// TODO: allow dispatching more events?
+export type Dispatcher = (
+	type: "scheduled",
+	init: { cron?: string }
+) => Awaitable<void>;
+
+export interface MiddlewareContext {
+	dispatch: Dispatcher;
+	next(request: Request, env: any): Awaitable<Response>;
+}
+
+export type Middleware = (
+	request: Request,
+	env: any,
+	ctx: ExecutionContext,
+	middlewareCtx: MiddlewareContext
+) => Awaitable<Response>;
+
+const __facade_middleware__: Middleware[] = [];
+
+export function __facade_register__(...args: (Middleware | Middleware[])[]) {
+	// This function allows for registering of one or many middleware
+	for (const arg of arguments) {
+		if (Array.isArray(arg)) {
+			for (const middleware of arg) {
+				__facade_middleware__.push(middleware);
+			}
+		} else {
+			__facade_middleware__.push(arg);
+		}
+	}
+}
+
+export function __facade_registerInternal__(
+	...args: (Middleware | Middleware[])[]
+) {
+	// This function allows for registering of one or many middleware
+	// For internal middleware we want to push to the start of the stack
+	// We reverse the ordering of the arrays such that they get inserted in the right order
+	for (const arg of Array.from(arguments).reverse()) {
+		if (Array.isArray(arg)) {
+			for (const middleware of arg.reverse()) {
+				__facade_middleware__.unshift(middleware);
+			}
+		} else {
+			__facade_middleware__.unshift(arg);
+		}
+	}
+}
+
+function __facade_invokeChain__(
+	request: Request,
+	env: any,
+	ctx: ExecutionContext,
+	dispatch: Dispatcher,
+	middlewareChain: Middleware[]
+): Awaitable<Response> {
+	const [head, ...tail] = middlewareChain;
+	const middlewareCtx: MiddlewareContext = {
+		dispatch,
+		next(newRequest, newEnv) {
+			return __facade_invokeChain__(newRequest, newEnv, ctx, dispatch, tail);
+		},
+	};
+	return head(request, env, ctx, middlewareCtx);
+}
+
+export function __facade_invoke__(
+	request: Request,
+	env: any,
+	ctx: ExecutionContext,
+	dispatch: Dispatcher,
+	finalMiddleware: Middleware
+): Awaitable<Response> {
+	return __facade_invokeChain__(request, env, ctx, dispatch, [
+		...__facade_middleware__,
+		finalMiddleware,
+	]);
+}

--- a/packages/wrangler/templates/middleware/common.ts
+++ b/packages/wrangler/templates/middleware/common.ts
@@ -19,18 +19,14 @@ export type Middleware = (
 
 const __facade_middleware__: Middleware[] = [];
 
-export function __facade_register__(...args: (Middleware | Middleware[])[]) {
-	// This function allows for registering of one or many middleware
-	__facade_middleware__.push(...args.flat());
-}
-
-export function __facade_registerInternal__(
-	...args: (Middleware | Middleware[])[]
+export function __facade_register__(
+	// If insertFront is true, we insert the middleware first (we do this with internal middleware)
+	middleware: Middleware | Middleware[],
+	insertFront = false
 ) {
 	// This function allows for registering of one or many middleware
-	// For internal middleware we want to push to the start of the stack
-	// We reverse the ordering of the arrays such that they get inserted in the right order
-	__facade_middleware__.unshift(...args.flat());
+	if (insertFront) __facade_middleware__.unshift(...[middleware].flat());
+	else __facade_middleware__.push(...[middleware].flat());
 }
 
 function __facade_invokeChain__(

--- a/packages/wrangler/templates/middleware/loader-modules.ts
+++ b/packages/wrangler/templates/middleware/loader-modules.ts
@@ -14,6 +14,10 @@ import {
 // @ts-expect-error We'll swap in the entry point during build
 import worker from "__ENTRY_POINT__";
 
+// We need to preserve all of the exports from the worker
+// @ts-expect-error We'll swap in the entry point during build
+export * from "__ENTRY_POINT__";
+
 class __Facade_ScheduledController__ implements ScheduledController {
 	constructor(readonly scheduledTime: number, readonly cron: string) {}
 

--- a/packages/wrangler/templates/middleware/loader-modules.ts
+++ b/packages/wrangler/templates/middleware/loader-modules.ts
@@ -1,0 +1,65 @@
+// // This loads all middlewares exposed on the middleware object
+// // and then starts the invocation chain.
+// // The big idea is that we can add these to the middleware export dynamically
+// // through wrangler, or we can potentially let users directly add them as a sort
+// // of "plugin" system.
+
+import {
+	Dispatcher,
+	Middleware,
+	__facade_invoke__,
+	__facade_register__,
+} from "./common";
+
+// @ts-expect-error We'll swap in the entry point during build
+import worker from "__ENTRY_POINT__";
+
+class __Facade_ScheduledController__ implements ScheduledController {
+	constructor(readonly scheduledTime: number, readonly cron: string) {}
+
+	noRetry() {}
+}
+
+const __facade_modules_fetch__: Middleware = function (request, env, ctx) {
+	if (worker.fetch === undefined) throw new Error("No fetch handler!"); // TODO: proper error message
+	return worker.fetch(request, env, ctx);
+};
+
+const facade: ExportedHandler<unknown> = {
+	fetch(request, env, ctx) {
+		// Get the chain of middleware from the worker object
+		if (worker.middleware && worker.middleware.length > 0) {
+			for (const middleware of worker.middleware) {
+				__facade_register__(middleware);
+			}
+
+			const __facade_modules_dispatch__: Dispatcher = function (type, init) {
+				if (type === "scheduled" && worker.scheduled !== undefined) {
+					const controller = new __Facade_ScheduledController__(
+						Date.now(),
+						init.cron ?? ""
+					);
+					return worker.scheduled(controller, env, ctx);
+				}
+			};
+
+			return __facade_invoke__(
+				request,
+				env,
+				ctx,
+				__facade_modules_dispatch__,
+				__facade_modules_fetch__
+			);
+		} else {
+			// We didn't have any middleware so we can skip the invocation chain,
+			// and just call the fetch handler directly
+
+			// We "don't care" if this is undefined as we want to have the same behaviour
+			// as if the worker completely bypassed middleware.
+			return worker.fetch!(request, env, ctx);
+		}
+	},
+	scheduled: worker.scheduled,
+};
+
+export default facade;

--- a/packages/wrangler/templates/middleware/loader-sw.ts
+++ b/packages/wrangler/templates/middleware/loader-sw.ts
@@ -1,5 +1,5 @@
 import { Awaitable, Dispatcher, Middleware, __facade_invoke__ } from "./common";
-export { __facade_register__, __facade_registerInternal__ } from "./common";
+export { __facade_register__ } from "./common";
 
 const __FACADE_EVENT_TARGET__ = new EventTarget();
 

--- a/packages/wrangler/templates/middleware/loader-sw.ts
+++ b/packages/wrangler/templates/middleware/loader-sw.ts
@@ -20,29 +20,21 @@ declare global {
 function __facade_isSpecialEvent__(type: string) {
 	return type === "fetch" || type === "scheduled";
 }
-globalThis.__facade_addEventListener__ = function (
-	type: string,
-	listener: EventListenerOrEventListenerObject,
-	options?: EventTargetAddEventListenerOptions | boolean
-) {
+globalThis.__facade_addEventListener__ = function (type, listener, options) {
 	if (__facade_isSpecialEvent__(type)) {
 		__FACADE_EVENT_TARGET__.addEventListener(type, listener, options);
 	} else {
 		globalThis.addEventListener(type as any, listener, options);
 	}
 };
-globalThis.__facade_removeEventListener__ = function (
-	type: string,
-	listener: EventListenerOrEventListenerObject,
-	options?: EventTargetEventListenerOptions | boolean
-) {
+globalThis.__facade_removeEventListener__ = function (type, listener, options) {
 	if (__facade_isSpecialEvent__(type)) {
 		__FACADE_EVENT_TARGET__.removeEventListener(type, listener, options);
 	} else {
 		globalThis.removeEventListener(type as any, listener, options);
 	}
 };
-globalThis.__facade_dispatchEvent__ = function (event: Event) {
+globalThis.__facade_dispatchEvent__ = function (event) {
 	if (__facade_isSpecialEvent__(event.type)) {
 		__FACADE_EVENT_TARGET__.dispatchEvent(event);
 	} else {

--- a/packages/wrangler/templates/middleware/loader-sw.ts
+++ b/packages/wrangler/templates/middleware/loader-sw.ts
@@ -1,0 +1,200 @@
+import {
+	Awaitable,
+	Dispatcher,
+	Middleware,
+	__facade_invoke__,
+	__facade_register__,
+	__facade_registerInternal__,
+} from "./common";
+
+const __FACADE_EVENT_TARGET__ = new EventTarget();
+
+function __facade_isSpecialEvent__(type: string) {
+	return type === "fetch" || type === "scheduled";
+}
+(globalThis as any).__facade_addEventListener__ = function (
+	type: string,
+	listener: EventListenerOrEventListenerObject,
+	options?: EventTargetAddEventListenerOptions | boolean
+) {
+	if (__facade_isSpecialEvent__(type)) {
+		__FACADE_EVENT_TARGET__.addEventListener(type, listener, options);
+	} else {
+		globalThis.addEventListener(type as any, listener, options);
+	}
+};
+(globalThis as any).__facade_removeEventListener__ = function (
+	type: string,
+	listener: EventListenerOrEventListenerObject,
+	options?: EventTargetEventListenerOptions | boolean
+) {
+	if (__facade_isSpecialEvent__(type)) {
+		__FACADE_EVENT_TARGET__.removeEventListener(type, listener, options);
+	} else {
+		globalThis.removeEventListener(type as any, listener, options);
+	}
+};
+(globalThis as any).__facade_dispatchEvent__ = function (event: Event) {
+	if (__facade_isSpecialEvent__(event.type)) {
+		__FACADE_EVENT_TARGET__.dispatchEvent(event);
+	} else {
+		globalThis.dispatchEvent(event as any);
+	}
+};
+
+const __facade_waitUntil__ = Symbol("__facade_waitUntil__");
+const __facade_response__ = Symbol("__facade_response__");
+const __facade_dispatched__ = Symbol("__facade_dispatched__");
+
+class __Facade_ExtendableEvent__ extends Event {
+	[__facade_waitUntil__]: Awaitable<unknown>[] = [];
+
+	waitUntil(promise: Awaitable<any>) {
+		if (!(this instanceof __Facade_ExtendableEvent__)) {
+			throw new TypeError("Illegal invocation");
+		}
+		this[__facade_waitUntil__].push(promise);
+	}
+}
+
+interface FetchEventInit extends EventInit {
+	request: Request;
+	passThroughOnException: FetchEvent["passThroughOnException"];
+}
+
+class __Facade_FetchEvent__ extends __Facade_ExtendableEvent__ {
+	#request: Request;
+	#passThroughOnException: FetchEvent["passThroughOnException"];
+	[__facade_response__]?: Awaitable<Response>;
+	[__facade_dispatched__] = false;
+
+	constructor(type: "fetch", init: FetchEventInit) {
+		super(type);
+		this.#request = init.request;
+		this.#passThroughOnException = init.passThroughOnException;
+	}
+
+	get request() {
+		return this.#request;
+	}
+
+	respondWith(response: Awaitable<Response>) {
+		if (!(this instanceof __Facade_FetchEvent__)) {
+			throw new TypeError("Illegal invocation");
+		}
+		if (this[__facade_response__] !== undefined) {
+			throw new DOMException(
+				"FetchEvent.respondWith() has already been called; it can only be called once.",
+				"InvalidStateError"
+			);
+		}
+		if (this[__facade_dispatched__]) {
+			throw new DOMException(
+				"Too late to call FetchEvent.respondWith(). It must be called synchronously in the event handler.",
+				"InvalidStateError"
+			);
+		}
+		this.stopImmediatePropagation();
+		this[__facade_response__] = response;
+	}
+
+	passThroughOnException() {
+		if (!(this instanceof __Facade_FetchEvent__)) {
+			throw new TypeError("Illegal invocation");
+		}
+		// Need to call native method immediately in case uncaught error thrown
+		this.#passThroughOnException();
+	}
+}
+
+interface ScheduledEventInit extends EventInit {
+	scheduledTime: number;
+	cron: string;
+	noRetry: ScheduledEvent["noRetry"];
+}
+
+class __Facade_ScheduledEvent__ extends __Facade_ExtendableEvent__ {
+	#scheduledTime: number;
+	#cron: string;
+	#noRetry: ScheduledEvent["noRetry"];
+
+	constructor(type: "scheduled", init: ScheduledEventInit) {
+		super(type);
+		this.#scheduledTime = init.scheduledTime;
+		this.#cron = init.cron;
+		this.#noRetry = init.noRetry;
+	}
+
+	get scheduledTime() {
+		return this.#scheduledTime;
+	}
+
+	get cron() {
+		return this.#cron;
+	}
+
+	noRetry() {
+		if (!(this instanceof __Facade_ScheduledEvent__)) {
+			throw new TypeError("Illegal invocation");
+		}
+		// Need to call native method immediately in case uncaught error thrown
+		this.#noRetry();
+	}
+}
+
+export const __facade_registerMiddlewares__ = function (
+	middlewares: Middleware[]
+) {
+	for (const middleware of middlewares) {
+		__facade_register__(middleware);
+	}
+};
+
+globalThis.addEventListener("fetch", (event) => {
+	const ctx: ExecutionContext = {
+		waitUntil: event.waitUntil.bind(event),
+		passThroughOnException: event.passThroughOnException.bind(event),
+	};
+
+	event.respondWith(
+		__facade_invoke__(
+			event.request,
+			globalThis,
+			ctx,
+			__facade_sw_dispatch__,
+			__facade_sw_fetch__
+		)
+	);
+});
+const __facade_sw_dispatch__: Dispatcher = function (type, init) {
+	if (type === "scheduled") {
+		const facadeEvent = new __Facade_ScheduledEvent__("scheduled", {
+			scheduledTime: Date.now(),
+			cron: init.cron ?? "",
+			noRetry() {},
+		});
+		__FACADE_EVENT_TARGET__.dispatchEvent(facadeEvent);
+	}
+};
+const __facade_sw_fetch__: Middleware = function (request, _env, ctx) {
+	const facadeEvent = new __Facade_FetchEvent__("fetch", {
+		request,
+		passThroughOnException: ctx.passThroughOnException,
+	});
+	__FACADE_EVENT_TARGET__.dispatchEvent(facadeEvent);
+	facadeEvent[__facade_dispatched__] = true;
+	const response = facadeEvent[__facade_response__];
+	if (response === undefined) {
+		throw new Error("No response!"); // TODO: proper error message
+	}
+	return response;
+};
+
+globalThis.addEventListener("scheduled", (event) => {
+	const facadeEvent = new __Facade_ScheduledEvent__("scheduled", {
+		scheduledTime: event.scheduledTime,
+		cron: event.cron,
+		noRetry: event.noRetry.bind(event),
+	});
+	__FACADE_EVENT_TARGET__.dispatchEvent(facadeEvent);
+});

--- a/packages/wrangler/templates/middleware/loader-sw.ts
+++ b/packages/wrangler/templates/middleware/loader-sw.ts
@@ -1,11 +1,5 @@
-import {
-	Awaitable,
-	Dispatcher,
-	Middleware,
-	__facade_invoke__,
-	__facade_register__,
-	__facade_registerInternal__,
-} from "./common";
+import { Awaitable, Dispatcher, Middleware, __facade_invoke__ } from "./common";
+export { __facade_register__, __facade_registerInternal__ } from "./common";
 
 const __FACADE_EVENT_TARGET__ = new EventTarget();
 
@@ -141,14 +135,6 @@ class __Facade_ScheduledEvent__ extends __Facade_ExtendableEvent__ {
 		this.#noRetry();
 	}
 }
-
-export const __facade_registerMiddlewares__ = function (
-	middlewares: Middleware[]
-) {
-	for (const middleware of middlewares) {
-		__facade_register__(middleware);
-	}
-};
 
 globalThis.addEventListener("fetch", (event) => {
 	const ctx: ExecutionContext = {

--- a/packages/wrangler/templates/middleware/loader-sw.ts
+++ b/packages/wrangler/templates/middleware/loader-sw.ts
@@ -1,7 +1,12 @@
 import { Awaitable, Dispatcher, Middleware, __facade_invoke__ } from "./common";
 export { __facade_register__, __facade_registerInternal__ } from "./common";
 
-const __FACADE_EVENT_TARGET__ = new EventTarget();
+let __FACADE_EVENT_TARGET__: EventTarget;
+if ((globalThis as any).MINIFLARE) {
+	__FACADE_EVENT_TARGET__ = new (Object.getPrototypeOf(WorkerGlobalScope))();
+} else {
+	__FACADE_EVENT_TARGET__ = new EventTarget();
+}
 
 declare global {
 	var __facade_addEventListener__: (

--- a/packages/wrangler/templates/middleware/loader-sw.ts
+++ b/packages/wrangler/templates/middleware/loader-sw.ts
@@ -155,7 +155,9 @@ globalThis.addEventListener("fetch", (event) => {
 				cron: init.cron ?? "",
 				noRetry() {},
 			});
+
 			__FACADE_EVENT_TARGET__.dispatchEvent(facadeEvent);
+			event.waitUntil(Promise.all(facadeEvent[__facade_waitUntil__]));
 		}
 	};
 
@@ -165,10 +167,9 @@ globalThis.addEventListener("fetch", (event) => {
 			passThroughOnException: ctx.passThroughOnException,
 		});
 
-		event.waitUntil(Promise.all(facadeEvent[__facade_waitUntil__]));
-
 		__FACADE_EVENT_TARGET__.dispatchEvent(facadeEvent);
 		facadeEvent[__facade_dispatched__] = true;
+		event.waitUntil(Promise.all(facadeEvent[__facade_waitUntil__]));
 
 		const response = facadeEvent[__facade_response__];
 		if (response === undefined) {
@@ -195,7 +196,6 @@ globalThis.addEventListener("scheduled", (event) => {
 		noRetry: event.noRetry.bind(event),
 	});
 
-	event.waitUntil(Promise.all(facadeEvent[__facade_waitUntil__]));
-
 	__FACADE_EVENT_TARGET__.dispatchEvent(facadeEvent);
+	event.waitUntil(Promise.all(facadeEvent[__facade_waitUntil__]));
 });

--- a/packages/wrangler/templates/middleware/loader-sw.ts
+++ b/packages/wrangler/templates/middleware/loader-sw.ts
@@ -1,6 +1,13 @@
 import { Awaitable, Dispatcher, Middleware, __facade_invoke__ } from "./common";
 export { __facade_register__, __facade_registerInternal__ } from "./common";
 
+// Miniflare's `EventTarget` follows the spec and doesn't allow exceptions to
+// be caught by `dispatchEvent`. Instead it has a custom`ThrowingEventTarget`
+// class that rethrows errors from event listeners in `dispatchEvent`.
+// We'd like errors to be propagated to the top-level `addEventListener`, so
+// we'd like to use `ThrowingEventTarget`. Unfortunately, `ThrowingEventTarget`
+// isn't exposed on the global scope, but `WorkerGlobalScope` (which extends
+// `ThrowingEventTarget`) is. Therefore, we get at it in this nasty way.
 let __FACADE_EVENT_TARGET__: EventTarget;
 if ((globalThis as any).MINIFLARE) {
 	__FACADE_EVENT_TARGET__ = new (Object.getPrototypeOf(WorkerGlobalScope))();

--- a/packages/wrangler/templates/middleware/loader-sw.ts
+++ b/packages/wrangler/templates/middleware/loader-sw.ts
@@ -1,5 +1,5 @@
 import { Awaitable, Dispatcher, Middleware, __facade_invoke__ } from "./common";
-export { __facade_register__ } from "./common";
+export { __facade_register__, __facade_registerInternal__ } from "./common";
 
 const __FACADE_EVENT_TARGET__ = new EventTarget();
 

--- a/packages/wrangler/templates/middleware/loader-sw.ts
+++ b/packages/wrangler/templates/middleware/loader-sw.ts
@@ -3,10 +3,24 @@ export { __facade_register__, __facade_registerInternal__ } from "./common";
 
 const __FACADE_EVENT_TARGET__ = new EventTarget();
 
+declare global {
+	var __facade_addEventListener__: (
+		type: string,
+		listener: EventListenerOrEventListenerObject,
+		options?: EventTargetAddEventListenerOptions | boolean
+	) => void;
+	var __facade_removeEventListener__: (
+		type: string,
+		listener: EventListenerOrEventListenerObject,
+		options?: EventTargetEventListenerOptions | boolean
+	) => void;
+	var __facade_dispatchEvent__: (event: Event) => void;
+}
+
 function __facade_isSpecialEvent__(type: string) {
 	return type === "fetch" || type === "scheduled";
 }
-(globalThis as any).__facade_addEventListener__ = function (
+globalThis.__facade_addEventListener__ = function (
 	type: string,
 	listener: EventListenerOrEventListenerObject,
 	options?: EventTargetAddEventListenerOptions | boolean
@@ -17,7 +31,7 @@ function __facade_isSpecialEvent__(type: string) {
 		globalThis.addEventListener(type as any, listener, options);
 	}
 };
-(globalThis as any).__facade_removeEventListener__ = function (
+globalThis.__facade_removeEventListener__ = function (
 	type: string,
 	listener: EventListenerOrEventListenerObject,
 	options?: EventTargetEventListenerOptions | boolean
@@ -28,7 +42,7 @@ function __facade_isSpecialEvent__(type: string) {
 		globalThis.removeEventListener(type as any, listener, options);
 	}
 };
-(globalThis as any).__facade_dispatchEvent__ = function (event: Event) {
+globalThis.__facade_dispatchEvent__ = function (event: Event) {
 	if (__facade_isSpecialEvent__(event.type)) {
 		__FACADE_EVENT_TARGET__.dispatchEvent(event);
 	} else {

--- a/packages/wrangler/templates/middleware/middleware-pretty-error.ts
+++ b/packages/wrangler/templates/middleware/middleware-pretty-error.ts
@@ -1,4 +1,3 @@
-// import { __facade_register__ } from "./common";
 import type { Middleware } from "./common";
 
 // A middleware has to be a function of type Middleware

--- a/packages/wrangler/templates/middleware/middleware-pretty-error.ts
+++ b/packages/wrangler/templates/middleware/middleware-pretty-error.ts
@@ -1,0 +1,41 @@
+// import { __facade_register__ } from "./common";
+import type { Middleware } from "./common";
+
+// A middleware has to be a function of type Middleware
+const prettyError: Middleware = async (request, env, _ctx, middlewareCtx) => {
+	try {
+		const response = await middlewareCtx.next(request, env);
+		return response;
+	} catch (e: any) {
+		const html = `
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Error 🚨</title>
+        <style>
+          pre {
+            margin: 16px auto;
+            max-width: 600px;
+            background-color: #eeeeee;
+            border-radius: 4px;
+            padding: 16px;
+          }
+        </style>
+    </head>
+    <body>
+        <pre>${e.stack}</pre>
+    </body>
+    </html>
+    `;
+
+		return new Response(html, {
+			status: 500,
+			headers: { "Content-Type": "text/html;charset=utf-8" },
+		});
+	}
+};
+
+export default prettyError;

--- a/packages/wrangler/templates/middleware/middleware-scheduled.ts
+++ b/packages/wrangler/templates/middleware/middleware-scheduled.ts
@@ -1,0 +1,14 @@
+import type { Middleware } from "./common";
+
+// A middleware has to be a function of type Middleware
+const scheduled: Middleware = async (request, env, _ctx, middlewareCtx) => {
+	const url = new URL(request.url);
+	if (url.pathname === "/__scheduled") {
+		const cron = url.searchParams.get("cron") ?? "";
+		await middlewareCtx.dispatch("scheduled", { cron });
+		return new Response("OK");
+	}
+	return middlewareCtx.next(request, env);
+};
+
+export default scheduled;


### PR DESCRIPTION
A new way of registering middleware that gets bundled and executed on the edge.

Notable features:
- the same middleware functions can be used for both modules workers and service workers
- only requires running esbuild a fixed number of times, rather than for each middleware added
- exposes a way for users to add their own middlewares (potentially opening up plugins in the future)

Two example middlewares have been included and enabled:
- `middleware-scheduled.ts`: allows for triggering scheduled events from a fetch event at `/__scheduled`
- `middleware-pretty-error.ts`: replaces cloudflare 1xxx error page with a pretty error page with stack trace

**Adding middleware:**
Middleware can be added in two places:
- within wrangler allowing toggling on and off dynamically based on build settings
- within the user written worker

Middleware is written **once** and is compatible with both types. An example middleware:

```js
const scheduled = async (request, env, _ctx, middlewareCtx) => {
  const url = new URL(request.url);
  if (url.pathname === "/__scheduled") {
    const cron = url.searchParams.get("cron") ?? "";
    await middlewareCtx.dispatch("scheduled", { cron });
    return new Response("OK");
  }
  return middlewareCtx.next(request, env);
};

export default scheduled;
```

To add for the user written worker, this is done slightly differently for module and service worker based workers.

**Module workers:**
Middleware is included by adding it to the `middleware` key of the default exported object.
```js
import PrettyErrorMiddleware from "./middleware-pretty-error";

export default {
  middleware: [
    PrettyErrorMiddleware,
  ],
  fetch(request, env, ctx) {
    const url = new URL(request.url);
    if (url.pathname === "/error") {
      throw new Error("😱");
    }

    return new Response("modules body");
  },
};
```

**Service workers:**
Middleware is included by using the `addMiddleware` function:
```js
import prettyError from "./middleware-pretty-error";

addMiddleware([prettyError]);

addEventListener("fetch", (event) => {
  const url = new URL(event.request.url);
  if (url.pathname === "/error") {
    throw new Error("😱");
  }

  event.respondWith(new Response("service worker body"));
});
```

(more details on service worker middleware in comment below)

Co-Authored-By: MrBBot <me@mrbbot.dev>