### PR TITLE
Fix patchUrl and add charset to 'Content-Type' on pages dev

### DIFF
--- a/.changeset/lemon-wolves-cover.md
+++ b/.changeset/lemon-wolves-cover.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Add 'charset' to 'Content-Type' on 'wrangler pages dev' responses

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,6 @@
 # Global owners
 * @petebacondarwin
+/packages/pages-shared/ @cloudflare/pages
 /packages/wrangler/pages/ @cloudflare/pages
 /packages/wrangler/src/pages/ @cloudflare/pages
 /packages/wrangler/src/pages.* @cloudflare/pages

--- a/packages/pages-shared/package.json
+++ b/packages/pages-shared/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cloudflare/pages-shared",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"files": [
 		"tsconfig.json",
 		"src/**/*",

--- a/packages/pages-shared/src/asset-server/patchUrl.ts
+++ b/packages/pages-shared/src/asset-server/patchUrl.ts
@@ -8,7 +8,7 @@ globalThis.URL = (function (globalURL) {
 	return PatchedURL as unknown as typeof globalURL;
 
 	function PatchedURL(input: string, base?: string | URL) {
-		const url = new URL(encodeURI(input), base);
+		const url = new globalURL(encodeURI(input), base);
 
 		return new Proxy(url, {
 			get(target, prop) {

--- a/packages/wrangler/src/miniflare-cli/assets.ts
+++ b/packages/wrangler/src/miniflare-cli/assets.ts
@@ -189,7 +189,14 @@ async function generateAssetsFetch(
 				}
 				const body = readFileSync(filepath) as unknown as ReadableStream;
 
-				const contentType = getType(filepath) || "application/octet-stream";
+				let contentType = getType(filepath) || "application/octet-stream";
+				if (
+					contentType.startsWith("text/") &&
+					!contentType.includes("charset")
+				) {
+					contentType = `${contentType}; charset=utf-8`;
+				}
+
 				return { body, contentType };
 			},
 		});


### PR DESCRIPTION
Missed a `URL` -> `globalURL` when refactoring this patch. Results in a recursion call stack size exceeded error on the runtime (but not Miniflare, seemingly).