### PR TITLE
Allow `--experimental-local` to be used with module workers

### DIFF
--- a/.changeset/curvy-laws-develop.md
+++ b/.changeset/curvy-laws-develop.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Allow `--experimental-local` to be used with module workers

--- a/packages/wrangler/src/module-collection.ts
+++ b/packages/wrangler/src/module-collection.ts
@@ -7,6 +7,13 @@ import type { Config, ConfigModuleRuleType } from "./config";
 import type { CfModule, CfModuleType, CfScriptFormat } from "./worker";
 import type esbuild from "esbuild";
 
+function flipObject<
+	K extends string | number | symbol,
+	V extends string | number | symbol
+>(obj: Record<K, V>): Record<V, K> {
+	return Object.fromEntries(Object.entries(obj).map(([k, v]) => [v, k]));
+}
+
 const RuleTypeToModuleType: Record<ConfigModuleRuleType, CfModuleType> = {
 	ESModule: "esm",
 	CommonJS: "commonjs",
@@ -14,6 +21,8 @@ const RuleTypeToModuleType: Record<ConfigModuleRuleType, CfModuleType> = {
 	Data: "buffer",
 	Text: "text",
 };
+
+export const ModuleTypeToRuleType = flipObject(RuleTypeToModuleType);
 
 // This is a combination of an esbuild plugin and a mutable array
 // that we use to collect module references from source code.


### PR DESCRIPTION
Previously, Miniflare 3 was automatically collecting modules. These collected modules were given names relative to the current working directory. Because Wrangler puts scripts in a temporary directory, these names started with `..`, which `workerd` was not happy with.

This change avoids the redundant automatic collection in Miniflare, and ensures module names are resolved relative to the temporary directory.