### PR TITLE
List "wrangler generate" in available commands

### DIFF
--- a/.changeset/lemon-colts-own.md
+++ b/.changeset/lemon-colts-own.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+List "wrangler generate" in available commands

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -301,12 +301,10 @@ function createCLIParser(argv: string[]) {
 	// I wish we could enforce this pattern, but this comment will have to do for now.
 	// (It's also annoying that choices[] doesn't get inferred as an enum. 🤷‍♂.)
 
-	// [DEPRECATED] generate
+	// generate
 	wrangler.command(
-		// we definitely want to move away from us cloning github templates
-		// we can do something better here, let's see
 		"generate [name] [template]",
-		false,
+		"🏗️ Generate a new workers project from an existing template",
 		generateOptions,
 		generateHandler
 	);


### PR DESCRIPTION
Un-hide `generate` and remove the "deprecated" comment
