### PR TITLE
Make sure cron triggers work with D1

### DIFF
--- a/.changeset/witty-rice-pull.md
+++ b/.changeset/witty-rice-pull.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Export scheduled() in the D1 facade. This will allow for D1 to be used in a cron trigger.

--- a/packages/wrangler/templates/d1-beta-facade.js
+++ b/packages/wrangler/templates/d1-beta-facade.js
@@ -166,5 +166,9 @@ var shim_default = {
 	async fetch(request, env, ctx) {
 		return worker.fetch(request, getMaskedEnv(env), ctx);
 	},
+
+	async scheduled(controller, env, ctx) {
+		return worker.scheduled(controller, getMaskedEnv(env), ctx);
+	},
 };
 export { shim_default as default };


### PR DESCRIPTION
You cannot currently use D1 in cron triggers since the scheduled function isn't exported. Cron triggers also don't fire at all since the function isn't exported
