### PR TITLE
Revert "Allow unsetting of Link headers using _headers (#1903)"

### DIFF
--- a/.changeset/silly-birds-work.md
+++ b/.changeset/silly-birds-work.md
@@ -1,5 +1,0 @@
----
-"wrangler": patch
----
-
-fix: Allow unsetting of automatically generated `Link` headers using `_headers` and the `! Link` operator

--- a/.changeset/six-trees-return.md
+++ b/.changeset/six-trees-return.md
@@ -1,7 +1,0 @@
----
-"wrangler": patch
----
-
-fix: Only generate `Link` headers from simple `<link>` elements.
-
-Specifically, only those with the `rel`, `href` and possibly `as` attributes. Any element with additional attributes will not be used to generate headers.


### PR DESCRIPTION
This reverts commit 01be5f543dcbaab540fd649840aaa8ea1b51e4b6.

Temporarily pulling out of #1903 to allow a small release out without this change. We'll add it back shortly.