### PR TITLE
feat: teach unstable_dev about the internet (remote mode)

### DIFF
--- a/.changeset/wet-pens-watch.md
+++ b/.changeset/wet-pens-watch.md
@@ -2,4 +2,14 @@
 "wrangler": patch
 ---
 
-chore: refactor remote.tsx to only destructure when necessary
+feat: implement remote mode for unstable_dev
+
+With this change, `unstable_dev` can now perform end-to-end (e2e) tests against your workers as you dev.
+
+Usage:
+
+```js
+await unstable_dev("src/index.ts", {
+	local: false,
+});
+```

--- a/.changeset/wet-pens-watch.md
+++ b/.changeset/wet-pens-watch.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+chore: refactor remote.tsx to only destructure when necessary

--- a/.changeset/wet-pens-watch.md
+++ b/.changeset/wet-pens-watch.md
@@ -6,6 +6,8 @@ feat: implement remote mode for unstable_dev
 
 With this change, `unstable_dev` can now perform end-to-end (e2e) tests against your workers as you dev.
 
+Note that to use this feature in CI, you'll need to configure `CLOUDFLARE_API_TOKEN` as an environment variable in your CI, and potentially add `CLOUDFLARE_ACCOUNT_ID` as an environment variable in your CI, or `account_id` in your `wrangler.toml`.
+
 Usage:
 
 ```js

--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -60,6 +60,8 @@ jobs:
 
       - name: Run tests & collect coverage
         run: npm run test:ci
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
       - name: Report Code Coverage
         uses: codecov/codecov-action@v3

--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Run tests & collect coverage
         run: npm run test:ci
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          TMP_CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
       - name: Report Code Coverage
         uses: codecov/codecov-action@v3

--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -62,6 +62,7 @@ jobs:
         run: npm run test:ci
         env:
           TMP_CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          TMP_CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Report Code Coverage
         uses: codecov/codecov-action@v3

--- a/fixtures/local-mode-tests/tests/unstableDev.test.ts
+++ b/fixtures/local-mode-tests/tests/unstableDev.test.ts
@@ -50,6 +50,9 @@ describe("worker in remote mode", () => {
 	};
 
 	beforeAll(async () => {
+		if (process.env.TMP_CLOUDFLARE_API_TOKEN) {
+			process.env.CLOUDFLARE_API_TOKEN = process.env.TMP_CLOUDFLARE_API_TOKEN;
+		}
 		//since the script is invoked from the directory above, need to specify index.js is in src/
 		worker = await unstable_dev(
 			"src/basicModule.ts",
@@ -57,6 +60,7 @@ describe("worker in remote mode", () => {
 				ip: "127.0.0.1",
 				port: 1337,
 				local: false,
+				logLevel: "debug",
 			},
 			{ disableExperimentalWarning: true }
 		);
@@ -64,6 +68,7 @@ describe("worker in remote mode", () => {
 
 	afterAll(async () => {
 		await worker?.stop();
+		process.env.CLOUDFLARE_API_TOKEN = undefined;
 	});
 
 	it("should invoke the worker and exit", async () => {

--- a/fixtures/local-mode-tests/tests/unstableDev.test.ts
+++ b/fixtures/local-mode-tests/tests/unstableDev.test.ts
@@ -3,7 +3,44 @@ import { unstable_dev } from "wrangler";
 // TODO: add test for `experimentalLocal: true` once issue with dynamic
 //  `import()` and `npx-import` resolved:
 //  https://github.com/cloudflare/wrangler2/pull/1940#issuecomment-1261166695
-describe("worker", () => {
+describe("worker in local mode", () => {
+	let worker: {
+		fetch: (
+			input?: RequestInfo,
+			init?: RequestInit
+		) => Promise<Response | undefined>;
+		stop: () => Promise<void>;
+	};
+
+	beforeAll(async () => {
+		//since the script is invoked from the directory above, need to specify index.js is in src/
+		worker = await unstable_dev(
+			"src/basicModule.ts",
+			{
+				ip: "127.0.0.1",
+				port: 1337,
+				local: true,
+			},
+			{ disableExperimentalWarning: true }
+		);
+	});
+
+	afterAll(async () => {
+		await worker?.stop();
+	});
+
+	it("should invoke the worker and exit", async () => {
+		const resp = await worker.fetch();
+		expect(resp).not.toBe(undefined);
+		if (resp) {
+			const text = await resp.text();
+
+			expect(text).toMatchInlineSnapshot(`"Hello World!"`);
+		}
+	});
+});
+
+describe("worker in remote mode", () => {
 	let worker: {
 		fetch: (
 			input?: RequestInfo,

--- a/fixtures/local-mode-tests/tests/unstableDev.test.ts
+++ b/fixtures/local-mode-tests/tests/unstableDev.test.ts
@@ -19,6 +19,7 @@ describe("worker", () => {
 			{
 				ip: "127.0.0.1",
 				port: 1337,
+				local: false,
 			},
 			{ disableExperimentalWarning: true }
 		);

--- a/fixtures/local-mode-tests/tests/unstableDev.test.ts
+++ b/fixtures/local-mode-tests/tests/unstableDev.test.ts
@@ -65,7 +65,6 @@ describe("worker in remote mode", () => {
 				ip: "127.0.0.1",
 				port: 1337,
 				local: false,
-				logLevel: "debug",
 			},
 			{ disableExperimentalWarning: true }
 		);

--- a/fixtures/local-mode-tests/tests/unstableDev.test.ts
+++ b/fixtures/local-mode-tests/tests/unstableDev.test.ts
@@ -53,6 +53,11 @@ describe("worker in remote mode", () => {
 		if (process.env.TMP_CLOUDFLARE_API_TOKEN) {
 			process.env.CLOUDFLARE_API_TOKEN = process.env.TMP_CLOUDFLARE_API_TOKEN;
 		}
+
+		if (process.env.TMP_CLOUDFLARE_ACCOUNT_ID) {
+			process.env.CLOUDFLARE_ACCOUNT_ID = process.env.TMP_CLOUDFLARE_ACCOUNT_ID;
+		}
+
 		//since the script is invoked from the directory above, need to specify index.js is in src/
 		worker = await unstable_dev(
 			"src/basicModule.ts",

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -102,8 +102,8 @@ export async function unstable_dev(
 					_: [],
 					$0: "",
 					port: options?.port ?? 0,
-					...options,
 					local: true,
+					...options,
 					onReady: (address, port) => {
 						readyPort = port;
 						readyAddress = address;

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -577,7 +577,7 @@ export async function startApiDev(args: StartDevOptions) {
 			showInteractiveDevSession: args.showInteractiveDevSession,
 			forceLocal: args.forceLocal,
 			enablePagesAssetsServiceBinding: args.enablePagesAssetsServiceBinding,
-			local: true,
+			local: args.local ?? true,
 			firstPartyWorker: configParam.first_party_worker,
 			sendMetrics: configParam.send_metrics,
 			testScheduled: args.testScheduled,

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -446,20 +446,18 @@ export async function getRemotePreviewToken(props: RemoteProps) {
 		return workerPreviewToken;
 	}
 	return start().catch((err) => {
-		// we want to log the error, but not end the process
-		// since it could recover after the developer fixes whatever's wrong
-		if ((err as { code: string }).code !== "ABORT_ERR") {
+		if ((err as { code?: string })?.code !== "ABORT_ERR") {
 			// instead of logging the raw API error to the user,
 			// give them friendly instructions
 			// for error 10063 (workers.dev subdomain required)
-			if (err.code === 10063) {
+			if (err?.code === 10063) {
 				const errorMessage =
 					"Error: You need to register a workers.dev subdomain before running the dev command in remote mode";
 				const solutionMessage =
 					"You can either enable local mode by pressing l, or register a workers.dev subdomain here:";
 				const onboardingLink = `https://dash.cloudflare.com/${props.accountId}/workers/onboarding`;
 				logger.error(`${errorMessage}\n${solutionMessage}\n${onboardingLink}`);
-			} else if (err.code === 10049) {
+			} else if (err?.code === 10049) {
 				// code 10049 happens when the preview token expires
 				logger.log("Preview token expired, restart server to fetch a new one");
 			} else {

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -397,7 +397,7 @@ export async function getRemotePreviewToken(props: RemoteProps) {
 	//setup the preview session
 	async function start() {
 		if (props.accountId === undefined) {
-			return;
+			throw logger.error("no accountId provided");
 		}
 		const abortController = new AbortController();
 		const { workerAccount, workerContext } = getWorkerAccountAndContext({
@@ -415,11 +415,9 @@ export async function getRemotePreviewToken(props: RemoteProps) {
 			abortController.signal
 		);
 		//use the session to upload the worker, and create a preview
-		if (props.accountId === undefined) {
-			return;
-		}
+
 		if (session === undefined) {
-			return;
+			throw logger.error("Failed to start a session");
 		}
 		if (!props.bundle || !props.format) return;
 

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -370,7 +370,7 @@ export function useWorker(
 export async function startRemoteServer(props: RemoteProps) {
 	const previewToken = await getRemotePreviewToken(props);
 	if (previewToken === undefined) {
-		throw logger.error("Failed to start remote server");
+		throw logger.error("Failed to get a previewToken");
 	}
 	// start our proxy server
 	const previewServer = await startPreviewServer({

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -368,7 +368,27 @@ export function useWorker(
 }
 
 export async function startRemoteServer(props: RemoteProps) {
-	const previewToken = await getRemotePreviewToken(props);
+	let accountId = props.accountId;
+	if (accountId === undefined) {
+		const accountChoices = await getAccountChoices();
+		if (accountChoices.length === 1) {
+			saveAccountToCache({
+				id: accountChoices[0].id,
+				name: accountChoices[0].name,
+			});
+			accountId = accountChoices[0].id;
+		} else {
+			throw logger.error(
+				"In a non-interactive environment, it is mandatory to specify an account ID, either by assigning its value to CLOUDFLARE_ACCOUNT_ID, or as `account_id` in your `wrangler.toml` file."
+			);
+		}
+	}
+
+	const previewToken = await getRemotePreviewToken({
+		...props,
+		accountId: accountId,
+	});
+
 	if (previewToken === undefined) {
 		throw logger.error("Failed to get a previewToken");
 	}

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -133,8 +133,7 @@ export async function startDevServer(
 				inspectorUrl,
 			};
 		} else {
-			//TODO: implement a stop function
-			await startRemoteServer({
+			const { stop } = await startRemoteServer({
 				name: props.name,
 				bundle: bundle,
 				format: props.entry.format,
@@ -159,6 +158,13 @@ export async function startDevServer(
 				sourceMapPath: bundle?.sourceMapPath,
 				sendMetrics: props.sendMetrics,
 			});
+			return {
+				stop: async () => {
+					stop();
+					await stopWorkerRegistry();
+				},
+				// TODO: inspectorUrl,
+			};
 		}
 	} catch (err) {
 		logger.error(err);

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -97,7 +97,7 @@ export async function startDevServer(
 			testScheduled: props.testScheduled,
 			experimentalLocalStubCache: props.experimentalLocal,
 		});
-		console.log("props.local: ", props.local);
+
 		if (props.local) {
 			const { stop, inspectorUrl } = await startLocalServer({
 				name: props.name,
@@ -122,42 +122,44 @@ export async function startDevServer(
 				enablePagesAssetsServiceBinding: props.enablePagesAssetsServiceBinding,
 				usageModel: props.usageModel,
 				workerDefinitions,
+				experimentalLocal: props.experimentalLocal,
 			});
 
-		//run local now
-		const { stop, inspectorUrl } = await startLocalServer({
-			name: props.name,
-			bundle: bundle,
-			format: props.entry.format,
-			compatibilityDate: props.compatibilityDate,
-			compatibilityFlags: props.compatibilityFlags,
-			bindings: props.bindings,
-			assetPaths: props.assetPaths,
-			port: props.port,
-			ip: props.ip,
-			rules: props.rules,
-			inspectorPort: props.inspectorPort,
-			localPersistencePath: props.localPersistencePath,
-			liveReload: props.liveReload,
-			crons: props.crons,
-			localProtocol: props.localProtocol,
-			localUpstream: props.localUpstream,
-			logPrefix: props.logPrefix,
-			inspect: props.inspect,
-			onReady: props.onReady,
-			enablePagesAssetsServiceBinding: props.enablePagesAssetsServiceBinding,
-			usageModel: props.usageModel,
-			workerDefinitions,
-			experimentalLocal: props.experimentalLocal,
-		});
-
-		return {
-			stop: async () => {
-				stop();
-				await stopWorkerRegistry();
-			},
-			inspectorUrl,
-		};
+			return {
+				stop: async () => {
+					stop();
+					await stopWorkerRegistry();
+				},
+				inspectorUrl,
+			};
+		} else {
+			//TODO: implement a stop function
+			await startRemoteServer({
+				name: props.name,
+				bundle: bundle,
+				format: props.entry.format,
+				accountId: props.accountId,
+				bindings: props.bindings,
+				assetPaths: props.assetPaths,
+				isWorkersSite: props.isWorkersSite,
+				port: props.port,
+				ip: props.ip,
+				localProtocol: props.localProtocol,
+				inspectorPort: props.inspectorPort,
+				inspect: props.inspect,
+				compatibilityDate: props.compatibilityDate,
+				compatibilityFlags: props.compatibilityFlags,
+				usageModel: props.usageModel,
+				env: props.env,
+				legacyEnv: props.legacyEnv,
+				zone: props.zone,
+				host: props.host,
+				routes: props.routes,
+				onReady: props.onReady,
+				sourceMapPath: bundle?.sourceMapPath,
+				sendMetrics: props.sendMetrics,
+			});
+		}
 	} catch (err) {
 		logger.error(err);
 	}

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -21,6 +21,7 @@ import {
 	setupMiniflareOptions,
 	setupNodeOptions,
 } from "./local";
+import { startRemoteServer } from "./remote";
 import { validateDevProps } from "./validate-dev-props";
 
 import type { Config } from "../config";
@@ -96,6 +97,32 @@ export async function startDevServer(
 			testScheduled: props.testScheduled,
 			experimentalLocalStubCache: props.experimentalLocal,
 		});
+		console.log("props.local: ", props.local);
+		if (props.local) {
+			const { stop, inspectorUrl } = await startLocalServer({
+				name: props.name,
+				bundle: bundle,
+				format: props.entry.format,
+				compatibilityDate: props.compatibilityDate,
+				compatibilityFlags: props.compatibilityFlags,
+				bindings: props.bindings,
+				assetPaths: props.assetPaths,
+				port: props.port,
+				ip: props.ip,
+				rules: props.rules,
+				inspectorPort: props.inspectorPort,
+				localPersistencePath: props.localPersistencePath,
+				liveReload: props.liveReload,
+				crons: props.crons,
+				localProtocol: props.localProtocol,
+				localUpstream: props.localUpstream,
+				logPrefix: props.logPrefix,
+				inspect: props.inspect,
+				onReady: props.onReady,
+				enablePagesAssetsServiceBinding: props.enablePagesAssetsServiceBinding,
+				usageModel: props.usageModel,
+				workerDefinitions,
+			});
 
 		//run local now
 		const { stop, inspectorUrl } = await startLocalServer({

--- a/packages/wrangler/src/proxy.ts
+++ b/packages/wrangler/src/proxy.ts
@@ -90,6 +90,166 @@ type PreviewProxy = {
 	terminator: HttpTerminator;
 };
 
+export async function startPreviewServer({
+	previewToken,
+	assetDirectory,
+	localProtocol,
+	localPort: port,
+	ip,
+}: {
+	previewToken: CfPreviewToken;
+	assetDirectory: string | undefined;
+	localProtocol: "https" | "http";
+	localPort: number;
+	ip: string;
+}) {
+	try {
+		const abortController = new AbortController();
+
+		const server = await createProxyServer(localProtocol);
+		const proxy = {
+			server,
+			terminator: createHttpTerminator({
+				server,
+				gracefulTerminationTimeout: 0,
+			}),
+		};
+
+		const cleanupListeners: (() => void)[] = [];
+		// We have a token. Let's proxy requests to the preview end point.
+
+		// create a ClientHttp2Session
+		logger.debug("PREVIEW URL:", `https://${previewToken.host}`);
+		const remote = connect(`https://${previewToken.host}`);
+		cleanupListeners.push(() => remote.destroy());
+
+		/** HTTP/2 -> HTTP/2  */
+		const handleStream = createStreamHandler(
+			previewToken,
+			remote,
+			port,
+			localProtocol
+		);
+		proxy.server.on("stream", handleStream);
+		cleanupListeners.push(() => proxy.server.off("stream", handleStream));
+
+		/** HTTP/1 -> HTTP/2  */
+		const handleRequest: RequestListener = (
+			message: IncomingMessage,
+			response: ServerResponse
+		) => {
+			const { httpVersionMajor, headers, method, url } = message;
+			if (httpVersionMajor >= 2) {
+				return; // Already handled by the "stream" event.
+			}
+			addCfPreviewTokenHeader(headers, previewToken.value);
+			headers[":method"] = method;
+			headers[":path"] = url;
+			headers[":authority"] = previewToken.host;
+			headers[":scheme"] = "https";
+			for (const name of Object.keys(headers)) {
+				if (HTTP1_HEADERS.has(name.toLowerCase())) {
+					delete headers[name];
+				}
+			}
+			const request = message.pipe(remote.request(headers));
+			logger.debug(
+				"WORKER REQUEST",
+				new Date().toLocaleTimeString(),
+				method,
+				url
+			);
+			logger.debug("HEADERS", JSON.stringify(headers, null, 2));
+			logger.debug("PREVIEW TOKEN", previewToken);
+
+			request.on("response", (responseHeaders) => {
+				const status = responseHeaders[":status"] ?? 500;
+
+				// log all requests to terminal
+				logger.log(new Date().toLocaleTimeString(), method, url, status);
+
+				rewriteRemoteHostToLocalHostInHeaders(
+					responseHeaders,
+					previewToken.host,
+					port,
+					localProtocol
+				);
+				for (const name of Object.keys(responseHeaders)) {
+					if (name.startsWith(":")) {
+						delete responseHeaders[name];
+					}
+				}
+				response.writeHead(status, responseHeaders);
+				request.pipe(response, { end: true });
+			});
+		};
+
+		// If an asset path is defined, check the file system
+		// for a file first and serve if it exists.
+		const actualHandleRequest = assetDirectory
+			? createHandleAssetsRequest(assetDirectory, handleRequest)
+			: handleRequest;
+
+		proxy.server.on("request", actualHandleRequest);
+		cleanupListeners.push(() =>
+			proxy.server.off("request", actualHandleRequest)
+		);
+
+		/** HTTP/1 -> WebSocket (over HTTP/1)  */
+		const handleUpgrade = (
+			message: IncomingMessage,
+			socket: WebSocket,
+			body: Buffer
+		) => {
+			const { headers, url } = message;
+			addCfPreviewTokenHeader(headers, previewToken.value);
+			headers["host"] = previewToken.host;
+			const localWebsocket = new WebSocket(message, socket, body) as IWebsocket;
+			// TODO(soon): Custom WebSocket protocol is not working?
+			const remoteWebsocketClient = new WebSocket.Client(
+				`wss://${previewToken.host}${url}`,
+				[],
+				{ headers }
+			) as IWebsocket;
+			localWebsocket.pipe(remoteWebsocketClient).pipe(localWebsocket);
+			// We close down websockets whenever we refresh the token.
+			cleanupListeners.push(() => {
+				localWebsocket.close();
+				remoteWebsocketClient.close();
+			});
+		};
+		proxy.server.on("upgrade", handleUpgrade);
+		cleanupListeners.push(() => proxy.server.off("upgrade", handleUpgrade));
+
+		waitForPortToBeAvailable(port, {
+			retryPeriod: 200,
+			timeout: 2000,
+			abortSignal: abortController.signal,
+		})
+			.then(() => {
+				proxy.server.on("listening", () => {
+					const address = proxy.server.address();
+					const usedPort =
+						address && typeof address === "object" ? address.port : port;
+					logger.log(`⬣ Listening at ${localProtocol}://${ip}:${usedPort}`);
+					const accessibleHosts =
+						ip !== "0.0.0.0" ? [ip] : getAccessibleHosts();
+					for (const accessibleHost of accessibleHosts) {
+						logger.log(`- ${localProtocol}://${accessibleHost}:${usedPort}`);
+					}
+				});
+				proxy.server.listen(port, ip);
+			})
+			.catch((err) => {
+				if ((err as { code: string }).code !== "ABORT_ERR") {
+					logger.error(`Failed to start server: ${err}`);
+				}
+			});
+	} catch (err) {
+		logger.error("Failed to create proxy server:", err);
+	}
+}
+
 export function usePreviewServer({
 	previewToken,
 	assetDirectory,


### PR DESCRIPTION
How to review this PR:

- Start in `fixtures/local-mode-tests/tests/unstableDev.test.ts`, where we call `unstable_dev` with `local: false`
- We then modify `packages/wrangler/src/api/dev.ts`, and make it possible to configure the `local` setting in `unstable_dev`
- We then pass that down to `packages/wrangler/src/dev.tsx`, in `startApiDev`
- We then move to `packages/wrangler/src/dev/start-server.ts`, where we pass `local` to `startDevServer`, which uses it to decide whether to start a local, or remote server
- Remote server is implemented in `packages/wrangler/src/dev/remote.tsx`
- Finally, we define a proxy server here: `packages/wrangler/src/proxy.ts`, which gets called by `startRemoteServer` above

Closes #1780