### PR TITLE
chore: add npmrc to webpack-plugin

### DIFF
--- a/packages/wranglerjs-compat-webpack-plugin/.npmrc
+++ b/packages/wranglerjs-compat-webpack-plugin/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_PUBLISH_TOKEN}


### PR DESCRIPTION
The Changeset GitHub Action expects the npmrc with the Publish token is needed for Changesets to work effectively in CI.  

Part of working on #1746