### PR TITLE
polish: loglevel flag

### DIFF
--- a/.changeset/gorgeous-moose-whisper.md
+++ b/.changeset/gorgeous-moose-whisper.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+polish: loglevel flag
+Added a '--log-level' flag that allows the user to specify between 'debug', 'info', 'log', 'warning', 'error', 'none'
+Currently 'none' will turn off all outputs in Miniflare (local mode), however, Wrangler will still output Errors.
+
+resolves #185

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -1028,7 +1028,8 @@ describe("wrangler dev", () => {
 			      --persist                                    Enable persistence for local mode, using default path: .wrangler/state  [boolean]
 			      --persist-to                                 Specify directory to use for local persistence (implies --persist)  [string]
 			      --inspect                                    Enable dev tools  [deprecated] [boolean]
-			      --test-scheduled                             Test scheduled events by visiting /__scheduled in browser  [boolean] [default: false]",
+			      --test-scheduled                             Test scheduled events by visiting /__scheduled in browser  [boolean] [default: false]
+			      --log-level                                  Specify logging level  [choices: \\"debug\\", \\"info\\", \\"log\\", \\"warn\\", \\"error\\", \\"none\\"] [default: \\"log\\"]",
 			  "warn": "",
 			}
 		`);
@@ -1209,6 +1210,42 @@ describe("wrangler dev", () => {
 			  "warn": "",
 			}
 		`);
+		});
+	});
+
+	describe("--log-level", () => {
+		it("should not output warnings with log-level 'none'", async () => {
+			fs.writeFileSync("index.js", `export default {};`);
+			await runWrangler("dev index.js --inspect --log-level none");
+			expect(std).toMatchInlineSnapshot(`
+			Object {
+			  "debug": "",
+			  "err": "",
+			  "out": "",
+			  "warn": "",
+			}
+		`);
+		});
+
+		it("should output warnings with log-level 'warn'", async () => {
+			fs.writeFileSync("index.js", `export default {};`);
+			await runWrangler("dev index.js --inspect --log-level warn");
+			expect(std).toMatchInlineSnapshot(`
+			Object {
+			  "debug": "",
+			  "err": "",
+			  "out": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mPassing --inspect is unnecessary, now you can always connect to devtools.[0m
+
+			",
+			}
+		`);
+		});
+
+		it("should not output Errors with log-level error", async () => {
+			fs.writeFileSync("index.js", `export default {};`);
+			await runWrangler("dev index.js --inspect --log-level debug");
+			expect(std.debug.length > 1).toBe(true);
 		});
 	});
 

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -279,6 +279,12 @@ export function devOptions(yargs: Argv): Argv<DevArgs> {
 				type: "boolean",
 				default: false,
 			})
+			.option("log-level", {
+				// "none" will currently default to "error" for Wrangler Logger
+				choices: ["debug", "info", "log", "warn", "error", "none"] as const,
+				describe: "Specify logging level",
+				default: "log",
+			})
 	);
 }
 

--- a/packages/wrangler/src/pages/dev.tsx
+++ b/packages/wrangler/src/pages/dev.tsx
@@ -146,6 +146,13 @@ export function Options(yargs: Argv) {
 				type: "string",
 				hidden: true,
 			},
+
+			"log-level": {
+				// "none" will currently default to "error" for Wrangler Logger
+				choices: ["debug", "info", "log", "warn", "error", "none"] as const,
+				describe: "Specify logging level",
+				default: "log",
+			},
 		})
 		.epilogue(pagesBetaWarning);
 }
@@ -172,9 +179,20 @@ export const Handler = async ({
 	"node-compat": nodeCompat,
 	config: config,
 	_: [_pages, _dev, ...remaining],
+	logLevel,
 }: PagesDevArgs) => {
 	// Beta message for `wrangler pages <commands>` usage
 	logger.log(pagesBetaWarning);
+
+	type LogLevelArg = "debug" | "info" | "log" | "warn" | "error" | "none";
+	if (logLevel) {
+		// we don't define a "none" logLevel, so "error" will do for now.
+		// The YargsOptionsToInterface doesn't handle the passing in of Unions from choices in Yargs
+		logger.loggerLevel =
+			(logLevel as LogLevelArg) === "none"
+				? "error"
+				: (logLevel as Exclude<"none", LogLevelArg>);
+	}
 
 	if (!local) {
 		throw new FatalError("Only local mode is supported at the moment.", 1);


### PR DESCRIPTION
Added a '--log-level' flag that allows the user to specify between 'debug', 'info', 'log', 'warning', 'error', 'none' Currently 'none' will turn off all outputs in Miniflare (local mode), however, Wrangler will still output Errors.

resolves #185