### PR TITLE
fix: remove leading asterisk from routes such as *example.com

### DIFF
--- a/packages/wrangler/src/zones.ts
+++ b/packages/wrangler/src/zones.ts
@@ -40,7 +40,7 @@ export async function getZoneForRoute(route: Route): Promise<Zone | undefined> {
  */
 function getHostFromUrl(urlLike: string): string | undefined {
 	// strip leading * / *.
-	urlLike = urlLike.replace(/^\*(\.)?/g, "");
+	urlLike = urlLike.replace(/\*(\.)?/g, "");
 
 	if (!(urlLike.startsWith("http://") || urlLike.startsWith("https://"))) {
 		urlLike = "http://" + urlLike;


### PR DESCRIPTION
By removing the leading caret, the regex now works as I think was intended.

Fixes https://github.com/cloudflare/wrangler2/issues/2040