### PR TITLE
Support Cloudflare Access for `wrangler dev`

### DIFF
--- a/.changeset/tiny-gifts-own.md
+++ b/.changeset/tiny-gifts-own.md
@@ -2,4 +2,4 @@
 "wrangler": minor
 ---
 
-Enable support for Workers behind Cloudflare Access
+Enable support for `wrangler dev` on Workers behind Cloudflare Access, utilising `cloudflared`. If you don't have `cloudflared` installed, Wrangler will prompt you to install it. If you _do_, then the first time you start developing using `wrangler dev` your default browser will open with a Cloudflare Access prompt.

--- a/.changeset/tiny-gifts-own.md
+++ b/.changeset/tiny-gifts-own.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Enable support for Workers behind Cloudflare Access

--- a/packages/wrangler/src/__tests__/access.test.ts
+++ b/packages/wrangler/src/__tests__/access.test.ts
@@ -1,0 +1,25 @@
+import { domainUsesAccess, getAccessToken } from "../user/access";
+import { msw, mswAccessHandlers } from "./helpers/msw";
+
+describe("access", () => {
+	beforeEach(() => {
+		msw.use(...mswAccessHandlers);
+	});
+
+	describe("basic", () => {
+		it("should correctly detect an access protected domain", async () => {
+			expect(await domainUsesAccess("access-protected.com")).toBeTruthy();
+			expect(await domainUsesAccess("not-access-protected.com")).toBeFalsy();
+		});
+		it("should not fail without cloudflared installed", async () => {
+			expect(await getAccessToken("not-access-protected.com")).toBeFalsy();
+		});
+		it("should error without cloudflared installed on an access protected domain", async () => {
+			await expect(getAccessToken("access-protected.com")).rejects.toEqual(
+				new Error(
+					"To use Wrangler with Cloudflare Access, please install `cloudflared` from https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation"
+				)
+			);
+		});
+	});
+});

--- a/packages/wrangler/src/__tests__/helpers/msw/handlers/access.ts
+++ b/packages/wrangler/src/__tests__/helpers/msw/handlers/access.ts
@@ -1,0 +1,13 @@
+import { rest } from "msw";
+
+export default [
+	rest.get("*access-protected.com*", (_, response, cxt) => {
+		return response.once(
+			cxt.status(302),
+			cxt.set("location", "access-protected-com.cloudflareaccess.com")
+		);
+	}),
+	rest.get("*not-access-protected.com*", (_, response, cxt) => {
+		return response.once(cxt.status(200), cxt.body("OK"));
+	}),
+];

--- a/packages/wrangler/src/__tests__/helpers/msw/index.ts
+++ b/packages/wrangler/src/__tests__/helpers/msw/index.ts
@@ -1,4 +1,5 @@
 import { setupServer } from "msw/node";
+import { default as mswAccessHandlers } from "./handlers/access";
 import { mswSuccessDeployments } from "./handlers/deployments";
 import { mswSuccessNamespacesHandlers } from "./handlers/namespaces";
 import { mswSuccessOauthHandlers } from "./handlers/oauth";
@@ -14,4 +15,5 @@ export {
 	mswSuccessNamespacesHandlers,
 	mswSucessScriptHandlers,
 	mswSuccessDeployments,
+	mswAccessHandlers,
 };

--- a/packages/wrangler/src/__tests__/jest.setup.ts
+++ b/packages/wrangler/src/__tests__/jest.setup.ts
@@ -39,6 +39,13 @@ jest.mock("get-port", () => {
 	};
 });
 
+jest.mock("child_process", () => {
+	return {
+		__esModule: true,
+		spawnSync: jest.fn().mockImplementation(async () => ({ error: true })),
+	};
+});
+
 jest.mock("ws", () => {
 	return {
 		__esModule: true,

--- a/packages/wrangler/src/__tests__/jest.setup.ts
+++ b/packages/wrangler/src/__tests__/jest.setup.ts
@@ -42,7 +42,11 @@ jest.mock("get-port", () => {
 jest.mock("child_process", () => {
 	return {
 		__esModule: true,
-		spawnSync: jest.fn().mockImplementation(async () => ({ error: true })),
+		...jest.requireActual("child_process"),
+		spawnSync: jest.fn().mockImplementation(async (binary, ...args) => {
+			if (binary === "cloudflared") return { error: true };
+			return jest.requireActual("child_process").spawnSync(binary, ...args);
+		}),
 	};
 });
 

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -104,6 +104,7 @@ export function Remote(props: RemoteProps) {
 		port: props.inspectorPort,
 		logToTerminal: true,
 		sourceMapPath: props.sourceMapPath,
+		host: previewToken?.host,
 	});
 
 	const errorHandler = useErrorHandler();

--- a/packages/wrangler/src/proxy.ts
+++ b/packages/wrangler/src/proxy.ts
@@ -8,6 +8,7 @@ import { useEffect, useRef, useState } from "react";
 import serveStatic from "serve-static";
 import { getHttpsOptions } from "./https-options";
 import { logger } from "./logger";
+import { getAccessToken } from "./user/access";
 import type { CfPreviewToken } from "./create-worker-preview";
 import type { HttpTerminator } from "http-terminator";
 import type {
@@ -20,7 +21,6 @@ import type {
 import type { ClientHttp2Session, ServerHttp2Stream } from "node:http2";
 import type { Server as HttpsServer } from "node:https";
 import type { Duplex, Writable } from "node:stream";
-import { getAccessToken } from "./user/access";
 
 /**
  * `usePreviewServer` is a React hook that creates a local development

--- a/packages/wrangler/src/user/access.ts
+++ b/packages/wrangler/src/user/access.ts
@@ -6,7 +6,7 @@ const cache: Record<string, string> = {};
 
 const usesAccessCache = new Map();
 
-async function domainUsesAccess(domain: string): Promise<boolean> {
+export async function domainUsesAccess(domain: string): Promise<boolean> {
 	logger.debug("Checking if domain has Access enabled:", domain);
 
 	if (usesAccessCache.has(domain)) {

--- a/packages/wrangler/src/user/access.ts
+++ b/packages/wrangler/src/user/access.ts
@@ -1,0 +1,69 @@
+import { spawnSync } from "child_process";
+import { fetch } from "undici";
+import { logger } from "../logger";
+
+const cache: Record<string, string> = {};
+
+const usesAccessCache = new Map();
+
+async function domainUsesAccess(domain: string): Promise<boolean> {
+	logger.debug("Checking if domain has Access enabled:", domain);
+
+	if (usesAccessCache.has(domain)) {
+		logger.debug(
+			"Using cached Access switch for:",
+			domain,
+			usesAccessCache.get(domain)
+		);
+		return usesAccessCache.get(domain);
+	}
+	logger.debug("Access switch not cached for:", domain);
+	try {
+		const controller = new AbortController();
+		const cancel = setTimeout(() => {
+			logger.debug("Timed out");
+			controller.abort();
+		}, 1000);
+
+		const output = await fetch(`https://${domain}`, {
+			redirect: "manual",
+			signal: controller.signal,
+		});
+		clearTimeout(cancel);
+		const usesAccess = !!(
+			output.status === 302 &&
+			output.headers.get("location")?.includes("cloudflareaccess.com")
+		);
+		logger.debug("Caching access switch for:", domain);
+
+		usesAccessCache.set(domain, usesAccess);
+		return usesAccess;
+	} catch (e) {
+		usesAccessCache.set(domain, false);
+		return false;
+	}
+}
+export async function getAccessToken(
+	domain: string
+): Promise<string | undefined> {
+	if (!(await domainUsesAccess(domain))) {
+		return undefined;
+	}
+	if (cache[domain]) {
+		return cache[domain];
+	}
+	const output = await spawnSync("cloudflared", ["access", "login", domain]);
+	if (output.error) {
+		// The cloudflared binary is not installed
+		throw new Error(
+			"To use Wrangler with Cloudflare Access, please install `cloudflared` from https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation"
+		);
+	}
+	const stringOutput = output.stdout.toString();
+	const matches = stringOutput.match(/fetched your token:\n\n(.*)/m);
+	if (matches && matches.length >= 2) {
+		cache[domain] = matches[1];
+		return matches[1];
+	}
+	throw new Error("Failed to authenticate with Cloudflare Access");
+}


### PR DESCRIPTION
Enable support for `wrangler dev` on Workers behind Cloudflare Access, utilising `cloudflared`. If you don't have `cloudflared` installed, Wrangler will prompt you to install it. If you _do_, then the first time you start developing using `wrangler dev` your default browser will open with a Cloudflare Access prompt.