### PR TITLE
feat: Publish Origin Messaging

### DIFF
--- a/.changeset/tender-pianos-kick.md
+++ b/.changeset/tender-pianos-kick.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+---
+
+feat: Publish Origin Messaging
+feat: warn about potential conflicts during `publish` and `init --from-dash`.
+
+- If publishing to a worker that has been modified in the dashboard, warn that the dashboard changes will be overwritten.
+- When initializing from the dashboard, warn that future changes via the dashboard will not automatically appear in the local Worker config.
+
+resolves #1737

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -47,6 +47,12 @@ describe("publish", () => {
 			setImmediate(fn);
 		});
 		setIsTTY(true);
+		setMockResponse(
+			"/accounts/:accountId/workers/services/:scriptName",
+			() => ({
+				default_environment: { script: { last_deployed_from: "dash" } },
+			})
+		);
 	});
 
 	afterEach(() => {
@@ -4178,6 +4184,7 @@ addEventListener('fetch', event => {});`
 			});
 
 			it("should use a script's current migration tag when publishing migrations", async () => {
+				unsetAllMocks();
 				writeWranglerToml({
 					durable_objects: {
 						bindings: [

--- a/packages/wrangler/src/dialogs.tsx
+++ b/packages/wrangler/src/dialogs.tsx
@@ -133,3 +133,15 @@ export function select(
 		);
 	});
 }
+
+export async function fromDashMessagePrompt(
+	deploySource: string
+): Promise<boolean | void> {
+	if (deploySource === "dash") {
+		logger.warn(
+			`You are about to publish a Workers Service that was last published via the Cloudflare Dashboard.
+		Edits that have been made via the dashboard will be overridden by your local code and config.`
+		);
+		return await confirm("Would you like to continue?");
+	}
+}

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -457,6 +457,10 @@ export async function initHandler(args: ArgumentsCamelCase<InitArgs>) {
 				path.join(creationDirectory, "./src/index.ts")
 			);
 			if (fromDashScriptName) {
+				logger.warn(
+					`After running "wrangler init --from-dash", modifying your worker via the Cloudflare dashboard is discouraged.
+					Edits made via the Dashboard will not be synchronized locally and will be overridden by your local code and config when you publish.`
+				);
 				const config = readConfig(args.config as ConfigPath, args);
 				const accountId = await requireAuth(config);
 				await mkdir(path.join(creationDirectory, "./src"), {
@@ -523,6 +527,10 @@ export async function initHandler(args: ArgumentsCamelCase<InitArgs>) {
 			);
 
 			if (fromDashScriptName) {
+				logger.warn(
+					`After running "wrangler init --from-dash", modifying your worker via the Cloudflare dashboard is discouraged.
+					Edits made via the Dashboard will not be synchronized locally and will be overridden by your local code and config when you publish.`
+				);
 				const config = readConfig(args.config as ConfigPath, args);
 				const accountId = await requireAuth(config);
 				await mkdir(path.join(creationDirectory, "./src"), {


### PR DESCRIPTION
Adding messaging around 'publish' informing the user
of the last Worker publish occured on dash, and how publishing from the CLI
will override that.

Messaging around 'init --from-dash' informing the user that the Worker
initialized from the dash cannot be synced from the dash again.

resolves #1737