### PR TITLE
Debug exchange

### DIFF
--- a/.changeset/shaggy-chicken-peel.md
+++ b/.changeset/shaggy-chicken-peel.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Add debug outputs to the exchange request

--- a/packages/wrangler/src/create-worker-preview.ts
+++ b/packages/wrangler/src/create-worker-preview.ts
@@ -3,6 +3,7 @@ import { fetch } from "undici";
 import { fetchResult } from "./cfetch";
 import { createWorkerUploadForm } from "./create-worker-upload-form";
 import { logger } from "./logger";
+import { parseJSON } from './parse';
 import type { CfAccount, CfWorkerContext, CfWorkerInit } from "./worker";
 
 /**
@@ -125,9 +126,24 @@ export async function createPreviewSession(
 		undefined,
 		abortSignal
 	);
-	const { inspector_websocket, prewarm, token } = (await (
-		await fetch(exchange_url, { signal: abortSignal })
-	).json()) as { inspector_websocket: string; token: string; prewarm: string };
+
+	logger.debug(
+		`-- START EXCHANGE API REQUEST: GET ${exchange_url}`
+	);
+	logger.debug("-- END EXCHANGE API REQUEST");
+	const exchangeResponse = await fetch(exchange_url, { signal: abortSignal });
+	const bodyText = await exchangeResponse.text();
+	logger.debug(
+		"-- START EXCHANGE API RESPONSE:",
+		exchangeResponse.statusText,
+		exchangeResponse.status
+	);
+	logger.debug("HEADERS:", JSON.stringify(exchangeResponse.headers, null, 2));
+	logger.debug("RESPONSE:", bodyText);
+	logger.debug("-- END EXCHANGE API RESPONSE");
+
+	const { inspector_websocket, prewarm, token } = parseJSON<{ inspector_websocket: string; token: string; prewarm: string }>(bodyText);
+
 	const { host } = new URL(inspector_websocket);
 	const query = `cf_workers_preview_token=${token}`;
 

--- a/packages/wrangler/src/create-worker-preview.ts
+++ b/packages/wrangler/src/create-worker-preview.ts
@@ -3,7 +3,7 @@ import { fetch } from "undici";
 import { fetchResult } from "./cfetch";
 import { createWorkerUploadForm } from "./create-worker-upload-form";
 import { logger } from "./logger";
-import { parseJSON } from './parse';
+import { parseJSON } from "./parse";
 import type { CfAccount, CfWorkerContext, CfWorkerInit } from "./worker";
 
 /**
@@ -127,9 +127,7 @@ export async function createPreviewSession(
 		abortSignal
 	);
 
-	logger.debug(
-		`-- START EXCHANGE API REQUEST: GET ${exchange_url}`
-	);
+	logger.debug(`-- START EXCHANGE API REQUEST: GET ${exchange_url}`);
 	logger.debug("-- END EXCHANGE API REQUEST");
 	const exchangeResponse = await fetch(exchange_url, { signal: abortSignal });
 	const bodyText = await exchangeResponse.text();
@@ -142,7 +140,11 @@ export async function createPreviewSession(
 	logger.debug("RESPONSE:", bodyText);
 	logger.debug("-- END EXCHANGE API RESPONSE");
 
-	const { inspector_websocket, prewarm, token } = parseJSON<{ inspector_websocket: string; token: string; prewarm: string }>(bodyText);
+	const { inspector_websocket, prewarm, token } = parseJSON<{
+		inspector_websocket: string;
+		token: string;
+		prewarm: string;
+	}>(bodyText);
 
 	const { host } = new URL(inspector_websocket);
 	const query = `cf_workers_preview_token=${token}`;


### PR DESCRIPTION
Adds debug logs to the exchange request which was not caught in the initial debug PR (https://github.com/cloudflare/wrangler2/pull/1712 - since it's not an internal fetch but to a users zone)

This allows us to fully debug previews :)