### PR TITLE
fix(wrangler): preserve colon when parsing vars and defines

### DIFF
--- a/packages/wrangler/src/__tests__/utils-collect.test.ts
+++ b/packages/wrangler/src/__tests__/utils-collect.test.ts
@@ -1,0 +1,39 @@
+import { collect } from "../utils/collect";
+
+// a test suite that handles the collect function
+describe("collect", () => {
+	it("should return an empty object when passed undefined", () => {
+		expect(collect(undefined)).toEqual({});
+	});
+
+	it("should return an empty object when passed an empty array", () => {
+		expect(collect([])).toEqual({});
+	});
+
+	it("should return an object with a single key/value pair when passed an array with a single string", () => {
+		expect(collect(["some-key:some-value"])).toEqual({
+			"some-key": "some-value",
+		});
+	});
+
+	it("should return an object with multiple key/value pairs when passed an array with multiple strings", () => {
+		expect(
+			collect(["some-key:some-value", "some-other-key:some-other-value"])
+		).toEqual({
+			"some-key": "some-value",
+			"some-other-key": "some-other-value",
+		});
+	});
+
+	it("should return an object with multiple key/value pairs when passed an array with multiple strings with multiple colons", () => {
+		expect(
+			collect([
+				"some-key:https://some-value.com",
+				"some-other-key:https://some-other-value.com",
+			])
+		).toEqual({
+			"some-key": "https://some-value.com",
+			"some-other-key": "https://some-other-value.com",
+		});
+	});
+});

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -14,6 +14,7 @@ import { logger } from "./logger";
 import * as metrics from "./metrics";
 import { getAssetPaths, getSiteAssetPaths } from "./sites";
 import { getAccountFromCache } from "./user";
+import { collect } from "./utils/collect";
 import { identifyD1BindingsAsBeta } from "./worker";
 import { getHostFromRoute, getZoneForRoute, getZoneIdFromHost } from "./zones";
 import {
@@ -739,12 +740,7 @@ async function validateDevServerSettings(
 		config.configPath
 	);
 
-	const cliDefines =
-		args.define?.reduce<Record<string, string>>((collectDefines, d) => {
-			const [key, ...value] = d.split(":");
-			collectDefines[key] = value.join(":");
-			return collectDefines;
-		}, {}) || {};
+	const cliDefines = collect(args.define);
 
 	return {
 		entry,
@@ -764,12 +760,7 @@ async function getBindingsAndAssetPaths(
 	args: StartDevOptions,
 	configParam: Config
 ) {
-	const cliVars =
-		args.var?.reduce<Record<string, string>>((collectVars, v) => {
-			const [key, ...value] = v.split(":");
-			collectVars[key] = value.join(":");
-			return collectVars;
-		}, {}) || {};
+	const cliVars = collect(args.var);
 
 	// now log all available bindings into the terminal
 	const bindings = await getBindings(configParam, {

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -742,7 +742,7 @@ async function validateDevServerSettings(
 	const cliDefines =
 		args.define?.reduce<Record<string, string>>((collectDefines, d) => {
 			const [key, ...value] = d.split(":");
-			collectDefines[key] = value.join("");
+			collectDefines[key] = value.join(":");
 			return collectDefines;
 		}, {}) || {};
 
@@ -767,7 +767,7 @@ async function getBindingsAndAssetPaths(
 	const cliVars =
 		args.var?.reduce<Record<string, string>>((collectVars, v) => {
 			const [key, ...value] = v.split(":");
-			collectVars[key] = value.join("");
+			collectVars[key] = value.join(":");
 			return collectVars;
 		}, {}) || {};
 

--- a/packages/wrangler/src/publish/index.ts
+++ b/packages/wrangler/src/publish/index.ts
@@ -11,6 +11,7 @@ import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { getAssetPaths, getSiteAssetPaths } from "../sites";
 import { requireAuth } from "../user";
+import { collect } from "../utils/collect";
 import publish from "./publish";
 import type { ConfigPath } from "../index";
 import type { YargsOptionsToInterface } from "../yargs-types";
@@ -220,19 +221,8 @@ export async function publishHandler(args: ArgumentsCamelCase<PublishArgs>) {
 		);
 	}
 
-	const cliVars =
-		args.var?.reduce<Record<string, string>>((collectVars, v) => {
-			const [key, ...value] = v.split(":");
-			collectVars[key] = value.join("");
-			return collectVars;
-		}, {}) || {};
-
-	const cliDefines =
-		args.define?.reduce<Record<string, string>>((collectDefines, d) => {
-			const [key, ...value] = d.split(":");
-			collectDefines[key] = value.join("");
-			return collectDefines;
-		}, {}) || {};
+	const cliVars = collect(args.var);
+	const cliDefines = collect(args.define);
 
 	const accountId = args.dryRun ? undefined : await requireAuth(config);
 

--- a/packages/wrangler/src/utils/collect.ts
+++ b/packages/wrangler/src/utils/collect.ts
@@ -1,0 +1,14 @@
+/**
+ * a function that takes an array of strings in `key:value` format
+ * (typically from yargs or config) and returns back
+ * a neat object with the keys and values
+ */
+export function collect(array?: string[]) {
+	return (
+		array?.reduce<Record<string, string>>((recordsToCollect, v) => {
+			const [key, ...value] = v.split(":");
+			recordsToCollect[key] = value.join(":");
+			return recordsToCollect;
+		}, {}) || {}
+	);
+}


### PR DESCRIPTION
# Motivation
Closes https://github.com/cloudflare/wrangler2/issues/1809.

# Solution
Re-join var/define values with colon when parsing them.