### PR TITLE
Offer to create a workers.dev subdomain on `wrangler publish` if necessary

### DIFF
--- a/.changeset/gold-ghosts-give.md
+++ b/.changeset/gold-ghosts-give.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+---
+
+Offer to create a workers.dev subdomain if a user needs one
+
+Previously, when a user wanted to publish a worker to https://workers.dev by setting `workers_dev = true` in their `wrangler.toml`,
+but their account didn't have a subdomain registered, we would error out.
+
+Now, we offer to create one for them. It's not implemented for `wrangler dev`, which also expects you to have registered a
+workers.dev subdomain, but we now error correctly and tell them what the problem is.

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -400,17 +400,17 @@ describe("publish", () => {
 				await expect(
 					runWrangler("publish index.js --env some-env --legacy-env true")
 				).rejects.toThrowErrorMatchingInlineSnapshot(`
-                "Processing wrangler.toml configuration:
-                  - No environment found in configuration with name \\"some-env\\".
-                    Before using \`--env=some-env\` there should be an equivalent environment section in the configuration.
-                    The available configured environment names are: [\\"other-env\\"]
+			                "Processing wrangler.toml configuration:
+			                  - No environment found in configuration with name \\"some-env\\".
+			                    Before using \`--env=some-env\` there should be an equivalent environment section in the configuration.
+			                    The available configured environment names are: [\\"other-env\\"]
 
-                    Consider adding an environment configuration section to the wrangler.toml file:
-                    \`\`\`
-                    [env.some-env]
-                    \`\`\`
-                "
-              `);
+			                    Consider adding an environment configuration section to the wrangler.toml file:
+			                    \`\`\`
+			                    [env.some-env]
+			                    \`\`\`
+			                "
+		              `);
 			});
 
 			it("should throw an error w/ helpful message when using --env --name", async () => {
@@ -790,9 +790,9 @@ describe("publish", () => {
 			});
 			await expect(runWrangler("publish ./index --env=staging")).rejects
 				.toThrowErrorMatchingInlineSnapshot(`
-              "Service environments combined with an API token that doesn't have 'All Zones' permissions is not supported.
-              Either turn off service environments by setting \`legacy_env = true\`, creating an API token with 'All Zones' permissions, or logging in via OAuth"
-            `);
+			              "Service environments combined with an API token that doesn't have 'All Zones' permissions is not supported.
+			              Either turn off service environments by setting \`legacy_env = true\`, creating an API token with 'All Zones' permissions, or logging in via OAuth"
+		            `);
 		});
 
 		describe("custom domains", () => {
@@ -1180,11 +1180,11 @@ Update them to point to this script instead?`,
 			});
 			await expect(runWrangler("publish")).rejects
 				.toThrowErrorMatchingInlineSnapshot(`
-              "Processing wrangler.toml configuration:
-                - Don't define both the \`main\` and \`build.upload.main\` fields in your configuration.
-                  They serve the same purpose: to point to the entry-point of your worker.
-                  Delete the \`build.upload.main\` and \`build.upload.dir\` field from your config."
-            `);
+			              "Processing wrangler.toml configuration:
+			                - Don't define both the \`main\` and \`build.upload.main\` fields in your configuration.
+			                  They serve the same purpose: to point to the entry-point of your worker.
+			                  Delete the \`build.upload.main\` and \`build.upload.dir\` field from your config."
+		            `);
 		});
 
 		it("should be able to transpile TypeScript (esm)", async () => {
@@ -1375,9 +1375,9 @@ addEventListener('fetch', event => {});`
 
 			await expect(runWrangler("publish ./index.js")).rejects
 				.toThrowErrorMatchingInlineSnapshot(`
-              "Processing wrangler.toml configuration:
-                - \\"site.bucket\\" is a required field."
-            `);
+			              "Processing wrangler.toml configuration:
+			                - \\"site.bucket\\" is a required field."
+		            `);
 
 			expect(std.out).toMatchInlineSnapshot(`
 			        "
@@ -1521,11 +1521,11 @@ addEventListener('fetch', event => {});`
 
 			await expect(runWrangler("publish")).rejects
 				.toThrowErrorMatchingInlineSnapshot(`
-              "Processing wrangler.toml configuration:
-                - Don't define both the \`main\` and \`site.entry-point\` fields in your configuration.
-                  They serve the same purpose: to point to the entry-point of your worker.
-                  Delete the deprecated \`site.entry-point\` field from your config."
-            `);
+			              "Processing wrangler.toml configuration:
+			                - Don't define both the \`main\` and \`site.entry-point\` fields in your configuration.
+			                  They serve the same purpose: to point to the entry-point of your worker.
+			                  Delete the deprecated \`site.entry-point\` field from your config."
+		            `);
 		});
 
 		it("should error if there is no entry-point specified", async () => {
@@ -3301,7 +3301,7 @@ addEventListener('fetch', event => {});`
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should error politely when publishing to workers_dev when there is no workers.dev subdomain", async () => {
+		it("should offer to create a new workers.dev subdomain when publishing to workers_dev without one", async () => {
 			writeWranglerToml({
 				workers_dev: true,
 			});
@@ -3309,12 +3309,16 @@ addEventListener('fetch', event => {});`
 			mockUploadWorkerRequest();
 			mockSubDomainRequest("does-not-exist", false);
 
+			mockConfirm({
+				text: `Would you like to register a workers.dev subdomain now?`,
+				result: false,
+			});
+
 			await expect(runWrangler("publish ./index")).rejects
 				.toThrowErrorMatchingInlineSnapshot(`
-              "Error: You need to register a workers.dev subdomain before publishing to workers.dev
-              You can either publish your worker to one or more routes by specifying them in wrangler.toml, or register a workers.dev subdomain here:
-              https://dash.cloudflare.com/some-account-id/workers/onboarding"
-            `);
+			"You can either publish your worker to one or more routes by specifying them in wrangler.toml, or register a workers.dev subdomain here:
+			https://dash.cloudflare.com/some-account-id/workers/onboarding"
+		`);
 		});
 
 		it("should not deploy to workers.dev if there are any routes defined", async () => {
@@ -3734,9 +3738,9 @@ addEventListener('fetch', event => {});`
 
 			await expect(runWrangler("publish index.js")).rejects
 				.toThrowErrorMatchingInlineSnapshot(`
-              "The expected output file at \\"index.js\\" was not found after running custom build: node -e \\"console.log('custom build');\\".
-              The \`main\` property in wrangler.toml should point to the file generated by the custom build."
-            `);
+			              "The expected output file at \\"index.js\\" was not found after running custom build: node -e \\"console.log('custom build');\\".
+			              The \`main\` property in wrangler.toml should point to the file generated by the custom build."
+		            `);
 			expect(std.out).toMatchInlineSnapshot(`
 			        "Running custom build: node -e \\"console.log('custom build');\\"
 
@@ -3766,16 +3770,16 @@ addEventListener('fetch', event => {});`
 
 			await expect(runWrangler("publish")).rejects
 				.toThrowErrorMatchingInlineSnapshot(`
-              "The expected output file at \\".\\" was not found after running custom build: node -e \\"console.log('custom build');\\".
-              The \`main\` property in wrangler.toml should point to the file generated by the custom build.
-              The provided entry-point path, \\".\\", points to a directory, rather than a file.
+			              "The expected output file at \\".\\" was not found after running custom build: node -e \\"console.log('custom build');\\".
+			              The \`main\` property in wrangler.toml should point to the file generated by the custom build.
+			              The provided entry-point path, \\".\\", points to a directory, rather than a file.
 
-              Did you mean to set the main field to one of:
-              \`\`\`
-              main = \\"./worker.js\\"
-              main = \\"./dist/index.ts\\"
-              \`\`\`"
-            `);
+			              Did you mean to set the main field to one of:
+			              \`\`\`
+			              main = \\"./worker.js\\"
+			              main = \\"./dist/index.ts\\"
+			              \`\`\`"
+		            `);
 			expect(std.out).toMatchInlineSnapshot(`
 			        "Running custom build: node -e \\"console.log('custom build');\\"
 
@@ -5538,12 +5542,12 @@ addEventListener('fetch', event => {});`
 
 				await expect(runWrangler("publish index.js")).rejects
 					.toThrowErrorMatchingInlineSnapshot(`
-                              "You seem to be trying to use Durable Objects in a Worker written as a service-worker.
-                              You can use Durable Objects defined in other Workers by specifying a \`script_name\` in your wrangler.toml, where \`script_name\` is the name of the Worker that implements that Durable Object. For example:
-                              { name = EXAMPLE_DO_BINDING, class_name = ExampleDurableObject } ==> { name = EXAMPLE_DO_BINDING, class_name = ExampleDurableObject, script_name = example-do-binding-worker }
-                              Alternatively, migrate your worker to ES Module syntax to implement a Durable Object in this Worker:
-                              https://developers.cloudflare.com/workers/learning/migrating-to-module-workers/"
-                          `);
+			                              "You seem to be trying to use Durable Objects in a Worker written as a service-worker.
+			                              You can use Durable Objects defined in other Workers by specifying a \`script_name\` in your wrangler.toml, where \`script_name\` is the name of the Worker that implements that Durable Object. For example:
+			                              { name = EXAMPLE_DO_BINDING, class_name = ExampleDurableObject } ==> { name = EXAMPLE_DO_BINDING, class_name = ExampleDurableObject, script_name = example-do-binding-worker }
+			                              Alternatively, migrate your worker to ES Module syntax to implement a Durable Object in this Worker:
+			                              https://developers.cloudflare.com/workers/learning/migrating-to-module-workers/"
+		                          `);
 			});
 		});
 

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -210,9 +210,20 @@ export function useWorker(
 			);
 		}
 		start().catch((err) => {
+			// instead of logging the raw API error to the user,
+			// give them friendly instructions
+			// for error 10063 (workers.dev subdomain required)
+			if (err.code === 10063) {
+				const errorMessage =
+					"Error: You need to register a workers.dev subdomain before running the dev command in remote mode";
+				const solutionMessage =
+					"You can either enable local mode by pressing l, or register a workers.dev subdomain here:";
+				const onboardingLink = `https://dash.cloudflare.com/${props.accountId}/workers/onboarding`;
+				logger.error(`${errorMessage}\n${solutionMessage}\n${onboardingLink}`);
+			}
 			// we want to log the error, but not end the process
 			// since it could recover after the developer fixes whatever's wrong
-			if ((err as { code: string }).code !== "ABORT_ERR") {
+			else if ((err as { code: string }).code !== "ABORT_ERR") {
 				logger.error("Error while creating remote dev session:", err);
 			}
 		});

--- a/packages/wrangler/src/publish/publish.ts
+++ b/packages/wrangler/src/publish/publish.ts
@@ -13,7 +13,7 @@ import { getMigrationsToUpload } from "../durable";
 import { logger } from "../logger";
 import { getMetricsUsageHeaders } from "../metrics";
 import { ParseError } from "../parse";
-import { getSubdomain } from "../routes";
+import { getWorkersDevSubdomain } from "../routes";
 import { syncAssets } from "../sites";
 import { identifyD1BindingsAsBeta } from "../worker";
 import { getZoneForRoute } from "../zones";
@@ -610,7 +610,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 
 	if (deployToWorkersDev) {
 		// Deploy to a subdomain of `workers.dev`
-		const userSubdomain = await getSubdomain(accountId);
+		const userSubdomain = await getWorkersDevSubdomain(accountId);
 		const scriptURL =
 			props.legacyEnv || !props.env
 				? `${scriptName}.${userSubdomain}.workers.dev`

--- a/packages/wrangler/src/publish/publish.ts
+++ b/packages/wrangler/src/publish/publish.ts
@@ -2,18 +2,18 @@ import assert from "node:assert";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { URLSearchParams } from "node:url";
-import chalk from "chalk";
 import tmp from "tmp-promise";
 import { bundleWorker } from "../bundle";
 import { printBundleSize } from "../bundle-reporter";
 import { fetchListResult, fetchResult } from "../cfetch";
 import { printBindings } from "../config";
 import { createWorkerUploadForm } from "../create-worker-upload-form";
-import { confirm, fromDashMessagePrompt, prompt } from "../dialogs";
+import { confirm, fromDashMessagePrompt } from "../dialogs";
 import { getMigrationsToUpload } from "../durable";
 import { logger } from "../logger";
 import { getMetricsUsageHeaders } from "../metrics";
 import { ParseError } from "../parse";
+import { getSubdomain } from "../routes";
 import { syncAssets } from "../sites";
 import { identifyD1BindingsAsBeta } from "../worker";
 import { getZoneForRoute } from "../zones";
@@ -709,140 +709,6 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 
 function formatTime(duration: number) {
 	return `(${(duration / 1000).toFixed(2)} sec)`;
-}
-
-async function getSubdomain(accountId: string): Promise<string> {
-	try {
-		// note: API docs say that this field is "name", but they're lying.
-		const { subdomain } = await fetchResult<{ subdomain: string }>(
-			`/accounts/${accountId}/workers/subdomain`
-		);
-		return subdomain;
-	} catch (e) {
-		const error = e as { code?: number };
-		if (typeof error === "object" && !!error && error.code === 10007) {
-			// 10007 error code: not found
-			// https://api.cloudflare.com/#worker-subdomain-get-subdomain
-
-			logger.warn(
-				"You need to register a workers.dev subdomain before publishing to workers.dev"
-			);
-
-			const wantsToRegister = await confirm(
-				"Would you like to register a workers.dev subdomain now?"
-			);
-			if (!wantsToRegister) {
-				const solutionMessage =
-					"You can either publish your worker to one or more routes by specifying them in wrangler.toml, or register a workers.dev subdomain here:";
-				const onboardingLink = `https://dash.cloudflare.com/${accountId}/workers/onboarding`;
-
-				throw new Error(`${solutionMessage}\n${onboardingLink}`);
-			}
-
-			return await registerSubdomain(accountId);
-		} else {
-			throw e;
-		}
-	}
-}
-
-async function registerSubdomain(accountId: string): Promise<string> {
-	let subdomain: string | undefined;
-
-	while (subdomain === undefined) {
-		const potentialName = await prompt(
-			"What would you like your workers.dev subdomain to be? It will be accessible at https://<subdomain>.workers.dev"
-		);
-
-		if (!/^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/.test(potentialName)) {
-			logger.warn(
-				`${potentialName} is invalid, please choose another subdomain.`
-			);
-			continue;
-		}
-
-		try {
-			await fetchResult<{ subdomain: string }>(
-				`/accounts/${accountId}/workers/subdomains/${potentialName}`
-			);
-		} catch (err) {
-			const subdomainAvailabilityCheckError = err as { code?: number };
-
-			if (
-				typeof subdomainAvailabilityCheckError === "object" &&
-				!!subdomainAvailabilityCheckError
-			) {
-				if (subdomainAvailabilityCheckError.code === 10032) {
-					// oddly enough, this is a `subdomain_unavailable` error, meaning...that the subdomain
-					// doesn't exist. and we can register it. this is exactly how the dashboard does it.
-				} else if (subdomainAvailabilityCheckError.code === 10031) {
-					logger.error(
-						"Subdomain is unavailable, please try a different subdomain"
-					);
-
-					continue;
-				} else {
-					logger.error("An unexpected error occurred, please try again.");
-
-					continue;
-				}
-			}
-		}
-
-		const ok = await confirm(
-			`Creating a workers.dev subdomain for your account at ${chalk.blue(
-				chalk.underline(`https://${potentialName}.workers.dev`)
-			)}. Ok to proceed?`
-		);
-		if (!ok) {
-			const solutionMessage =
-				"You can either publish your worker to one or more routes by specifying them in wrangler.toml, or register a workers.dev subdomain here:";
-			const onboardingLink = `https://dash.cloudflare.com/${accountId}/workers/onboarding`;
-
-			throw new Error(`${solutionMessage}\n${onboardingLink}`);
-		}
-
-		try {
-			const result = await fetchResult<{ subdomain: string }>(
-				`/accounts/${accountId}/workers/subdomain`,
-				{
-					method: "PUT",
-					body: JSON.stringify({ subdomain: potentialName }),
-				}
-			);
-
-			subdomain = result.subdomain;
-		} catch (err) {
-			const subdomainCreationError = err as { code?: number };
-			if (
-				typeof subdomainCreationError === "object" &&
-				!!subdomainCreationError &&
-				subdomainCreationError.code !== undefined
-			) {
-				switch (subdomainCreationError.code) {
-					case 10031:
-						logger.error(
-							"Subdomain is unavailable, please try a different subdomain."
-						);
-						break;
-					default:
-						logger.error("An unexpected error occurred, please try again.");
-						break;
-				}
-			}
-		}
-	}
-
-	logger.log("Success! It may take a few minutes for DNS records to update.");
-	logger.log(
-		`Visit ${chalk.blue(
-			chalk.underline(
-				`https://dash.cloudflare.com/${accountId}/workers/subdomain`
-			)
-		)} to edit your workers.dev subdomain`
-	);
-
-	return subdomain;
 }
 
 /**

--- a/packages/wrangler/src/routes.ts
+++ b/packages/wrangler/src/routes.ts
@@ -1,0 +1,138 @@
+import chalk from "chalk";
+import { fetchResult } from "./cfetch";
+import { confirm, prompt } from "./dialogs";
+import { logger } from "./logger";
+
+export async function getSubdomain(accountId: string): Promise<string> {
+	try {
+		// note: API docs say that this field is "name", but they're lying.
+		const { subdomain } = await fetchResult<{ subdomain: string }>(
+			`/accounts/${accountId}/workers/subdomain`
+		);
+		return subdomain;
+	} catch (e) {
+		const error = e as { code?: number };
+		if (typeof error === "object" && !!error && error.code === 10007) {
+			// 10007 error code: not found
+			// https://api.cloudflare.com/#worker-subdomain-get-subdomain
+
+			logger.warn(
+				"You need to register a workers.dev subdomain before publishing to workers.dev"
+			);
+
+			const wantsToRegister = await confirm(
+				"Would you like to register a workers.dev subdomain now?"
+			);
+			if (!wantsToRegister) {
+				const solutionMessage =
+					"You can either publish your worker to one or more routes by specifying them in wrangler.toml, or register a workers.dev subdomain here:";
+				const onboardingLink = `https://dash.cloudflare.com/${accountId}/workers/onboarding`;
+
+				throw new Error(`${solutionMessage}\n${onboardingLink}`);
+			}
+
+			return await registerSubdomain(accountId);
+		} else {
+			throw e;
+		}
+	}
+}
+
+async function registerSubdomain(accountId: string): Promise<string> {
+	let subdomain: string | undefined;
+
+	while (subdomain === undefined) {
+		const potentialName = await prompt(
+			"What would you like your workers.dev subdomain to be? It will be accessible at https://<subdomain>.workers.dev"
+		);
+
+		if (!/^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/.test(potentialName)) {
+			logger.warn(
+				`${potentialName} is invalid, please choose another subdomain.`
+			);
+			continue;
+		}
+
+		try {
+			await fetchResult<{ subdomain: string }>(
+				`/accounts/${accountId}/workers/subdomains/${potentialName}`
+			);
+		} catch (err) {
+			const subdomainAvailabilityCheckError = err as { code?: number };
+
+			if (
+				typeof subdomainAvailabilityCheckError === "object" &&
+				!!subdomainAvailabilityCheckError
+			) {
+				if (subdomainAvailabilityCheckError.code === 10032) {
+					// oddly enough, this is a `subdomain_unavailable` error, meaning...that the subdomain
+					// doesn't exist. and we can register it. this is exactly how the dashboard does it.
+				} else if (subdomainAvailabilityCheckError.code === 10031) {
+					logger.error(
+						"Subdomain is unavailable, please try a different subdomain"
+					);
+
+					continue;
+				} else {
+					logger.error("An unexpected error occurred, please try again.");
+
+					continue;
+				}
+			}
+		}
+
+		const ok = await confirm(
+			`Creating a workers.dev subdomain for your account at ${chalk.blue(
+				chalk.underline(`https://${potentialName}.workers.dev`)
+			)}. Ok to proceed?`
+		);
+		if (!ok) {
+			const solutionMessage =
+				"You can either publish your worker to one or more routes by specifying them in wrangler.toml, or register a workers.dev subdomain here:";
+			const onboardingLink = `https://dash.cloudflare.com/${accountId}/workers/onboarding`;
+
+			throw new Error(`${solutionMessage}\n${onboardingLink}`);
+		}
+
+		try {
+			const result = await fetchResult<{ subdomain: string }>(
+				`/accounts/${accountId}/workers/subdomain`,
+				{
+					method: "PUT",
+					body: JSON.stringify({ subdomain: potentialName }),
+				}
+			);
+
+			subdomain = result.subdomain;
+		} catch (err) {
+			const subdomainCreationError = err as { code?: number };
+			if (
+				typeof subdomainCreationError === "object" &&
+				!!subdomainCreationError &&
+				subdomainCreationError.code !== undefined
+			) {
+				switch (subdomainCreationError.code) {
+					case 10031:
+						logger.error(
+							"Subdomain is unavailable, please try a different subdomain."
+						);
+						break;
+					default:
+						logger.error("An unexpected error occurred, please try again.");
+						break;
+				}
+			}
+		}
+	}
+
+	logger.log("Success! It may take a few minutes for DNS records to update.");
+	logger.log(
+		`Visit ${chalk.blue(
+			chalk.underline(
+				`https://dash.cloudflare.com/${accountId}/workers/subdomain`
+			)
+		)} to edit your workers.dev subdomain`
+	);
+
+	return subdomain;
+}

--- a/packages/wrangler/src/routes.ts
+++ b/packages/wrangler/src/routes.ts
@@ -3,7 +3,9 @@ import { fetchResult } from "./cfetch";
 import { confirm, prompt } from "./dialogs";
 import { logger } from "./logger";
 
-export async function getSubdomain(accountId: string): Promise<string> {
+export async function getWorkersDevSubdomain(
+	accountId: string
+): Promise<string> {
 	try {
 		// note: API docs say that this field is "name", but they're lying.
 		const { subdomain } = await fetchResult<{ subdomain: string }>(


### PR DESCRIPTION
Offer to create a workers.dev subdomain if a user needs one

Previously, when a user wanted to publish a worker to https://workers.dev by setting `workers_dev = true` in their `wrangler.toml`,
but their account didn't have a subdomain registered, we would error out.

Now, we offer to create one for them. It's not implemented for `wrangler dev`, which also expects you to have registered a
workers.dev subdomain, but we now error correctly and tell them what the problem is.

Closes #535 