### PR TITLE
Slightly relax the selectors for `Link` header generation in Pages Early Hints

### DIFF
--- a/.changeset/empty-vans-sneeze.md
+++ b/.changeset/empty-vans-sneeze.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/pages-shared": patch
+---
+
+feat: Slightly relax the selectors for generating `Link` headers from `<link>` elements in Pages Early Hints feature
+
+Previously, we'd only generate `Link` headers if the `rel="preload"` or `rel="preconnect"` matched exactly. Now, this change will generate `Link` headers if `preload` or `preconnect` appears as a whitespace-separated value in the `rel` attribute. For example, `rel="stylesheet preconnect"` is now valid.
+
+For more info, check out [this GitHub issue on the Cloudflare Developer Docs repo](https://github.com/cloudflare/cloudflare-docs/pull/6183#issuecomment-1272007522).

--- a/packages/pages-shared/asset-server/handler.ts
+++ b/packages/pages-shared/asset-server/handler.ts
@@ -325,7 +325,7 @@ export async function generateHandler<
 							const links: { href: string; rel: string; as?: string }[] = [];
 
 							const transformedResponse = new HTMLRewriter()
-								.on("link[rel=preconnect],link[rel=preload]", {
+								.on("link[rel~=preconnect],link[rel~=preload]", {
 									element(element) {
 										for (const [attributeName] of element.attributes) {
 											if (


### PR DESCRIPTION
Slightly relax the selectors for generating `Link` headers from `<link>` elements in Pages Early Hints feature

Previously, we'd only generate `Link` headers if the `rel="preload"` or `rel="preconnect"` matched exactly. Now, this change will generate `Link` headers if `preload` or `preconnect` appears as a whitespace-separated value in the `rel` attribute. For example, `rel="stylesheet preconnect"` is now valid.

For more info, check out [this GitHub issue on the Cloudflare Developer Docs repo](https://github.com/cloudflare/cloudflare-docs/pull/6183#issuecomment-1272007522).

---

Fixes #1999