### PR TITLE
fix(pages): `/` exclude rule in `_routes.json` overrides include routes for `wrangler pages dev`

### DIFF
--- a/.changeset/new-maps-share.md
+++ b/.changeset/new-maps-share.md
@@ -1,0 +1,13 @@
+---
+"pages-functions-with-routes-app": patch
+"pages-workerjs-with-routes-app": patch
+"wrangler": patch
+---
+
+fix(pages): `/` exclude rule in `_routes.json` overrides any include routes when running `wrangler pages dev`
+
+Because of the way we perform custom route rule matching, and because we always
+apply `exclude` rules first, `wrangler pages dev` will ignore any `include` rules, if `exclude` contains a rule that references a root level index (`/`).
+
+This commit makes sure that root level `exclude` rules are properly handled and will
+not override any `include` rules we have in place.

--- a/fixtures/pages-functions-with-routes-app/functions/index.ts
+++ b/fixtures/pages-functions-with-routes-app/functions/index.ts
@@ -1,0 +1,3 @@
+export async function onRequest() {
+	return new Response("ROOT");
+}

--- a/fixtures/pages-workerjs-with-routes-app/public/_worker.js
+++ b/fixtures/pages-workerjs-with-routes-app/public/_worker.js
@@ -17,6 +17,10 @@ export default {
 			return new Response(new Date().toISOString());
 		}
 
+		if (url.pathname === "/") {
+			return new Response("ROOT");
+		}
+
 		return env.ASSETS.fetch(request);
 	},
 };

--- a/packages/wrangler/templates/pages-dev-pipeline.ts
+++ b/packages/wrangler/templates/pages-dev-pipeline.ts
@@ -4,6 +4,10 @@ import worker from "__ENTRY_POINT__";
 export * from "__ENTRY_POINT__";
 
 const transformToRegex = (filter: string) => {
+	// special case rule that should match only the root
+	if (filter === "/") {
+		return "^/$";
+	}
 	return filter.replace("*", ".*");
 };
 


### PR DESCRIPTION
Because of the way we perform custom route rule matching, and because we always apply `exclude` rules first, `wrangler pages dev` will ignore any `include` rules, if `exclude` contains a rule that references a root level index  (`/`).

This commit makes sure that root level `exclude` rules are properly handled and will not override any `include` rules we have in place.