### PR TITLE
Allow unsetting of Link headers using _headers

### DIFF
--- a/.changeset/silly-birds-work.md
+++ b/.changeset/silly-birds-work.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Allow unsetting of automatically generated `Link` headers using `_headers` and the `! Link` operator

--- a/.changeset/six-trees-return.md
+++ b/.changeset/six-trees-return.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: Only generate `Link` headers from simple `<link>` elements.
+
+Specifically, only those with the `rel`, `href` and possibly `as` attributes. Any element with additional attributes will not be used to generate headers.

--- a/packages/pages-shared/src/asset-server/handler.ts
+++ b/packages/pages-shared/src/asset-server/handler.ts
@@ -34,6 +34,11 @@ export const HEADERS_VERSION = 2;
 export const HEADERS_VERSION_V1 = 1;
 export const ANALYTICS_VERSION = 1;
 
+// In rolling this out, we're taking a conservative approach to only generate these Link headers from <link> elements that have these attributes.
+// We'll ignore any <link> elements that contain other attributes (e.g. `fetchpriority`, `crossorigin` or `data-please-dont-generate-a-header`).
+// We're not confident in browser support for all of these additional attributes, so we'll wait until we have that information before proceeding further.
+const ALLOWED_EARLY_HINT_LINK_ATTRIBUTES = ["rel", "as", "href"];
+
 // Takes metadata headers and "normalise" them
 // to the latest version
 export function normaliseHeaders(
@@ -322,6 +327,16 @@ export async function generateHandler<
 							const transformedResponse = new HTMLRewriter()
 								.on("link[rel=preconnect],link[rel=preload]", {
 									element(element) {
+										for (const [attributeName] of element.attributes) {
+											if (
+												!ALLOWED_EARLY_HINT_LINK_ATTRIBUTES.includes(
+													attributeName.toLowerCase()
+												)
+											) {
+												return;
+											}
+										}
+
 										const href = element.getAttribute("href") || undefined;
 										const rel = element.getAttribute("rel") || undefined;
 										const as = element.getAttribute("as") || undefined;


### PR DESCRIPTION
We're moving the logic of the auto-generated `Link` header above the `_headers` handling so that there is a way to forcibly unset these with

```txt
/*
  ! Link
```

Unfortunately, testing isn't easy as we aren't set up to properly emulate `caches` and `waitUntil`.