### PR TITLE
fix(pages): `wrangler pages dev` matches routing rules in `_routes.json too loosely

### DIFF
--- a/.changeset/new-maps-share.md
+++ b/.changeset/new-maps-share.md
@@ -1,0 +1,18 @@
+---
+"pages-functions-with-routes-app": patch
+"pages-workerjs-with-routes-app": patch
+"wrangler": patch
+---
+
+fix(pages): `wrangler pages dev` matches routing rules in `_routes.json` too loosely
+
+Currently, the logic by which we transform routing rules in `_routes.json` to
+regular expressions, so we can perform `pathname` matching & routing when we
+run `wrangler pages dev`, is too permissive, and leads to serving incorrect
+assets for certain url paths.
+
+For example, a routing rule such as `/foo` will incorrectly match pathname
+`/bar/foo`. Similarly, pathname `/foo` will be incorrectly matched by the
+`/` routing rule.
+This commit fixes our routing rule to pathname matching logic and brings
+`wrangler pages dev` on par with routing in deployed Pages projects.

--- a/fixtures/pages-functions-with-routes-app/functions/bye.ts
+++ b/fixtures/pages-functions-with-routes-app/functions/bye.ts
@@ -1,0 +1,3 @@
+export async function onRequest() {
+	return new Response("[/functions/bye]: Adieu 🙁");
+}

--- a/fixtures/pages-functions-with-routes-app/functions/date.ts
+++ b/fixtures/pages-functions-with-routes-app/functions/date.ts
@@ -1,3 +1,3 @@
 export async function onRequest() {
-	return new Response(new Date().toISOString());
+	return new Response(`[/functions/date]: ${new Date().toISOString()}`);
 }

--- a/fixtures/pages-functions-with-routes-app/functions/greeting/bye.ts
+++ b/fixtures/pages-functions-with-routes-app/functions/greeting/bye.ts
@@ -1,0 +1,3 @@
+export async function onRequest() {
+	return new Response("[/functions/greeting/bye]: A plus tard alligator 👋");
+}

--- a/fixtures/pages-functions-with-routes-app/functions/greeting/goodbye.ts
+++ b/fixtures/pages-functions-with-routes-app/functions/greeting/goodbye.ts
@@ -1,3 +1,0 @@
-export async function onRequest() {
-	return new Response("A plus tard alligator 👋");
-}

--- a/fixtures/pages-functions-with-routes-app/functions/greeting/hello.ts
+++ b/fixtures/pages-functions-with-routes-app/functions/greeting/hello.ts
@@ -1,3 +1,3 @@
 export async function onRequest() {
-	return new Response("Bonjour le monde!");
+	return new Response("[/functions/greeting/hello]: Bonjour le monde!");
 }

--- a/fixtures/pages-functions-with-routes-app/functions/greeting/index.ts
+++ b/fixtures/pages-functions-with-routes-app/functions/greeting/index.ts
@@ -1,0 +1,3 @@
+export async function onRequest() {
+	return new Response("[/functions/greeting/index]: Bonjour alligator!");
+}

--- a/fixtures/pages-functions-with-routes-app/functions/greetings.ts
+++ b/fixtures/pages-functions-with-routes-app/functions/greetings.ts
@@ -1,0 +1,3 @@
+export async function onRequest() {
+	return new Response("[/functions/greetings]: Bonjour à tous!");
+}

--- a/fixtures/pages-functions-with-routes-app/functions/index.ts
+++ b/fixtures/pages-functions-with-routes-app/functions/index.ts
@@ -1,0 +1,3 @@
+export async function onRequest() {
+	return new Response("ROOT");
+}

--- a/fixtures/pages-functions-with-routes-app/public/_routes.json
+++ b/fixtures/pages-functions-with-routes-app/public/_routes.json
@@ -1,5 +1,5 @@
 {
 	"version": 1,
-	"include": ["/greeting/*"],
-	"exclude": ["/date"]
+	"include": ["/", "/greeting/*", "/greeting*", "/date"],
+	"exclude": ["/bye*", "/date"]
 }

--- a/fixtures/pages-functions-with-routes-app/tests/index.test.ts
+++ b/fixtures/pages-functions-with-routes-app/tests/index.test.ts
@@ -54,7 +54,9 @@ describe("Pages Functions with custom _routes.json", () => {
 	});
 
 	it("should render static pages", async () => {
-		const response = await waitUntilReady("http://localhost:8776/");
+		const response = await waitUntilReady(
+			"http://localhost:8776/undefined-route"
+		);
 		const text = await response.text();
 		expect(text).toContain(
 			"Bienvenue sur notre projet &#10024; pages-functions-with-routes-app!"
@@ -62,18 +64,43 @@ describe("Pages Functions with custom _routes.json", () => {
 	});
 
 	it("should correctly apply the routing rules provided in the custom _routes.json file", async () => {
-		let response = await waitUntilReady("http://localhost:8776/greeting/hello");
+		// matches / include rule
+		let response = await waitUntilReady("http://localhost:8776");
 		let text = await response.text();
-		expect(text).toEqual("Bonjour le monde!");
+		expect(text).toEqual("ROOT");
 
-		response = await waitUntilReady("http://localhost:8776/greeting/goodbye");
+		// matches /greeting/* include rule
+		response = await waitUntilReady("http://localhost:8776/greeting");
 		text = await response.text();
-		expect(text).toEqual("A plus tard alligator 👋");
+		expect(text).toEqual("[/functions/greeting/index]: Bonjour alligator!");
 
+		// matches /greeting/* include rule
+		response = await waitUntilReady("http://localhost:8776/greeting/hello");
+		text = await response.text();
+		expect(text).toEqual("[/functions/greeting/hello]: Bonjour le monde!");
+
+		// matches /greeting/* include rule
+		response = await waitUntilReady("http://localhost:8776/greeting/bye");
+		text = await response.text();
+		expect(text).toEqual("[/functions/greeting/bye]: A plus tard alligator 👋");
+
+		// matches both include|exclude /date rules, but exclude has priority
 		response = await waitUntilReady("http://localhost:8776/date");
 		text = await response.text();
 		expect(text).toContain(
 			"Bienvenue sur notre projet &#10024; pages-functions-with-routes-app!"
 		);
+
+		// matches /bye* exclude rule
+		response = await waitUntilReady("http://localhost:8776/bye");
+		text = await response.text();
+		expect(text).toContain(
+			"Bienvenue sur notre projet &#10024; pages-functions-with-routes-app!"
+		);
+
+		// matches /greeting* include rule
+		response = await waitUntilReady("http://localhost:8776/greetings");
+		text = await response.text();
+		expect(text).toEqual("[/functions/greetings]: Bonjour à tous!");
 	});
 });

--- a/fixtures/pages-workerjs-with-routes-app/public/_routes.json
+++ b/fixtures/pages-workerjs-with-routes-app/public/_routes.json
@@ -1,5 +1,5 @@
 {
 	"version": 1,
-	"include": ["/greeting/*", "/date"],
-	"exclude": ["/party"]
+	"include": ["/greeting/*", "/date", "/party*"],
+	"exclude": ["/", "/party"]
 }

--- a/fixtures/pages-workerjs-with-routes-app/public/_worker.js
+++ b/fixtures/pages-workerjs-with-routes-app/public/_worker.js
@@ -1,20 +1,39 @@
 export default {
 	async fetch(request, env) {
 		const url = new URL(request.url);
-		if (url.pathname.startsWith("/greeting/hello")) {
-			return new Response("Bonjour le monde!");
+
+		if (url.pathname === "/") {
+			return new Response("ROOT");
 		}
 
-		if (url.pathname.startsWith("/greeting/goodbye")) {
-			return new Response("A plus tard alligator 👋");
+		if (url.pathname === "/party") {
+			return new Response(
+				"[/party]: Oops! Tous les alligators sont allés à la fête 🎉"
+			);
 		}
 
-		if (url.pathname.startsWith("/party")) {
-			return new Response("Oops! Tous les alligators sont allés à la fête 🎉");
+		if (url.pathname === "/party-disco") {
+			return new Response("[/party-disco]: Tout le monde à la discothèque 🪩");
 		}
 
-		if (url.pathname.startsWith("/date")) {
-			return new Response(new Date().toISOString());
+		if (url.pathname === "/date") {
+			return new Response(`[/date]: ${new Date().toISOString()}`);
+		}
+
+		if (url.pathname === "/greeting") {
+			return new Response("[/greeting]: Bonjour à tous!");
+		}
+
+		if (url.pathname === "/greeting/hello") {
+			return new Response("[/greeting/hello]: Bonjour le monde!");
+		}
+
+		if (url.pathname === "/greeting/bye") {
+			return new Response("[/greeting/bye]: A plus tard alligator 👋");
+		}
+
+		if (url.pathname === "/greetings") {
+			return new Response("[/greetings]: Bonjour alligators!");
 		}
 
 		return env.ASSETS.fetch(request);

--- a/fixtures/pages-workerjs-with-routes-app/tests/index.test.ts
+++ b/fixtures/pages-workerjs-with-routes-app/tests/index.test.ts
@@ -64,19 +64,41 @@ describe("Pages Advanced Mode with custom _routes.json", () => {
 	});
 
 	it("runs our _worker.js", async () => {
+		// matches /greeting/* include rule
 		let response = await waitUntilReady("http://127.0.0.1:8751/greeting/hello");
 		let text = await response.text();
-		expect(text).toEqual("Bonjour le monde!");
+		expect(text).toEqual("[/greeting/hello]: Bonjour le monde!");
 
-		response = await waitUntilReady("http://127.0.0.1:8751/greeting/goodbye");
+		// matches /greeting/* include rule
+		response = await waitUntilReady("http://127.0.0.1:8751/greeting/bye");
 		text = await response.text();
-		expect(text).toEqual("A plus tard alligator 👋");
+		expect(text).toEqual("[/greeting/bye]: A plus tard alligator 👋");
 
+		// matches /date include rule
 		response = await waitUntilReady("http://127.0.0.1:8751/date");
 		text = await response.text();
 		expect(text).toMatch(/\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d/);
 
+		// matches both /party* include and /party exclude rules, but exclude
+		// has priority
 		response = await waitUntilReady("http://127.0.0.1:8751/party");
+		text = await response.text();
+		expect(text).toContain(
+			"Bienvenue sur notre projet &#10024; pages-workerjs-with-routes-app!"
+		);
+
+		// matches /party* include rule
+		response = await waitUntilReady("http://127.0.0.1:8751/party-disco");
+		text = await response.text();
+		expect(text).toEqual("[/party-disco]: Tout le monde à la discothèque 🪩");
+
+		// matches /greeting/* include rule
+		response = await waitUntilReady("http://127.0.0.1:8751/greeting");
+		text = await response.text();
+		expect(text).toEqual("[/greeting]: Bonjour à tous!");
+
+		// matches no rule
+		response = await waitUntilReady("http://127.0.0.1:8751/greetings");
 		text = await response.text();
 		expect(text).toContain(
 			"Bienvenue sur notre projet &#10024; pages-workerjs-with-routes-app!"

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -1306,7 +1306,7 @@ describe("init", () => {
 						contents: {
 							config: {
 								compilerOptions: expect.objectContaining({
-									types: ["@cloudflare/workers-types"],
+									types: ["@cloudflare/workers-types", "jest"],
 								}),
 							},
 							error: undefined,

--- a/packages/wrangler/src/pages/dev.tsx
+++ b/packages/wrangler/src/pages/dev.tsx
@@ -379,6 +379,10 @@ export const Handler = async ({
 					plugins: [
 						esbuildAliasExternalPlugin({
 							__ENTRY_POINT__: entrypointFile,
+							"./pages-dev-util": resolve(
+								getBasePath(),
+								"templates/pages-dev-util.ts"
+							),
 						}),
 					],
 					outfile,

--- a/packages/wrangler/templates/__tests__/pages-dev-util.test.ts
+++ b/packages/wrangler/templates/__tests__/pages-dev-util.test.ts
@@ -1,0 +1,128 @@
+import { isRoutingRuleMatch } from "../pages-dev-util";
+
+describe("isRoutingRuleMatch", () => {
+	it("should match rules referencing root level correctly", () => {
+		const routingRule = "/";
+
+		expect(isRoutingRuleMatch("/", routingRule)).toBeTruthy();
+		expect(isRoutingRuleMatch("/foo", routingRule)).toBeFalsy();
+		expect(isRoutingRuleMatch("/foo/", routingRule)).toBeFalsy();
+		expect(isRoutingRuleMatch("/foo/bar", routingRule)).toBeFalsy();
+	});
+
+	it("should match include-all rules correctly", () => {
+		const routingRule = "/*";
+
+		expect(isRoutingRuleMatch("/", routingRule)).toBeTruthy();
+		expect(isRoutingRuleMatch("/foo", routingRule)).toBeTruthy();
+		expect(isRoutingRuleMatch("/foo/", routingRule)).toBeTruthy();
+		expect(isRoutingRuleMatch("/foo/bar", routingRule)).toBeTruthy();
+		expect(isRoutingRuleMatch("/foo/bar/", routingRule)).toBeTruthy();
+		expect(isRoutingRuleMatch("/foo/bar/baz", routingRule)).toBeTruthy();
+		expect(isRoutingRuleMatch("/foo/bar/baz/", routingRule)).toBeTruthy();
+	});
+
+	it("should match `/*` suffix-ed rules correctly", () => {
+		let routingRule = "/foo/*";
+
+		expect(isRoutingRuleMatch("/foo", routingRule)).toBeTruthy();
+		expect(isRoutingRuleMatch("/foo/", routingRule)).toBeTruthy();
+		expect(isRoutingRuleMatch("/foobar", routingRule)).toBeFalsy();
+		expect(isRoutingRuleMatch("/foo/bar", routingRule)).toBeTruthy();
+		expect(isRoutingRuleMatch("/foo/bar/baz", routingRule)).toBeTruthy();
+		expect(isRoutingRuleMatch("/bar/foo", routingRule)).toBeFalsy();
+		expect(isRoutingRuleMatch("/bar/foo/baz", routingRule)).toBeFalsy();
+
+		routingRule = "/foo/bar/*";
+
+		expect(isRoutingRuleMatch("/foo", routingRule)).toBeFalsy();
+		expect(isRoutingRuleMatch("/foo/", routingRule)).toBeFalsy();
+		expect(isRoutingRuleMatch("/foo/bar", routingRule)).toBeTruthy();
+		expect(isRoutingRuleMatch("/foo/bar/baz", routingRule)).toBeTruthy();
+		expect(isRoutingRuleMatch("/foo/barfoo", routingRule)).toBeFalsy();
+		expect(isRoutingRuleMatch("baz/foo/bar", routingRule)).toBeFalsy();
+		expect(isRoutingRuleMatch("baz/foo/bar/", routingRule)).toBeFalsy();
+	});
+
+	it("should match `/` suffix-ed rules correctly", () => {
+		let routingRule = "/foo/";
+		expect(isRoutingRuleMatch("/foo/", routingRule)).toBeTruthy();
+		expect(isRoutingRuleMatch("/foo", routingRule)).toBeTruthy();
+
+		routingRule = "/foo/bar/";
+		expect(isRoutingRuleMatch("/foo/bar/", routingRule)).toBeTruthy();
+		expect(isRoutingRuleMatch("/foo/bar", routingRule)).toBeTruthy();
+	});
+
+	it("should match `*` suffix-ed rules correctly", () => {
+		let routingRule = "/foo*";
+		expect(isRoutingRuleMatch("/foo", routingRule)).toBeTruthy();
+		expect(isRoutingRuleMatch("/foo/", routingRule)).toBeTruthy();
+		expect(isRoutingRuleMatch("/foobar", routingRule)).toBeTruthy();
+		expect(isRoutingRuleMatch("/barfoo", routingRule)).toBeFalsy();
+		expect(isRoutingRuleMatch("/foo/bar", routingRule)).toBeTruthy();
+		expect(isRoutingRuleMatch("/bar/foo", routingRule)).toBeFalsy();
+		expect(isRoutingRuleMatch("/bar/foobar", routingRule)).toBeFalsy();
+		expect(isRoutingRuleMatch("/foo/bar/baz", routingRule)).toBeTruthy();
+		expect(isRoutingRuleMatch("/bar/foo/baz", routingRule)).toBeFalsy();
+
+		routingRule = "/foo/bar*";
+		expect(isRoutingRuleMatch("/foo/bar", routingRule)).toBeTruthy();
+		expect(isRoutingRuleMatch("/foo/bar/", routingRule)).toBeTruthy();
+		expect(isRoutingRuleMatch("/foo/barfoo", routingRule)).toBeTruthy();
+		expect(isRoutingRuleMatch("/bar/foo/barfoo", routingRule)).toBeFalsy();
+		expect(isRoutingRuleMatch("/foo/bar/baz", routingRule)).toBeTruthy();
+		expect(isRoutingRuleMatch("/bar/foo/bar/baz", routingRule)).toBeFalsy();
+	});
+
+	it("should match rules without wildcards correctly", () => {
+		let routingRule = "/foo";
+
+		expect(isRoutingRuleMatch("/foo", routingRule)).toBeTruthy();
+		expect(isRoutingRuleMatch("/foo/", routingRule)).toBeTruthy();
+		expect(isRoutingRuleMatch("/foo/bar", routingRule)).toBeFalsy();
+		expect(isRoutingRuleMatch("/bar/foo", routingRule)).toBeFalsy();
+
+		routingRule = "/foo/bar";
+		expect(isRoutingRuleMatch("/foo/bar", routingRule)).toBeTruthy();
+		expect(isRoutingRuleMatch("/foo/bar/", routingRule)).toBeTruthy();
+		expect(isRoutingRuleMatch("/foo/bar/baz", routingRule)).toBeFalsy();
+		expect(isRoutingRuleMatch("/baz/foo/bar", routingRule)).toBeFalsy();
+	});
+
+	it("should throw an error if pathname or routing rule params are missing", () => {
+		// MISSING PATHNAME
+		expect(() =>
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore: sanity check
+			isRoutingRuleMatch(undefined, "/*")
+		).toThrow("Pathname is undefined.");
+
+		expect(() =>
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore: sanity check
+			isRoutingRuleMatch(null, "/*")
+		).toThrow("Pathname is undefined.");
+
+		expect(() => isRoutingRuleMatch("", "/*")).toThrow(
+			"Pathname is undefined."
+		);
+
+		// MISSING ROUTING RULE
+		expect(() =>
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore: sanity check
+			isRoutingRuleMatch("/foo", undefined)
+		).toThrow("Routing rule is undefined.");
+
+		expect(() =>
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore: sanity check
+			isRoutingRuleMatch("/foo", null)
+		).toThrow("Routing rule is undefined.");
+
+		expect(() => isRoutingRuleMatch("/foo", "")).toThrow(
+			"Routing rule is undefined."
+		);
+	});
+});

--- a/packages/wrangler/templates/pages-dev-pipeline.ts
+++ b/packages/wrangler/templates/pages-dev-pipeline.ts
@@ -2,30 +2,23 @@
 import worker from "__ENTRY_POINT__";
 // @ts-ignore entry point will get replaced
 export * from "__ENTRY_POINT__";
+import { isRoutingRuleMatch } from "./pages-dev-util";
 
-const transformToRegex = (filter: string) => {
-	return filter.replace("*", ".*");
-};
-
-const routes = {
-	// @ts-ignore routes are injected
-	include: __ROUTES__.include.map(transformToRegex),
-	// @ts-ignore routes are injected
-	exclude: __ROUTES__.exclude.map(transformToRegex) || [],
-};
+// @ts-ignore routes are injected
+const routes = __ROUTES__;
 
 export default {
 	fetch(request, env, context) {
 		const { pathname } = new URL(request.url);
 
 		for (const exclude of routes.exclude) {
-			if (pathname.match(exclude)) {
+			if (isRoutingRuleMatch(pathname, exclude)) {
 				return env.ASSETS.fetch(request);
 			}
 		}
 
 		for (const include of routes.include) {
-			if (pathname.match(include)) {
+			if (isRoutingRuleMatch(pathname, include)) {
 				return worker.fetch(request, env, context);
 			}
 		}

--- a/packages/wrangler/templates/pages-dev-util.ts
+++ b/packages/wrangler/templates/pages-dev-util.ts
@@ -1,0 +1,52 @@
+/**
+ * @param pathname A pathname string, such as `/foo` or `/foo/bar`
+ * @param routingRule The routing rule, such as `/foo/*`
+ * @returns True if pathname matches the routing rule
+ *
+ * /       ->  /
+ * /*      ->  /*
+ * /foo    ->  /foo
+ * /foo*   ->  /foo, /foo-bar, /foo/*
+ * /foo/*  ->  /foo, /foo/bar
+ */
+export function isRoutingRuleMatch(
+	pathname: string,
+	routingRule: string
+): boolean {
+	// sanity checks
+	if (!pathname) {
+		throw new Error("Pathname is undefined.");
+	}
+	if (!routingRule) {
+		throw new Error("Routing rule is undefined.");
+	}
+
+	const ruleRegExp = transformRoutingRuleToRegExp(routingRule);
+	return pathname.match(ruleRegExp) !== null;
+}
+
+function transformRoutingRuleToRegExp(rule: string): RegExp {
+	let transformedRule;
+
+	if (rule === "/" || rule === "/*") {
+		transformedRule = rule;
+	} else if (rule.endsWith("/*")) {
+		// make `/*` an optional group so we can match both /foo/* and /foo
+		// /foo/* => /foo(/*)?
+		transformedRule = `${rule.substring(0, rule.length - 2)}(/*)?`;
+	} else if (rule.endsWith("/")) {
+		// make `/` an optional group so we can match both /foo/ and /foo
+		// /foo/ => /foo(/)?
+		transformedRule = `${rule.substring(0, rule.length - 1)}(/)?`;
+	} else if (rule.endsWith("*")) {
+		transformedRule = rule;
+	} else {
+		transformedRule = `${rule}(/)?`;
+	}
+
+	// /foo* => /foo.* => ^/foo.*$
+	transformedRule = `^${transformedRule.replace("*", ".*")}$`;
+
+	// ^/foo.*$ => /^\/foo.*$/
+	return new RegExp(transformedRule);
+}

--- a/packages/wrangler/templates/tsconfig.json
+++ b/packages/wrangler/templates/tsconfig.json
@@ -34,7 +34,8 @@
 		// "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
 		// "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
 		"types": [
-			"@cloudflare/workers-types"
+			"@cloudflare/workers-types",
+			"jest"
 		] /* Specify type package names to be included without being referenced in a source file. */,
 		// "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
 		"resolveJsonModule": true /* Enable importing .json files */,


### PR DESCRIPTION
Currently, the logic by which we transform routing rules in `_routes.json` to
regular expressions, so we can perform `pathname` matching & routing when we
run `wrangler pages dev`, is too permissive, and leads to serving incorrect
assets for certain url paths.

For example, a routing rule such as `/foo` will incorrectly match pathname
`/bar/foo`. Similarly, pathname `/foo` will be incorrectly matched by the
`/` routing rule.
This commit fixes our routing rule to pathname matching logic and brings
`wrangler pages dev` on par with routing in deployed Pages projects.