### PR TITLE
bugfix: Closes #1872

### DIFF
--- a/.changeset/selfish-dogs-accept.md
+++ b/.changeset/selfish-dogs-accept.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Correctly place the `.wrangler/state` local state directory in the same directory as `wrangler.toml` by default

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -714,7 +714,10 @@ async function validateDevServerSettings(
 		: args.persist
 		? // If just flagged on, treat it as relative to wrangler.toml,
 		  // if one can be found, otherwise cwd()
-		  path.resolve(config.configPath || process.cwd(), ".wrangler/state")
+		  path.resolve(
+				config.configPath ? path.dirname(config.configPath) : process.cwd(),
+				".wrangler/state"
+		  )
 		: null;
 
 	const cliDefines =


### PR DESCRIPTION
Get the `path.dirname()` of `wrangler.toml` before using it as a base for `.wrangler/state`

Closes #1872