### PR TITLE
chore: add `env` and `ctx` params to `fetch` in javascript example template

### DIFF
--- a/.changeset/brave-ties-obey.md
+++ b/.changeset/brave-ties-obey.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+chore: add `env` and `ctx` params to `fetch` in javascript example template
+
+Just like in the typescript templates, and the javascript template for scheduled workers, we include `env` and `ctx` as parameters to the `fetch` export. This makes it clearer where environment variables live.

--- a/packages/wrangler/templates/new-worker.js
+++ b/packages/wrangler/templates/new-worker.js
@@ -9,7 +9,7 @@
  */
 
 export default {
-	async fetch(request) {
+	async fetch(request, env, ctx) {
 		return new Response("Hello World!");
 	},
 };


### PR DESCRIPTION
Just like in the typescript templates, and the javascript template for scheduled workers, we include `env` and `ctx` as parameters to the `fetch` export. This makes it clearer where environment variables live.

Closes https://github.com/cloudflare/wrangler2/issues/1942