### PR TITLE
Add `repository` field to `package.json`s

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "wrangler-root",
 	"version": "0.0.0",
+	"private": true,
 	"description": "Monorepo for wrangler and associated packages",
 	"homepage": "https://github.com/cloudflare/wrangler2#readme",
 	"bugs": {

--- a/packages/pages-shared/package.json
+++ b/packages/pages-shared/package.json
@@ -1,6 +1,11 @@
 {
 	"name": "@cloudflare/pages-shared",
 	"version": "0.0.8",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/cloudflare/wrangler2.git",
+		"directory": "packages/pages-shared"
+	},
 	"files": [
 		"tsconfig.json",
 		"asset-server/**/*",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -28,6 +28,11 @@
 	"bugs": {
 		"url": "https://github.com/cloudflare/wrangler2/issues"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/cloudflare/wrangler2.git",
+		"directory": "packages/wrangler"
+	},
 	"license": "MIT OR Apache-2.0",
 	"author": "wrangler@cloudflare.com",
 	"main": "wrangler-dist/cli.js",

--- a/packages/wranglerjs-compat-webpack-plugin/package.json
+++ b/packages/wranglerjs-compat-webpack-plugin/package.json
@@ -6,6 +6,11 @@
 	"bugs": {
 		"url": "https://github.com/cloudflare/wrangler2/issues"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/cloudflare/wrangler2.git",
+		"directory": "packages/wranglerjs-compat-webpack-plugin"
+	},
 	"license": "MIT OR Apache-2.0",
 	"author": "wrangler@cloudflare.com",
 	"type": "commonjs",


### PR DESCRIPTION
Helps computers associate the repo on GitHub with the package on npm.