### PR TITLE
Default to today's compatibility date in `wrangler pages dev`

### DIFF
--- a/.changeset/lovely-chairs-taste.md
+++ b/.changeset/lovely-chairs-taste.md
@@ -1,0 +1,10 @@
+---
+"wrangler": patch
+---
+
+fix: Default to today's compatibility date in `wrangler pages dev`
+
+Like `wrangler dev` proper, `wrangler pages dev` now defaults to using today's compatibility date.
+It can be overriden with `--compatibility-date=YYYY-MM-DD`.
+
+https://developers.cloudflare.com/workers/platform/compatibility-dates/

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -48,7 +48,7 @@ describe("wrangler dev", () => {
 			          \`\`\`
 			          --compatibility-date=<current-date>
 			          \`\`\`
-			          See [4mhttps://developers.cloudflare.com/workers/platform/compatibility-dates[0m for more information.
+			          See [4mhttps://developers.cloudflare.com/workers/platform/compatibility-dates/[0m for more information.
 
 			        "
 		      `);

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -539,7 +539,7 @@ export function getDevCompatibilityDate(
 				"```\n" +
 				`--compatibility-date=${currentDate}\n` +
 				"```\n" +
-				"See https://developers.cloudflare.com/workers/platform/compatibility-dates for more information."
+				"See https://developers.cloudflare.com/workers/platform/compatibility-dates/ for more information."
 		);
 	}
 	return compatibilityDate ?? currentDate;

--- a/packages/wrangler/src/pages/dev.tsx
+++ b/packages/wrangler/src/pages/dev.tsx
@@ -54,17 +54,6 @@ export function Options(yargs: Argv) {
 				type: "string",
 				array: true,
 			},
-
-			// TODO
-			// For now, all Pages projects are set to 2021-11-02. We're adding compat date soon, and we can then adopt `wrangler dev`'s `default: true`.
-			// However, it looks like it isn't actually connected up properly in `wrangler dev` at the moment, hence commenting this out for now.
-
-			// latest: {
-			// 	describe: "Use the latest version of the worker runtime",
-			// 	type: "boolean",
-			// 	default: false,
-			// },
-
 			ip: {
 				type: "string",
 				default: "0.0.0.0",
@@ -161,7 +150,7 @@ export function Options(yargs: Argv) {
 export const Handler = async ({
 	local,
 	directory,
-	"compatibility-date": compatibilityDate = "2021-11-02",
+	"compatibility-date": compatibilityDate,
 	"compatibility-flags": compatibilityFlags,
 	ip,
 	port,
@@ -217,6 +206,19 @@ export const Handler = async ({
 		if (proxyPort === undefined) return undefined;
 	} else {
 		directory = resolve(directory);
+	}
+
+	if (!compatibilityDate) {
+		const currentDate = new Date().toISOString().substring(0, 10);
+		logger.warn(
+			`No compatibility_date was specified. Using today's date: ${currentDate}.\n` +
+				"Pass it in your terminal:\n" +
+				"```\n" +
+				`--compatibility-date=${currentDate}\n` +
+				"```\n" +
+				"See https://developers.cloudflare.com/workers/platform/compatibility-dates/ for more information."
+		);
+		compatibilityDate = currentDate;
 	}
 
 	if (experimentalEnableLocalPersistence) {


### PR DESCRIPTION
Like `wrangler dev` proper, `wrangler pages dev` now defaults to using today's compatibility date. It can be overriden with `--compatibility-date=YYYY-MM-DD`.

https://developers.cloudflare.com/workers/platform/compatibility-dates/