### PR TITLE
Add `--experimental-local` support to `unstable_dev`

### DIFF
--- a/fixtures/local-mode-tests/package.json
+++ b/fixtures/local-mode-tests/package.json
@@ -9,8 +9,8 @@
 	"main": "index.js",
 	"scripts": {
 		"check:type": "tsc",
-		"test": "cross-env NODE_ENV=local-testing npx jest --forceExit",
-		"test:ci": "cross-env NODE_ENV=local-testing npx jest --forceExit"
+		"test": "cross-env NODE_ENV=local-testing NODE_OPTIONS=--experimental-vm-modules npx jest --forceExit",
+		"test:ci": "cross-env NODE_ENV=local-testing NODE_OPTIONS=--experimental-vm-modules npx jest --forceExit"
 	},
 	"jest": {
 		"restoreMocks": true,

--- a/fixtures/local-mode-tests/tests/unstableDev.test.ts
+++ b/fixtures/local-mode-tests/tests/unstableDev.test.ts
@@ -1,6 +1,6 @@
 import { unstable_dev } from "wrangler";
 
-describe("worker", () => {
+describe.each([false, true])("experimentalLocal: %s", (experimentalLocal) => {
 	let worker: {
 		fetch: (
 			input?: RequestInfo,
@@ -16,13 +16,17 @@ describe("worker", () => {
 			{
 				ip: "127.0.0.1",
 				port: 1337,
+				experimentalLocal,
+				// Compatibility date currently required when experimentalLocal is
+				// enabled due to `workerd` restrictions
+				compatibilityDate: "2022-09-26",
 			},
 			{ disableExperimentalWarning: true }
 		);
 	});
 
 	afterAll(async () => {
-		await worker.stop();
+		await worker?.stop();
 	});
 
 	it("should invoke the worker and exit", async () => {

--- a/fixtures/local-mode-tests/tests/unstableDev.test.ts
+++ b/fixtures/local-mode-tests/tests/unstableDev.test.ts
@@ -1,6 +1,9 @@
 import { unstable_dev } from "wrangler";
 
-describe.each([false, true])("experimentalLocal: %s", (experimentalLocal) => {
+// TODO: add test for `experimentalLocal: true` once issue with dynamic
+//  `import()` and `npx-import` resolved:
+//  https://github.com/cloudflare/wrangler2/pull/1940#issuecomment-1261166695
+describe("worker", () => {
 	let worker: {
 		fetch: (
 			input?: RequestInfo,
@@ -16,10 +19,6 @@ describe.each([false, true])("experimentalLocal: %s", (experimentalLocal) => {
 			{
 				ip: "127.0.0.1",
 				port: 1337,
-				experimentalLocal,
-				// Compatibility date currently required when experimentalLocal is
-				// enabled due to `workerd` restrictions
-				compatibilityDate: "2022-09-26",
 			},
 			{ disableExperimentalWarning: true }
 		);

--- a/package-lock.json
+++ b/package-lock.json
@@ -883,9 +883,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20220926.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20220926.0.tgz",
-			"integrity": "sha512-MwaAX/16YSu797/QhYU+x+Ddlk/JquTWD7vCtmhf+VeG+4Tt8/ru03MyRnnoI3vgXizox2yfQnfqI1YVlJOR8Q==",
+			"version": "1.20220926.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20220926.1.tgz",
+			"integrity": "sha512-jWVxVsUDggsZPBusmzcj5ZxYjMPWJDfcYvwp2O9IIZaKaYLrr+SIablGxLwSevGxOaFtyTvl+auLBCr+FMLwXw==",
 			"cpu": [
 				"arm64"
 			],
@@ -899,9 +899,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20220926.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20220926.0.tgz",
-			"integrity": "sha512-zk9t5RG9GmcSayh2mMPLSItKCu/EPiHIog5Spmfc5Qsr/GHhA0/X2LISjgvozGTNLFiVSyoUL9jegG4xvLMRSw==",
+			"version": "1.20220926.2",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20220926.2.tgz",
+			"integrity": "sha512-f+xS32N7fwzYTphiPdoonZCgr46arw5gaH0tcJGrHpIy6f2aCnHd9SvoI53YJ7SVqfHX1o8eXvOZJ3F5CrHWrw==",
 			"cpu": [
 				"x64"
 			],
@@ -915,9 +915,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20220926.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20220926.0.tgz",
-			"integrity": "sha512-1s8fwDOWPdHiTmEiZDgQLyEBwi5IA191Uy7vxfLvC0rOpbNqEo4MVNJ4TiVf7xjiS7X6mJ0SFyz8aDf+lrgcQA==",
+			"version": "1.20220926.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20220926.1.tgz",
+			"integrity": "sha512-PY4mYaKybLlhvkaXEs/wG4mFqmc2FQ71mBWWjUPjpcUe+Zhyhy/viDbq2MhjcryV5o69GPe4jHTVAe/PyKC6BA==",
 			"cpu": [
 				"arm64"
 			],
@@ -2778,9 +2778,9 @@
 			}
 		},
 		"node_modules/@miniflare/tre": {
-			"version": "3.0.0-next.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/tre/-/tre-3.0.0-next.1.tgz",
-			"integrity": "sha512-y2K4VuM8AuMkuwWbEpA5CAZb4mc+KrLxiHBQ+HwJYMCfds7Og5nAEJZ11V9lEY8OhOaFDWBHrW0PH0MFvH1MzA==",
+			"version": "3.0.0-next.2",
+			"resolved": "https://registry.npmjs.org/@miniflare/tre/-/tre-3.0.0-next.2.tgz",
+			"integrity": "sha512-P9dkNk2KDG56C7KOPZX1qD/nNESh1Srof/Kg8qutXhLNJPgI3igroE0q+XOvnwmlhmIrNxuUKQ/PZQo9WhUjNg==",
 			"dev": true,
 			"dependencies": {
 				"acorn": "^8.8.0",
@@ -2792,7 +2792,7 @@
 				"kleur": "^4.1.5",
 				"stoppable": "^1.1.0",
 				"undici": "^5.10.0",
-				"workerd": "^1.20220926.0",
+				"workerd": "^1.20220926.3",
 				"zod": "^3.18.0"
 			},
 			"engines": {
@@ -21493,9 +21493,9 @@
 			}
 		},
 		"node_modules/workerd": {
-			"version": "1.20220926.0",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20220926.0.tgz",
-			"integrity": "sha512-pJmF9adeO0/Utbs3Fq/u9H6can6SxtWtSEKGpxPekBlUECwNhUoVYxjFFx1aS6BpIa1bgugvc1JMJA+td6QTcQ==",
+			"version": "1.20220926.3",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20220926.3.tgz",
+			"integrity": "sha512-/lmXRhgLixIkNNwsrFquPlT+qgFD71QbYJ8qroYQVL2hQVOuqw5N4TzMZS6gaNtVW+EUUnps+t/zbz98vjeuTg==",
 			"dev": true,
 			"bin": {
 				"workerd": "bin/workerd"
@@ -21504,10 +21504,10 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20220926.0",
-				"@cloudflare/workerd-darwin-arm64": "1.20220926.0",
-				"@cloudflare/workerd-linux-64": "1.20220926.0",
-				"@cloudflare/workerd-linux-arm64": "1.20220926.0"
+				"@cloudflare/workerd-darwin-64": "^1.20220926.0",
+				"@cloudflare/workerd-darwin-arm64": "^1.20220926.0",
+				"@cloudflare/workerd-linux-64": "^1.20220926.0",
+				"@cloudflare/workerd-linux-arm64": "^1.20220926.0"
 			}
 		},
 		"node_modules/workers-chat-demo": {
@@ -21893,7 +21893,7 @@
 				"@databases/sql": "^3.2.0",
 				"@iarna/toml": "^3.0.0",
 				"@microsoft/api-extractor": "^7.28.3",
-				"@miniflare/tre": "3.0.0-next.1",
+				"@miniflare/tre": "3.0.0-next.2",
 				"@types/better-sqlite3": "^7.6.0",
 				"@types/busboy": "^1.5.0",
 				"@types/command-exists": "^1.2.0",
@@ -23722,23 +23722,23 @@
 			"optional": true
 		},
 		"@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20220926.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20220926.0.tgz",
-			"integrity": "sha512-MwaAX/16YSu797/QhYU+x+Ddlk/JquTWD7vCtmhf+VeG+4Tt8/ru03MyRnnoI3vgXizox2yfQnfqI1YVlJOR8Q==",
+			"version": "1.20220926.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20220926.1.tgz",
+			"integrity": "sha512-jWVxVsUDggsZPBusmzcj5ZxYjMPWJDfcYvwp2O9IIZaKaYLrr+SIablGxLwSevGxOaFtyTvl+auLBCr+FMLwXw==",
 			"dev": true,
 			"optional": true
 		},
 		"@cloudflare/workerd-linux-64": {
-			"version": "1.20220926.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20220926.0.tgz",
-			"integrity": "sha512-zk9t5RG9GmcSayh2mMPLSItKCu/EPiHIog5Spmfc5Qsr/GHhA0/X2LISjgvozGTNLFiVSyoUL9jegG4xvLMRSw==",
+			"version": "1.20220926.2",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20220926.2.tgz",
+			"integrity": "sha512-f+xS32N7fwzYTphiPdoonZCgr46arw5gaH0tcJGrHpIy6f2aCnHd9SvoI53YJ7SVqfHX1o8eXvOZJ3F5CrHWrw==",
 			"dev": true,
 			"optional": true
 		},
 		"@cloudflare/workerd-linux-arm64": {
-			"version": "1.20220926.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20220926.0.tgz",
-			"integrity": "sha512-1s8fwDOWPdHiTmEiZDgQLyEBwi5IA191Uy7vxfLvC0rOpbNqEo4MVNJ4TiVf7xjiS7X6mJ0SFyz8aDf+lrgcQA==",
+			"version": "1.20220926.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20220926.1.tgz",
+			"integrity": "sha512-PY4mYaKybLlhvkaXEs/wG4mFqmc2FQ71mBWWjUPjpcUe+Zhyhy/viDbq2MhjcryV5o69GPe4jHTVAe/PyKC6BA==",
 			"dev": true,
 			"optional": true
 		},
@@ -24991,9 +24991,9 @@
 			}
 		},
 		"@miniflare/tre": {
-			"version": "3.0.0-next.1",
-			"resolved": "https://registry.npmjs.org/@miniflare/tre/-/tre-3.0.0-next.1.tgz",
-			"integrity": "sha512-y2K4VuM8AuMkuwWbEpA5CAZb4mc+KrLxiHBQ+HwJYMCfds7Og5nAEJZ11V9lEY8OhOaFDWBHrW0PH0MFvH1MzA==",
+			"version": "3.0.0-next.2",
+			"resolved": "https://registry.npmjs.org/@miniflare/tre/-/tre-3.0.0-next.2.tgz",
+			"integrity": "sha512-P9dkNk2KDG56C7KOPZX1qD/nNESh1Srof/Kg8qutXhLNJPgI3igroE0q+XOvnwmlhmIrNxuUKQ/PZQo9WhUjNg==",
 			"dev": true,
 			"requires": {
 				"acorn": "^8.8.0",
@@ -25005,7 +25005,7 @@
 				"kleur": "^4.1.5",
 				"stoppable": "^1.1.0",
 				"undici": "^5.10.0",
-				"workerd": "^1.20220926.0",
+				"workerd": "^1.20220926.3",
 				"zod": "^3.18.0"
 			},
 			"dependencies": {
@@ -37313,15 +37313,15 @@
 			}
 		},
 		"workerd": {
-			"version": "1.20220926.0",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20220926.0.tgz",
-			"integrity": "sha512-pJmF9adeO0/Utbs3Fq/u9H6can6SxtWtSEKGpxPekBlUECwNhUoVYxjFFx1aS6BpIa1bgugvc1JMJA+td6QTcQ==",
+			"version": "1.20220926.3",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20220926.3.tgz",
+			"integrity": "sha512-/lmXRhgLixIkNNwsrFquPlT+qgFD71QbYJ8qroYQVL2hQVOuqw5N4TzMZS6gaNtVW+EUUnps+t/zbz98vjeuTg==",
 			"dev": true,
 			"requires": {
-				"@cloudflare/workerd-darwin-64": "1.20220926.0",
-				"@cloudflare/workerd-darwin-arm64": "1.20220926.0",
-				"@cloudflare/workerd-linux-64": "1.20220926.0",
-				"@cloudflare/workerd-linux-arm64": "1.20220926.0"
+				"@cloudflare/workerd-darwin-64": "^1.20220926.0",
+				"@cloudflare/workerd-darwin-arm64": "^1.20220926.0",
+				"@cloudflare/workerd-linux-64": "^1.20220926.0",
+				"@cloudflare/workerd-linux-arm64": "^1.20220926.0"
 			}
 		},
 		"workers-chat-demo": {
@@ -37340,7 +37340,7 @@
 				"@miniflare/core": "2.9.0",
 				"@miniflare/d1": "2.9.0",
 				"@miniflare/durable-objects": "2.9.0",
-				"@miniflare/tre": "3.0.0-next.1",
+				"@miniflare/tre": "3.0.0-next.2",
 				"@types/better-sqlite3": "^7.6.0",
 				"@types/busboy": "^1.5.0",
 				"@types/command-exists": "^1.2.0",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -112,7 +112,7 @@
 		"@databases/sql": "^3.2.0",
 		"@iarna/toml": "^3.0.0",
 		"@microsoft/api-extractor": "^7.28.3",
-		"@miniflare/tre": "3.0.0-next.1",
+		"@miniflare/tre": "3.0.0-next.2",
 		"@types/better-sqlite3": "^7.6.0",
 		"@types/busboy": "^1.5.0",
 		"@types/command-exists": "^1.2.0",

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -54,6 +54,7 @@ interface DevOptions {
 	_?: (string | number)[]; //yargs wants this
 	$0?: string; //yargs wants this
 	testScheduled?: boolean;
+	experimentalLocal?: boolean;
 }
 
 interface DevApiOptions {

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -561,10 +561,13 @@ export async function startApiDev(args: StartDevOptions) {
 			isWorkersSite: Boolean(args.site || configParam.site),
 			compatibilityDate: getDevCompatibilityDate(
 				config,
-				args["compatibility-date"]
+				// Only `compatibilityDate` will be set when using `unstable_dev`
+				args["compatibility-date"] ?? args.compatibilityDate
 			),
 			compatibilityFlags:
-				args["compatibility-flags"] || configParam.compatibility_flags,
+				args["compatibility-flags"] ??
+				args.compatibilityFlags ??
+				configParam.compatibility_flags,
 			usageModel: configParam.usage_model,
 			bindings: bindings,
 			crons: configParam.triggers.crons,
@@ -578,7 +581,7 @@ export async function startApiDev(args: StartDevOptions) {
 			firstPartyWorker: configParam.first_party_worker,
 			sendMetrics: configParam.send_metrics,
 			testScheduled: args.testScheduled,
-			experimentalLocal: undefined,
+			experimentalLocal: args.experimentalLocal,
 		});
 	}
 

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -204,6 +204,7 @@ function useLocalWorker({
 				// TODO: refactor setupMiniflareOptions so we don't need to parse here
 				const mf2Options: MiniflareOptions = JSON.parse(forkOptions[0]);
 				const mf = await setupExperimentalLocal(mf2Options, format, bundle);
+				await mf.ready;
 				experimentalLocalRef.current = mf;
 				removeSignalExitListener.current = onExit(() => {
 					logger.log("⎔ Shutting down experimental local server.");
@@ -678,10 +679,8 @@ export async function setupExperimentalLocal(
 		({ Miniflare } = await npxImport<
 			// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 			typeof import("@miniflare/tre")
-		>("@miniflare/tre"));
+		>("@miniflare/tre@next"));
 	}
 
-	const mf = new Miniflare(options);
-	await mf.ready;
-	return mf;
+	return new Miniflare(options);
 }

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -39,10 +39,6 @@ import type {
 import type { MiniflareOptions } from "miniflare";
 import type { ChildProcess } from "node:child_process";
 
-// caching of the miniflare package
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-let Miniflare: typeof import("@miniflare/tre")["Miniflare"];
-
 export interface LocalProps {
 	name: string | undefined;
 	bundle: EsbuildBundle | undefined;
@@ -78,10 +74,6 @@ export function Local(props: LocalProps) {
 		logToTerminal: false,
 	});
 	return null;
-}
-
-function arrayToObject(values: string[] = []): Record<string, string> {
-	return Object.fromEntries(values.map((value) => [value, value]));
 }
 
 function useLocalWorker({
@@ -210,61 +202,14 @@ function useLocalWorker({
 
 			if (experimentalLocal) {
 				// TODO: refactor setupMiniflareOptions so we don't need to parse here
-				const miniflare2Options: MiniflareOptions = JSON.parse(forkOptions[0]);
-				const options: Miniflare3Options = {
-					...miniflare2Options,
-					// Miniflare 3 distinguishes between binding name and namespace/bucket
-					// IDs. For now, just use the same value as we did in Miniflare 2.
-					// TODO: use defined KV preview ID if any
-					kvNamespaces: arrayToObject(miniflare2Options.kvNamespaces),
-					r2Buckets: arrayToObject(miniflare2Options.r2Buckets),
-					// TODO: pass-through collected modules instead of getting Miniflare
-					//  to collect them again
-				};
-
-				if (format === "modules") {
-					// Manually specify all modules from the bundle. If we didn't do this,
-					// Miniflare 3 would try collect them automatically again itself.
-
-					// Resolve entrypoint relative to the temporary directory, ensuring
-					// path doesn't start with `..`, which causes issues in `workerd`.
-					// Also ensures other modules with relative names can be resolved.
-					const root = path.dirname(bundle.path);
-
-					assert.strictEqual(bundle.type, "esm");
-					options.modules = [
-						// Entrypoint
-						{
-							type: "ESModule",
-							path: path.relative(root, bundle.path),
-							contents: await readFile(bundle.path, "utf-8"),
-						},
-						// Misc (WebAssembly, etc, ...)
-						...bundle.modules.map((module) => ({
-							type: ModuleTypeToRuleType[module.type ?? "esm"],
-							path: module.name,
-							contents: module.content,
-						})),
-					];
-				}
-
-				logger.log("⎔ Starting an experimental local server...");
-
-				if (Miniflare === undefined) {
-					({ Miniflare } = await npxImport<
-						// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-						typeof import("@miniflare/tre")
-					>("@miniflare/tre"));
-				}
-
-				const mf = new Miniflare(options);
+				const mf2Options: MiniflareOptions = JSON.parse(forkOptions[0]);
+				const mf = await setupExperimentalLocal(mf2Options, format, bundle);
 				experimentalLocalRef.current = mf;
-				removeSignalExitListener.current = onExit((_code, _signal) => {
+				removeSignalExitListener.current = onExit(() => {
 					logger.log("⎔ Shutting down experimental local server.");
 					mf.dispose();
 					experimentalLocalRef.current = undefined;
 				});
-				await mf.ready;
 				return;
 			}
 
@@ -677,4 +622,66 @@ export function setupNodeOptions({
 		nodeOptions.push("--inspect=" + `${ip}:${inspectorPort}`); // start Miniflare listening for a debugger to attach
 	}
 	return nodeOptions;
+}
+
+// Caching of the `npx-import`ed `@miniflare/tre` package
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+let Miniflare: typeof import("@miniflare/tre").Miniflare;
+
+function arrayToObject(values: string[] = []): Record<string, string> {
+	return Object.fromEntries(values.map((value) => [value, value]));
+}
+
+export async function setupExperimentalLocal(
+	mf2Options: MiniflareOptions,
+	format: CfScriptFormat,
+	bundle: EsbuildBundle
+): Promise<Miniflare3Type> {
+	const options: Miniflare3Options = {
+		...mf2Options,
+		// Miniflare 3 distinguishes between binding name and namespace/bucket IDs.
+		// For now, just use the same value as we did in Miniflare 2.
+		// TODO: use defined KV preview ID if any
+		kvNamespaces: arrayToObject(mf2Options.kvNamespaces),
+		r2Buckets: arrayToObject(mf2Options.r2Buckets),
+	};
+
+	if (format === "modules") {
+		// Manually specify all modules from the bundle. If we didn't do this,
+		// Miniflare 3 would try collect them automatically again itself.
+
+		// Resolve entrypoint relative to the temporary directory, ensuring
+		// path doesn't start with `..`, which causes issues in `workerd`.
+		// Also ensures other modules with relative names can be resolved.
+		const root = path.dirname(bundle.path);
+
+		assert.strictEqual(bundle.type, "esm");
+		options.modules = [
+			// Entrypoint
+			{
+				type: "ESModule",
+				path: path.relative(root, bundle.path),
+				contents: await readFile(bundle.path, "utf-8"),
+			},
+			// Misc (WebAssembly, etc, ...)
+			...bundle.modules.map((module) => ({
+				type: ModuleTypeToRuleType[module.type ?? "esm"],
+				path: module.name,
+				contents: module.content,
+			})),
+		];
+	}
+
+	logger.log("⎔ Starting an experimental local server...");
+
+	if (Miniflare === undefined) {
+		({ Miniflare } = await npxImport<
+			// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+			typeof import("@miniflare/tre")
+		>("@miniflare/tre"));
+	}
+
+	const mf = new Miniflare(options);
+	await mf.ready;
+	return mf;
 }

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -17,6 +17,7 @@ import { logger } from "../logger";
 import { waitForPortToBeAvailable } from "../proxy";
 import {
 	setupBindings,
+	setupExperimentalLocal,
 	setupMiniflareOptions,
 	setupNodeOptions,
 } from "./local";
@@ -28,6 +29,8 @@ import type { Entry } from "../entry";
 import type { DevProps, DirectorySyncResult } from "./dev";
 import type { LocalProps } from "./local";
 import type { EsbuildBundle } from "./use-esbuild";
+import type { Miniflare as Miniflare3Type } from "@miniflare/tre";
+import type { MiniflareOptions } from "miniflare";
 
 import type { ChildProcess } from "node:child_process";
 
@@ -118,6 +121,7 @@ export async function startDevServer(
 			enablePagesAssetsServiceBinding: props.enablePagesAssetsServiceBinding,
 			usageModel: props.usageModel,
 			workerDefinitions,
+			experimentalLocal: props.experimentalLocal,
 		});
 
 		return {
@@ -252,8 +256,10 @@ export async function startLocalServer({
 	onReady,
 	logPrefix,
 	enablePagesAssetsServiceBinding,
+	experimentalLocal,
 }: LocalProps) {
 	let local: ChildProcess | undefined;
+	let experimentalLocalRef: Miniflare3Type | undefined;
 	let removeSignalExitListener: (() => void) | undefined;
 	let inspectorUrl: string | undefined;
 	const setInspectorUrl = (url: string) => {
@@ -340,6 +346,20 @@ export async function startLocalServer({
 			workerDefinitions,
 			enablePagesAssetsServiceBinding,
 		});
+
+		if (experimentalLocal) {
+			// TODO: refactor setupMiniflareOptions so we don't need to parse here
+			const mf2Options: MiniflareOptions = JSON.parse(forkOptions[0]);
+			const mf = await setupExperimentalLocal(mf2Options, format, bundle);
+			experimentalLocalRef = mf;
+			removeSignalExitListener = onExit((_code, _signal) => {
+				logger.log("⎔ Shutting down experimental local server.");
+				mf.dispose();
+				experimentalLocalRef = undefined;
+			});
+			onReady?.(ip, mf2Options.port ?? 8787);
+			return;
+		}
 
 		const nodeOptions = setupNodeOptions({ inspect, ip, inspectorPort });
 		logger.log("⎔ Starting a local server...");
@@ -435,9 +455,16 @@ export async function startLocalServer({
 				logger.log("⎔ Shutting down local server.");
 				local.kill();
 				local = undefined;
-				removeSignalExitListener && removeSignalExitListener();
-				removeSignalExitListener = undefined;
 			}
+			if (experimentalLocalRef) {
+				logger.log("⎔ Shutting down experimental local server.");
+				// Initialisation errors are also thrown asynchronously by dispose().
+				// The catch() above should've caught them though.
+				experimentalLocalRef?.dispose().catch(() => {});
+				experimentalLocalRef = undefined;
+			}
+			removeSignalExitListener?.();
+			removeSignalExitListener = undefined;
 		},
 	};
 }

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -351,13 +351,14 @@ export async function startLocalServer({
 			// TODO: refactor setupMiniflareOptions so we don't need to parse here
 			const mf2Options: MiniflareOptions = JSON.parse(forkOptions[0]);
 			const mf = await setupExperimentalLocal(mf2Options, format, bundle);
+			const runtimeURL = await mf.ready;
 			experimentalLocalRef = mf;
 			removeSignalExitListener = onExit((_code, _signal) => {
 				logger.log("⎔ Shutting down experimental local server.");
 				mf.dispose();
 				experimentalLocalRef = undefined;
 			});
-			onReady?.(ip, mf2Options.port ?? 8787);
+			onReady?.(runtimeURL.hostname, parseInt(runtimeURL.port ?? 8787));
 			return;
 		}
 


### PR DESCRIPTION
This PR adds a new `experimentalLocal` option to `unstable_dev`. If enabled, this uses Miniflare 3 and the `workerd` runtime, as opposed to Miniflare 2.