### PR TITLE
chore: Emoji space in help description

### DIFF
--- a/.changeset/strange-clouds-judge.md
+++ b/.changeset/strange-clouds-judge.md
@@ -1,0 +1,6 @@
+---
+"wrangler": patch
+---
+
+chore: Emoji space in help description
+Added a space between the Emoji and description for the secret:bulk command.

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -36,7 +36,7 @@ describe("wrangler", () => {
 			  wrangler publish [script]    🆙 Publish your Worker to Cloudflare.
 			  wrangler tail [worker]       🦚 Starts a log tailing session for a published Worker.
 			  wrangler secret              🤫 Generate a secret that can be referenced in a Worker
-			  wrangler secret:bulk <json>  🗄️ Bulk upload secrets for a Worker
+			  wrangler secret:bulk <json>  🗄️  Bulk upload secrets for a Worker
 			  wrangler kv:namespace        🗂️  Interact with your Workers KV Namespaces
 			  wrangler kv:key              🔑 Individually manage Workers KV key-value pairs
 			  wrangler kv:bulk             💪 Interact with multiple Workers KV key-value pairs at once
@@ -77,7 +77,7 @@ describe("wrangler", () => {
 			  wrangler publish [script]    🆙 Publish your Worker to Cloudflare.
 			  wrangler tail [worker]       🦚 Starts a log tailing session for a published Worker.
 			  wrangler secret              🤫 Generate a secret that can be referenced in a Worker
-			  wrangler secret:bulk <json>  🗄️ Bulk upload secrets for a Worker
+			  wrangler secret:bulk <json>  🗄️  Bulk upload secrets for a Worker
 			  wrangler kv:namespace        🗂️  Interact with your Workers KV Namespaces
 			  wrangler kv:key              🔑 Individually manage Workers KV key-value pairs
 			  wrangler kv:bulk             💪 Interact with multiple Workers KV key-value pairs at once

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -1172,7 +1172,7 @@ function createCLIParser(argv: string[]) {
 
 	wrangler.command(
 		"secret:bulk <json>",
-		"🗄️ Bulk upload secrets for a Worker",
+		"🗄️  Bulk upload secrets for a Worker",
 		(yargs) => {
 			return yargs
 				.positional("json", {


### PR DESCRIPTION
Added a space between the Emoji and description for the secret:bulk command.