### PR TITLE
fix(pages): `wrangler pages publish` should prioritize `_worker.js`

### DIFF
--- a/.changeset/nervous-boats-invent.md
+++ b/.changeset/nervous-boats-invent.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+`wrangler pages publish` should prioritize `_worker.js` over `/functions` if both exist


### PR DESCRIPTION
When using a `_worker.js` file, the entire `/functions` directory should be ignored – this
includes its routing and middleware characteristics. Currently `wrangler pages publish` 
does the reverse, by prioritizing `/functions` over `_worker.js`. This commit fixes that.