### PR TITLE
refactor: implement `getBasePath()` as a replacement for `__dirname`

### DIFF
--- a/.changeset/good-ads-exercise.md
+++ b/.changeset/good-ads-exercise.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+---
+
+Use getBasePath() when trying to specify paths to files relative to the
+base of the Wrangler package directory rather than trying to compute the
+path from Node.js constants like **dirname and **filename. This is
+because the act of bundling the source code can move the file that contains
+these constants around potentially breaking the relative path to the desired files.
+
+Fixes #1755

--- a/package.json
+++ b/package.json
@@ -102,6 +102,23 @@
 						}
 					]
 				}
+			},
+			{
+				"files": "packages/wrangler/src/**/*.ts",
+				"excludedFiles": "*.test.ts",
+				"rules": {
+					"no-restricted-globals": [
+						"error",
+						{
+							"name": "__dirname",
+							"message": "Use `getBasePath()` instead."
+						},
+						{
+							"name": "__filename",
+							"message": "Use `getBasePath()` instead."
+						}
+					]
+				}
 			}
 		],
 		"ignorePatterns": [

--- a/packages/wrangler/scripts/bundle.ts
+++ b/packages/wrangler/scripts/bundle.ts
@@ -21,16 +21,32 @@ function watchLogger(outputPath: string): WatchMode {
 }
 
 async function buildMain(flags: BuildFlags = {}) {
+	const outdir = path.resolve("./wrangler-dist");
+	const wranglerPackageDir = path.resolve(".");
+	/**
+	 * The relative path between the bundled code and the Wrangler package.
+	 * This is used as a reliable way to compute paths relative to the Wrangler package
+	 * in the source files, rather than relying upon `__dirname` which can change depending
+	 * on whether the source files have been bundled and the location of the outdir.
+	 *
+	 * This is exposed in the source via the `getBasePath()` function, which should be used
+	 * in place of `__dirname` and similar Node.js constants.
+	 */
+	const __RELATIVE_PACKAGE_PATH__ = `"${path.relative(
+		outdir,
+		wranglerPackageDir
+	)}"`;
 	await build({
 		entryPoints: ["./src/cli.ts"],
 		bundle: true,
-		outdir: "./wrangler-dist",
+		outdir,
 		platform: "node",
 		format: "cjs",
 		external: EXTERNAL_DEPENDENCIES,
 		sourcemap: process.env.SOURCEMAPS !== "false",
 		inject: [path.join(__dirname, "../import_meta_url.js")],
 		define: {
+			__RELATIVE_PACKAGE_PATH__,
 			"import.meta.url": "import_meta_url",
 			"process.env.NODE_ENV": `'${process.env.NODE_ENV || "production"}'`,
 			...(process.env.SPARROW_SOURCE_KEY

--- a/packages/wrangler/src/__tests__/jest.setup.ts
+++ b/packages/wrangler/src/__tests__/jest.setup.ts
@@ -15,6 +15,19 @@ import {
 } from "./helpers/mock-cfetch";
 import { MockWebSocket } from "./helpers/mock-web-socket";
 
+/**
+ * The relative path between the bundled code and the Wrangler package.
+ * This is used as a reliable way to compute paths relative to the Wrangler package
+ * in the source files, rather than relying upon `__dirname` which can change depending
+ * on whether the source files have been bundled and the location of the outdir.
+ *
+ * This is exposed in the source via the `getBasePath()` function, which should be used
+ * in place of `__dirname` and similar Node.js constants.
+ */
+(
+	global as unknown as { __RELATIVE_PACKAGE_PATH__: string }
+).__RELATIVE_PACKAGE_PATH__ = "..";
+
 // Mock out getPort since we don't actually care about what ports are open in unit tests.
 jest.mock("get-port", () => {
 	return {

--- a/packages/wrangler/src/__tests__/paths.test.ts
+++ b/packages/wrangler/src/__tests__/paths.test.ts
@@ -1,0 +1,17 @@
+import * as path from "node:path";
+import { getBasePath } from "../paths";
+
+describe("paths", () => {
+	describe("getBasePath()", () => {
+		it("should return the path to the wrangler package", () => {
+			expect(getBasePath()).toMatch(/packages[/\\]wrangler$/);
+		});
+
+		it("should use the __RELATIVE_PACKAGE_PATH__ as defined on the global context to compute the base path", () => {
+			(
+				global as unknown as { __RELATIVE_PACKAGE_PATH__: string }
+			).__RELATIVE_PACKAGE_PATH__ = "/foo/bar";
+			expect(getBasePath()).toEqual(path.resolve("/foo/bar"));
+		});
+	});
+});

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -7,6 +7,7 @@ import NodeModulesPolyfills from "@esbuild-plugins/node-modules-polyfill";
 import * as esbuild from "esbuild";
 import tmp from "tmp-promise";
 import createModuleCollector from "./module-collection";
+import { getBasePath } from "./paths";
 import type { Config } from "./config";
 import type { WorkerRegistry } from "./dev-registry";
 import type { Entry } from "./entry";
@@ -129,7 +130,7 @@ export async function bundleWorker(
 		});
 		fs.writeFileSync(
 			checkedFetchFileToInject,
-			fs.readFileSync(path.resolve(__dirname, "../templates/checked-fetch.js"))
+			fs.readFileSync(path.resolve(getBasePath(), "templates/checked-fetch.js"))
 		);
 	}
 
@@ -302,7 +303,9 @@ async function applyFormatDevErrorsFacade(
 ): Promise<Entry> {
 	const targetPath = path.join(tmpDirPath, "format-dev-errors.entry.js");
 	await esbuild.build({
-		entryPoints: [path.resolve(__dirname, "../templates/format-dev-errors.ts")],
+		entryPoints: [
+			path.resolve(getBasePath(), "templates/format-dev-errors.ts"),
+		],
 		bundle: true,
 		sourcemap: true,
 		format: "esm",
@@ -334,7 +337,7 @@ async function applyStaticAssetFacade(
 
 	await esbuild.build({
 		entryPoints: [
-			path.resolve(__dirname, "../templates/serve-static-assets.ts"),
+			path.resolve(getBasePath(), "templates/serve-static-assets.ts"),
 		],
 		bundle: true,
 		format: "esm",
@@ -342,7 +345,7 @@ async function applyStaticAssetFacade(
 		plugins: [
 			esbuildAliasExternalPlugin({
 				__ENTRY_POINT__: entry.file,
-				__KV_ASSET_HANDLER__: path.join(__dirname, "../kv-asset-handler.js"),
+				__KV_ASSET_HANDLER__: path.join(getBasePath(), "kv-asset-handler.js"),
 				__STATIC_CONTENT_MANIFEST: "__STATIC_CONTENT_MANIFEST",
 			}),
 		],
@@ -391,10 +394,10 @@ async function applyMultiWorkerDevFacade(
 	await esbuild.build({
 		entryPoints: [
 			path.join(
-				__dirname,
+				getBasePath(),
 				entry.format === "modules"
-					? "../templates/service-bindings-module-facade.js"
-					: "../templates/service-bindings-sw-facade.js"
+					? "templates/service-bindings-module-facade.js"
+					: "templates/service-bindings-sw-facade.js"
 			),
 		],
 		bundle: true,
@@ -440,8 +443,8 @@ async function applyFirstPartyWorkerDevFacade(
 	await esbuild.build({
 		entryPoints: [
 			path.resolve(
-				__dirname,
-				"../templates/first-party-worker-module-facade.ts"
+				getBasePath(),
+				"templates/first-party-worker-module-facade.ts"
 			),
 		],
 		bundle: true,

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -8,6 +8,7 @@ import { registerWorker } from "../dev-registry";
 import useInspector from "../inspect";
 import { logger } from "../logger";
 import { DEFAULT_MODULE_RULES } from "../module-collection";
+import { getBasePath } from "../paths";
 import { waitForPortToBeAvailable } from "../proxy";
 import type { Config } from "../config";
 import type { WorkerRegistry } from "../dev-registry";
@@ -299,8 +300,8 @@ function useLocalWorker({
 			// `wrangler-dist` and that the CLI is found in `miniflare-dist`.
 			// If either of those paths change this line needs updating.
 			const miniflareCLIPath = path.resolve(
-				__dirname,
-				"../miniflare-dist/index.mjs"
+				getBasePath(),
+				"miniflare-dist/index.mjs"
 			);
 			const miniflareOptions = JSON.stringify(options, null);
 

--- a/packages/wrangler/src/entry.ts
+++ b/packages/wrangler/src/entry.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import * as esbuild from "esbuild";
 import { execaCommand } from "execa";
 import { logger } from "./logger";
+import { getBasePath } from "./paths";
 import type { Config } from "./config";
 import type { CfScriptFormat } from "./worker";
 import type { Metafile } from "esbuild";
@@ -40,7 +41,7 @@ export async function getEntry(
 				: // site.entry-point could be a directory
 				  path.resolve(config.site?.["entry-point"], "index.js");
 		} else if (args.assets || config.assets) {
-			file = path.resolve(__dirname, "../templates/no-op-worker.js");
+			file = path.resolve(getBasePath(), "templates/no-op-worker.js");
 		} else {
 			throw new Error(
 				`Missing entry-point: The entry-point should be specified via the command line (e.g. \`wrangler ${command} path/to/script\`) or the \`main\` config field.`

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -12,10 +12,10 @@ import { initializeGit, isGitInstalled, isInsideGitRepo } from "./git-client";
 import { logger } from "./logger";
 import { getPackageManager } from "./package-manager";
 import { parsePackageJSON, parseTOML, readFileSync } from "./parse";
+import { getBasePath } from "./paths";
 import { requireAuth } from "./user";
 import { CommandLineArgsError, printWranglerBanner } from "./index";
 import type { ConfigPath } from "./index";
-
 import type { Argv, ArgumentsCamelCase } from "yargs";
 
 export async function initOptions(yargs: Argv) {
@@ -162,7 +162,7 @@ export async function initHandler(args: ArgumentsCamelCase<InitArgs>) {
 			await initializeGit(creationDirectory);
 			await writeFile(
 				path.join(creationDirectory, ".gitignore"),
-				readFileSync(path.join(__dirname, "../templates/gitignore"))
+				readFileSync(path.join(getBasePath(), "templates/gitignore"))
 			);
 			logger.log(
 				args.name && args.name !== "."
@@ -254,7 +254,7 @@ export async function initHandler(args: ArgumentsCamelCase<InitArgs>) {
 			isTypescriptProject = true;
 			await writeFile(
 				path.join(creationDirectory, "./tsconfig.json"),
-				readFileSync(path.join(__dirname, "../templates/tsconfig.json"))
+				readFileSync(path.join(getBasePath(), "templates/tsconfig.json"))
 			);
 			devDepsToInstall.push("@cloudflare/workers-types");
 			devDepsToInstall.push("typescript");
@@ -495,7 +495,7 @@ export async function initHandler(args: ArgumentsCamelCase<InitArgs>) {
 					});
 					await writeFile(
 						path.join(creationDirectory, "./src/index.ts"),
-						readFileSync(path.join(__dirname, `../templates/${template}`))
+						readFileSync(path.join(getBasePath(), `templates/${template}`))
 					);
 
 					logger.log(
@@ -561,7 +561,7 @@ export async function initHandler(args: ArgumentsCamelCase<InitArgs>) {
 					});
 					await writeFile(
 						path.join(creationDirectory, "./src/index.js"),
-						readFileSync(path.join(__dirname, `../templates/${template}`))
+						readFileSync(path.join(getBasePath(), `templates/${template}`))
 					);
 
 					logger.log(

--- a/packages/wrangler/src/pages/dev.tsx
+++ b/packages/wrangler/src/pages/dev.tsx
@@ -8,6 +8,7 @@ import { unstable_dev } from "../api";
 import { FatalError } from "../errors";
 import { logger } from "../logger";
 import * as metrics from "../metrics";
+import { getBasePath } from "../paths";
 import { buildFunctions } from "./build";
 import { SECONDS_TO_WAIT_FOR_PROXY } from "./constants";
 import { FunctionsNoRoutesError, getFunctionsNoRoutesWarning } from "./errors";
@@ -274,7 +275,7 @@ export const Handler = async ({
 
 		if (!existsSync(scriptPath)) {
 			logger.log("No functions. Shimming...");
-			scriptPath = resolve(__dirname, "../templates/pages-shim.ts");
+			scriptPath = resolve(getBasePath(), "templates/pages-shim.ts");
 		} else {
 			const runBuild = async () => {
 				try {

--- a/packages/wrangler/src/pages/functions/buildPlugin.ts
+++ b/packages/wrangler/src/pages/functions/buildPlugin.ts
@@ -3,6 +3,7 @@ import { dirname, relative, resolve } from "node:path";
 import NodeGlobalsPolyfills from "@esbuild-plugins/node-globals-polyfill";
 import NodeModulesPolyfills from "@esbuild-plugins/node-modules-polyfill";
 import { build } from "esbuild";
+import { getBasePath } from "../../paths";
 
 type Options = {
 	routesModule: string;
@@ -24,7 +25,7 @@ export function buildPlugin({
 	onEnd = () => {},
 }: Options) {
 	return build({
-		entryPoints: [resolve(__dirname, "../templates/pages-template-plugin.ts")],
+		entryPoints: [resolve(getBasePath(), "templates/pages-template-plugin.ts")],
 		inject: [routesModule],
 		bundle: true,
 		format: "esm",

--- a/packages/wrangler/src/pages/functions/buildWorker.ts
+++ b/packages/wrangler/src/pages/functions/buildWorker.ts
@@ -4,6 +4,7 @@ import NodeGlobalsPolyfills from "@esbuild-plugins/node-globals-polyfill";
 import NodeModulesPolyfills from "@esbuild-plugins/node-modules-polyfill";
 import { build } from "esbuild";
 import { nanoid } from "nanoid";
+import { getBasePath } from "../../paths";
 
 type Options = {
 	routesModule: string;
@@ -29,7 +30,7 @@ export function buildWorker({
 	nodeCompat,
 }: Options) {
 	return build({
-		entryPoints: [resolve(__dirname, "../templates/pages-template-worker.ts")],
+		entryPoints: [resolve(getBasePath(), "templates/pages-template-worker.ts")],
 		inject: [routesModule],
 		bundle: true,
 		format: "esm",

--- a/packages/wrangler/src/paths.ts
+++ b/packages/wrangler/src/paths.ts
@@ -1,4 +1,5 @@
-import { assert } from "console";
+import { assert } from "node:console";
+import { resolve } from "node:path";
 
 type DiscriminatedPath<Discriminator extends string> = string & {
 	_discriminator: Discriminator;
@@ -23,4 +24,22 @@ export function toUrlPath(path: string): UrlPath {
 		"Tried to convert a Windows file path with a drive to a URL path."
 	);
 	return path.replace(/\\/g, "/") as UrlPath;
+}
+
+/**
+ * The __RELATIVE_PACKAGE_PATH__ is defined either in the esbuild config (for production)
+ * or the jest.setup.ts (for unit testing).
+ */
+declare const __RELATIVE_PACKAGE_PATH__: string;
+
+/**
+ * Use this function (rather than node.js constants like `__dirname`) to specify
+ * paths that are relative to the base path of the Wrangler package.
+ *
+ * It is important to use this function because it reliably maps to the root of the package
+ * no matter whether the code has been bundled or not.
+ */
+export function getBasePath(): string {
+	// eslint-disable-next-line no-restricted-globals
+	return resolve(__dirname, __RELATIVE_PACKAGE_PATH__);
 }


### PR DESCRIPTION
Use `getBasePath()` when trying to specify paths to files relative to the
base of the Wrangler package directory rather than trying to compute the
path from Node.js constants like `__dirname` and `__filename`. This is
because the act of bundling the source code can move the file that contains
these constants around potentially breaking the relative path to the desired files.

Fixes #1755