### PR TITLE
chore: error if d1 bindings used with `no-bundle`

### DIFF
--- a/.changeset/kind-crews-sing.md
+++ b/.changeset/kind-crews-sing.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+chore: error if d1 bindings used with `no-bundle`
+
+While in beta, you cannot use D1 bindings without bundling your worker as these are added in through a facade which gets bypassed when using the `no-bundle` option.

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -245,6 +245,16 @@ function DevSession(props: DevSessionProps) {
 		);
 	}
 
+	// If we are using d1 bindings, and are not bundling the worker
+	// we should error here as the d1 shim won't be added
+	if (Array.isArray(betaD1Shims) && betaD1Shims.length > 0 && props.noBundle) {
+		handleError(
+			new Error(
+				"While in beta, you cannot use D1 bindings without bundling your worker. Please remove `no_bundle` from your wrangler.toml file or remove the `--no-bundle` flag to access D1 bindings."
+			)
+		);
+	}
+
 	const workerDefinitions = useDevRegistry(
 		props.name,
 		props.bindings.services,

--- a/packages/wrangler/src/publish.ts
+++ b/packages/wrangler/src/publish.ts
@@ -390,6 +390,19 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			);
 		}
 
+		// If we are using d1 bindings, and are not bundling the worker
+		// we should error here as the d1 shim won't be added
+		const betaD1Shims = identifyD1BindingsAsBeta(config.d1_databases);
+		if (
+			Array.isArray(betaD1Shims) &&
+			betaD1Shims.length > 0 &&
+			props.noBundle
+		) {
+			throw new Error(
+				"While in beta, you cannot use D1 bindings without bundling your worker. Please remove `no_bundle` from your wrangler.toml file or remove the `--no-bundle` flag to access D1 bindings."
+			);
+		}
+
 		const {
 			modules,
 			resolvedEntryPointPath,


### PR DESCRIPTION
While in beta, you cannot use D1 bindings without bundling your worker as these are added in through a facade which gets bypassed when using the `no-bundle` option.

This will be removed once the bindings are no longer needing to be added using a shim.

Closes https://github.com/cloudflare/wrangler2/issues/1954