### PR TITLE
fix: allow URL object to be passed to local `fetch()` calls

### DIFF
--- a/.changeset/warm-nails-clap.md
+++ b/.changeset/warm-nails-clap.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+allow `fetch()` calls locally to accept URL Objects

--- a/packages/wrangler/templates/checked-fetch.js
+++ b/packages/wrangler/templates/checked-fetch.js
@@ -1,7 +1,7 @@
 const urls = new Set();
 
-export function checkedFetch(fetchRequest, init) {
-	const { request, url } = getRequestDetails(fetchRequest, init);
+export function checkedFetch(request, init) {
+	const url = new URL(new Request(request, init).url);
 	if (url.port && url.port !== "443" && url.protocol === "https:") {
 		if (!urls.has(url.toString())) {
 			urls.add(url.toString());
@@ -12,24 +12,4 @@ export function checkedFetch(fetchRequest, init) {
 		}
 	}
 	return globalThis.fetch(request, init);
-}
-
-function getRequestDetails(fetchRequest, init) {
-	let request;
-	let url;
-
-	if (fetchRequest instanceof URL) {
-		url = fetchRequest;
-		request = new Request(url, init);
-	} else {
-		request = fetchRequest;
-		url = new URL(
-			(typeof request === "string" ? new Request(request, init) : request).url
-		);
-	}
-
-	return {
-		request,
-		url,
-	};
 }

--- a/packages/wrangler/templates/checked-fetch.js
+++ b/packages/wrangler/templates/checked-fetch.js
@@ -1,9 +1,7 @@
 const urls = new Set();
 
-export function checkedFetch(request, init) {
-	const url = new URL(
-		(typeof request === "string" ? new Request(request, init) : request).url
-	);
+export function checkedFetch(fetchRequest, init) {
+	const { request, url } = getRequestDetails(fetchRequest, init);
 	if (url.port && url.port !== "443" && url.protocol === "https:") {
 		if (!urls.has(url.toString())) {
 			urls.add(url.toString());
@@ -14,4 +12,24 @@ export function checkedFetch(request, init) {
 		}
 	}
 	return globalThis.fetch(request, init);
+}
+
+function getRequestDetails(fetchRequest, init) {
+	let request;
+	let url;
+
+	if (fetchRequest instanceof URL) {
+		url = fetchRequest;
+		request = new Request(url, init);
+	} else {
+		request = fetchRequest;
+		url = new URL(
+			(typeof request === "string" ? new Request(request, init) : request).url
+		);
+	}
+
+	return {
+		request,
+		url,
+	};
 }


### PR DESCRIPTION
Due to the local fetch check, URL objects are wrongly not accepted by `fetch()` calls,
amend the `checkedFetch` function in order to allow such scenario (which
anyways works after deployment).

resolves #1588