### PR TITLE
Fix `--local` mode logging and enable colours

### DIFF
--- a/.changeset/tough-rules-wonder.md
+++ b/.changeset/tough-rules-wonder.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fixed issue where information and warning messages from Miniflare were being
+discarded when using `wrangler dev --local`. Logs from Miniflare will now be
+coloured too, if the terminal supports this.

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -3,6 +3,7 @@ import { fork } from "node:child_process";
 import { realpathSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
+import chalk from "chalk";
 import { npxImport } from "npx-import";
 import { useState, useEffect, useRef } from "react";
 import onExit from "signal-exit";
@@ -221,6 +222,10 @@ function useLocalWorker({
 				cwd: path.dirname(scriptPath),
 				execArgv: nodeOptions,
 				stdio: "pipe",
+				env: {
+					...process.env,
+					FORCE_COLOR: chalk.supportsColor.hasBasic ? "1" : undefined,
+				},
 			}));
 
 			child.on("message", async (messageString) => {

--- a/packages/wrangler/src/logger.ts
+++ b/packages/wrangler/src/logger.ts
@@ -2,7 +2,7 @@ import { format } from "node:util";
 import { formatMessagesSync } from "esbuild";
 import { getEnvironmentVariableFactory } from "./environment-variables";
 
-const LOGGER_LEVELS = {
+export const LOGGER_LEVELS = {
 	none: -1,
 	error: 0,
 	warn: 1,
@@ -11,7 +11,7 @@ const LOGGER_LEVELS = {
 	debug: 4,
 } as const;
 
-type LoggerLevel = keyof typeof LOGGER_LEVELS;
+export type LoggerLevel = keyof typeof LOGGER_LEVELS;
 
 /** A map from LOGGER_LEVEL to the error `kind` needed by `formatMessagesSync()`. */
 const LOGGER_LEVEL_FORMAT_TYPE_MAP = {


### PR DESCRIPTION
Previously, Miniflare's `Log` was being constructed with an incorrectly typed log level (TypeScript enum issues :upside_down_face:). Miniflare's package for coloured `console` output was unable to detect whether the current terminal supported colours. This PR fixes the log level issues, and sets the `FORCE_COLOR` environment variable when starting the Miniflare CLI process if the terminal supports colour.

Ref: #2036