### PR TITLE
fix: let users know when we'll use their proxy for requests

### DIFF
--- a/.changeset/empty-baboons-happen.md
+++ b/.changeset/empty-baboons-happen.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: let users know when we'll use their proxy for requests

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -99,6 +99,9 @@ const proxy =
 
 if (proxy) {
 	setGlobalDispatcher(new ProxyAgent(proxy));
+	logger.log(
+		`Proxy environment variables detected. Using ${proxy} for all fetch requests.`
+	);
 }
 
 export function getRules(config: Config): Config["rules"] {

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -100,7 +100,7 @@ const proxy =
 if (proxy) {
 	setGlobalDispatcher(new ProxyAgent(proxy));
 	logger.log(
-		`Proxy environment variables detected. Using ${proxy} for all fetch requests.`
+		`Proxy environment variables detected. We'll use your proxy for fetch requests.`
 	);
 }
 


### PR DESCRIPTION
At the moment, it isn't clear if wrangler correctly picks up the user's proxy from environment variables.

This PR lets them know which proxy they're using, when one is configured.