### PR TITLE
Initial `--experimental-local` implementation using Miniflare 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,33 @@
 				"node": ">=16.13.0"
 			}
 		},
+		"../miniflare3/packages/tre": {
+			"name": "@miniflare/tre",
+			"version": "3.0.0-next.1",
+			"license": "MIT",
+			"dependencies": {
+				"@miniflare/shared": "3.0.0-next.1",
+				"acorn": "^8.8.0",
+				"acorn-walk": "^8.2.0",
+				"capnp-ts": "^0.7.0",
+				"exit-hook": "^2.2.1",
+				"get-port": "^5.1.1",
+				"glob-to-regexp": "^0.4.1",
+				"kleur": "^4.1.5",
+				"stoppable": "^1.1.0",
+				"undici": "5.8.2",
+				"zod": "^3.18.0"
+			},
+			"devDependencies": {
+				"@types/debug": "^4.1.7",
+				"@types/estree": "^1.0.0",
+				"@types/glob-to-regexp": "^0.4.1",
+				"@types/stoppable": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=16.13"
+			}
+		},
 		"fixtures/external-durable-objects-app": {
 			"devDependencies": {
 				"@cloudflare/workers-types": "^3.14.1"
@@ -2666,6 +2693,10 @@
 			"engines": {
 				"node": ">=16.13"
 			}
+		},
+		"node_modules/@miniflare/tre": {
+			"resolved": "../miniflare3/packages/tre",
+			"link": true
 		},
 		"node_modules/@miniflare/watcher": {
 			"version": "2.8.1",
@@ -21554,6 +21585,7 @@
 				"@cloudflare/kv-asset-handler": "^0.2.0",
 				"@esbuild-plugins/node-globals-polyfill": "^0.1.1",
 				"@esbuild-plugins/node-modules-polyfill": "^0.1.4",
+				"@miniflare/tre": "file:../../../miniflare3/packages/tre",
 				"blake3-wasm": "^2.1.5",
 				"chokidar": "^3.5.3",
 				"esbuild": "0.14.51",
@@ -24574,6 +24606,26 @@
 			"version": "2.8.1",
 			"requires": {
 				"@miniflare/shared": "2.8.1"
+			}
+		},
+		"@miniflare/tre": {
+			"version": "file:../miniflare3/packages/tre",
+			"requires": {
+				"@miniflare/shared": "3.0.0-next.1",
+				"@types/debug": "^4.1.7",
+				"@types/estree": "^1.0.0",
+				"@types/glob-to-regexp": "^0.4.1",
+				"@types/stoppable": "^1.1.1",
+				"acorn": "^8.8.0",
+				"acorn-walk": "^8.2.0",
+				"capnp-ts": "^0.7.0",
+				"exit-hook": "^2.2.1",
+				"get-port": "^5.1.1",
+				"glob-to-regexp": "^0.4.1",
+				"kleur": "^4.1.5",
+				"stoppable": "^1.1.0",
+				"undici": "5.8.2",
+				"zod": "^3.18.0"
 			}
 		},
 		"@miniflare/watcher": {
@@ -36746,6 +36798,7 @@
 				"@esbuild-plugins/node-modules-polyfill": "^0.1.4",
 				"@iarna/toml": "^3.0.0",
 				"@microsoft/api-extractor": "^7.28.3",
+				"@miniflare/tre": "file:../../../miniflare3/packages/tre",
 				"@types/busboy": "^1.5.0",
 				"@types/command-exists": "^1.2.0",
 				"@types/express": "^4.17.13",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -94,6 +94,7 @@
 		"@cloudflare/kv-asset-handler": "^0.2.0",
 		"@esbuild-plugins/node-globals-polyfill": "^0.1.1",
 		"@esbuild-plugins/node-modules-polyfill": "^0.1.4",
+		"@miniflare/tre": "file:../../../miniflare3/packages/tre",
 		"blake3-wasm": "^2.1.5",
 		"chokidar": "^3.5.3",
 		"esbuild": "0.14.51",

--- a/packages/wrangler/scripts/deps.ts
+++ b/packages/wrangler/scripts/deps.ts
@@ -12,6 +12,7 @@ export const EXTERNAL_DEPENDENCIES = [
 	"miniflare",
 	"@miniflare/core",
 	"@miniflare/durable-objects",
+	"@miniflare/tre", // TODO: remove once Miniflare 3 moved in miniflare package
 	// todo - bundle miniflare too
 	"selfsigned",
 	"source-map",

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -60,6 +60,7 @@ interface DevArgs {
 	"jsx-fragment"?: string;
 	tsconfig?: string;
 	local?: boolean;
+	"experimental-local"?: boolean;
 	minify?: boolean;
 	var?: string[];
 	define?: string[];
@@ -231,6 +232,11 @@ export function devOptions(yargs: Argv): Argv<DevArgs> {
 				describe: "Run on my machine",
 				type: "boolean",
 				default: false, // I bet this will a point of contention. We'll revisit it.
+			})
+			.option("experimental-local", {
+				describe: "Run on my machine using the Cloudflare Workers runtime",
+				type: "boolean",
+				default: false,
 			})
 			.option("minify", {
 				describe: "Minify the script",
@@ -404,7 +410,9 @@ export async function startDev(args: StartDevOptions) {
 					nodeCompat={nodeCompat}
 					build={configParam.build || {}}
 					define={{ ...configParam.define, ...cliDefines }}
-					initialMode={args.local ? "local" : "remote"}
+					initialMode={
+						args.local || args.experimentalLocal ? "local" : "remote"
+					}
 					jsxFactory={args["jsx-factory"] || configParam.jsx_factory}
 					jsxFragment={args["jsx-fragment"] || configParam.jsx_fragment}
 					tsconfig={args.tsconfig ?? configParam.tsconfig}
@@ -444,6 +452,7 @@ export async function startDev(args: StartDevOptions) {
 					firstPartyWorker={configParam.first_party_worker}
 					sendMetrics={configParam.send_metrics}
 					testScheduled={args["test-scheduled"]}
+					experimentalMiniflare3={args.experimentalLocal}
 				/>
 			);
 		}
@@ -558,6 +567,7 @@ export async function startApiDev(args: StartDevOptions) {
 			firstPartyWorker: configParam.first_party_worker,
 			sendMetrics: configParam.send_metrics,
 			testScheduled: args.testScheduled,
+			experimentalMiniflare3: undefined,
 		});
 	}
 

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -154,6 +154,7 @@ export type DevProps = {
 	firstPartyWorker: boolean | undefined;
 	sendMetrics: boolean | undefined;
 	testScheduled: boolean | undefined;
+	experimentalMiniflare3: boolean | undefined;
 };
 
 export function DevImplementation(props: DevProps): JSX.Element {
@@ -214,6 +215,7 @@ function InteractiveDevSession(props: DevProps) {
 
 type DevSessionProps = DevProps & {
 	local: boolean;
+	experimentalMiniflare3?: boolean;
 };
 
 function DevSession(props: DevSessionProps) {
@@ -277,6 +279,7 @@ function DevSession(props: DevSessionProps) {
 			inspect={props.inspect}
 			onReady={props.onReady}
 			enablePagesAssetsServiceBinding={props.enablePagesAssetsServiceBinding}
+			experimentalMiniflare3={props.experimentalMiniflare3}
 		/>
 	) : (
 		<Remote


### PR DESCRIPTION
This is a WIP implementation of an `--experimental-local` flag that uses a version of Miniflare powered by the open-source runtime. There are a few small TODOs still to resolve, but other than that... 🙂 