### PR TITLE
Fix _headers and _redirects

### DIFF
--- a/.changeset/slimy-scissors-study.md
+++ b/.changeset/slimy-scissors-study.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: \_headers and \_redirects parsing in 'wrangler pages dev'

--- a/fixtures/pages-functions-app/public/_headers
+++ b/fixtures/pages-functions-app/public/_headers
@@ -1,0 +1,2 @@
+/*
+	A-Header: Some-Value

--- a/fixtures/pages-functions-app/public/_redirects
+++ b/fixtures/pages-functions-app/public/_redirects
@@ -1,0 +1,1 @@
+/redirect /me

--- a/fixtures/pages-functions-app/tests/index.test.ts
+++ b/fixtures/pages-functions-app/tests/index.test.ts
@@ -207,8 +207,8 @@ describe("Pages Functions", () => {
 		});
 	});
 
-	describe("it still attaches redirects correctly", () => {
-		it("should allow creates", async () => {
+	describe("redirects", () => {
+		it("still attaches redirects correctly", async () => {
 			const response = await waitUntilReady("http://localhost:8789/redirect", {
 				redirect: "manual",
 			});
@@ -217,8 +217,8 @@ describe("Pages Functions", () => {
 		});
 	});
 
-	describe("it still attaches headers correctly", () => {
-		it("should allow creates", async () => {
+	describe("headers", () => {
+		it("still attaches headers correctly", async () => {
 			const response = await waitUntilReady("http://localhost:8789/");
 
 			expect(response.headers.get("A-Header")).toEqual("Some-Value");

--- a/fixtures/pages-functions-app/tests/index.test.ts
+++ b/fixtures/pages-functions-app/tests/index.test.ts
@@ -206,4 +206,22 @@ describe("Pages Functions", () => {
 			expect(getObject.version).toEqual(object.version);
 		});
 	});
+
+	describe("it still attaches redirects correctly", () => {
+		it("should allow creates", async () => {
+			const response = await waitUntilReady("http://localhost:8789/redirect", {
+				redirect: "manual",
+			});
+			expect(response.status).toEqual(302);
+			expect(response.headers.get("Location")).toEqual("/me");
+		});
+	});
+
+	describe("it still attaches headers correctly", () => {
+		it("should allow creates", async () => {
+			const response = await waitUntilReady("http://localhost:8789/");
+
+			expect(response.headers.get("A-Header")).toEqual("Some-Value");
+		});
+	});
 });

--- a/packages/wrangler/src/miniflare-cli/assets.ts
+++ b/packages/wrangler/src/miniflare-cli/assets.ts
@@ -100,7 +100,7 @@ async function generateAssetsFetch(
 	let metadata = createMetadataObject({
 		redirects,
 		headers,
-		logger: (message) => log.warn(message),
+		logger: log.warn.bind(log),
 	});
 
 	watch([headersFile, redirectsFile], { persistent: true }).on(

--- a/packages/wrangler/src/miniflare-cli/assets.ts
+++ b/packages/wrangler/src/miniflare-cli/assets.ts
@@ -100,7 +100,7 @@ async function generateAssetsFetch(
 	let metadata = createMetadataObject({
 		redirects,
 		headers,
-		logger: log.warn,
+		logger: (message) => log.warn(message),
 	});
 
 	watch([headersFile, redirectsFile], { persistent: true }).on(


### PR DESCRIPTION
We recently broke parsing `_headers` and `_redirects` in 2.1.0 because the logger wasn't getting it's `this` context overridden. This fixes it so we correctly log parsing messages now (and stops the Miniflare process from crashing on start-up).