### PR TITLE
Concurrent fixture tests

### DIFF
--- a/fixtures/external-durable-objects-app/tests/index.test.ts
+++ b/fixtures/external-durable-objects-app/tests/index.test.ts
@@ -20,53 +20,206 @@ const waitUntilReady = async (url: string): Promise<Response> => {
 
 const isWindows = process.platform === "win32";
 
-describe.skip("Pages Functions", () => {
-	let wranglerProcess: ChildProcess;
+describe("Pages Functions", () => {
+	let aProcess: ChildProcess;
+	let aIP: string;
+	let aPort: number;
+	let aResolveReadyPromise: (value: unknown) => void;
+	const aReadyPromise = new Promise((resolve) => {
+		aResolveReadyPromise = resolve;
+	});
 
-	beforeEach(() => {
-		wranglerProcess = spawn("npm", ["run", "dev"], {
-			shell: isWindows,
-			cwd: path.resolve(__dirname, "../"),
+	let bProcess: ChildProcess;
+	let bIP: string;
+	let bPort: number;
+	let bResolveReadyPromise: (value: unknown) => void;
+	const bReadyPromise = new Promise((resolve) => {
+		bResolveReadyPromise = resolve;
+	});
+
+	let cProcess: ChildProcess;
+	let cIP: string;
+	let cPort: number;
+	let cResolveReadyPromise: (value: unknown) => void;
+	const cReadyPromise = new Promise((resolve) => {
+		cResolveReadyPromise = resolve;
+	});
+
+	let dProcess: ChildProcess;
+	let dIP: string;
+	let dPort: number;
+	let dResolveReadyPromise: (value: unknown) => void;
+	const dReadyPromise = new Promise((resolve) => {
+		dResolveReadyPromise = resolve;
+	});
+
+	beforeAll(() => {
+		aProcess = spawn(
+			"node",
+			[
+				path.join("..", "..", "packages", "wrangler", "bin", "wrangler.js"),
+				"dev",
+				"a/index.ts",
+				"--local",
+				"--port",
+				"0",
+			],
+			{
+				shell: isWindows,
+				stdio: ["inherit", "inherit", "inherit", "ipc"],
+				cwd: path.resolve(__dirname, "../"),
+			}
+		).on("message", (message) => {
+			const parsedMessage = JSON.parse(message.toString());
+			aIP = parsedMessage.ip;
+			aPort = parsedMessage.port;
+			aResolveReadyPromise(null);
 		});
-		wranglerProcess.stdout?.on("data", (chunk) => {
-			console.log(chunk.toString());
+
+		bProcess = spawn(
+			"node",
+			[
+				path.join("..", "..", "packages", "wrangler", "bin", "wrangler.js"),
+				"dev",
+				"b/index.ts",
+				"--local",
+				"--port",
+				"0",
+			],
+			{
+				shell: isWindows,
+				stdio: ["inherit", "inherit", "inherit", "ipc"],
+				cwd: path.resolve(__dirname, "../"),
+			}
+		).on("message", (message) => {
+			const parsedMessage = JSON.parse(message.toString());
+			bIP = parsedMessage.ip;
+			bPort = parsedMessage.port;
+			bResolveReadyPromise(null);
 		});
-		wranglerProcess.stderr?.on("data", (chunk) => {
-			console.log(chunk.toString());
+
+		cProcess = spawn(
+			"node",
+			[
+				path.join("..", "..", "packages", "wrangler", "bin", "wrangler.js"),
+				"dev",
+				"c/index.ts",
+				"--local",
+				"--port",
+				"0",
+			],
+			{
+				shell: isWindows,
+				stdio: ["inherit", "inherit", "inherit", "ipc"],
+				cwd: path.resolve(__dirname, "../"),
+			}
+		).on("message", (message) => {
+			const parsedMessage = JSON.parse(message.toString());
+			cIP = parsedMessage.ip;
+			cPort = parsedMessage.port;
+			cResolveReadyPromise(null);
+		});
+
+		dProcess = spawn(
+			"node",
+			[
+				path.join(
+					"..",
+					"..",
+					"..",
+					"packages",
+					"wrangler",
+					"bin",
+					"wrangler.js"
+				),
+				"pages",
+				"dev",
+				"public",
+				"--do",
+				"PAGES_REFERENCED_DO=MyDurableObject@a",
+				"--port",
+				"0",
+			],
+			{
+				shell: isWindows,
+				stdio: ["inherit", "inherit", "inherit", "ipc"],
+				cwd: path.resolve(__dirname, "../d"),
+			}
+		).on("message", (message) => {
+			const parsedMessage = JSON.parse(message.toString());
+			dIP = parsedMessage.ip;
+			dPort = parsedMessage.port;
+			dResolveReadyPromise(null);
 		});
 	});
 
-	afterEach(async () => {
+	afterAll(async () => {
 		await new Promise((resolve, reject) => {
-			wranglerProcess.once("exit", (code) => {
+			aProcess.once("exit", (code) => {
 				if (!code) {
 					resolve(code);
 				} else {
 					reject(code);
 				}
 			});
-			wranglerProcess.kill("SIGTERM");
+			aProcess.kill("SIGTERM");
+
+			bProcess.once("exit", (code) => {
+				if (!code) {
+					resolve(code);
+				} else {
+					reject(code);
+				}
+			});
+			bProcess.kill("SIGTERM");
+
+			cProcess.once("exit", (code) => {
+				if (!code) {
+					resolve(code);
+				} else {
+					reject(code);
+				}
+			});
+			cProcess.kill("SIGTERM");
+
+			dProcess.once("exit", (code) => {
+				if (!code) {
+					resolve(code);
+				} else {
+					reject(code);
+				}
+			});
+			dProcess.kill("SIGTERM");
 		});
 	});
 
-	it("connects up Durable Objects and keeps state across wrangler instances", async () => {
-		const responseA = await waitUntilReady("http://localhost:8400/");
-		const dataA = (await responseA.json()) as { count: number; id: string };
-		expect(dataA.count).toEqual(1);
-		const responseB = await waitUntilReady("http://localhost:8401/");
-		const dataB = (await responseB.json()) as { count: number; id: string };
-		expect(dataB.count).toEqual(2);
-		const responseC = await waitUntilReady("http://localhost:8402/");
-		const dataC = (await responseC.json()) as { count: number; id: string };
-		expect(dataC.count).toEqual(3);
-		const responseD = await waitUntilReady("http://localhost:8403/");
-		const dataD = (await responseD.json()) as { count: number; id: string };
-		expect(dataD.count).toEqual(4);
-		const responseA2 = await waitUntilReady("http://localhost:8400/");
-		const dataA2 = (await responseA2.json()) as { count: number; id: string };
-		expect(dataA2.count).toEqual(5);
-		expect(dataA.id).toEqual(dataB.id);
-		expect(dataA.id).toEqual(dataC.id);
-		expect(dataA.id).toEqual(dataA2.id);
-	});
+	it.concurrent(
+		"connects up Durable Objects and keeps state across wrangler instances",
+		async () => {
+			await aReadyPromise;
+			await bReadyPromise;
+			await cReadyPromise;
+			await dReadyPromise;
+
+			const responseA = await waitUntilReady(`http://${aIP}:${aPort}/`);
+			const dataA = (await responseA.json()) as { count: number; id: string };
+			expect(dataA.count).toEqual(1);
+			const responseB = await waitUntilReady(`http://${bIP}:${bPort}/`);
+			const dataB = (await responseB.json()) as { count: number; id: string };
+			expect(dataB.count).toEqual(2);
+			const responseC = await waitUntilReady(`http://${cIP}:${cPort}/`);
+			const dataC = (await responseC.json()) as { count: number; id: string };
+			expect(dataC.count).toEqual(3);
+			const responseD = await waitUntilReady(`http://${dIP}:${dPort}/`);
+			const dataD = (await responseD.json()) as { count: number; id: string };
+			expect(dataD.count).toEqual(4);
+			const responseA2 = await waitUntilReady(`http://${aIP}:${aPort}/`);
+			const dataA2 = (await responseA2.json()) as { count: number; id: string };
+			expect(dataA2.count).toEqual(5);
+
+			expect(dataA.id).toEqual(dataB.id);
+			expect(dataA.id).toEqual(dataC.id);
+			expect(dataA.id).toEqual(dataA2.id);
+		}
+	);
 });

--- a/fixtures/external-durable-objects-app/tests/index.test.ts
+++ b/fixtures/external-durable-objects-app/tests/index.test.ts
@@ -2,21 +2,6 @@ import { spawn } from "child_process";
 import * as path from "path";
 import { fetch } from "undici";
 import type { ChildProcess } from "child_process";
-import type { Response } from "undici";
-
-const waitUntilReady = async (url: string): Promise<Response> => {
-	let response: Response | undefined = undefined;
-
-	while (response === undefined) {
-		await new Promise((resolvePromise) => setTimeout(resolvePromise, 500));
-
-		try {
-			response = await fetch(url);
-		} catch {}
-	}
-
-	return response as Response;
-};
 
 const isWindows = process.platform === "win32";
 
@@ -201,19 +186,19 @@ describe("Pages Functions", () => {
 			await cReadyPromise;
 			await dReadyPromise;
 
-			const responseA = await waitUntilReady(`http://${aIP}:${aPort}/`);
+			const responseA = await fetch(`http://${aIP}:${aPort}/`);
 			const dataA = (await responseA.json()) as { count: number; id: string };
 			expect(dataA.count).toEqual(1);
-			const responseB = await waitUntilReady(`http://${bIP}:${bPort}/`);
+			const responseB = await fetch(`http://${bIP}:${bPort}/`);
 			const dataB = (await responseB.json()) as { count: number; id: string };
 			expect(dataB.count).toEqual(2);
-			const responseC = await waitUntilReady(`http://${cIP}:${cPort}/`);
+			const responseC = await fetch(`http://${cIP}:${cPort}/`);
 			const dataC = (await responseC.json()) as { count: number; id: string };
 			expect(dataC.count).toEqual(3);
-			const responseD = await waitUntilReady(`http://${dIP}:${dPort}/`);
+			const responseD = await fetch(`http://${dIP}:${dPort}/`);
 			const dataD = (await responseD.json()) as { count: number; id: string };
 			expect(dataD.count).toEqual(4);
-			const responseA2 = await waitUntilReady(`http://${aIP}:${aPort}/`);
+			const responseA2 = await fetch(`http://${aIP}:${aPort}/`);
 			const dataA2 = (await responseA2.json()) as { count: number; id: string };
 			expect(dataA2.count).toEqual(5);
 

--- a/fixtures/external-durable-objects-app/tests/index.test.ts
+++ b/fixtures/external-durable-objects-app/tests/index.test.ts
@@ -27,7 +27,6 @@ describe.skip("Pages Functions", () => {
 		wranglerProcess = spawn("npm", ["run", "dev"], {
 			shell: isWindows,
 			cwd: path.resolve(__dirname, "../"),
-			env: { BROWSER: "none", ...process.env },
 		});
 		wranglerProcess.stdout?.on("data", (chunk) => {
 			console.log(chunk.toString());

--- a/fixtures/local-mode-tests/jest.setup.ts
+++ b/fixtures/local-mode-tests/jest.setup.ts
@@ -1,0 +1,11 @@
+const originalNodeEnv = process.env.NODE_ENV;
+
+beforeAll(() => {
+	process.env.NODE_ENV = "local-testing";
+});
+
+afterAll(() => {
+	process.env.NODE_ENV = originalNodeEnv;
+});
+
+export {};

--- a/fixtures/local-mode-tests/package.json
+++ b/fixtures/local-mode-tests/package.json
@@ -9,11 +9,14 @@
 	"main": "index.js",
 	"scripts": {
 		"check:type": "tsc",
-		"test": "cross-env NODE_ENV=local-testing npx jest --forceExit",
-		"test:ci": "cross-env NODE_ENV=local-testing npx jest --forceExit"
+		"test": "npx jest --forceExit",
+		"test:ci": "npx jest --forceExit"
 	},
 	"jest": {
 		"restoreMocks": true,
+		"setupFilesAfterEnv": [
+			"./jest.setup.ts"
+		],
 		"testRegex": ".*.(test|spec)\\.[jt]sx?$",
 		"testTimeout": 30000,
 		"transform": {

--- a/fixtures/local-mode-tests/tests/headers.test.ts
+++ b/fixtures/local-mode-tests/tests/headers.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { unstable_dev } from "wrangler";
 
 describe("worker", () => {
@@ -8,20 +9,26 @@ describe("worker", () => {
 		) => Promise<Response | undefined>;
 		stop: () => Promise<void>;
 	};
+	let resolveReadyPromise: (value: unknown) => void;
+	const readyPromise = new Promise((resolve) => {
+		resolveReadyPromise = resolve;
+	});
 
 	beforeAll(async () => {
 		worker = await unstable_dev(
-			"src/headers.ts",
+			join(__dirname, "../src/headers.ts"),
 			{},
 			{ disableExperimentalWarning: true }
 		);
+		resolveReadyPromise(null);
 	});
 
 	afterAll(async () => {
 		await worker.stop();
 	});
 
-	it("should return Hi by default", async () => {
+	it.concurrent("should return Hi by default", async () => {
+		await readyPromise;
 		const resp = await worker.fetch("/");
 		expect(resp).not.toBe(undefined);
 		if (resp) {
@@ -29,7 +36,8 @@ describe("worker", () => {
 			expect(respJson).toBe(JSON.stringify({ greeting: "Hi!" }));
 		}
 	});
-	it("should return Bonjour when French", async () => {
+	it.concurrent("should return Bonjour when French", async () => {
+		await readyPromise;
 		const resp = await worker.fetch("/", { headers: { lang: "fr-FR" } });
 		expect(resp).not.toBe(undefined);
 		if (resp) {
@@ -38,7 +46,8 @@ describe("worker", () => {
 		}
 	});
 
-	it("should return G'day when Australian", async () => {
+	it.concurrent("should return G'day when Australian", async () => {
+		await readyPromise;
 		const resp = await worker.fetch("/", { headers: { lang: "en-AU" } });
 		expect(resp).not.toBe(undefined);
 		if (resp) {
@@ -47,7 +56,8 @@ describe("worker", () => {
 		}
 	});
 
-	it("should return Good day when British", async () => {
+	it.concurrent("should return Good day when British", async () => {
+		await readyPromise;
 		const resp = await worker.fetch("/", { headers: { lang: "en-GB" } });
 		expect(resp).not.toBe(undefined);
 		if (resp) {
@@ -56,7 +66,8 @@ describe("worker", () => {
 		}
 	});
 
-	it("should return Howdy when Texan", async () => {
+	it.concurrent("should return Howdy when Texan", async () => {
+		await readyPromise;
 		const resp = await worker.fetch("/", { headers: { lang: "en-TX" } });
 		expect(resp).not.toBe(undefined);
 		if (resp) {
@@ -65,7 +76,8 @@ describe("worker", () => {
 		}
 	});
 
-	it("should return Hello when American", async () => {
+	it.concurrent("should return Hello when American", async () => {
+		await readyPromise;
 		const resp = await worker.fetch("/", { headers: { lang: "en-US" } });
 		expect(resp).not.toBe(undefined);
 		if (resp) {
@@ -74,7 +86,8 @@ describe("worker", () => {
 		}
 	});
 
-	it("should return Hola when Spanish", async () => {
+	it.concurrent("should return Hola when Spanish", async () => {
+		await readyPromise;
 		const resp = await worker.fetch("/", { headers: { lang: "es-ES" } });
 		expect(resp).not.toBe(undefined);
 		if (resp) {

--- a/fixtures/local-mode-tests/tests/module.test.ts
+++ b/fixtures/local-mode-tests/tests/module.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { unstable_dev } from "wrangler";
 
 describe("worker", () => {
@@ -5,23 +6,29 @@ describe("worker", () => {
 		fetch: (input?: RequestInfo, init?: RequestInit) => Promise<Response>;
 		stop: () => Promise<void>;
 	};
+	let resolveReadyPromise: (value: unknown) => void;
+	const readyPromise = new Promise((resolve) => {
+		resolveReadyPromise = resolve;
+	});
 
 	beforeAll(async () => {
 		//since the script is invoked from the directory above, need to specify index.js is in src/
 		worker = await unstable_dev(
-			"src/module.ts",
+			join(__dirname, "../src/module.ts"),
 			{
-				config: "src/wrangler.module.toml",
+				config: join(__dirname, "../src/wrangler.module.toml"),
 			},
 			{ disableExperimentalWarning: true }
 		);
+		resolveReadyPromise(null);
 	});
 
 	afterAll(async () => {
 		await worker.stop();
 	});
 
-	it("renders", async () => {
+	it.concurrent("renders", async () => {
+		await readyPromise;
 		const resp = await worker.fetch();
 		expect(resp).not.toBe(undefined);
 

--- a/fixtures/local-mode-tests/tests/ports.test.ts
+++ b/fixtures/local-mode-tests/tests/ports.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { unstable_dev } from "wrangler";
 
 describe("worker", () => {
@@ -6,59 +7,65 @@ describe("worker", () => {
 		stop: () => Promise<void>;
 	};
 	let workers: Worker[];
+	let resolveReadyPromise: (value: unknown) => void;
+	const readyPromise = new Promise((resolve) => {
+		resolveReadyPromise = resolve;
+	});
 
 	beforeAll(async () => {
 		//since the script is invoked from the directory above, need to specify index.js is in src/
 
 		workers = await Promise.all([
 			unstable_dev(
-				"src/basicModule.ts",
+				join(__dirname, "../src/basicModule.ts"),
 				{},
 				{ disableExperimentalWarning: true }
 			) as Worker,
 			unstable_dev(
-				"src/basicModule.ts",
+				join(__dirname, "../src/basicModule.ts"),
 				{},
 				{ disableExperimentalWarning: true }
 			) as Worker,
 			unstable_dev(
-				"src/basicModule.ts",
+				join(__dirname, "../src/basicModule.ts"),
 				{},
 				{ disableExperimentalWarning: true }
 			) as Worker,
 			unstable_dev(
-				"src/basicModule.ts",
+				join(__dirname, "../src/basicModule.ts"),
 				{},
 				{ disableExperimentalWarning: true }
 			) as Worker,
 			unstable_dev(
-				"src/basicModule.ts",
+				join(__dirname, "../src/basicModule.ts"),
 				{},
 				{ disableExperimentalWarning: true }
 			) as Worker,
 			unstable_dev(
-				"src/basicModule.ts",
+				join(__dirname, "../src/basicModule.ts"),
 				{},
 				{ disableExperimentalWarning: true }
 			) as Worker,
 			unstable_dev(
-				"src/basicModule.ts",
+				join(__dirname, "../src/basicModule.ts"),
 				{},
 				{ disableExperimentalWarning: true }
 			) as Worker,
 			unstable_dev(
-				"src/basicModule.ts",
+				join(__dirname, "../src/basicModule.ts"),
 				{},
 				{ disableExperimentalWarning: true }
 			) as Worker,
 		]);
+		resolveReadyPromise(null);
 	});
 
 	afterAll(async () => {
 		await Promise.all(workers.map(async (worker) => await worker.stop()));
 	});
 
-	it("should invoke the worker and exit", async () => {
+	it.concurrent("should invoke the worker and exit", async () => {
+		await readyPromise;
 		const responses = await Promise.all(
 			workers.map(async (worker) => await worker.fetch())
 		);

--- a/fixtures/pages-functions-with-routes-app/tests/index.test.ts
+++ b/fixtures/pages-functions-with-routes-app/tests/index.test.ts
@@ -2,45 +2,43 @@ import { spawn } from "child_process";
 import * as path from "path";
 import { fetch } from "undici";
 import type { ChildProcess } from "child_process";
-import type { Response, RequestInit } from "undici";
-
-const waitUntilReady = async (
-	url: string,
-	requestInit?: RequestInit
-): Promise<Response> => {
-	let response: Response | undefined = undefined;
-
-	while (response === undefined) {
-		await new Promise((resolvePromise) => setTimeout(resolvePromise, 500));
-
-		try {
-			response = await fetch(url, requestInit);
-		} catch {}
-	}
-
-	return response as Response;
-};
 
 const isWindows = process.platform === "win32";
 
 describe("Pages Functions with custom _routes.json", () => {
 	let wranglerProcess: ChildProcess;
+	let ip: string;
+	let port: number;
+	let resolveReadyPromise: (value: unknown) => void;
+	const readyPromise = new Promise((resolve) => {
+		resolveReadyPromise = resolve;
+	});
 
-	beforeEach(() => {
-		wranglerProcess = spawn("npm", ["run", "dev"], {
-			shell: isWindows,
-			cwd: path.resolve(__dirname, "../"),
-			env: { BROWSER: "none", ...process.env },
-		});
-		wranglerProcess.stdout?.on("data", (chunk) => {
-			console.log(chunk.toString());
-		});
-		wranglerProcess.stderr?.on("data", (chunk) => {
-			console.log(chunk.toString());
+	beforeAll(() => {
+		wranglerProcess = spawn(
+			"node",
+			[
+				path.join("..", "..", "packages", "wrangler", "bin", "wrangler.js"),
+				"pages",
+				"dev",
+				"public",
+				"--port",
+				"0",
+			],
+			{
+				shell: isWindows,
+				stdio: ["inherit", "inherit", "inherit", "ipc"],
+				cwd: path.resolve(__dirname, "../"),
+			}
+		).on("message", (message) => {
+			const parsedMessage = JSON.parse(message.toString());
+			ip = parsedMessage.ip;
+			port = parsedMessage.port;
+			resolveReadyPromise(null);
 		});
 	});
 
-	afterEach(async () => {
+	afterAll(async () => {
 		await new Promise((resolve, reject) => {
 			wranglerProcess.once("exit", (code) => {
 				if (!code) {
@@ -53,27 +51,32 @@ describe("Pages Functions with custom _routes.json", () => {
 		});
 	});
 
-	it("should render static pages", async () => {
-		const response = await waitUntilReady("http://localhost:8776/");
+	it.concurrent("should render static pages", async () => {
+		await readyPromise;
+		const response = await fetch(`http://${ip}:${port}/`);
 		const text = await response.text();
 		expect(text).toContain(
 			"Bienvenue sur notre projet &#10024; pages-functions-with-routes-app!"
 		);
 	});
 
-	it("should correctly apply the routing rules provided in the custom _routes.json file", async () => {
-		let response = await waitUntilReady("http://localhost:8776/greeting/hello");
-		let text = await response.text();
-		expect(text).toEqual("Bonjour le monde!");
+	it.concurrent(
+		"should correctly apply the routing rules provided in the custom _routes.json file",
+		async () => {
+			await readyPromise;
+			let response = await fetch(`http://${ip}:${port}/greeting/hello`);
+			let text = await response.text();
+			expect(text).toEqual("Bonjour le monde!");
 
-		response = await waitUntilReady("http://localhost:8776/greeting/goodbye");
-		text = await response.text();
-		expect(text).toEqual("A plus tard alligator 👋");
+			response = await fetch(`http://${ip}:${port}/greeting/goodbye`);
+			text = await response.text();
+			expect(text).toEqual("A plus tard alligator 👋");
 
-		response = await waitUntilReady("http://localhost:8776/date");
-		text = await response.text();
-		expect(text).toContain(
-			"Bienvenue sur notre projet &#10024; pages-functions-with-routes-app!"
-		);
-	});
+			response = await fetch(`http://${ip}:${port}/date`);
+			text = await response.text();
+			expect(text).toContain(
+				"Bienvenue sur notre projet &#10024; pages-functions-with-routes-app!"
+			);
+		}
+	);
 });

--- a/fixtures/pages-workerjs-app/tests/index.test.ts
+++ b/fixtures/pages-workerjs-app/tests/index.test.ts
@@ -2,45 +2,44 @@ import { spawn } from "child_process";
 import * as path from "path";
 import patchConsole from "patch-console";
 import { fetch } from "undici";
-// import { mockConsoleMethods } from "../../../packages/wrangler/src/__tests__/helpers/mock-console";
 import type { ChildProcess } from "child_process";
-import type { Response } from "undici";
-
-const waitUntilReady = async (url: string): Promise<Response> => {
-	let response: Response | undefined = undefined;
-
-	while (response === undefined) {
-		await new Promise((resolvePromise) => setTimeout(resolvePromise, 500));
-
-		try {
-			response = await fetch(url);
-		} catch (err) {}
-	}
-
-	return response as Response;
-};
 
 const isWindows = process.platform === "win32";
 
 describe("Pages _worker.js", () => {
 	let wranglerProcess: ChildProcess;
+	let ip: string;
+	let port: number;
+	let resolveReadyPromise: (value: unknown) => void;
+	const readyPromise = new Promise((resolve) => {
+		resolveReadyPromise = resolve;
+	});
 
-	// const std = mockConsoleMethods();
-	beforeEach(() => {
-		wranglerProcess = spawn("npm", ["run", "dev"], {
-			shell: isWindows,
-			cwd: path.resolve(__dirname, "../"),
-			env: { BROWSER: "none", ...process.env },
-		});
-		wranglerProcess.stdout?.on("data", (chunk) => {
-			console.log(chunk.toString());
-		});
-		wranglerProcess.stderr?.on("data", (chunk) => {
-			console.log(chunk.toString());
+	beforeAll(() => {
+		wranglerProcess = spawn(
+			"node",
+			[
+				path.join("..", "..", "packages", "wrangler", "bin", "wrangler.js"),
+				"pages",
+				"dev",
+				"./workerjs-test",
+				"--port",
+				"0",
+			],
+			{
+				shell: isWindows,
+				stdio: ["inherit", "inherit", "pipe", "ipc"],
+				cwd: path.resolve(__dirname, "../"),
+			}
+		).on("message", (message) => {
+			const parsedMessage = JSON.parse(message.toString());
+			ip = parsedMessage.ip;
+			port = parsedMessage.port;
+			resolveReadyPromise(null);
 		});
 	});
 
-	afterEach(async () => {
+	afterAll(async () => {
 		patchConsole(() => {});
 
 		await new Promise((resolve, reject) => {
@@ -55,15 +54,26 @@ describe("Pages _worker.js", () => {
 		});
 	});
 
-	it("renders static pages", async () => {
-		const response = await waitUntilReady("http://127.0.0.1:8792/");
+	it.concurrent("renders static pages", async () => {
+		await readyPromise;
+		const response = await fetch(`http://${ip}:${port}/`);
 		const text = await response.text();
 		expect(text).toContain("test");
 	});
 
-	it.todo("shows an error for the import in _worker.js");
-	// it("shows an error for the import in _worker.js", async () => {
-	// 	const _ = await waitUntilReady("http://127.0.0.1:8792/");
-	// 	expect(std.err).toMatchInlineSnapshot(`""`);
-	// });
+	it.concurrent("shows an error for the import in _worker.js", async () => {
+		await readyPromise;
+		let stderr = "";
+		wranglerProcess.stderr.on("data", (chunk) => {
+			console.error(stderr.toString());
+			stderr += chunk.toString();
+		});
+		const response = await fetch(`http://${ip}:${port}/`);
+		const text = await response.text();
+		expect(text).toContain("test");
+
+		expect(stderr).toContain(
+			"_worker.js is importing from another file. This will throw an error if deployed."
+		);
+	});
 });

--- a/fixtures/pages-workerjs-with-routes-app/tests/index.test.ts
+++ b/fixtures/pages-workerjs-with-routes-app/tests/index.test.ts
@@ -1,48 +1,44 @@
 import { spawn } from "child_process";
 import * as path from "path";
-import patchConsole from "patch-console";
 import { fetch } from "undici";
-// import { mockConsoleMethods } from "../../../packages/wrangler/src/__tests__/helpers/mock-console";
 import type { ChildProcess } from "child_process";
-import type { Response } from "undici";
-
-const waitUntilReady = async (url: string): Promise<Response> => {
-	let response: Response | undefined = undefined;
-
-	while (response === undefined) {
-		await new Promise((resolvePromise) => setTimeout(resolvePromise, 500));
-
-		try {
-			response = await fetch(url);
-		} catch (err) {}
-	}
-
-	return response as Response;
-};
 
 const isWindows = process.platform === "win32";
 
 describe("Pages Advanced Mode with custom _routes.json", () => {
 	let wranglerProcess: ChildProcess;
+	let ip: string;
+	let port: number;
+	let resolveReadyPromise: (value: unknown) => void;
+	const readyPromise = new Promise((resolve) => {
+		resolveReadyPromise = resolve;
+	});
 
-	// const std = mockConsoleMethods();
-	beforeEach(() => {
-		wranglerProcess = spawn("npm", ["run", "dev"], {
-			shell: isWindows,
-			cwd: path.resolve(__dirname, "../"),
-			env: { BROWSER: "none", ...process.env },
-		});
-		wranglerProcess.stdout?.on("data", (chunk) => {
-			console.log(chunk.toString());
-		});
-		wranglerProcess.stderr?.on("data", (chunk) => {
-			console.log(chunk.toString());
+	beforeAll(() => {
+		wranglerProcess = spawn(
+			"node",
+			[
+				path.join("..", "..", "packages", "wrangler", "bin", "wrangler.js"),
+				"pages",
+				"dev",
+				"public",
+				"--port",
+				"0",
+			],
+			{
+				shell: isWindows,
+				stdio: ["inherit", "inherit", "inherit", "ipc"],
+				cwd: path.resolve(__dirname, "../"),
+			}
+		).on("message", (message) => {
+			const parsedMessage = JSON.parse(message.toString());
+			ip = parsedMessage.ip;
+			port = parsedMessage.port;
+			resolveReadyPromise(null);
 		});
 	});
 
-	afterEach(async () => {
-		patchConsole(() => {});
-
+	afterAll(async () => {
 		await new Promise((resolve, reject) => {
 			wranglerProcess.once("exit", (code) => {
 				if (!code) {
@@ -55,28 +51,30 @@ describe("Pages Advanced Mode with custom _routes.json", () => {
 		});
 	});
 
-	it("renders static pages", async () => {
-		const response = await waitUntilReady("http://127.0.0.1:8751/");
+	it.concurrent("renders static pages", async () => {
+		await readyPromise;
+		const response = await fetch(`http://${ip}:${port}/`);
 		const text = await response.text();
 		expect(text).toContain(
 			"Bienvenue sur notre projet &#10024; pages-workerjs-with-routes-app!"
 		);
 	});
 
-	it("runs our _worker.js", async () => {
-		let response = await waitUntilReady("http://127.0.0.1:8751/greeting/hello");
+	it.concurrent("runs our _worker.js", async () => {
+		await readyPromise;
+		let response = await fetch(`http://${ip}:${port}/greeting/hello`);
 		let text = await response.text();
 		expect(text).toEqual("Bonjour le monde!");
 
-		response = await waitUntilReady("http://127.0.0.1:8751/greeting/goodbye");
+		response = await fetch(`http://${ip}:${port}/greeting/goodbye`);
 		text = await response.text();
 		expect(text).toEqual("A plus tard alligator 👋");
 
-		response = await waitUntilReady("http://127.0.0.1:8751/date");
+		response = await fetch(`http://${ip}:${port}/date`);
 		text = await response.text();
 		expect(text).toMatch(/\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d/);
 
-		response = await waitUntilReady("http://127.0.0.1:8751/party");
+		response = await fetch(`http://${ip}:${port}/party`);
 		text = await response.text();
 		expect(text).toContain(
 			"Bienvenue sur notre projet &#10024; pages-workerjs-with-routes-app!"

--- a/fixtures/remix-pages-app/tests/index.test.ts
+++ b/fixtures/remix-pages-app/tests/index.test.ts
@@ -2,42 +2,43 @@ import { spawn, spawnSync } from "child_process";
 import * as path from "path";
 import { fetch } from "undici";
 import type { ChildProcess } from "child_process";
-import type { Response } from "undici";
-
-const waitUntilReady = async (url: string): Promise<Response> => {
-	let response: Response | undefined = undefined;
-
-	while (response === undefined) {
-		await new Promise((resolvePromise) => setTimeout(resolvePromise, 500));
-
-		try {
-			response = await fetch(url);
-		} catch {}
-	}
-
-	return response as Response;
-};
 
 const isWindows = process.platform === "win32";
 
 describe("Remix", () => {
 	let wranglerProcess: ChildProcess;
+	let ip: string;
+	let port: number;
+	let resolveReadyPromise: (value: unknown) => void;
+	const readyPromise = new Promise((resolve) => {
+		resolveReadyPromise = resolve;
+	});
 
 	beforeAll(async () => {
 		spawnSync("npm", ["run", "build"], {
 			shell: isWindows,
 			cwd: path.resolve(__dirname, "../"),
 		});
-		wranglerProcess = spawn("npm", ["run", "dev:wrangler"], {
-			shell: isWindows,
-			cwd: path.resolve(__dirname, "../"),
-			env: { BROWSER: "none", ...process.env },
-		});
-		wranglerProcess.stdout?.on("data", (chunk) => {
-			console.log(chunk.toString());
-		});
-		wranglerProcess.stderr?.on("data", (chunk) => {
-			console.log(chunk.toString());
+		wranglerProcess = spawn(
+			"node",
+			[
+				path.join("..", "..", "packages", "wrangler", "bin", "wrangler.js"),
+				"pages",
+				"dev",
+				"./public",
+				"--port",
+				"0",
+			],
+			{
+				shell: isWindows,
+				stdio: ["inherit", "inherit", "inherit", "ipc"],
+				cwd: path.resolve(__dirname, "../"),
+			}
+		).on("message", (message) => {
+			const parsedMessage = JSON.parse(message.toString());
+			ip = parsedMessage.ip;
+			port = parsedMessage.port;
+			resolveReadyPromise(null);
 		});
 	});
 
@@ -54,8 +55,9 @@ describe("Remix", () => {
 		});
 	});
 
-	it("renders", async () => {
-		const response = await waitUntilReady("http://localhost:8788/");
+	it.concurrent("renders", async () => {
+		await readyPromise;
+		const response = await fetch(`http://${ip}:${port}/`);
 		const text = await response.text();
 		expect(text).toContain("Welcome to Remix");
 	});

--- a/fixtures/service-bindings-app/tests/index.test.ts
+++ b/fixtures/service-bindings-app/tests/index.test.ts
@@ -27,7 +27,6 @@ describe.skip("Pages Functions", () => {
 		wranglerProcess = spawn("npm", ["run", "dev"], {
 			shell: isWindows,
 			cwd: path.resolve(__dirname, "../"),
-			env: { BROWSER: "none", ...process.env },
 		});
 		wranglerProcess.stdout?.on("data", (chunk) => {
 			console.log(chunk.toString());

--- a/package-lock.json
+++ b/package-lock.json
@@ -21486,7 +21486,7 @@
 		},
 		"packages/pages-shared": {
 			"name": "@cloudflare/pages-shared",
-			"version": "0.0.4",
+			"version": "0.0.5",
 			"dependencies": {
 				"@miniflare/core": "2.8.1"
 			},

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
 		"check:type": "npm run check:type --workspaces --if-present",
 		"fix": "npm run prettify && npm run check:lint -- --fix",
 		"prettify": "prettier . --write --ignore-unknown",
-		"test": "npm run clean --workspace=wrangler && npm run bundle --workspace=wrangler && npm run test --workspaces --if-present",
-		"test:ci": "npm run test:ci --workspaces --if-present"
+		"test": "npm run clean --workspace=wrangler && npm run bundle --workspace=wrangler && npm run test --workspace=packages/wrangler --workspace=packages/pages-shared --if-present && npx jest --forceExit",
+		"test:ci": "npm run test:ci --workspace=packages/wrangler --workspace=packages/pages-shared --if-present && npx jest --forceExit"
 	},
 	"eslintConfig": {
 		"parser": "@typescript-eslint/parser",
@@ -132,6 +132,11 @@
 			"packages/wrangler-devtools/built-devtools"
 		],
 		"root": true
+	},
+	"jest": {
+		"projects": [
+			"<rootDir>/fixtures/**/package.json"
+		]
 	},
 	"dependencies": {
 		"@changesets/changelog-github": "^0.4.5",

--- a/packages/pages-shared/package.json
+++ b/packages/pages-shared/package.json
@@ -8,7 +8,9 @@
 	],
 	"scripts": {
 		"build": "node scripts/build.js",
-		"check:type": "tsc"
+		"check:type": "tsc",
+		"test": "npx jest",
+		"test:ci": "npx jest"
 	},
 	"jest": {
 		"coverageReporters": [

--- a/packages/wrangler/bin/wrangler.js
+++ b/packages/wrangler/bin/wrangler.js
@@ -62,15 +62,21 @@ Consider using a Node.js version manager such as https://volta.sh/ or https://gi
 			...process.argv.slice(2),
 		],
 		{
-			stdio: "inherit",
+			stdio: ["inherit", "inherit", "inherit", "ipc"],
 			env: {
 				...process.env,
 				NODE_EXTRA_CA_CERTS: pathToCACerts,
 			},
 		}
-	).on("exit", (code) =>
-		process.exit(code === undefined || code === null ? 0 : code)
-	);
+	)
+		.on("exit", (code) =>
+			process.exit(code === undefined || code === null ? 0 : code)
+		)
+		.on("message", (message) => {
+			if (process.send) {
+				process.send(message);
+			}
+		});
 }
 
 /**
@@ -95,11 +101,17 @@ function runDelegatedWrangler() {
 		process.execPath,
 		[resolvedBinaryPath, ...process.argv.slice(2)],
 		{
-			stdio: "inherit",
+			stdio: ["inherit", "inherit", "inherit", "ipc"],
 		}
-	).on("exit", (code) =>
-		process.exit(code === undefined || code === null ? 0 : code)
-	);
+	)
+		.on("exit", (code) =>
+			process.exit(code === undefined || code === null ? 0 : code)
+		)
+		.on("message", (message) => {
+			if (process.send) {
+				process.send(message);
+			}
+		});
 }
 
 /**

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -416,7 +416,7 @@ export async function startDev(args: StartDevOptions) {
 					accountId={configParam.account_id || getAccountFromCache()?.id}
 					assetPaths={assetPaths}
 					assetsConfig={configParam.assets}
-					port={args.port || configParam.dev.port || (await getLocalPort())}
+					port={args.port ?? configParam.dev.port ?? (await getLocalPort())}
 					ip={args.ip || configParam.dev.ip}
 					inspectorPort={
 						args.inspectorPort ||
@@ -528,10 +528,7 @@ export async function startApiDev(args: StartDevOptions) {
 			assetPaths: assetPaths,
 			assetsConfig: configParam.assets,
 			//port can be 0, which means to use a random port
-			port:
-				args.port === 0
-					? args.port
-					: args.port || configParam.dev.port || (await getLocalPort()),
+			port: args.port ?? configParam.dev.port ?? (await getLocalPort()),
 			ip: args.ip || configParam.dev.ip,
 			inspectorPort:
 				args["inspector-port"] ||

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -252,6 +252,16 @@ function DevSession(props: DevSessionProps) {
 		testScheduled: props.testScheduled ?? false,
 	});
 
+	const announceAndOnReady: typeof props.onReady = (ip, port) => {
+		if (process.send) {
+			process.send(JSON.stringify({ event: "DEV_SERVER_READY", ip, port }));
+		}
+
+		if (props.onReady) {
+			props.onReady(ip, port);
+		}
+	};
+
 	return props.local ? (
 		<Local
 			name={props.name}
@@ -275,7 +285,7 @@ function DevSession(props: DevSessionProps) {
 			logLevel={props.logLevel}
 			logPrefix={props.logPrefix}
 			inspect={props.inspect}
-			onReady={props.onReady}
+			onReady={announceAndOnReady}
 			enablePagesAssetsServiceBinding={props.enablePagesAssetsServiceBinding}
 		/>
 	) : (
@@ -302,7 +312,7 @@ function DevSession(props: DevSessionProps) {
 			zone={props.zone}
 			host={props.host}
 			routes={props.routes}
-			onReady={props.onReady}
+			onReady={announceAndOnReady}
 			sourceMapPath={bundle?.sourceMapPath}
 			sendMetrics={props.sendMetrics}
 		/>

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -205,7 +205,7 @@ function useLocalWorker({
 						await registerWorker(workerName, {
 							protocol: localProtocol,
 							mode: "local",
-							port,
+							port: message.port,
 							host: ip,
 							durableObjects: internalDurableObjects.map((binding) => ({
 								name: binding.name,
@@ -219,7 +219,7 @@ function useLocalWorker({
 								: {}),
 						});
 					}
-					onReady?.(ip, message.mfPort);
+					onReady?.(ip, message.port);
 				}
 			});
 

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -355,7 +355,7 @@ export async function startLocalServer({
 					await registerWorker(workerName, {
 						protocol: localProtocol,
 						mode: "local",
-						port: message.mfPort,
+						port: message.port,
 						host: ip,
 						durableObjects: internalDurableObjects.map((binding) => ({
 							name: binding.name,
@@ -369,7 +369,7 @@ export async function startLocalServer({
 							: {}),
 					});
 				}
-				onReady?.(ip, message.mfPort);
+				onReady?.(ip, message.port);
 			}
 		});
 

--- a/packages/wrangler/src/miniflare-cli/index.ts
+++ b/packages/wrangler/src/miniflare-cli/index.ts
@@ -196,7 +196,7 @@ async function main() {
 		process.send &&
 			process.send(
 				JSON.stringify({
-					mfPort: mfPort,
+					port: mfPort,
 					ready: true,
 					durableObjectsPort: durableObjectsMfPort,
 				})


### PR DESCRIPTION
This makes all the fixture tests less flaky, since they no longer compete for fixed ports. They all now start up on port 0 and await a message from wrangler telling them which port they were assigned. This means that the fixtures can be run concurrently.

- [x] Announce with IPC running server
- [x] Re-write tests to be concurrent and consume IPC message
- [x] `local-mode-tests`
- [x] Actually run the fixtures concurrently
- [x] `external-durable-objects-app`
- [ ] `service-bindings-app`
- [ ] https://github.com/cloudflare/miniflare/pull/382
