### PR TITLE
Closes #1814: Support subdomains with `wrangler dev` 

### DIFF
--- a/.changeset/wicked-pears-train.md
+++ b/.changeset/wicked-pears-train.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Support subdomains with wrangler dev for routes defined with zone_name (instead of just for routes defined with zone_id)

--- a/.changeset/wicked-pears-train.md
+++ b/.changeset/wicked-pears-train.md
@@ -2,4 +2,4 @@
 "wrangler": patch
 ---
 
-Support subdomains with wrangler dev for routes defined with zone_name (instead of just for routes defined with zone_id)
+Support subdomains with wrangler dev for routes defined with `zone_name` (instead of just for routes defined with `zone_id`)

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -301,7 +301,10 @@ describe("wrangler dev", () => {
 			writeWranglerToml({
 				main: "index.js",
 				routes: [
-					{ pattern: "https://some-domain.com/*", zone_name: "some-zone.com" },
+					{
+						pattern: "https://some-zone.com/*",
+						zone_name: "some-zone.com",
+					},
 				],
 			});
 			fs.writeFileSync("index.js", `export default {};`);

--- a/packages/wrangler/src/zones.ts
+++ b/packages/wrangler/src/zones.ts
@@ -13,9 +13,7 @@ export function getHostFromRoute(route: Route): string | undefined {
 	return typeof route === "string"
 		? getHostFromUrl(route)
 		: typeof route === "object"
-		? "zone_name" in route
-			? getHostFromUrl(route.zone_name)
-			: getHostFromUrl(route.pattern)
+		? getHostFromUrl(route.pattern)
 		: undefined;
 }
 


### PR DESCRIPTION
For routes defined with `zone_name` (instead of just for routes defined with `zone_id`)