### PR TITLE
fix: fails to publish due to empty migrations

### DIFF
--- a/.changeset/blue-pots-thank.md
+++ b/.changeset/blue-pots-thank.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+---
+
+fix: fails to publish due to empty migrations
+After this change, `wrangler init --from-dash` will not attempt to add durable object migrations to `wrangler.toml` for Workers that don't have durable objects.
+
+fixes #1854

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -2609,21 +2609,25 @@ describe("init", () => {
 		});
 
 		it("should not inlcude migrations in config file when none are necessary", async () => {
+			const mockDate = "1988-08-07";
+			jest
+				.spyOn(Date.prototype, "toISOString")
+				.mockImplementation(() => `${mockDate}T00:00:00.000Z`);
 			const mockData = {
 				id: "memory-crystal",
 				default_environment: {
 					environment: "test",
-					created_on: "1987-9-27",
-					modified_on: "1987-9-27",
+					created_on: "1988-08-07",
+					modified_on: "1988-08-07",
 					script: {
 						id: "memory-crystal",
 						tag: "test-tag",
 						etag: "some-etag",
 						handlers: [],
-						modified_on: "1987-9-27",
-						created_on: "1987-9-27",
+						modified_on: "1988-08-07",
+						created_on: "1988-08-07",
 						usage_model: "bundled",
-						compatibility_date: "1987-9-27",
+						compatibility_date: "1988-08-07",
 					},
 				},
 				environments: [],
@@ -2690,7 +2694,7 @@ describe("init", () => {
 			checkFiles({
 				items: {
 					"isolinear-optical-chip/wrangler.toml": wranglerToml({
-						compatibility_date: "2022-09-27",
+						compatibility_date: "1988-08-07",
 						env: {},
 						main: "src/index.ts",
 						triggers: {

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -946,12 +946,16 @@ async function getWorkerConfig(
 			new Date().toISOString().substring(0, 10),
 		...routeOrRoutesToConfig,
 		usage_model: serviceEnvMetadata.script.usage_model,
-		migrations: [
-			{
-				tag: serviceEnvMetadata.script.migration_tag,
-				new_classes: durableObjectClassNames,
-			},
-		],
+		...(durableObjectClassNames.length
+			? {
+					migrations: [
+						{
+							tag: serviceEnvMetadata.script.migration_tag,
+							new_classes: durableObjectClassNames,
+						},
+					],
+			  }
+			: {}),
 		triggers: {
 			crons: cronTriggers.schedules.map((scheduled) => scheduled.cron),
 		},


### PR DESCRIPTION
The Durable Objects migrations will no longer show in the auto generated config file.