### PR TITLE
Fix importing npm packages with same name of Node built-ins

### DIFF
--- a/.changeset/modern-carrots-relate.md
+++ b/.changeset/modern-carrots-relate.md
@@ -1,0 +1,6 @@
+---
+"wrangler": patch
+---
+
+Fixed importing installed npm packages with the same name as Node built-in
+modules if `node_compat` is disabled.

--- a/fixtures/local-mode-tests/package.json
+++ b/fixtures/local-mode-tests/package.json
@@ -31,6 +31,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^3.2.0",
-		"@types/node": "^17.0.33"
+		"@types/node": "^17.0.33",
+		"buffer": "^6.0.3"
 	}
 }

--- a/fixtures/local-mode-tests/src/nodeBuiltinPackage.ts
+++ b/fixtures/local-mode-tests/src/nodeBuiltinPackage.ts
@@ -1,0 +1,10 @@
+// Because we have the `buffer` npm package installed, this shouldn't fail,
+// as esbuild can resolve that instead:
+// https://github.com/cloudflare/wrangler2/issues/2038
+import { Buffer } from "buffer";
+
+export default {
+	fetch() {
+		return new Response(Buffer.from("hello").toString("hex"));
+	},
+};

--- a/fixtures/local-mode-tests/tests/nodeBuiltinPackage.test.ts
+++ b/fixtures/local-mode-tests/tests/nodeBuiltinPackage.test.ts
@@ -1,0 +1,26 @@
+import { unstable_dev } from "wrangler";
+
+describe("worker", () => {
+	let worker: {
+		fetch: (input?: RequestInfo, init?: RequestInit) => Promise<Response>;
+		stop: () => Promise<void>;
+	};
+
+	beforeAll(async () => {
+		worker = await unstable_dev("src/nodeBuiltinPackage.ts", {
+			disableExperimentalWarning: true,
+		});
+	});
+
+	afterAll(async () => {
+		await worker.stop();
+	});
+
+	it("returns hex string", async () => {
+		const resp = await worker.fetch();
+		expect(resp).not.toBe(undefined);
+
+		const text = await resp.text();
+		expect(text).toMatch("68656c6c6f");
+	});
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,13 +53,38 @@
 			"license": "ISC",
 			"devDependencies": {
 				"@cloudflare/workers-types": "^3.2.0",
-				"@types/node": "^17.0.33"
+				"@types/node": "^17.0.33",
+				"buffer": "^6.0.3"
 			}
 		},
 		"fixtures/local-mode-tests/node_modules/@types/node": {
 			"version": "17.0.45",
 			"dev": true,
 			"license": "MIT"
+		},
+		"fixtures/local-mode-tests/node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
 		},
 		"fixtures/node-app-pages": {
 			"version": "0.0.0",
@@ -32514,12 +32539,23 @@
 			"version": "file:fixtures/local-mode-tests",
 			"requires": {
 				"@cloudflare/workers-types": "^3.2.0",
-				"@types/node": "^17.0.33"
+				"@types/node": "^17.0.33",
+				"buffer": "*"
 			},
 			"dependencies": {
 				"@types/node": {
 					"version": "17.0.45",
 					"dev": true
+				},
+				"buffer": {
+					"version": "6.0.3",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+					"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+					"dev": true,
+					"requires": {
+						"base64-js": "^1.3.1",
+						"ieee754": "^1.2.1"
+					}
 				}
 			}
 		},

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -6270,14 +6270,16 @@ addEventListener('fetch', event => {});`
       export default {}
       `
 			);
-			let err: Error | undefined;
+			let err: esbuild.BuildFailure | undefined;
 			try {
 				await runWrangler("publish index.js --dry-run"); // expecting this to throw, as node compatibility isn't enabled
 			} catch (e) {
-				err = e as Error;
+				err = e as esbuild.BuildFailure;
 			}
-			expect(err?.message).toMatch(
-				`Detected a Node builtin module import while Node compatibility is disabled.\nAdd node_compat = true to your wrangler.toml file to enable Node compatibility.`
+			expect(
+				esbuild.formatMessagesSync(err?.errors ?? [], { kind: "error" }).join()
+			).toMatch(
+				/The package "path" wasn't found on the file system but is built into node\.\s+Add "node_compat = true" to your wrangler\.toml file to enable Node compatibility\./
 			);
 		});
 

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -28,31 +28,48 @@ type StaticAssetsConfig =
 	| undefined;
 
 /**
- * Searches for any uses of node's builtin modules, and throws an error if it
- * finds anything. This plugin is only used when nodeCompat is not enabled.
- * Supports both regular node builtins, and the new "node:<MODULE>" format.
+ * RegExp matching against esbuild's error text when it is unable to resolve
+ * a Node built-in module. If we detect this when node_compat is disabled,
+ * we'll rewrite the error to suggest enabling it.
  */
-const checkForNodeBuiltinsPlugin = {
-	name: "checkForNodeBuiltins",
-	setup(build: esbuild.PluginBuild) {
-		build.onResolve(
-			{
-				filter: new RegExp(
-					"^(" +
-						builtinModules.join("|") +
-						"|" +
-						builtinModules.map((module) => "node:" + module).join("|") +
-						")$"
-				),
-			},
-			() => {
-				throw new Error(
-					`Detected a Node builtin module import while Node compatibility is disabled.\nAdd node_compat = true to your wrangler.toml file to enable Node compatibility.`
-				);
-			}
-		);
-	},
-};
+const nodeBuiltinResolveErrorText = new RegExp(
+	'^Could not resolve "(' +
+		builtinModules.join("|") +
+		"|" +
+		builtinModules.map((module) => "node:" + module).join("|") +
+		')"$'
+);
+
+/**
+ * Returns true if the passed value looks like an esbuild BuildFailure object
+ */
+export function isBuildFailure(err: unknown): err is esbuild.BuildFailure {
+	return (
+		typeof err === "object" &&
+		err !== null &&
+		"errors" in err &&
+		"warnings" in err
+	);
+}
+
+/**
+ * Rewrites esbuild BuildFailures for failing to resolve Node built-in modules
+ * to suggest enabling Node compat as opposed to `platform: "node"`.
+ */
+export function rewriteNodeCompatBuildFailure(err: esbuild.BuildFailure) {
+	for (const error of err.errors) {
+		const match = nodeBuiltinResolveErrorText.exec(error.text);
+		if (match !== null) {
+			error.notes = [
+				{
+					location: null,
+					text: `The package "${match[1]}" wasn't found on the file system but is built into node.
+Add "node_compat = true" to your wrangler.toml file to enable Node compatibility.`,
+				},
+			];
+		}
+	}
+}
 
 /**
  * Generate a bundle for the worker identified by the arguments passed in.
@@ -243,7 +260,7 @@ export async function bundleWorker(
 		);
 	}
 
-	const result = await esbuild.build({
+	const buildOptions: esbuild.BuildOptions & { metafile: true } = {
 		entryPoints: [inputEntry.file],
 		bundle: true,
 		absWorkingDir: entry.directory,
@@ -282,15 +299,24 @@ export async function bundleWorker(
 				: []),
 			...(nodeCompat
 				? [NodeGlobalsPolyfills({ buffer: true }), NodeModulesPolyfills()]
-				: // we use checkForNodeBuiltinsPlugin to throw a nicer error
-				  // if we find node builtins when nodeCompat isn't turned on
-				  [checkForNodeBuiltinsPlugin]),
+				: []),
 		],
 		...(jsxFactory && { jsxFactory }),
 		...(jsxFragment && { jsxFragment }),
 		...(tsconfig && { tsconfig }),
 		watch,
-	});
+		// The default logLevel is "warning". So that we can rewrite errors before
+		// logging, we disable esbuild's default logging, and log build failures
+		// ourselves.
+		logLevel: "silent",
+	};
+	let result;
+	try {
+		result = await esbuild.build(buildOptions);
+	} catch (e) {
+		if (!nodeCompat && isBuildFailure(e)) rewriteNodeCompatBuildFailure(e);
+		throw e;
+	}
 
 	const entryPointOutputs = Object.entries(result.metafile.outputs).filter(
 		([_path, output]) => output.entryPoint !== undefined

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -2,8 +2,8 @@ import assert from "node:assert";
 import { watch } from "chokidar";
 import { useApp } from "ink";
 import { useState, useEffect } from "react";
-import { bundleWorker } from "../bundle";
-import { logger } from "../logger";
+import { bundleWorker, rewriteNodeCompatBuildFailure } from "../bundle";
+import { logBuildFailure, logger } from "../logger";
 import type { Config } from "../config";
 import type { WorkerRegistry } from "../dev-registry";
 import type { Entry } from "../entry";
@@ -83,8 +83,11 @@ export function useEsbuild({
 
 		const watchMode: WatchMode = {
 			async onRebuild(error) {
-				if (error) logger.error("Watch build failed:", error);
-				else {
+				if (error !== null) {
+					if (!nodeCompat) rewriteNodeCompatBuildFailure(error);
+					logBuildFailure(error);
+					logger.error("Watch build failed:", error.message);
+				} else {
 					updateBundle();
 				}
 			},

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -5,6 +5,7 @@ import supportsColor from "supports-color";
 import { ProxyAgent, setGlobalDispatcher } from "undici";
 import makeCLI from "yargs";
 import { version as wranglerVersion } from "../package.json";
+import { isBuildFailure } from "./bundle";
 import { fetchResult } from "./cfetch";
 import { readConfig } from "./config";
 import { d1 } from "./d1";
@@ -27,7 +28,7 @@ import { devHandler, devOptions } from "./dev";
 import { workerNamespaceCommands } from "./dispatch-namespace";
 import { initHandler, initOptions } from "./init";
 import { kvNamespace, kvKey, kvBulk } from "./kv";
-import { logger } from "./logger";
+import { logBuildFailure, logger } from "./logger";
 import * as metrics from "./metrics";
 import { pages } from "./pages";
 import { formatMessage, ParseError } from "./parse";
@@ -640,6 +641,9 @@ export async function main(argv: string[]): Promise<void> {
 			logger.error(
 				`${thisTerminalIsUnsupported}\n${soWranglerWontWork}\n${tryRunningItIn}${oneOfThese}`
 			);
+		} else if (isBuildFailure(e)) {
+			logBuildFailure(e);
+			logger.error(e.message);
 		} else {
 			logger.error(e instanceof Error ? e.message : e);
 			logger.log(

--- a/packages/wrangler/src/logger.ts
+++ b/packages/wrangler/src/logger.ts
@@ -1,6 +1,7 @@
 import { format } from "node:util";
 import { formatMessagesSync } from "esbuild";
 import { getEnvironmentVariableFactory } from "./environment-variables";
+import type { BuildFailure } from "esbuild";
 
 export const LOGGER_LEVELS = {
 	none: -1,
@@ -78,3 +79,14 @@ class Logger {
  * to filter out logging messages.
  */
 export const logger = new Logger();
+
+/**
+ * Logs all errors/warnings associated with an esbuild BuildFailure in the same
+ * style esbuild would.
+ */
+export function logBuildFailure(failure: BuildFailure) {
+	let logs = formatMessagesSync(failure.errors, { kind: "error", color: true });
+	for (const log of logs) console.error(log);
+	logs = formatMessagesSync(failure.warnings, { kind: "warning", color: true });
+	for (const log of logs) console.warn(log);
+}


### PR DESCRIPTION
Previously, if `node_compat` was disabled, and the user had an npm package with the same name as a Node built-in module installed (e.g. `buffer`), esbuild would always throw instead of resolving it. This PR fixes the issue by relying on esbuild's resolver, and instead rewriting the error message on failure to suggest enabling `node_compat` instead of `platform: "node"`.

Closes #2038