### PR TITLE
fix: Publish error when no upstream Worker existed

### DIFF
--- a/.changeset/cyan-cherries-stare.md
+++ b/.changeset/cyan-cherries-stare.md
@@ -1,0 +1,10 @@
+---
+"wrangler": patch
+---
+
+fix: Publish error when no upstream Worker existed
+try/catch handles the check for last deployed source.
+The check breaking when no available Worker was upstream to check,
+which was causing deployments of new workers to fail.
+
+fixes #1824

--- a/.changeset/cyan-cherries-stare.md
+++ b/.changeset/cyan-cherries-stare.md
@@ -2,8 +2,10 @@
 "wrangler": patch
 ---
 
-fix: Publish error when no upstream Worker existed
-Add a try/catch when checking when the worker was last deployed
+fix: Publish error when deploying new Workers
+
+This fix adds a try/catch when checking when the Worker was last deployed.
+
 The check was failing when a Worker had never been deployed, causing deployments of new Workers to fail.
 
 fixes #1824

--- a/.changeset/cyan-cherries-stare.md
+++ b/.changeset/cyan-cherries-stare.md
@@ -5,6 +5,5 @@
 fix: Publish error when no upstream Worker existed
 Add a try/catch when checking when the worker was last deployed
 The check was failing when a Worker had never been deployed, causing deployments of new Workers to fail.
-which was causing deployments of new workers to fail.
 
 fixes #1824

--- a/.changeset/cyan-cherries-stare.md
+++ b/.changeset/cyan-cherries-stare.md
@@ -3,8 +3,8 @@
 ---
 
 fix: Publish error when no upstream Worker existed
-try/catch handles the check for last deployed source.
-The check breaking when no available Worker was upstream to check,
+Add a try/catch when checking when the worker was last deployed
+The check was failing when a Worker had never been deployed, causing deployments of new Workers to fail.
 which was causing deployments of new workers to fail.
 
 fixes #1824

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -6488,6 +6488,38 @@ addEventListener('fetch', event => {});`
 		`);
 		});
 	});
+
+	it("should publish if the last deployed source check fails", async () => {
+		writeWorkerSource();
+		writeWranglerToml();
+		mockSubDomainRequest();
+		mockUploadWorkerRequest();
+		setMockRawResponse(
+			"/accounts/:accountId/workers/scripts/:scriptName",
+			"PUT",
+			() => {
+				return createFetchResult({}, true, [
+					{
+						code: 10090,
+						message: "workers.api.error.service_not_found",
+					},
+				]);
+			}
+		);
+
+		await runWrangler("publish index.js");
+		expect(std).toMatchInlineSnapshot(`
+		Object {
+			"debug": "",
+			"err": "",
+			"out": "Total Upload: xx KiB / gzip: xx KiB
+		Uploaded test-name (TIMINGS)
+		Published test-name (TIMINGS)
+			https://test-name.test-sub-domain.workers.dev",
+			"warn": "",
+		}
+	`);
+	});
 });
 
 /** Write mock assets to the file system so they can be uploaded. */

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -6510,13 +6510,13 @@ addEventListener('fetch', event => {});`
 		await runWrangler("publish index.js");
 		expect(std).toMatchInlineSnapshot(`
 		Object {
-			"debug": "",
-			"err": "",
-			"out": "Total Upload: xx KiB / gzip: xx KiB
+		  "debug": "",
+		  "err": "",
+		  "out": "Total Upload: xx KiB / gzip: xx KiB
 		Uploaded test-name (TIMINGS)
 		Published test-name (TIMINGS)
-			https://test-name.test-sub-domain.workers.dev",
-			"warn": "",
+		  https://test-name.test-sub-domain.workers.dev",
+		  "warn": "",
 		}
 	`);
 	});

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -220,21 +220,26 @@ export default async function publish(props: Props): Promise<void> {
 	// TODO: warn if git/hg has uncommitted changes
 	const { config, accountId, name } = props;
 	if (accountId && name) {
-		const serviceMetaData = await fetchResult(
-			`/accounts/${accountId}/workers/services/${name}`
-		);
-		const { default_environment } = serviceMetaData as {
-			default_environment: {
-				script: { last_deployed_from: "dash" | "wrangler" | "api" };
+		try {
+			const serviceMetaData = await fetchResult(
+				`/accounts/${accountId}/workers/services/${name}`
+			);
+			const { default_environment } = serviceMetaData as {
+				default_environment: {
+					script: { last_deployed_from: "dash" | "wrangler" | "api" };
+				};
 			};
-		};
 
-		if (
-			(await fromDashMessagePrompt(
-				default_environment.script.last_deployed_from
-			)) === false
-		)
-			return;
+			if (
+				(await fromDashMessagePrompt(
+					default_environment.script.last_deployed_from
+				)) === false
+			)
+				return;
+		} catch (e) {
+			if ((e as { code?: number }).code === 10090) return;
+			logger.error(e);
+		}
 	}
 
 	if (!(props.compatibilityDate || config.compatibility_date)) {


### PR DESCRIPTION
The check for last deployed was breaking when no available Worker was upstream to check.

fixes #1824