### PR TITLE
chore: remove hidden on --from-dash

### DIFF
--- a/.changeset/wet-deers-bow.md
+++ b/.changeset/wet-deers-bow.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+---
+
+chore: remove hidden on --from-dash
+The --from-dash can now be used with the dashboard features to support moving Worker developmment to a local machine.
+
+resolves #1783

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -51,7 +51,6 @@ export async function initOptions(yargs: Argv) {
 			describe: "Download script from the dashboard for local development",
 			type: "string",
 			requiresArg: true,
-			hidden: true,
 		});
 }
 


### PR DESCRIPTION
The --from-dash can now be used with the dashboard features to support moving Worker developmment to a local machine.

resolves #1783