### PR TITLE
feat: expose port and address on (Unstable)DevWorker

### DIFF
--- a/.changeset/lucky-fishes-invent.md
+++ b/.changeset/lucky-fishes-invent.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+feat: expose port and address on (Unstable)DevWorker
+
+when using `unstable_dev()`, I think we want to expose the port/address that the server has started on. The usecase is when trying to connect to the server _without_ calling `.fetch()` (example: when making a websocket connection).

--- a/packages/wrangler/src/__tests__/api-dev.test.ts
+++ b/packages/wrangler/src/__tests__/api-dev.test.ts
@@ -19,6 +19,26 @@ describe("unstable_dev", () => {
 		}
 		await worker.stop();
 	});
+
+	it("should return the port that the server started on (1)", async () => {
+		const worker = await unstable_dev(
+			"src/__tests__/helpers/worker-scripts/hello-world-worker.js",
+			{},
+			{ disableExperimentalWarning: true }
+		);
+		expect(worker.port).toBeGreaterThan(0);
+		await worker.stop();
+	});
+
+	it("should return the port that the server started on (2)", async () => {
+		const worker = await unstable_dev(
+			"src/__tests__/helpers/worker-scripts/hello-world-worker.js",
+			{ port: 9191 },
+			{ disableExperimentalWarning: true }
+		);
+		expect(worker.port).toBe(9191);
+		await worker.stop();
+	});
 });
 
 describe("unstable dev fetch input protocol", () => {

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -60,25 +60,20 @@ interface DevApiOptions {
 }
 
 export interface UnstableDevWorker {
+	port: number;
+	address: string;
 	stop: () => Promise<void>;
-	fetch: (
-		input?: RequestInfo,
-		init?: RequestInit
-	) => Promise<Response | undefined>;
+	fetch: (input?: RequestInfo, init?: RequestInit) => Promise<Response>;
 	waitUntilExit: () => Promise<void>;
 }
 /**
  *  unstable_dev starts a wrangler dev server, and returns a promise that resolves with utility functions to interact with it.
- *  @param {string} script
- *  @param {DevOptions} options
- *  @param {DevApiOptions} apiOptions
- * @returns {Promise<UnstableDev>}
  */
 export async function unstable_dev(
 	script: string,
 	options?: DevOptions,
 	apiOptions?: DevApiOptions
-) {
+): Promise<UnstableDevWorker> {
 	const { testMode = true, disableExperimentalWarning = false } =
 		apiOptions || {};
 	if (!disableExperimentalWarning) {
@@ -116,6 +111,8 @@ export async function unstable_dev(
 				// now that the inner promise has resolved, we can resolve the outer promise
 				// with an object that lets you fetch and stop the dev server
 				resolve({
+					port: readyPort,
+					address: readyAddress,
 					stop: devServer.stop,
 					fetch: async (input?: RequestInfo, init?: RequestInit) => {
 						return await fetch(
@@ -157,6 +154,8 @@ export async function unstable_dev(
 				});
 			}).then((devServer) => {
 				resolve({
+					port: readyPort,
+					address: readyAddress,
 					stop: devServer.stop,
 					fetch: async (input?: RequestInfo, init?: RequestInit) => {
 						return await fetch(


### PR DESCRIPTION
when using `unstable_dev()`, I think we want to expose the port/address that the server has started on. The usecase is when trying to connect to the server _without_ calling `.fetch()` (example: when making a websocket connection).