### PR TITLE
chore: upgrade `miniflare` to `2.8.1`

### DIFF
--- a/.changeset/long-kangaroos-invent.md
+++ b/.changeset/long-kangaroos-invent.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Upgrade `miniflare` to [`2.8`](https://github.com/cloudflare/miniflare/releases/tag/v2.8.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2629,12 +2629,12 @@
 			}
 		},
 		"node_modules/@miniflare/cache": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.7.1.tgz",
-			"integrity": "sha512-QxN4yp8+cIlggbjIVP17xbSOjjJMco4coW5mXNPcTXazvqnbslwie9GDWmt4BkRvP77uwomf2CDUqEgxZC0frw==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.8.1.tgz",
+			"integrity": "sha512-7b+x6TB2Jee+G0wdlW/w0GW5UpNM7e1PxDkrn2Xw1wnTLgGNTUXqPPcVNgughrszlMfvXez+PQpm3yAQ32HPmg==",
 			"dependencies": {
-				"@miniflare/core": "2.7.1",
-				"@miniflare/shared": "2.7.1",
+				"@miniflare/core": "2.8.1",
+				"@miniflare/shared": "2.8.1",
 				"http-cache-semantics": "^4.1.0",
 				"undici": "5.9.1"
 			},
@@ -2643,11 +2643,11 @@
 			}
 		},
 		"node_modules/@miniflare/cli-parser": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.7.1.tgz",
-			"integrity": "sha512-kuY6sWClFBQoc22g7P7gR3fv5dXDI8ezvPvNX6tHXPLiPxiYCoz8XTRUqG5CW12zTxrI3yPjEaTQoFlHzdnQkg==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.8.1.tgz",
+			"integrity": "sha512-3pt3DlsV3BsA8/JcbZpN1vLq1CMrbpV5NBBpopzY0zlhjbjhjD0cbeVkXB7iODQmdSyIskotiie7OJtvQUPmDw==",
 			"dependencies": {
-				"@miniflare/shared": "2.7.1",
+				"@miniflare/shared": "2.8.1",
 				"kleur": "^4.1.4"
 			},
 			"engines": {
@@ -2655,13 +2655,14 @@
 			}
 		},
 		"node_modules/@miniflare/core": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.7.1.tgz",
-			"integrity": "sha512-Pdq5+FPSg0L0/eUOKrEfGFowcmbcEXKCIJa8iYz1iA35koSytgTN+6zeuuGPGVXQbGGEPhNugWlOz4u70FJ1GA==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.8.1.tgz",
+			"integrity": "sha512-7x32lo4p3dtPAMAYvt+yiUPdtUt2hbYP2JvE7d1pasNWl4mFtgbfEQxRp1jcSFlFcatJszTsR4CAtlDP6n0Esg==",
 			"dependencies": {
 				"@iarna/toml": "^2.2.5",
-				"@miniflare/shared": "2.7.1",
-				"@miniflare/watcher": "2.7.1",
+				"@miniflare/queues": "2.8.1",
+				"@miniflare/shared": "2.8.1",
+				"@miniflare/watcher": "2.8.1",
 				"busboy": "^1.6.0",
 				"dotenv": "^10.0.0",
 				"kleur": "^4.1.4",
@@ -2682,13 +2683,13 @@
 			}
 		},
 		"node_modules/@miniflare/durable-objects": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.7.1.tgz",
-			"integrity": "sha512-bzTzhu9KgtBZ3itR/u/izBHBzQnxhfOt1IQcJNCM/TBwSf8wr6ztDdsTDFE0j9/oQYj4umbGynzZvYYUm/SniQ==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.8.1.tgz",
+			"integrity": "sha512-qdBKjQssugMMtS+5g2qMvkJ37rnK37Vhlp6+I5w6g5CLEkA6hxpgWX7T7p/c5i0aBr/oT/RPsiumkXWkwzBceA==",
 			"dependencies": {
-				"@miniflare/core": "2.7.1",
-				"@miniflare/shared": "2.7.1",
-				"@miniflare/storage-memory": "2.7.1",
+				"@miniflare/core": "2.8.1",
+				"@miniflare/shared": "2.8.1",
+				"@miniflare/storage-memory": "2.8.1",
 				"undici": "5.9.1"
 			},
 			"engines": {
@@ -2696,12 +2697,12 @@
 			}
 		},
 		"node_modules/@miniflare/html-rewriter": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.7.1.tgz",
-			"integrity": "sha512-7088TlpQBXdKX1OPOL+34xKSF5IjiHyjggM7HizJG14IIw1kSiJYojqaOi5f/DxstTUJJCOIxHn3zKf6QSpukA==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.8.1.tgz",
+			"integrity": "sha512-TkoK8jB06uwXyYTSEarmXG/FnnD90Q4FCwN9dtixlQVyGUBiVI3/KRxsXDApCJhinQRthdh4tQOMb3K2KsVd1Q==",
 			"dependencies": {
-				"@miniflare/core": "2.7.1",
-				"@miniflare/shared": "2.7.1",
+				"@miniflare/core": "2.8.1",
+				"@miniflare/shared": "2.8.1",
 				"html-rewriter-wasm": "^0.4.1",
 				"undici": "5.9.1"
 			},
@@ -2710,13 +2711,13 @@
 			}
 		},
 		"node_modules/@miniflare/http-server": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.7.1.tgz",
-			"integrity": "sha512-fcLrEVxtwMhj3qO5Wg5844s6WNTiixRjGEV/Top2TjP3CM6DtIc5l6zca4vozaTba39So627NDalLZQaCAcSBQ==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.8.1.tgz",
+			"integrity": "sha512-Xp5h37G10zVDN13Nqv3RsfCI89UqGLf5YTlQ7Wj2JZi9Oz4+fWShzZCzKjtpefrPAyV0w9hPnI3088rjypUKXQ==",
 			"dependencies": {
-				"@miniflare/core": "2.7.1",
-				"@miniflare/shared": "2.7.1",
-				"@miniflare/web-sockets": "2.7.1",
+				"@miniflare/core": "2.8.1",
+				"@miniflare/shared": "2.8.1",
+				"@miniflare/web-sockets": "2.8.1",
 				"kleur": "^4.1.4",
 				"selfsigned": "^2.0.0",
 				"undici": "5.9.1",
@@ -2748,22 +2749,33 @@
 			}
 		},
 		"node_modules/@miniflare/kv": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.7.1.tgz",
-			"integrity": "sha512-p3BUSgp2BK2l7GxM9wVnaXTM8/thzCzAITDbeyZLevtd8r3Vl1rE8W9Q+qrUbX454+zvHfG71O+BdtfFchgWkA==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.8.1.tgz",
+			"integrity": "sha512-UQkWNqNkCohMceqHwismvxUDk99+e8YAxhWBQBuHm8L1L236aID5rGVaAodlzwWFXiEwlDsqEYWXyX0x8NYGlw==",
 			"dependencies": {
-				"@miniflare/shared": "2.7.1"
+				"@miniflare/shared": "2.8.1"
 			},
 			"engines": {
 				"node": ">=16.13"
 			}
 		},
-		"node_modules/@miniflare/r2": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.7.1.tgz",
-			"integrity": "sha512-UFqU2y4Qccto4PilHEn8JpTKi+lPZ61eV0G50Nnfnwa19yDKf0Wu6rYXecLTPetln10v6pCLvRvk4O93d99A6Q==",
+		"node_modules/@miniflare/queues": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.8.1.tgz",
+			"integrity": "sha512-+VPogDWD9CnauNw5C1z8lwxBH0FX/qlPI6BGLQGXS4czPqio1py4AwZXZ4wymh7jMIn853+nExKeeZDmyl2J6Q==",
 			"dependencies": {
-				"@miniflare/shared": "2.7.1",
+				"@miniflare/shared": "2.8.1"
+			},
+			"engines": {
+				"node": ">=16.7"
+			}
+		},
+		"node_modules/@miniflare/r2": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.8.1.tgz",
+			"integrity": "sha512-5MMciySrss1Beh2IKNRGLmbg7do0fjvItWJcShYuyFLUXbu6WONWkhLcMP0VOAJCKs8QoPpk+ghBHODT0dybAQ==",
+			"dependencies": {
+				"@miniflare/shared": "2.8.1",
 				"undici": "5.9.1"
 			},
 			"engines": {
@@ -2771,23 +2783,23 @@
 			}
 		},
 		"node_modules/@miniflare/runner-vm": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.7.1.tgz",
-			"integrity": "sha512-kcntTSq38Jk81EQbEYs1wSrcziz/KO1JD1DyyDSw1C9pDSFmhusgObDW0VxaGgEVyh92No8l5CNlTjY7kjiMHw==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.8.1.tgz",
+			"integrity": "sha512-oQjJdT/3k1Lq8TymAcPaWor7ik+qSjznNb8G+1GwNz5F3qT5fH8ccdmNgtqTwHTq12+U3VrmXD5c5HR7UcWaCg==",
 			"dependencies": {
-				"@miniflare/shared": "2.7.1"
+				"@miniflare/shared": "2.8.1"
 			},
 			"engines": {
 				"node": ">=16.13"
 			}
 		},
 		"node_modules/@miniflare/scheduler": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.7.1.tgz",
-			"integrity": "sha512-00DCtvSi0/Kamo1OLtvfG+zxAS9VqrFO8Q1Wg7yEJpJBUlnUn+oOXKT//aCpZuVBJLSf7tXxzRXJYNPpu09fwg==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.8.1.tgz",
+			"integrity": "sha512-evhZtZMJJHalKDaqzlAaHTgLSDyj3A1mbJB3oHZQ3XLG9ufNSEPveDorLTppi0yYjGz9ju+duX/GPXlky35InQ==",
 			"dependencies": {
-				"@miniflare/core": "2.7.1",
-				"@miniflare/shared": "2.7.1",
+				"@miniflare/core": "2.8.1",
+				"@miniflare/shared": "2.8.1",
 				"cron-schedule": "^3.0.4"
 			},
 			"engines": {
@@ -2795,9 +2807,9 @@
 			}
 		},
 		"node_modules/@miniflare/shared": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.7.1.tgz",
-			"integrity": "sha512-hQsx/mt5N/zBxJ3DyAJyGMtdT07WeuU+nYiWjkIwQOkPgH/p72Xu0tdi2kO/KQogtxeT2B+eTMVXlE0JqZOyhA==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.8.1.tgz",
+			"integrity": "sha512-FzTMDdE1CBdfd0gJeRlT0qZHTHjul2tzPyzohRLZqy+FEeCp5ONtvjFfFUQdu8MUJTdEumaU28Dyov3vMTLT/Q==",
 			"dependencies": {
 				"kleur": "^4.1.4",
 				"picomatch": "^2.3.1"
@@ -2807,59 +2819,59 @@
 			}
 		},
 		"node_modules/@miniflare/sites": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.7.1.tgz",
-			"integrity": "sha512-b5pgVx5qifb9YejBfWjh5lnphc7wTX41CvBxssmCdQCxvQ+C5LgNelccNUvIBIMC+N5Ids+Fbd+Hx8MNGjp3iw==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.8.1.tgz",
+			"integrity": "sha512-28OivP5IawW5IeDAGiKpmWx9HjLzEfsU7GItnlPGLz74Lx9K99dYYU7Z2PqGjV9QhXiz5qWSD7sGKc4EdvCcrw==",
 			"dependencies": {
-				"@miniflare/kv": "2.7.1",
-				"@miniflare/shared": "2.7.1",
-				"@miniflare/storage-file": "2.7.1"
+				"@miniflare/kv": "2.8.1",
+				"@miniflare/shared": "2.8.1",
+				"@miniflare/storage-file": "2.8.1"
 			},
 			"engines": {
 				"node": ">=16.13"
 			}
 		},
 		"node_modules/@miniflare/storage-file": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.7.1.tgz",
-			"integrity": "sha512-6WiLGCeE1jIDJ3pp2ff1vFWCH1uf9BNWRkF3FpK7LyINzdDUlV56RtchPTBgk61oE8NYjlTqoYd4+KUvBul3/w==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.8.1.tgz",
+			"integrity": "sha512-39xNWssHvQQKtuAq/gc4aXBQ1koyy2peoYHN5iFIhuOFmnzQpBKJFlEjRIGNBq6yEefqTYzZa4NKwil4Qt3fZw==",
 			"dependencies": {
-				"@miniflare/shared": "2.7.1",
-				"@miniflare/storage-memory": "2.7.1"
+				"@miniflare/shared": "2.8.1",
+				"@miniflare/storage-memory": "2.8.1"
 			},
 			"engines": {
 				"node": ">=16.13"
 			}
 		},
 		"node_modules/@miniflare/storage-memory": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.7.1.tgz",
-			"integrity": "sha512-/YD6PshGEQneLmPC/FO+TnhN2STXT4oTuPxVo81fZ+q/XKglTA8iULtcgmF025lZ8S871ZANfmBtUzlxZJmW8Q==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.8.1.tgz",
+			"integrity": "sha512-JHqaLN5B0BAo9KrZd4J+Jsk7gKijN8UZk8QOnlWCE8MHBOnjQKHcKFAU2oR3FZmUsMXj6BTkG4ZbfmWT9WFLWg==",
 			"dependencies": {
-				"@miniflare/shared": "2.7.1"
+				"@miniflare/shared": "2.8.1"
 			},
 			"engines": {
 				"node": ">=16.13"
 			}
 		},
 		"node_modules/@miniflare/watcher": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.7.1.tgz",
-			"integrity": "sha512-0P0jG2IoMIQtX2JHTABY13Yq3Fs2w5gs6f/LG/X0O9pBCN3SxeQXt0bp3ELkEHjNANQWLMUs6aohb7yZ6ZTfHg==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.8.1.tgz",
+			"integrity": "sha512-tQNwNiSqKGtuJXLFiz50cqBbfuF6sro9WhNlphDn48lXM13s/HKJ8thJSL/i0rwpv5zyyJENm4teDe+4dddrfA==",
 			"dependencies": {
-				"@miniflare/shared": "2.7.1"
+				"@miniflare/shared": "2.8.1"
 			},
 			"engines": {
 				"node": ">=16.13"
 			}
 		},
 		"node_modules/@miniflare/web-sockets": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.7.1.tgz",
-			"integrity": "sha512-VO0BhkYDn82LTRhvK1vJA1/PA9GXMJGlkt2wYomdQFOz4Rmybau4sgVyAdKWTTYV7XexEVAVRl8BDUM97Pdxvw==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.8.1.tgz",
+			"integrity": "sha512-Tdzr1OPjzod+JCCnCgNoyGCc3rFIVgoMF6gVBvv/9Aqdi1+ZXxb7tBf4W8rr85IJtVdTpS6mpBwS07P5vDttxA==",
 			"dependencies": {
-				"@miniflare/core": "2.7.1",
-				"@miniflare/shared": "2.7.1",
+				"@miniflare/core": "2.8.1",
+				"@miniflare/shared": "2.8.1",
 				"undici": "5.9.1",
 				"ws": "^8.2.2"
 			},
@@ -16254,25 +16266,26 @@
 			}
 		},
 		"node_modules/miniflare": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.7.1.tgz",
-			"integrity": "sha512-O9kjSORazNCAGVkS0bRHhKGH1LcFOJZyBD0TchB02TalnQ3W21+QWO5PAXDGz/IATO8C8iXrPnN2XKDdDav2CA==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.8.1.tgz",
+			"integrity": "sha512-Icp9SMl/GwrdcQYSVU0HZ8insZeEG0K3QUXP+a1FKQ6UvoRcP5gw3c0OTcZaoZErOnE6YFh7xO7cuE1KSOWRFA==",
 			"dependencies": {
-				"@miniflare/cache": "2.7.1",
-				"@miniflare/cli-parser": "2.7.1",
-				"@miniflare/core": "2.7.1",
-				"@miniflare/durable-objects": "2.7.1",
-				"@miniflare/html-rewriter": "2.7.1",
-				"@miniflare/http-server": "2.7.1",
-				"@miniflare/kv": "2.7.1",
-				"@miniflare/r2": "2.7.1",
-				"@miniflare/runner-vm": "2.7.1",
-				"@miniflare/scheduler": "2.7.1",
-				"@miniflare/shared": "2.7.1",
-				"@miniflare/sites": "2.7.1",
-				"@miniflare/storage-file": "2.7.1",
-				"@miniflare/storage-memory": "2.7.1",
-				"@miniflare/web-sockets": "2.7.1",
+				"@miniflare/cache": "2.8.1",
+				"@miniflare/cli-parser": "2.8.1",
+				"@miniflare/core": "2.8.1",
+				"@miniflare/durable-objects": "2.8.1",
+				"@miniflare/html-rewriter": "2.8.1",
+				"@miniflare/http-server": "2.8.1",
+				"@miniflare/kv": "2.8.1",
+				"@miniflare/queues": "2.8.1",
+				"@miniflare/r2": "2.8.1",
+				"@miniflare/runner-vm": "2.8.1",
+				"@miniflare/scheduler": "2.8.1",
+				"@miniflare/shared": "2.8.1",
+				"@miniflare/sites": "2.8.1",
+				"@miniflare/storage-file": "2.8.1",
+				"@miniflare/storage-memory": "2.8.1",
+				"@miniflare/web-sockets": "2.8.1",
 				"kleur": "^4.1.4",
 				"semiver": "^1.1.0",
 				"source-map-support": "^0.5.20",
@@ -16285,7 +16298,7 @@
 				"node": ">=16.13"
 			},
 			"peerDependencies": {
-				"@miniflare/storage-redis": "2.7.1",
+				"@miniflare/storage-redis": "2.8.1",
 				"cron-schedule": "^3.0.4",
 				"ioredis": "^4.27.9"
 			},
@@ -22369,7 +22382,7 @@
 				"blake3-wasm": "^2.1.5",
 				"chokidar": "^3.5.3",
 				"esbuild": "0.14.51",
-				"miniflare": "^2.7.1",
+				"miniflare": "^2.8.1",
 				"nanoid": "^3.3.3",
 				"path-to-regexp": "^6.2.0",
 				"selfsigned": "^2.0.1",
@@ -25668,33 +25681,34 @@
 			}
 		},
 		"@miniflare/cache": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.7.1.tgz",
-			"integrity": "sha512-QxN4yp8+cIlggbjIVP17xbSOjjJMco4coW5mXNPcTXazvqnbslwie9GDWmt4BkRvP77uwomf2CDUqEgxZC0frw==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.8.1.tgz",
+			"integrity": "sha512-7b+x6TB2Jee+G0wdlW/w0GW5UpNM7e1PxDkrn2Xw1wnTLgGNTUXqPPcVNgughrszlMfvXez+PQpm3yAQ32HPmg==",
 			"requires": {
-				"@miniflare/core": "2.7.1",
-				"@miniflare/shared": "2.7.1",
+				"@miniflare/core": "2.8.1",
+				"@miniflare/shared": "2.8.1",
 				"http-cache-semantics": "^4.1.0",
 				"undici": "5.9.1"
 			}
 		},
 		"@miniflare/cli-parser": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.7.1.tgz",
-			"integrity": "sha512-kuY6sWClFBQoc22g7P7gR3fv5dXDI8ezvPvNX6tHXPLiPxiYCoz8XTRUqG5CW12zTxrI3yPjEaTQoFlHzdnQkg==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.8.1.tgz",
+			"integrity": "sha512-3pt3DlsV3BsA8/JcbZpN1vLq1CMrbpV5NBBpopzY0zlhjbjhjD0cbeVkXB7iODQmdSyIskotiie7OJtvQUPmDw==",
 			"requires": {
-				"@miniflare/shared": "2.7.1",
+				"@miniflare/shared": "2.8.1",
 				"kleur": "^4.1.4"
 			}
 		},
 		"@miniflare/core": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.7.1.tgz",
-			"integrity": "sha512-Pdq5+FPSg0L0/eUOKrEfGFowcmbcEXKCIJa8iYz1iA35koSytgTN+6zeuuGPGVXQbGGEPhNugWlOz4u70FJ1GA==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.8.1.tgz",
+			"integrity": "sha512-7x32lo4p3dtPAMAYvt+yiUPdtUt2hbYP2JvE7d1pasNWl4mFtgbfEQxRp1jcSFlFcatJszTsR4CAtlDP6n0Esg==",
 			"requires": {
 				"@iarna/toml": "^2.2.5",
-				"@miniflare/shared": "2.7.1",
-				"@miniflare/watcher": "2.7.1",
+				"@miniflare/queues": "2.8.1",
+				"@miniflare/shared": "2.8.1",
+				"@miniflare/watcher": "2.8.1",
 				"busboy": "^1.6.0",
 				"dotenv": "^10.0.0",
 				"kleur": "^4.1.4",
@@ -25711,35 +25725,35 @@
 			}
 		},
 		"@miniflare/durable-objects": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.7.1.tgz",
-			"integrity": "sha512-bzTzhu9KgtBZ3itR/u/izBHBzQnxhfOt1IQcJNCM/TBwSf8wr6ztDdsTDFE0j9/oQYj4umbGynzZvYYUm/SniQ==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.8.1.tgz",
+			"integrity": "sha512-qdBKjQssugMMtS+5g2qMvkJ37rnK37Vhlp6+I5w6g5CLEkA6hxpgWX7T7p/c5i0aBr/oT/RPsiumkXWkwzBceA==",
 			"requires": {
-				"@miniflare/core": "2.7.1",
-				"@miniflare/shared": "2.7.1",
-				"@miniflare/storage-memory": "2.7.1",
+				"@miniflare/core": "2.8.1",
+				"@miniflare/shared": "2.8.1",
+				"@miniflare/storage-memory": "2.8.1",
 				"undici": "5.9.1"
 			}
 		},
 		"@miniflare/html-rewriter": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.7.1.tgz",
-			"integrity": "sha512-7088TlpQBXdKX1OPOL+34xKSF5IjiHyjggM7HizJG14IIw1kSiJYojqaOi5f/DxstTUJJCOIxHn3zKf6QSpukA==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.8.1.tgz",
+			"integrity": "sha512-TkoK8jB06uwXyYTSEarmXG/FnnD90Q4FCwN9dtixlQVyGUBiVI3/KRxsXDApCJhinQRthdh4tQOMb3K2KsVd1Q==",
 			"requires": {
-				"@miniflare/core": "2.7.1",
-				"@miniflare/shared": "2.7.1",
+				"@miniflare/core": "2.8.1",
+				"@miniflare/shared": "2.8.1",
 				"html-rewriter-wasm": "^0.4.1",
 				"undici": "5.9.1"
 			}
 		},
 		"@miniflare/http-server": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.7.1.tgz",
-			"integrity": "sha512-fcLrEVxtwMhj3qO5Wg5844s6WNTiixRjGEV/Top2TjP3CM6DtIc5l6zca4vozaTba39So627NDalLZQaCAcSBQ==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.8.1.tgz",
+			"integrity": "sha512-Xp5h37G10zVDN13Nqv3RsfCI89UqGLf5YTlQ7Wj2JZi9Oz4+fWShzZCzKjtpefrPAyV0w9hPnI3088rjypUKXQ==",
 			"requires": {
-				"@miniflare/core": "2.7.1",
-				"@miniflare/shared": "2.7.1",
-				"@miniflare/web-sockets": "2.7.1",
+				"@miniflare/core": "2.8.1",
+				"@miniflare/shared": "2.8.1",
+				"@miniflare/web-sockets": "2.8.1",
 				"kleur": "^4.1.4",
 				"selfsigned": "^2.0.0",
 				"undici": "5.9.1",
@@ -25756,91 +25770,99 @@
 			}
 		},
 		"@miniflare/kv": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.7.1.tgz",
-			"integrity": "sha512-p3BUSgp2BK2l7GxM9wVnaXTM8/thzCzAITDbeyZLevtd8r3Vl1rE8W9Q+qrUbX454+zvHfG71O+BdtfFchgWkA==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.8.1.tgz",
+			"integrity": "sha512-UQkWNqNkCohMceqHwismvxUDk99+e8YAxhWBQBuHm8L1L236aID5rGVaAodlzwWFXiEwlDsqEYWXyX0x8NYGlw==",
 			"requires": {
-				"@miniflare/shared": "2.7.1"
+				"@miniflare/shared": "2.8.1"
+			}
+		},
+		"@miniflare/queues": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.8.1.tgz",
+			"integrity": "sha512-+VPogDWD9CnauNw5C1z8lwxBH0FX/qlPI6BGLQGXS4czPqio1py4AwZXZ4wymh7jMIn853+nExKeeZDmyl2J6Q==",
+			"requires": {
+				"@miniflare/shared": "2.8.1"
 			}
 		},
 		"@miniflare/r2": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.7.1.tgz",
-			"integrity": "sha512-UFqU2y4Qccto4PilHEn8JpTKi+lPZ61eV0G50Nnfnwa19yDKf0Wu6rYXecLTPetln10v6pCLvRvk4O93d99A6Q==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.8.1.tgz",
+			"integrity": "sha512-5MMciySrss1Beh2IKNRGLmbg7do0fjvItWJcShYuyFLUXbu6WONWkhLcMP0VOAJCKs8QoPpk+ghBHODT0dybAQ==",
 			"requires": {
-				"@miniflare/shared": "2.7.1",
+				"@miniflare/shared": "2.8.1",
 				"undici": "5.9.1"
 			}
 		},
 		"@miniflare/runner-vm": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.7.1.tgz",
-			"integrity": "sha512-kcntTSq38Jk81EQbEYs1wSrcziz/KO1JD1DyyDSw1C9pDSFmhusgObDW0VxaGgEVyh92No8l5CNlTjY7kjiMHw==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.8.1.tgz",
+			"integrity": "sha512-oQjJdT/3k1Lq8TymAcPaWor7ik+qSjznNb8G+1GwNz5F3qT5fH8ccdmNgtqTwHTq12+U3VrmXD5c5HR7UcWaCg==",
 			"requires": {
-				"@miniflare/shared": "2.7.1"
+				"@miniflare/shared": "2.8.1"
 			}
 		},
 		"@miniflare/scheduler": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.7.1.tgz",
-			"integrity": "sha512-00DCtvSi0/Kamo1OLtvfG+zxAS9VqrFO8Q1Wg7yEJpJBUlnUn+oOXKT//aCpZuVBJLSf7tXxzRXJYNPpu09fwg==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.8.1.tgz",
+			"integrity": "sha512-evhZtZMJJHalKDaqzlAaHTgLSDyj3A1mbJB3oHZQ3XLG9ufNSEPveDorLTppi0yYjGz9ju+duX/GPXlky35InQ==",
 			"requires": {
-				"@miniflare/core": "2.7.1",
-				"@miniflare/shared": "2.7.1",
+				"@miniflare/core": "2.8.1",
+				"@miniflare/shared": "2.8.1",
 				"cron-schedule": "^3.0.4"
 			}
 		},
 		"@miniflare/shared": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.7.1.tgz",
-			"integrity": "sha512-hQsx/mt5N/zBxJ3DyAJyGMtdT07WeuU+nYiWjkIwQOkPgH/p72Xu0tdi2kO/KQogtxeT2B+eTMVXlE0JqZOyhA==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.8.1.tgz",
+			"integrity": "sha512-FzTMDdE1CBdfd0gJeRlT0qZHTHjul2tzPyzohRLZqy+FEeCp5ONtvjFfFUQdu8MUJTdEumaU28Dyov3vMTLT/Q==",
 			"requires": {
 				"kleur": "^4.1.4",
 				"picomatch": "^2.3.1"
 			}
 		},
 		"@miniflare/sites": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.7.1.tgz",
-			"integrity": "sha512-b5pgVx5qifb9YejBfWjh5lnphc7wTX41CvBxssmCdQCxvQ+C5LgNelccNUvIBIMC+N5Ids+Fbd+Hx8MNGjp3iw==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.8.1.tgz",
+			"integrity": "sha512-28OivP5IawW5IeDAGiKpmWx9HjLzEfsU7GItnlPGLz74Lx9K99dYYU7Z2PqGjV9QhXiz5qWSD7sGKc4EdvCcrw==",
 			"requires": {
-				"@miniflare/kv": "2.7.1",
-				"@miniflare/shared": "2.7.1",
-				"@miniflare/storage-file": "2.7.1"
+				"@miniflare/kv": "2.8.1",
+				"@miniflare/shared": "2.8.1",
+				"@miniflare/storage-file": "2.8.1"
 			}
 		},
 		"@miniflare/storage-file": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.7.1.tgz",
-			"integrity": "sha512-6WiLGCeE1jIDJ3pp2ff1vFWCH1uf9BNWRkF3FpK7LyINzdDUlV56RtchPTBgk61oE8NYjlTqoYd4+KUvBul3/w==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.8.1.tgz",
+			"integrity": "sha512-39xNWssHvQQKtuAq/gc4aXBQ1koyy2peoYHN5iFIhuOFmnzQpBKJFlEjRIGNBq6yEefqTYzZa4NKwil4Qt3fZw==",
 			"requires": {
-				"@miniflare/shared": "2.7.1",
-				"@miniflare/storage-memory": "2.7.1"
+				"@miniflare/shared": "2.8.1",
+				"@miniflare/storage-memory": "2.8.1"
 			}
 		},
 		"@miniflare/storage-memory": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.7.1.tgz",
-			"integrity": "sha512-/YD6PshGEQneLmPC/FO+TnhN2STXT4oTuPxVo81fZ+q/XKglTA8iULtcgmF025lZ8S871ZANfmBtUzlxZJmW8Q==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.8.1.tgz",
+			"integrity": "sha512-JHqaLN5B0BAo9KrZd4J+Jsk7gKijN8UZk8QOnlWCE8MHBOnjQKHcKFAU2oR3FZmUsMXj6BTkG4ZbfmWT9WFLWg==",
 			"requires": {
-				"@miniflare/shared": "2.7.1"
+				"@miniflare/shared": "2.8.1"
 			}
 		},
 		"@miniflare/watcher": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.7.1.tgz",
-			"integrity": "sha512-0P0jG2IoMIQtX2JHTABY13Yq3Fs2w5gs6f/LG/X0O9pBCN3SxeQXt0bp3ELkEHjNANQWLMUs6aohb7yZ6ZTfHg==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.8.1.tgz",
+			"integrity": "sha512-tQNwNiSqKGtuJXLFiz50cqBbfuF6sro9WhNlphDn48lXM13s/HKJ8thJSL/i0rwpv5zyyJENm4teDe+4dddrfA==",
 			"requires": {
-				"@miniflare/shared": "2.7.1"
+				"@miniflare/shared": "2.8.1"
 			}
 		},
 		"@miniflare/web-sockets": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.7.1.tgz",
-			"integrity": "sha512-VO0BhkYDn82LTRhvK1vJA1/PA9GXMJGlkt2wYomdQFOz4Rmybau4sgVyAdKWTTYV7XexEVAVRl8BDUM97Pdxvw==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.8.1.tgz",
+			"integrity": "sha512-Tdzr1OPjzod+JCCnCgNoyGCc3rFIVgoMF6gVBvv/9Aqdi1+ZXxb7tBf4W8rr85IJtVdTpS6mpBwS07P5vDttxA==",
 			"requires": {
-				"@miniflare/core": "2.7.1",
-				"@miniflare/shared": "2.7.1",
+				"@miniflare/core": "2.8.1",
+				"@miniflare/shared": "2.8.1",
 				"undici": "5.9.1",
 				"ws": "^8.2.2"
 			},
@@ -35243,25 +35265,26 @@
 			"version": "1.0.1"
 		},
 		"miniflare": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.7.1.tgz",
-			"integrity": "sha512-O9kjSORazNCAGVkS0bRHhKGH1LcFOJZyBD0TchB02TalnQ3W21+QWO5PAXDGz/IATO8C8iXrPnN2XKDdDav2CA==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.8.1.tgz",
+			"integrity": "sha512-Icp9SMl/GwrdcQYSVU0HZ8insZeEG0K3QUXP+a1FKQ6UvoRcP5gw3c0OTcZaoZErOnE6YFh7xO7cuE1KSOWRFA==",
 			"requires": {
-				"@miniflare/cache": "2.7.1",
-				"@miniflare/cli-parser": "2.7.1",
-				"@miniflare/core": "2.7.1",
-				"@miniflare/durable-objects": "2.7.1",
-				"@miniflare/html-rewriter": "2.7.1",
-				"@miniflare/http-server": "2.7.1",
-				"@miniflare/kv": "2.7.1",
-				"@miniflare/r2": "2.7.1",
-				"@miniflare/runner-vm": "2.7.1",
-				"@miniflare/scheduler": "2.7.1",
-				"@miniflare/shared": "2.7.1",
-				"@miniflare/sites": "2.7.1",
-				"@miniflare/storage-file": "2.7.1",
-				"@miniflare/storage-memory": "2.7.1",
-				"@miniflare/web-sockets": "2.7.1",
+				"@miniflare/cache": "2.8.1",
+				"@miniflare/cli-parser": "2.8.1",
+				"@miniflare/core": "2.8.1",
+				"@miniflare/durable-objects": "2.8.1",
+				"@miniflare/html-rewriter": "2.8.1",
+				"@miniflare/http-server": "2.8.1",
+				"@miniflare/kv": "2.8.1",
+				"@miniflare/queues": "2.8.1",
+				"@miniflare/r2": "2.8.1",
+				"@miniflare/runner-vm": "2.8.1",
+				"@miniflare/scheduler": "2.8.1",
+				"@miniflare/shared": "2.8.1",
+				"@miniflare/sites": "2.8.1",
+				"@miniflare/storage-file": "2.8.1",
+				"@miniflare/storage-memory": "2.8.1",
+				"@miniflare/web-sockets": "2.8.1",
 				"kleur": "^4.1.4",
 				"semiver": "^1.1.0",
 				"source-map-support": "^0.5.20",
@@ -39503,7 +39526,7 @@
 				"jest-fetch-mock": "^3.0.3",
 				"jest-websocket-mock": "^2.3.0",
 				"mime": "^3.0.0",
-				"miniflare": "^2.7.1",
+				"miniflare": "^2.8.1",
 				"nanoid": "^3.3.3",
 				"open": "^8.4.0",
 				"p-queue": "^7.2.0",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -97,7 +97,7 @@
 		"blake3-wasm": "^2.1.5",
 		"chokidar": "^3.5.3",
 		"esbuild": "0.14.51",
-		"miniflare": "^2.7.1",
+		"miniflare": "^2.8.1",
 		"nanoid": "^3.3.3",
 		"path-to-regexp": "^6.2.0",
 		"selfsigned": "^2.0.1",


### PR DESCRIPTION
Hey! 👋 This PR upgrades `miniflare` to version `2.8.1` See the [changelog for `2.8.0` here](https://github.com/cloudflare/miniflare/releases/tag/v2.8.0) and [`2.8.1` here](https://github.com/cloudflare/miniflare/releases/tag/v2.8.1). Big things in this update are queues, populated Workers Sites manifests (closing #1632), improved Web Streams runtime compatibility, and lots of other small fixes.