### PR TITLE
Load `.env`/`.dev.vars` file based on `--env`

### DIFF
--- a/.changeset/lazy-teachers-melt.md
+++ b/.changeset/lazy-teachers-melt.md
@@ -1,0 +1,6 @@
+---
+"wrangler": patch
+---
+
+If `--env <env>` is specified, we'll now check `.env.<env>`/`.dev.vars.<env>` first.
+If they don't exist, we'll fallback to `.env`/`.dev.vars`.

--- a/packages/wrangler/src/__tests__/d1.test.ts
+++ b/packages/wrangler/src/__tests__/d1.test.ts
@@ -29,6 +29,7 @@ describe("d1", () => {
 
 		Flags:
 		  -c, --config   Path to .toml configuration file  [string]
+		  -e, --env      Environment to use for operations and .env files  [string]
 		  -h, --help     Show help  [boolean]
 		  -v, --version  Show version number  [boolean]
 
@@ -61,6 +62,7 @@ describe("d1", () => {
 
 		Flags:
 		  -c, --config   Path to .toml configuration file  [string]
+		  -e, --env      Environment to use for operations and .env files  [string]
 		  -h, --help     Show help  [boolean]
 		  -v, --version  Show version number  [boolean]
 

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -54,6 +54,7 @@ describe("wrangler", () => {
 
 			Flags:
 			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
 			  -h, --help     Show help  [boolean]
 			  -v, --version  Show version number  [boolean]"
 		`);
@@ -98,6 +99,7 @@ describe("wrangler", () => {
 
 			Flags:
 			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
 			  -h, --help     Show help  [boolean]
 			  -v, --version  Show version number  [boolean]"
 		`);
@@ -144,6 +146,7 @@ describe("wrangler", () => {
 
 			Flags:
 			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
 			  -h, --help     Show help  [boolean]
 			  -v, --version  Show version number  [boolean]"
 		`);
@@ -153,60 +156,63 @@ describe("wrangler", () => {
 			await runWrangler("kv:namespace");
 			await endEventLoop();
 			expect(std.out).toMatchInlineSnapshot(`
-			        "wrangler kv:namespace
+			"wrangler kv:namespace
 
-			        🗂️  Interact with your Workers KV Namespaces
+			🗂️  Interact with your Workers KV Namespaces
 
-			        Commands:
-			          wrangler kv:namespace create <namespace>  Create a new namespace
-			          wrangler kv:namespace list                Outputs a list of all KV namespaces associated with your account id.
-			          wrangler kv:namespace delete              Deletes a given namespace.
+			Commands:
+			  wrangler kv:namespace create <namespace>  Create a new namespace
+			  wrangler kv:namespace list                Outputs a list of all KV namespaces associated with your account id.
+			  wrangler kv:namespace delete              Deletes a given namespace.
 
-			        Flags:
-			          -c, --config   Path to .toml configuration file  [string]
-			          -h, --help     Show help  [boolean]
-			          -v, --version  Show version number  [boolean]"
-		      `);
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]"
+		`);
 		});
 
 		it("no subcommand 'kv:key' should display a list of available subcommands", async () => {
 			await runWrangler("kv:key");
 			await endEventLoop();
 			expect(std.out).toMatchInlineSnapshot(`
-			        "wrangler kv:key
+			"wrangler kv:key
 
-			        🔑 Individually manage Workers KV key-value pairs
+			🔑 Individually manage Workers KV key-value pairs
 
-			        Commands:
-			          wrangler kv:key put <key> [value]  Writes a single key/value pair to the given namespace.
-			          wrangler kv:key list               Outputs a list of all keys in a given namespace.
-			          wrangler kv:key get <key>          Reads a single value by key from the given namespace.
-			          wrangler kv:key delete <key>       Removes a single key value pair from the given namespace.
+			Commands:
+			  wrangler kv:key put <key> [value]  Writes a single key/value pair to the given namespace.
+			  wrangler kv:key list               Outputs a list of all keys in a given namespace.
+			  wrangler kv:key get <key>          Reads a single value by key from the given namespace.
+			  wrangler kv:key delete <key>       Removes a single key value pair from the given namespace.
 
-			        Flags:
-			          -c, --config   Path to .toml configuration file  [string]
-			          -h, --help     Show help  [boolean]
-			          -v, --version  Show version number  [boolean]"
-		      `);
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]"
+		`);
 		});
 
 		it("no subcommand 'kv:bulk' should display a list of available subcommands", async () => {
 			await runWrangler("kv:bulk");
 			await endEventLoop();
 			expect(std.out).toMatchInlineSnapshot(`
-			        "wrangler kv:bulk
+			"wrangler kv:bulk
 
-			        💪 Interact with multiple Workers KV key-value pairs at once
+			💪 Interact with multiple Workers KV key-value pairs at once
 
-			        Commands:
-			          wrangler kv:bulk put <filename>     Upload multiple key-value pairs to a namespace
-			          wrangler kv:bulk delete <filename>  Delete multiple key-value pairs from a namespace
+			Commands:
+			  wrangler kv:bulk put <filename>     Upload multiple key-value pairs to a namespace
+			  wrangler kv:bulk delete <filename>  Delete multiple key-value pairs from a namespace
 
-			        Flags:
-			          -c, --config   Path to .toml configuration file  [string]
-			          -h, --help     Show help  [boolean]
-			          -v, --version  Show version number  [boolean]"
-		      `);
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]"
+		`);
 		});
 
 		it("no subcommand 'r2' should display a list of available subcommands", async () => {
@@ -223,6 +229,7 @@ describe("wrangler", () => {
 
 			Flags:
 			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
 			  -h, --help     Show help  [boolean]
 			  -v, --version  Show version number  [boolean]"
 		`);

--- a/packages/wrangler/src/__tests__/kv.test.ts
+++ b/packages/wrangler/src/__tests__/kv.test.ts
@@ -57,28 +57,28 @@ describe("wrangler", () => {
 					`"Not enough non-option arguments: got 0, need at least 1"`
 				);
 				expect(std.out).toMatchInlineSnapshot(`
-          "
-          wrangler kv:namespace create <namespace>
+			"
+			wrangler kv:namespace create <namespace>
 
-          Create a new namespace
+			Create a new namespace
 
-          Positionals:
-            namespace  The name of the new namespace  [string] [required]
+			Positionals:
+			  namespace  The name of the new namespace  [string] [required]
 
-          Flags:
-            -c, --config   Path to .toml configuration file  [string]
-            -h, --help     Show help  [boolean]
-            -v, --version  Show version number  [boolean]
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]
 
-          Options:
-            -e, --env      Perform on a specific environment  [string]
-                --preview  Interact with a preview namespace  [boolean]"
-        `);
+			Options:
+			      --preview  Interact with a preview namespace  [boolean]"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`
-          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot enough non-option arguments: got 0, need at least 1[0m
+			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot enough non-option arguments: got 0, need at least 1[0m
 
-          "
-        `);
+			          "
+		        `);
 			});
 
 			it("should error if the namespace to create contains spaces", async () => {
@@ -88,28 +88,28 @@ describe("wrangler", () => {
 					`"Unknown arguments: def, ghi"`
 				);
 				expect(std.out).toMatchInlineSnapshot(`
-          "
-          wrangler kv:namespace create <namespace>
+			"
+			wrangler kv:namespace create <namespace>
 
-          Create a new namespace
+			Create a new namespace
 
-          Positionals:
-            namespace  The name of the new namespace  [string] [required]
+			Positionals:
+			  namespace  The name of the new namespace  [string] [required]
 
-          Flags:
-            -c, --config   Path to .toml configuration file  [string]
-            -h, --help     Show help  [boolean]
-            -v, --version  Show version number  [boolean]
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]
 
-          Options:
-            -e, --env      Perform on a specific environment  [string]
-                --preview  Interact with a preview namespace  [boolean]"
-        `);
+			Options:
+			      --preview  Interact with a preview namespace  [boolean]"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`
-          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mUnknown arguments: def, ghi[0m
+			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mUnknown arguments: def, ghi[0m
 
-          "
-        `);
+			          "
+		        `);
 			});
 
 			it("should error if the namespace to create is not valid", async () => {
@@ -120,50 +120,50 @@ describe("wrangler", () => {
 				);
 
 				expect(std.out).toMatchInlineSnapshot(`
-          "
-          wrangler kv:namespace create <namespace>
+			"
+			wrangler kv:namespace create <namespace>
 
-          Create a new namespace
+			Create a new namespace
 
-          Positionals:
-            namespace  The name of the new namespace  [string] [required]
+			Positionals:
+			  namespace  The name of the new namespace  [string] [required]
 
-          Flags:
-            -c, --config   Path to .toml configuration file  [string]
-            -h, --help     Show help  [boolean]
-            -v, --version  Show version number  [boolean]
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]
 
-          Options:
-            -e, --env      Perform on a specific environment  [string]
-                --preview  Interact with a preview namespace  [boolean]"
-        `);
+			Options:
+			      --preview  Interact with a preview namespace  [boolean]"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`
-          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mThe namespace binding name \\"abc-def\\" is invalid. It can only have alphanumeric and _ characters, and cannot begin with a number.[0m
+			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mThe namespace binding name \\"abc-def\\" is invalid. It can only have alphanumeric and _ characters, and cannot begin with a number.[0m
 
-          "
-        `);
+			          "
+		        `);
 			});
 
 			it("should create a namespace", async () => {
 				mockCreateRequest("worker-UnitTestNamespace");
 				await runWrangler("kv:namespace create UnitTestNamespace");
 				expect(std.out).toMatchInlineSnapshot(`
-          "🌀 Creating namespace with title \\"worker-UnitTestNamespace\\"
-          ✨ Success!
-          Add the following to your configuration file in your kv_namespaces array:
-          { binding = \\"UnitTestNamespace\\", id = \\"some-namespace-id\\" }"
-        `);
+			          "🌀 Creating namespace with title \\"worker-UnitTestNamespace\\"
+			          ✨ Success!
+			          Add the following to your configuration file in your kv_namespaces array:
+			          { binding = \\"UnitTestNamespace\\", id = \\"some-namespace-id\\" }"
+		        `);
 			});
 
 			it("should create a preview namespace if configured to do so", async () => {
 				mockCreateRequest("worker-UnitTestNamespace_preview");
 				await runWrangler("kv:namespace create UnitTestNamespace --preview");
 				expect(std.out).toMatchInlineSnapshot(`
-          "🌀 Creating namespace with title \\"worker-UnitTestNamespace_preview\\"
-          ✨ Success!
-          Add the following to your configuration file in your kv_namespaces array:
-          { binding = \\"UnitTestNamespace\\", preview_id = \\"some-namespace-id\\" }"
-        `);
+			          "🌀 Creating namespace with title \\"worker-UnitTestNamespace_preview\\"
+			          ✨ Success!
+			          Add the following to your configuration file in your kv_namespaces array:
+			          { binding = \\"UnitTestNamespace\\", preview_id = \\"some-namespace-id\\" }"
+		        `);
 			});
 
 			it("should create a namespace using configured worker name", async () => {
@@ -171,11 +171,11 @@ describe("wrangler", () => {
 				mockCreateRequest("other-worker-UnitTestNamespace");
 				await runWrangler("kv:namespace create UnitTestNamespace");
 				expect(std.out).toMatchInlineSnapshot(`
-            "🌀 Creating namespace with title \\"other-worker-UnitTestNamespace\\"
-            ✨ Success!
-            Add the following to your configuration file in your kv_namespaces array:
-            { binding = \\"UnitTestNamespace\\", id = \\"some-namespace-id\\" }"
-            `);
+			            "🌀 Creating namespace with title \\"other-worker-UnitTestNamespace\\"
+			            ✨ Success!
+			            Add the following to your configuration file in your kv_namespaces array:
+			            { binding = \\"UnitTestNamespace\\", id = \\"some-namespace-id\\" }"
+		            `);
 			});
 
 			it("should create a namespace in an environment if configured to do so", async () => {
@@ -184,11 +184,11 @@ describe("wrangler", () => {
 					"kv:namespace create UnitTestNamespace --env customEnv"
 				);
 				expect(std.out).toMatchInlineSnapshot(`
-          "🌀 Creating namespace with title \\"worker-customEnv-UnitTestNamespace\\"
-          ✨ Success!
-          Add the following to your configuration file in your kv_namespaces array under [env.customEnv]:
-          { binding = \\"UnitTestNamespace\\", id = \\"some-namespace-id\\" }"
-        `);
+			          "🌀 Creating namespace with title \\"worker-customEnv-UnitTestNamespace\\"
+			          ✨ Success!
+			          Add the following to your configuration file in your kv_namespaces array under [env.customEnv]:
+			          { binding = \\"UnitTestNamespace\\", id = \\"some-namespace-id\\" }"
+		        `);
 			});
 		});
 
@@ -290,12 +290,12 @@ describe("wrangler", () => {
 						                A namespace with binding name \\"otherBinding\\" was not found in the configured \\"kv_namespaces\\"."
 					              `);
 				expect(std.err).toMatchInlineSnapshot(`
-          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot able to delete namespace.[0m
+			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot able to delete namespace.[0m
 
-            A namespace with binding name \\"otherBinding\\" was not found in the configured \\"kv_namespaces\\".
+			            A namespace with binding name \\"otherBinding\\" was not found in the configured \\"kv_namespaces\\".
 
-          "
-        `);
+			          "
+		        `);
 			});
 
 			it("should delete a namespace specified by binding name in a given environment", async () => {
@@ -531,35 +531,35 @@ describe("wrangler", () => {
 				);
 
 				expect(std.out).toMatchInlineSnapshot(`
-          "
-          wrangler kv:key put <key> [value]
+			"
+			wrangler kv:key put <key> [value]
 
-          Writes a single key/value pair to the given namespace.
+			Writes a single key/value pair to the given namespace.
 
-          Positionals:
-            key    The key to write to  [string] [required]
-            value  The value to write  [string]
+			Positionals:
+			  key    The key to write to  [string] [required]
+			  value  The value to write  [string]
 
-          Flags:
-            -c, --config   Path to .toml configuration file  [string]
-            -h, --help     Show help  [boolean]
-            -v, --version  Show version number  [boolean]
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]
 
-          Options:
-                --binding       The binding of the namespace to write to  [string]
-                --namespace-id  The id of the namespace to write to  [string]
-            -e, --env           Perform on a specific environment  [string]
-                --preview       Interact with a preview namespace  [boolean]
-                --ttl           Time for which the entries should be visible  [number]
-                --expiration    Time since the UNIX epoch after which the entry expires  [number]
-                --metadata      Arbitrary JSON that is associated with a key  [string]
-                --path          Read value from the file at a given path  [string]"
-        `);
+			Options:
+			      --binding       The binding of the namespace to write to  [string]
+			      --namespace-id  The id of the namespace to write to  [string]
+			      --preview       Interact with a preview namespace  [boolean]
+			      --ttl           Time for which the entries should be visible  [number]
+			      --expiration    Time since the UNIX epoch after which the entry expires  [number]
+			      --metadata      Arbitrary JSON that is associated with a key  [string]
+			      --path          Read value from the file at a given path  [string]"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`
-          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot enough non-option arguments: got 0, need at least 1[0m
+			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot enough non-option arguments: got 0, need at least 1[0m
 
-          "
-        `);
+			          "
+		        `);
 			});
 
 			it("should error if no binding nor namespace is provided", async () => {
@@ -570,35 +570,35 @@ describe("wrangler", () => {
 				);
 
 				expect(std.out).toMatchInlineSnapshot(`
-          "
-          wrangler kv:key put <key> [value]
+			"
+			wrangler kv:key put <key> [value]
 
-          Writes a single key/value pair to the given namespace.
+			Writes a single key/value pair to the given namespace.
 
-          Positionals:
-            key    The key to write to  [string] [required]
-            value  The value to write  [string]
+			Positionals:
+			  key    The key to write to  [string] [required]
+			  value  The value to write  [string]
 
-          Flags:
-            -c, --config   Path to .toml configuration file  [string]
-            -h, --help     Show help  [boolean]
-            -v, --version  Show version number  [boolean]
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]
 
-          Options:
-                --binding       The binding of the namespace to write to  [string]
-                --namespace-id  The id of the namespace to write to  [string]
-            -e, --env           Perform on a specific environment  [string]
-                --preview       Interact with a preview namespace  [boolean]
-                --ttl           Time for which the entries should be visible  [number]
-                --expiration    Time since the UNIX epoch after which the entry expires  [number]
-                --metadata      Arbitrary JSON that is associated with a key  [string]
-                --path          Read value from the file at a given path  [string]"
-        `);
+			Options:
+			      --binding       The binding of the namespace to write to  [string]
+			      --namespace-id  The id of the namespace to write to  [string]
+			      --preview       Interact with a preview namespace  [boolean]
+			      --ttl           Time for which the entries should be visible  [number]
+			      --expiration    Time since the UNIX epoch after which the entry expires  [number]
+			      --metadata      Arbitrary JSON that is associated with a key  [string]
+			      --path          Read value from the file at a given path  [string]"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`
-          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mExactly one of the arguments binding and namespace-id is required[0m
+			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mExactly one of the arguments binding and namespace-id is required[0m
 
-          "
-        `);
+			          "
+		        `);
 			});
 
 			it("should error if both binding and namespace is provided", async () => {
@@ -609,35 +609,35 @@ describe("wrangler", () => {
 				);
 
 				expect(std.out).toMatchInlineSnapshot(`
-          "
-          wrangler kv:key put <key> [value]
+			"
+			wrangler kv:key put <key> [value]
 
-          Writes a single key/value pair to the given namespace.
+			Writes a single key/value pair to the given namespace.
 
-          Positionals:
-            key    The key to write to  [string] [required]
-            value  The value to write  [string]
+			Positionals:
+			  key    The key to write to  [string] [required]
+			  value  The value to write  [string]
 
-          Flags:
-            -c, --config   Path to .toml configuration file  [string]
-            -h, --help     Show help  [boolean]
-            -v, --version  Show version number  [boolean]
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]
 
-          Options:
-                --binding       The binding of the namespace to write to  [string]
-                --namespace-id  The id of the namespace to write to  [string]
-            -e, --env           Perform on a specific environment  [string]
-                --preview       Interact with a preview namespace  [boolean]
-                --ttl           Time for which the entries should be visible  [number]
-                --expiration    Time since the UNIX epoch after which the entry expires  [number]
-                --metadata      Arbitrary JSON that is associated with a key  [string]
-                --path          Read value from the file at a given path  [string]"
-        `);
+			Options:
+			      --binding       The binding of the namespace to write to  [string]
+			      --namespace-id  The id of the namespace to write to  [string]
+			      --preview       Interact with a preview namespace  [boolean]
+			      --ttl           Time for which the entries should be visible  [number]
+			      --expiration    Time since the UNIX epoch after which the entry expires  [number]
+			      --metadata      Arbitrary JSON that is associated with a key  [string]
+			      --path          Read value from the file at a given path  [string]"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`
-          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mArguments binding and namespace-id are mutually exclusive[0m
+			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mArguments binding and namespace-id are mutually exclusive[0m
 
-          "
-        `);
+			          "
+		        `);
 			});
 
 			it("should error if no value nor path is provided", async () => {
@@ -648,35 +648,35 @@ describe("wrangler", () => {
 				);
 
 				expect(std.out).toMatchInlineSnapshot(`
-          "
-          wrangler kv:key put <key> [value]
+			"
+			wrangler kv:key put <key> [value]
 
-          Writes a single key/value pair to the given namespace.
+			Writes a single key/value pair to the given namespace.
 
-          Positionals:
-            key    The key to write to  [string] [required]
-            value  The value to write  [string]
+			Positionals:
+			  key    The key to write to  [string] [required]
+			  value  The value to write  [string]
 
-          Flags:
-            -c, --config   Path to .toml configuration file  [string]
-            -h, --help     Show help  [boolean]
-            -v, --version  Show version number  [boolean]
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]
 
-          Options:
-                --binding       The binding of the namespace to write to  [string]
-                --namespace-id  The id of the namespace to write to  [string]
-            -e, --env           Perform on a specific environment  [string]
-                --preview       Interact with a preview namespace  [boolean]
-                --ttl           Time for which the entries should be visible  [number]
-                --expiration    Time since the UNIX epoch after which the entry expires  [number]
-                --metadata      Arbitrary JSON that is associated with a key  [string]
-                --path          Read value from the file at a given path  [string]"
-        `);
+			Options:
+			      --binding       The binding of the namespace to write to  [string]
+			      --namespace-id  The id of the namespace to write to  [string]
+			      --preview       Interact with a preview namespace  [boolean]
+			      --ttl           Time for which the entries should be visible  [number]
+			      --expiration    Time since the UNIX epoch after which the entry expires  [number]
+			      --metadata      Arbitrary JSON that is associated with a key  [string]
+			      --path          Read value from the file at a given path  [string]"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`
-          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mExactly one of the arguments value and path is required[0m
+			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mExactly one of the arguments value and path is required[0m
 
-          "
-        `);
+			          "
+		        `);
 			});
 
 			it("should error if both value and path is provided", async () => {
@@ -687,35 +687,35 @@ describe("wrangler", () => {
 				);
 
 				expect(std.out).toMatchInlineSnapshot(`
-          "
-          wrangler kv:key put <key> [value]
+			"
+			wrangler kv:key put <key> [value]
 
-          Writes a single key/value pair to the given namespace.
+			Writes a single key/value pair to the given namespace.
 
-          Positionals:
-            key    The key to write to  [string] [required]
-            value  The value to write  [string]
+			Positionals:
+			  key    The key to write to  [string] [required]
+			  value  The value to write  [string]
 
-          Flags:
-            -c, --config   Path to .toml configuration file  [string]
-            -h, --help     Show help  [boolean]
-            -v, --version  Show version number  [boolean]
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]
 
-          Options:
-                --binding       The binding of the namespace to write to  [string]
-                --namespace-id  The id of the namespace to write to  [string]
-            -e, --env           Perform on a specific environment  [string]
-                --preview       Interact with a preview namespace  [boolean]
-                --ttl           Time for which the entries should be visible  [number]
-                --expiration    Time since the UNIX epoch after which the entry expires  [number]
-                --metadata      Arbitrary JSON that is associated with a key  [string]
-                --path          Read value from the file at a given path  [string]"
-        `);
+			Options:
+			      --binding       The binding of the namespace to write to  [string]
+			      --namespace-id  The id of the namespace to write to  [string]
+			      --preview       Interact with a preview namespace  [boolean]
+			      --ttl           Time for which the entries should be visible  [number]
+			      --expiration    Time since the UNIX epoch after which the entry expires  [number]
+			      --metadata      Arbitrary JSON that is associated with a key  [string]
+			      --path          Read value from the file at a given path  [string]"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`
-          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mArguments value and path are mutually exclusive[0m
+			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mArguments value and path are mutually exclusive[0m
 
-          "
-        `);
+			          "
+		        `);
 			});
 
 			it("should error if a given binding name is not in the configured kv namespaces", async () => {
@@ -727,14 +727,14 @@ describe("wrangler", () => {
 				);
 
 				expect(std.out).toMatchInlineSnapshot(`
-          "
-          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
-        `);
+			          "
+			          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
+		        `);
 				expect(std.err).toMatchInlineSnapshot(`
-          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA namespace with binding name \\"otherBinding\\" was not found in the configured \\"kv_namespaces\\".[0m
+			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA namespace with binding name \\"otherBinding\\" was not found in the configured \\"kv_namespaces\\".[0m
 
-          "
-        `);
+			          "
+		        `);
 			});
 
 			it("should error if a given binding has both preview and non-preview and --preview is not specified", async () => {
@@ -749,14 +749,14 @@ describe("wrangler", () => {
 					`"someBinding has both a namespace ID and a preview ID. Specify \\"--preview\\" or \\"--preview false\\" to avoid writing data to the wrong namespace."`
 				);
 				expect(std.out).toMatchInlineSnapshot(`
-          "
-          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
-        `);
+			          "
+			          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
+		        `);
 				expect(std.err).toMatchInlineSnapshot(`
-          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1msomeBinding has both a namespace ID and a preview ID. Specify \\"--preview\\" or \\"--preview false\\" to avoid writing data to the wrong namespace.[0m
+			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1msomeBinding has both a namespace ID and a preview ID. Specify \\"--preview\\" or \\"--preview false\\" to avoid writing data to the wrong namespace.[0m
 
-          "
-        `);
+			          "
+		        `);
 				expect(requests.count).toEqual(0);
 			});
 		});
@@ -772,20 +772,20 @@ describe("wrangler", () => {
 				await runWrangler("kv:key list --namespace-id some-namespace-id");
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.out).toMatchInlineSnapshot(`
-          "[
-            {
-              \\"name\\": \\"key-1\\"
-            },
-            {
-              \\"name\\": \\"key-2\\",
-              \\"expiration\\": 123456789
-            },
-            {
-              \\"name\\": \\"key-3\\",
-              \\"expiration_ttl\\": 666
-            }
-          ]"
-        `);
+			          "[
+			            {
+			              \\"name\\": \\"key-1\\"
+			            },
+			            {
+			              \\"name\\": \\"key-2\\",
+			              \\"expiration\\": 123456789
+			            },
+			            {
+			              \\"name\\": \\"key-3\\",
+			              \\"expiration_ttl\\": 666
+			            }
+			          ]"
+		        `);
 			});
 
 			it("should list the keys of a namespace specified by binding", async () => {
@@ -796,18 +796,18 @@ describe("wrangler", () => {
 				await runWrangler("kv:key list --binding someBinding");
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.out).toMatchInlineSnapshot(`
-          "[
-            {
-              \\"name\\": \\"key-1\\"
-            },
-            {
-              \\"name\\": \\"key-2\\"
-            },
-            {
-              \\"name\\": \\"key-3\\"
-            }
-          ]"
-        `);
+			          "[
+			            {
+			              \\"name\\": \\"key-1\\"
+			            },
+			            {
+			              \\"name\\": \\"key-2\\"
+			            },
+			            {
+			              \\"name\\": \\"key-3\\"
+			            }
+			          ]"
+		        `);
 			});
 
 			it("should list the keys of a preview namespace specified by binding", async () => {
@@ -817,18 +817,18 @@ describe("wrangler", () => {
 				await runWrangler("kv:key list --binding someBinding --preview");
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.out).toMatchInlineSnapshot(`
-          "[
-            {
-              \\"name\\": \\"key-1\\"
-            },
-            {
-              \\"name\\": \\"key-2\\"
-            },
-            {
-              \\"name\\": \\"key-3\\"
-            }
-          ]"
-        `);
+			          "[
+			            {
+			              \\"name\\": \\"key-1\\"
+			            },
+			            {
+			              \\"name\\": \\"key-2\\"
+			            },
+			            {
+			              \\"name\\": \\"key-3\\"
+			            }
+			          ]"
+		        `);
 			});
 
 			it("should list the keys of a namespace specified by binding, in a given environment", async () => {
@@ -840,18 +840,18 @@ describe("wrangler", () => {
 				);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.out).toMatchInlineSnapshot(`
-          "[
-            {
-              \\"name\\": \\"key-1\\"
-            },
-            {
-              \\"name\\": \\"key-2\\"
-            },
-            {
-              \\"name\\": \\"key-3\\"
-            }
-          ]"
-        `);
+			          "[
+			            {
+			              \\"name\\": \\"key-1\\"
+			            },
+			            {
+			              \\"name\\": \\"key-2\\"
+			            },
+			            {
+			              \\"name\\": \\"key-3\\"
+			            }
+			          ]"
+		        `);
 			});
 
 			it("should list the keys of a preview namespace specified by binding, in a given environment", async () => {
@@ -863,18 +863,18 @@ describe("wrangler", () => {
 				);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.out).toMatchInlineSnapshot(`
-          "[
-            {
-              \\"name\\": \\"key-1\\"
-            },
-            {
-              \\"name\\": \\"key-2\\"
-            },
-            {
-              \\"name\\": \\"key-3\\"
-            }
-          ]"
-        `);
+			          "[
+			            {
+			              \\"name\\": \\"key-1\\"
+			            },
+			            {
+			              \\"name\\": \\"key-2\\"
+			            },
+			            {
+			              \\"name\\": \\"key-3\\"
+			            }
+			          ]"
+		        `);
 			});
 
 			// We'll run the next test with variations on the cursor
@@ -915,14 +915,14 @@ describe("wrangler", () => {
 					`"A namespace with binding name \\"otherBinding\\" was not found in the configured \\"kv_namespaces\\"."`
 				);
 				expect(std.err).toMatchInlineSnapshot(`
-          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA namespace with binding name \\"otherBinding\\" was not found in the configured \\"kv_namespaces\\".[0m
+			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA namespace with binding name \\"otherBinding\\" was not found in the configured \\"kv_namespaces\\".[0m
 
-          "
-        `);
+			          "
+		        `);
 				expect(std.out).toMatchInlineSnapshot(`
-          "
-          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
-        `);
+			          "
+			          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
+		        `);
 			});
 		});
 
@@ -955,13 +955,13 @@ describe("wrangler", () => {
 				);
 				expect(proc.write).not.toEqual(Buffer.from("my-value"));
 				expect(std).toMatchInlineSnapshot(`
-          Object {
-            "debug": "",
-            "err": "",
-            "out": "my-value",
-            "warn": "",
-          }
-        `);
+			          Object {
+			            "debug": "",
+			            "err": "",
+			            "out": "my-value",
+			            "warn": "",
+			          }
+		        `);
 			});
 
 			it("should get a binary and decode as utf8 text, resulting in improper decoding", async () => {
@@ -1064,31 +1064,31 @@ describe("wrangler", () => {
 					`"Not enough non-option arguments: got 0, need at least 1"`
 				);
 				expect(std.out).toMatchInlineSnapshot(`
-          "
-          wrangler kv:key get <key>
+			"
+			wrangler kv:key get <key>
 
-          Reads a single value by key from the given namespace.
+			Reads a single value by key from the given namespace.
 
-          Positionals:
-            key  The key value to get.  [string] [required]
+			Positionals:
+			  key  The key value to get.  [string] [required]
 
-          Flags:
-            -c, --config   Path to .toml configuration file  [string]
-            -h, --help     Show help  [boolean]
-            -v, --version  Show version number  [boolean]
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]
 
-          Options:
-                --binding       The name of the namespace to get from  [string]
-                --namespace-id  The id of the namespace to get from  [string]
-            -e, --env           Perform on a specific environment  [string]
-                --preview       Interact with a preview namespace  [boolean] [default: false]
-                --text          Decode the returned value as a utf8 string  [boolean] [default: false]"
-        `);
+			Options:
+			      --binding       The name of the namespace to get from  [string]
+			      --namespace-id  The id of the namespace to get from  [string]
+			      --preview       Interact with a preview namespace  [boolean] [default: false]
+			      --text          Decode the returned value as a utf8 string  [boolean] [default: false]"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`
-          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot enough non-option arguments: got 0, need at least 1[0m
+			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot enough non-option arguments: got 0, need at least 1[0m
 
-          "
-        `);
+			          "
+		        `);
 			});
 
 			it("should error if no binding nor namespace is provided", async () => {
@@ -1098,31 +1098,31 @@ describe("wrangler", () => {
 					`"Exactly one of the arguments binding and namespace-id is required"`
 				);
 				expect(std.out).toMatchInlineSnapshot(`
-          "
-          wrangler kv:key get <key>
+			"
+			wrangler kv:key get <key>
 
-          Reads a single value by key from the given namespace.
+			Reads a single value by key from the given namespace.
 
-          Positionals:
-            key  The key value to get.  [string] [required]
+			Positionals:
+			  key  The key value to get.  [string] [required]
 
-          Flags:
-            -c, --config   Path to .toml configuration file  [string]
-            -h, --help     Show help  [boolean]
-            -v, --version  Show version number  [boolean]
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]
 
-          Options:
-                --binding       The name of the namespace to get from  [string]
-                --namespace-id  The id of the namespace to get from  [string]
-            -e, --env           Perform on a specific environment  [string]
-                --preview       Interact with a preview namespace  [boolean] [default: false]
-                --text          Decode the returned value as a utf8 string  [boolean] [default: false]"
-        `);
+			Options:
+			      --binding       The name of the namespace to get from  [string]
+			      --namespace-id  The id of the namespace to get from  [string]
+			      --preview       Interact with a preview namespace  [boolean] [default: false]
+			      --text          Decode the returned value as a utf8 string  [boolean] [default: false]"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`
-          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mExactly one of the arguments binding and namespace-id is required[0m
+			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mExactly one of the arguments binding and namespace-id is required[0m
 
-          "
-        `);
+			          "
+		        `);
 			});
 
 			it("should error if both binding and namespace is provided", async () => {
@@ -1133,31 +1133,31 @@ describe("wrangler", () => {
 				);
 
 				expect(std.out).toMatchInlineSnapshot(`
-          "
-          wrangler kv:key get <key>
+			"
+			wrangler kv:key get <key>
 
-          Reads a single value by key from the given namespace.
+			Reads a single value by key from the given namespace.
 
-          Positionals:
-            key  The key value to get.  [string] [required]
+			Positionals:
+			  key  The key value to get.  [string] [required]
 
-          Flags:
-            -c, --config   Path to .toml configuration file  [string]
-            -h, --help     Show help  [boolean]
-            -v, --version  Show version number  [boolean]
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]
 
-          Options:
-                --binding       The name of the namespace to get from  [string]
-                --namespace-id  The id of the namespace to get from  [string]
-            -e, --env           Perform on a specific environment  [string]
-                --preview       Interact with a preview namespace  [boolean] [default: false]
-                --text          Decode the returned value as a utf8 string  [boolean] [default: false]"
-        `);
+			Options:
+			      --binding       The name of the namespace to get from  [string]
+			      --namespace-id  The id of the namespace to get from  [string]
+			      --preview       Interact with a preview namespace  [boolean] [default: false]
+			      --text          Decode the returned value as a utf8 string  [boolean] [default: false]"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`
-          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mArguments binding and namespace-id are mutually exclusive[0m
+			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mArguments binding and namespace-id are mutually exclusive[0m
 
-          "
-        `);
+			          "
+		        `);
 			});
 
 			it("should error if a given binding name is not in the configured kv namespaces", async () => {
@@ -1168,14 +1168,14 @@ describe("wrangler", () => {
 					`"A namespace with binding name \\"otherBinding\\" was not found in the configured \\"kv_namespaces\\"."`
 				);
 				expect(std.out).toMatchInlineSnapshot(`
-          "
-          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
-        `);
+			          "
+			          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
+		        `);
 				expect(std.err).toMatchInlineSnapshot(`
-          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA namespace with binding name \\"otherBinding\\" was not found in the configured \\"kv_namespaces\\".[0m
+			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA namespace with binding name \\"otherBinding\\" was not found in the configured \\"kv_namespaces\\".[0m
 
-          "
-        `);
+			          "
+		        `);
 			});
 
 			describe("non-interactive", () => {
@@ -1313,10 +1313,10 @@ describe("wrangler", () => {
 				);
 
 				expect(std.err).toMatchInlineSnapshot(`
-          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA namespace with binding name \\"otherBinding\\" was not found in the configured \\"kv_namespaces\\".[0m
+			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA namespace with binding name \\"otherBinding\\" was not found in the configured \\"kv_namespaces\\".[0m
 
-          "
-        `);
+			          "
+		        `);
 			});
 
 			it("should delete a key in a namespace specified by binding name in a given environment", async () => {
@@ -1399,12 +1399,12 @@ describe("wrangler", () => {
 				);
 				expect(requests.count).toEqual(3);
 				expect(std.out).toMatchInlineSnapshot(`
-          "Uploaded 0% (0 out of 12,000)
-          Uploaded 41% (5,000 out of 12,000)
-          Uploaded 83% (10,000 out of 12,000)
-          Uploaded 100% (12,000 out of 12,000)
-          Success!"
-        `);
+			          "Uploaded 0% (0 out of 12,000)
+			          Uploaded 41% (5,000 out of 12,000)
+			          Uploaded 83% (10,000 out of 12,000)
+			          Uploaded 100% (12,000 out of 12,000)
+			          Success!"
+		        `);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
@@ -1419,9 +1419,9 @@ describe("wrangler", () => {
 						                Expected an array of key-value objects but got type \\"object\\"."
 					              `);
 				expect(std.out).toMatchInlineSnapshot(`
-          "
-          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
-        `);
+			          "
+			          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
+		        `);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
 
@@ -1481,16 +1481,16 @@ describe("wrangler", () => {
 					              `);
 
 				expect(std.out).toMatchInlineSnapshot(`
-          "
-          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
-        `);
+			          "
+			          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
+		        `);
 				expect(std.warn).toMatchInlineSnapshot(`
-          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mUnexpected key-value properties in \\"keys.json\\".[0m
+			          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mUnexpected key-value properties in \\"keys.json\\".[0m
 
-            The item at index 5 contains unexpected properties: [\\"invalid\\"].
+			            The item at index 5 contains unexpected properties: [\\"invalid\\"].
 
-          "
-        `);
+			          "
+		        `);
 			});
 		});
 
@@ -1552,12 +1552,12 @@ describe("wrangler", () => {
 				);
 				expect(requests.count).toEqual(3);
 				expect(std.out).toMatchInlineSnapshot(`
-          "Deleted 0% (0 out of 12,000)
-          Deleted 41% (5,000 out of 12,000)
-          Deleted 83% (10,000 out of 12,000)
-          Deleted 100% (12,000 out of 12,000)
-          Success!"
-        `);
+			          "Deleted 0% (0 out of 12,000)
+			          Deleted 41% (5,000 out of 12,000)
+			          Deleted 83% (10,000 out of 12,000)
+			          Deleted 100% (12,000 out of 12,000)
+			          Success!"
+		        `);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
@@ -1622,9 +1622,9 @@ describe("wrangler", () => {
 						                12354"
 					              `);
 				expect(std.out).toMatchInlineSnapshot(`
-          "
-          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
-        `);
+			          "
+			          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
+		        `);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
 
@@ -1647,9 +1647,9 @@ describe("wrangler", () => {
 						                The item at index 3 is type: \\"object\\" - null"
 					              `);
 				expect(std.out).toMatchInlineSnapshot(`
-          "
-          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
-        `);
+			          "
+			          [32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose[0m"
+		        `);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
 		});

--- a/packages/wrangler/src/__tests__/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages.test.ts
@@ -60,23 +60,24 @@ describe("pages", () => {
 		await endEventLoop();
 
 		expect(std.out).toMatchInlineSnapshot(`
-		      "wrangler pages
+		"wrangler pages
 
-		      ⚡️ Configure Cloudflare Pages
+		⚡️ Configure Cloudflare Pages
 
-		      Commands:
-		        wrangler pages dev [directory] [-- command..]  🧑‍💻 Develop your full-stack Pages application locally
-		        wrangler pages project                         ⚡️ Interact with your Pages projects
-		        wrangler pages deployment                      🚀 Interact with the deployments of a project
-		        wrangler pages publish [directory]             🆙 Publish a directory of static assets as a Pages deployment
+		Commands:
+		  wrangler pages dev [directory] [-- command..]  🧑‍💻 Develop your full-stack Pages application locally
+		  wrangler pages project                         ⚡️ Interact with your Pages projects
+		  wrangler pages deployment                      🚀 Interact with the deployments of a project
+		  wrangler pages publish [directory]             🆙 Publish a directory of static assets as a Pages deployment
 
-		      Flags:
-		        -c, --config   Path to .toml configuration file  [string]
-		        -h, --help     Show help  [boolean]
-		        -v, --version  Show version number  [boolean]
+		Flags:
+		  -c, --config   Path to .toml configuration file  [string]
+		  -e, --env      Environment to use for operations and .env files  [string]
+		  -h, --help     Show help  [boolean]
+		  -v, --version  Show version number  [boolean]
 
-		      🚧 'wrangler pages <command>' is a beta command. Please report any issues to https://github.com/cloudflare/wrangler2/issues/new/choose"
-	    `);
+		🚧 'wrangler pages <command>' is a beta command. Please report any issues to https://github.com/cloudflare/wrangler2/issues/new/choose"
+	`);
 	});
 
 	describe("beta message for subcommands", () => {
@@ -315,26 +316,27 @@ describe("pages", () => {
 			await endEventLoop();
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "wrangler pages publish [directory]
+			"wrangler pages publish [directory]
 
-			        🆙 Publish a directory of static assets as a Pages deployment
+			🆙 Publish a directory of static assets as a Pages deployment
 
-			        Positionals:
-			          directory  The directory of static files to upload  [string]
+			Positionals:
+			  directory  The directory of static files to upload  [string]
 
-			        Flags:
-			          -h, --help     Show help  [boolean]
-			          -v, --version  Show version number  [boolean]
+			Flags:
+			  -e, --env      Environment to use for operations and .env files  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]
 
-			        Options:
-			              --project-name    The name of the project you want to deploy to  [string]
-			              --branch          The name of the branch you want to deploy to  [string]
-			              --commit-hash     The SHA to attach to this deployment  [string]
-			              --commit-message  The commit message to attach to this deployment  [string]
-			              --commit-dirty    Whether or not the workspace should be considered dirty for this deployment  [boolean]
+			Options:
+			      --project-name    The name of the project you want to deploy to  [string]
+			      --branch          The name of the branch you want to deploy to  [string]
+			      --commit-hash     The SHA to attach to this deployment  [string]
+			      --commit-message  The commit message to attach to this deployment  [string]
+			      --commit-dirty    Whether or not the workspace should be considered dirty for this deployment  [boolean]
 
-			        🚧 'wrangler pages <command>' is a beta command. Please report any issues to https://github.com/cloudflare/wrangler2/issues/new/choose"
-		      `);
+			🚧 'wrangler pages <command>' is a beta command. Please report any issues to https://github.com/cloudflare/wrangler2/issues/new/choose"
+		`);
 		});
 
 		it("should upload a directory of files", async () => {

--- a/packages/wrangler/src/__tests__/pubsub.test.ts
+++ b/packages/wrangler/src/__tests__/pubsub.test.ts
@@ -38,6 +38,7 @@ describe("wrangler", () => {
 
 			Flags:
 			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
 			  -h, --help     Show help  [boolean]
 			  -v, --version  Show version number  [boolean]
 
@@ -68,6 +69,7 @@ describe("wrangler", () => {
 
 				Flags:
 				  -c, --config   Path to .toml configuration file  [string]
+				  -e, --env      Environment to use for operations and .env files  [string]
 				  -h, --help     Show help  [boolean]
 				  -v, --version  Show version number  [boolean]
 
@@ -158,6 +160,7 @@ describe("wrangler", () => {
 
 				Flags:
 				  -c, --config   Path to .toml configuration file  [string]
+				  -e, --env      Environment to use for operations and .env files  [string]
 				  -h, --help     Show help  [boolean]
 				  -v, --version  Show version number  [boolean]
 

--- a/packages/wrangler/src/__tests__/queues.test.ts
+++ b/packages/wrangler/src/__tests__/queues.test.ts
@@ -20,21 +20,22 @@ describe("wrangler", () => {
 			await runWrangler("queues --help");
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.out).toMatchInlineSnapshot(`
-				"wrangler queues
+			"wrangler queues
 
-				🆀 Configure Workers Queues
+			🆀 Configure Workers Queues
 
-				Commands:
-				  wrangler queues list           List Queues
-				  wrangler queues create <name>  Create a Queue
-				  wrangler queues delete <name>  Delete a Queue
-				  wrangler queues consumer       Configure Queue Consumers
+			Commands:
+			  wrangler queues list           List Queues
+			  wrangler queues create <name>  Create a Queue
+			  wrangler queues delete <name>  Delete a Queue
+			  wrangler queues consumer       Configure Queue Consumers
 
-				Flags:
-				  -c, --config   Path to .toml configuration file  [string]
-				  -h, --help     Show help  [boolean]
-				  -v, --version  Show version number  [boolean]"
-			`);
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]"
+		`);
 		});
 
 		describe("list", () => {
@@ -57,18 +58,19 @@ describe("wrangler", () => {
 				await runWrangler("queues list --help");
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.out).toMatchInlineSnapshot(`
-					"wrangler queues list
+			"wrangler queues list
 
-					List Queues
+			List Queues
 
-					Flags:
-					  -c, --config   Path to .toml configuration file  [string]
-					  -h, --help     Show help  [boolean]
-					  -v, --version  Show version number  [boolean]
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]
 
-					Options:
-					      --page  Page number for pagination  [number]"
-				`);
+			Options:
+			      --page  Page number for pagination  [number]"
+		`);
 			});
 
 			it("should list queues on page 1 with no --page", async () => {
@@ -131,18 +133,19 @@ describe("wrangler", () => {
 				await runWrangler("queues create --help");
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.out).toMatchInlineSnapshot(`
-					"wrangler queues create <name>
+			"wrangler queues create <name>
 
-					Create a Queue
+			Create a Queue
 
-					Positionals:
-					  name  The name of the queue  [string] [required]
+			Positionals:
+			  name  The name of the queue  [string] [required]
 
-					Flags:
-					  -c, --config   Path to .toml configuration file  [string]
-					  -h, --help     Show help  [boolean]
-					  -v, --version  Show version number  [boolean]"
-				`);
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]"
+		`);
 			});
 
 			it("should create a queue", async () => {
@@ -174,18 +177,19 @@ describe("wrangler", () => {
 				await runWrangler("queues delete --help");
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.out).toMatchInlineSnapshot(`
-					"wrangler queues delete <name>
+			"wrangler queues delete <name>
 
-					Delete a Queue
+			Delete a Queue
 
-					Positionals:
-					  name  The name of the queue  [string] [required]
+			Positionals:
+			  name  The name of the queue  [string] [required]
 
-					Flags:
-					  -c, --config   Path to .toml configuration file  [string]
-					  -h, --help     Show help  [boolean]
-					  -v, --version  Show version number  [boolean]"
-				`);
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]"
+		`);
 			});
 
 			it("should delete a queue", async () => {
@@ -205,19 +209,20 @@ describe("wrangler", () => {
 
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.out).toMatchInlineSnapshot(`
-					"wrangler queues consumer
+			"wrangler queues consumer
 
-					Configure Queue Consumers
+			Configure Queue Consumers
 
-					Commands:
-					  wrangler queues consumer add <queue-name> <script-name>     Add a Queue Consumer
-					  wrangler queues consumer remove <queue-name> <script-name>  Remove a Queue Consumer
+			Commands:
+			  wrangler queues consumer add <queue-name> <script-name>     Add a Queue Consumer
+			  wrangler queues consumer remove <queue-name> <script-name>  Remove a Queue Consumer
 
-					Flags:
-					  -c, --config   Path to .toml configuration file  [string]
-					  -h, --help     Show help  [boolean]
-					  -v, --version  Show version number  [boolean]"
-				`);
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]"
+		`);
 			});
 
 			describe("add", () => {
@@ -242,26 +247,27 @@ describe("wrangler", () => {
 					await runWrangler("queues consumer add --help");
 					expect(std.err).toMatchInlineSnapshot(`""`);
 					expect(std.out).toMatchInlineSnapshot(`
-						"wrangler queues consumer add <queue-name> <script-name>
+				"wrangler queues consumer add <queue-name> <script-name>
 
-						Add a Queue Consumer
+				Add a Queue Consumer
 
-						Positionals:
-						  queue-name   Name of the queue to configure  [string] [required]
-						  script-name  Name of the consumer script  [string] [required]
+				Positionals:
+				  queue-name   Name of the queue to configure  [string] [required]
+				  script-name  Name of the consumer script  [string] [required]
 
-						Flags:
-						  -c, --config   Path to .toml configuration file  [string]
-						  -h, --help     Show help  [boolean]
-						  -v, --version  Show version number  [boolean]
+				Flags:
+				  -c, --config   Path to .toml configuration file  [string]
+				  -e, --env      Environment to use for operations and .env files  [string]
+				  -h, --help     Show help  [boolean]
+				  -v, --version  Show version number  [boolean]
 
-						Options:
-						      --environment        Environment of the consumer script  [string]
-						      --batch-size         Maximum number of messages per batch  [number]
-						      --batch-timeout      Maximum number of seconds to wait to fill a batch with messages  [number]
-						      --message-retries    Maximum number of retries for each message  [number]
-						      --dead-letter-queue  Queue to send messages that failed to be consumed  [string]"
-					`);
+				Options:
+				      --environment        Environment of the consumer script  [string]
+				      --batch-size         Maximum number of messages per batch  [number]
+				      --batch-timeout      Maximum number of seconds to wait to fill a batch with messages  [number]
+				      --message-retries    Maximum number of retries for each message  [number]
+				      --dead-letter-queue  Queue to send messages that failed to be consumed  [string]"
+			`);
 				});
 
 				it("should add a consumer using defaults", async () => {
@@ -325,22 +331,23 @@ describe("wrangler", () => {
 					await runWrangler("queues consumer remove --help");
 					expect(std.err).toMatchInlineSnapshot(`""`);
 					expect(std.out).toMatchInlineSnapshot(`
-						"wrangler queues consumer remove <queue-name> <script-name>
+				"wrangler queues consumer remove <queue-name> <script-name>
 
-						Remove a Queue Consumer
+				Remove a Queue Consumer
 
-						Positionals:
-						  queue-name   Name of the queue to configure  [string] [required]
-						  script-name  Name of the consumer script  [string] [required]
+				Positionals:
+				  queue-name   Name of the queue to configure  [string] [required]
+				  script-name  Name of the consumer script  [string] [required]
 
-						Flags:
-						  -c, --config   Path to .toml configuration file  [string]
-						  -h, --help     Show help  [boolean]
-						  -v, --version  Show version number  [boolean]
+				Flags:
+				  -c, --config   Path to .toml configuration file  [string]
+				  -e, --env      Environment to use for operations and .env files  [string]
+				  -h, --help     Show help  [boolean]
+				  -v, --version  Show version number  [boolean]
 
-						Options:
-						      --environment  Environment of the consumer script  [string]"
-					`);
+				Options:
+				      --environment  Environment of the consumer script  [string]"
+			`);
 				});
 
 				it("should delete a consumer with no --environment", async () => {

--- a/packages/wrangler/src/__tests__/queues.test.ts
+++ b/packages/wrangler/src/__tests__/queues.test.ts
@@ -262,7 +262,6 @@ describe("wrangler", () => {
 				  -v, --version  Show version number  [boolean]
 
 				Options:
-				      --environment        Environment of the consumer script  [string]
 				      --batch-size         Maximum number of messages per batch  [number]
 				      --batch-timeout      Maximum number of seconds to wait to fill a batch with messages  [number]
 				      --message-retries    Maximum number of retries for each message  [number]
@@ -303,7 +302,7 @@ describe("wrangler", () => {
 					mockPostRequest("testQueue", expectedBody);
 
 					await runWrangler(
-						"queues consumer add testQueue testScript --environment myEnv --batch-size 20 --batch-timeout 10 --message-retries 3 --dead-letter-queue myDLQ"
+						"queues consumer add testQueue testScript --env myEnv --batch-size 20 --batch-timeout 10 --message-retries 3 --dead-letter-queue myDLQ"
 					);
 					expect(std.out).toMatchInlineSnapshot(`
 						"Adding consumer to queue testQueue.
@@ -343,14 +342,11 @@ describe("wrangler", () => {
 				  -c, --config   Path to .toml configuration file  [string]
 				  -e, --env      Environment to use for operations and .env files  [string]
 				  -h, --help     Show help  [boolean]
-				  -v, --version  Show version number  [boolean]
-
-				Options:
-				      --environment  Environment of the consumer script  [string]"
+				  -v, --version  Show version number  [boolean]"
 			`);
 				});
 
-				it("should delete a consumer with no --environment", async () => {
+				it("should delete a consumer with no --env", async () => {
 					mockDeleteRequest("testQueue", "testScript");
 					await runWrangler("queues consumer remove testQueue testScript");
 					expect(std.out).toMatchInlineSnapshot(`
@@ -359,10 +355,10 @@ describe("wrangler", () => {
 					`);
 				});
 
-				it("should delete a consumer with --environment", async () => {
+				it("should delete a consumer with --env", async () => {
 					mockDeleteRequest("testQueue", "testScript", "myEnv");
 					await runWrangler(
-						"queues consumer remove testQueue testScript --environment myEnv"
+						"queues consumer remove testQueue testScript --env myEnv"
 					);
 					expect(std.out).toMatchInlineSnapshot(`
 						"Removing consumer from queue testQueue.

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -26,21 +26,22 @@ describe("r2", () => {
 			          "
 		        `);
 			expect(std.out).toMatchInlineSnapshot(`
-			          "
-			          wrangler r2 bucket
+			"
+			wrangler r2 bucket
 
-			          Manage R2 buckets
+			Manage R2 buckets
 
-			          Commands:
-			            wrangler r2 bucket create <name>  Create a new R2 bucket
-			            wrangler r2 bucket list           List R2 buckets
-			            wrangler r2 bucket delete <name>  Delete an R2 bucket
+			Commands:
+			  wrangler r2 bucket create <name>  Create a new R2 bucket
+			  wrangler r2 bucket list           List R2 buckets
+			  wrangler r2 bucket delete <name>  Delete an R2 bucket
 
-			          Flags:
-			            -c, --config   Path to .toml configuration file  [string]
-			            -h, --help     Show help  [boolean]
-			            -v, --version  Show version number  [boolean]"
-		        `);
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]"
+		`);
 		});
 
 		describe("list", () => {
@@ -95,19 +96,20 @@ describe("r2", () => {
 					`"Not enough non-option arguments: got 0, need at least 1"`
 				);
 				expect(std.out).toMatchInlineSnapshot(`
-				            "
-				            wrangler r2 bucket create <name>
+			"
+			wrangler r2 bucket create <name>
 
-				            Create a new R2 bucket
+			Create a new R2 bucket
 
-				            Positionals:
-				              name  The name of the new bucket  [string] [required]
+			Positionals:
+			  name  The name of the new bucket  [string] [required]
 
-				            Flags:
-				              -c, --config   Path to .toml configuration file  [string]
-				              -h, --help     Show help  [boolean]
-				              -v, --version  Show version number  [boolean]"
-			          `);
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`
 				            "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot enough non-option arguments: got 0, need at least 1[0m
 
@@ -122,19 +124,20 @@ describe("r2", () => {
 					`"Unknown arguments: def, ghi"`
 				);
 				expect(std.out).toMatchInlineSnapshot(`
-				            "
-				            wrangler r2 bucket create <name>
+			"
+			wrangler r2 bucket create <name>
 
-				            Create a new R2 bucket
+			Create a new R2 bucket
 
-				            Positionals:
-				              name  The name of the new bucket  [string] [required]
+			Positionals:
+			  name  The name of the new bucket  [string] [required]
 
-				            Flags:
-				              -c, --config   Path to .toml configuration file  [string]
-				              -h, --help     Show help  [boolean]
-				              -v, --version  Show version number  [boolean]"
-			          `);
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`
 				            "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mUnknown arguments: def, ghi[0m
 
@@ -178,19 +181,20 @@ describe("r2", () => {
 					`"Not enough non-option arguments: got 0, need at least 1"`
 				);
 				expect(std.out).toMatchInlineSnapshot(`
-				            "
-				            wrangler r2 bucket delete <name>
+			"
+			wrangler r2 bucket delete <name>
 
-				            Delete an R2 bucket
+			Delete an R2 bucket
 
-				            Positionals:
-				              name  The name of the bucket to delete  [string] [required]
+			Positionals:
+			  name  The name of the bucket to delete  [string] [required]
 
-				            Flags:
-				              -c, --config   Path to .toml configuration file  [string]
-				              -h, --help     Show help  [boolean]
-				              -v, --version  Show version number  [boolean]"
-			          `);
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`
 				            "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot enough non-option arguments: got 0, need at least 1[0m
 
@@ -205,19 +209,20 @@ describe("r2", () => {
 					`"Unknown arguments: def, ghi"`
 				);
 				expect(std.out).toMatchInlineSnapshot(`
-				            "
-				            wrangler r2 bucket delete <name>
+			"
+			wrangler r2 bucket delete <name>
 
-				            Delete an R2 bucket
+			Delete an R2 bucket
 
-				            Positionals:
-				              name  The name of the bucket to delete  [string] [required]
+			Positionals:
+			  name  The name of the bucket to delete  [string] [required]
 
-				            Flags:
-				              -c, --config   Path to .toml configuration file  [string]
-				              -h, --help     Show help  [boolean]
-				              -v, --version  Show version number  [boolean]"
-			          `);
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]"
+		`);
 				expect(std.err).toMatchInlineSnapshot(`
 				            "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mUnknown arguments: def, ghi[0m
 

--- a/packages/wrangler/src/__tests__/worker-namespace.test.ts
+++ b/packages/wrangler/src/__tests__/worker-namespace.test.ts
@@ -36,6 +36,7 @@ describe("dispatch-namespace", () => {
 
 		Flags:
 		  -c, --config   Path to .toml configuration file  [string]
+		  -e, --env      Environment to use for operations and .env files  [string]
 		  -h, --help     Show help  [boolean]
 		  -v, --version  Show version number  [boolean]",
 		  "warn": "",
@@ -87,6 +88,7 @@ describe("dispatch-namespace", () => {
 
 			Flags:
 			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
 			  -h, --help     Show help  [boolean]
 			  -v, --version  Show version number  [boolean]"
 		`);
@@ -135,6 +137,7 @@ describe("dispatch-namespace", () => {
 
 			Flags:
 			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
 			  -h, --help     Show help  [boolean]
 			  -v, --version  Show version number  [boolean]"
 		`);
@@ -183,19 +186,20 @@ describe("dispatch-namespace", () => {
 			);
 
 			expect(std.out).toMatchInlineSnapshot(`
-			        "
-			        wrangler dispatch-namespace get <name>
+			"
+			wrangler dispatch-namespace get <name>
 
-			        Get information about a dispatch namespace
+			Get information about a dispatch namespace
 
-			        Positionals:
-			          name  Name of the dispatch namespace  [string] [required]
+			Positionals:
+			  name  Name of the dispatch namespace  [string] [required]
 
-			        Flags:
-			          -c, --config   Path to .toml configuration file  [string]
-			          -h, --help     Show help  [boolean]
-			          -v, --version  Show version number  [boolean]"
-		      `);
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]"
+		`);
 		});
 
 		it("should attempt to get info for the given namespace", async () => {
@@ -302,6 +306,7 @@ describe("dispatch-namespace", () => {
 
 			Flags:
 			  -c, --config   Path to .toml configuration file  [string]
+			  -e, --env      Environment to use for operations and .env files  [string]
 			  -h, --help     Show help  [boolean]
 			  -v, --version  Show version number  [boolean]"
 		`);

--- a/packages/wrangler/src/cli.ts
+++ b/packages/wrangler/src/cli.ts
@@ -1,4 +1,3 @@
-import "dotenv/config"; // Grab locally specified env params from a `.env` file.
 import process from "process";
 import { hideBin } from "yargs/helpers";
 import { unstable_dev } from "./api";

--- a/packages/wrangler/src/d1/index.ts
+++ b/packages/wrangler/src/d1/index.ts
@@ -4,9 +4,10 @@ import * as Delete from "./delete";
 import * as Execute from "./execute";
 import * as List from "./list";
 import { d1BetaWarning } from "./utils";
+import type { CommonYargsOptions } from "../yargs-types";
 import type { Argv } from "yargs";
 
-export const d1 = (yargs: Argv) => {
+export const d1 = (yargs: Argv<CommonYargsOptions>) => {
 	return (
 		yargs
 			.command("list", "List D1 databases", List.Options, List.Handler)

--- a/packages/wrangler/src/delete.ts
+++ b/packages/wrangler/src/delete.ts
@@ -11,17 +11,14 @@ import * as metrics from "./metrics";
 import { requireAuth } from "./user";
 import { getScriptName, printWranglerBanner } from "./index";
 import type { ConfigPath } from "./index";
-import type { YargsOptionsToInterface } from "./yargs-types";
-import type { Argv, ArgumentsCamelCase } from "yargs";
+import type {
+	CommonYargsOptions,
+	YargsOptionsToInterface,
+} from "./yargs-types";
+import type { Argv } from "yargs";
 
-export function deleteOptions(yargs: Argv) {
+export function deleteOptions(yargs: Argv<CommonYargsOptions>) {
 	return yargs
-		.option("env", {
-			type: "string",
-			requiresArg: true,
-			describe: "Perform on a specific environment",
-			alias: "e",
-		})
 		.positional("script", {
 			describe: "The path to an entry point for your worker",
 			type: "string",
@@ -45,7 +42,7 @@ export function deleteOptions(yargs: Argv) {
 
 type DeleteArgs = YargsOptionsToInterface<typeof deleteOptions>;
 
-export async function deleteHandler(args: ArgumentsCamelCase<DeleteArgs>) {
+export async function deleteHandler(args: DeleteArgs) {
 	await printWranglerBanner();
 
 	const configPath =

--- a/packages/wrangler/src/deprecated/index.ts
+++ b/packages/wrangler/src/deprecated/index.ts
@@ -10,7 +10,10 @@ import {
 import { initHandler } from "../init";
 import { logger } from "../logger";
 import { formatMessage } from "../parse";
-import type { YargsOptionsToInterface } from "../yargs-types";
+import type {
+	CommonYargsOptions,
+	YargsOptionsToInterface,
+} from "../yargs-types";
 import type { Argv, ArgumentsCamelCase, BuilderCallback } from "yargs";
 
 // https://github.com/cloudflare/wrangler/blob/master/src/cli/mod.rs#L106-L123
@@ -21,7 +24,7 @@ interface GenerateArgs {
 	site?: boolean;
 }
 
-export function generateOptions(yargs: Argv) {
+export function generateOptions(yargs: Argv<CommonYargsOptions>) {
 	return yargs
 		.positional("name", {
 			describe: "Name of the Workers project",
@@ -298,11 +301,8 @@ function parseTemplatePath(templatePath: string): {
 	return { remote, subdirectory };
 }
 
-export function buildOptions(yargs: Argv) {
-	return yargs.option("env", {
-		describe: "Perform on a specific environment",
-		type: "string",
-	});
+export function buildOptions(yargs: Argv<CommonYargsOptions>) {
+	return yargs;
 }
 type BuildArgs = YargsOptionsToInterface<typeof buildOptions>;
 export async function buildHandler(buildArgs: BuildArgs) {
@@ -340,7 +340,7 @@ export const configHandler = () => {
 	);
 };
 
-export function previewOptions(yargs: Argv) {
+export function previewOptions(yargs: Argv<CommonYargsOptions>) {
 	return yargs
 		.positional("method", {
 			type: "string",
@@ -349,11 +349,6 @@ export function previewOptions(yargs: Argv) {
 		.positional("body", {
 			type: "string",
 			describe: "Body string to post to your preview worker request.",
-		})
-		.option("env", {
-			type: "string",
-			requiresArg: true,
-			describe: "Perform on a specific environment",
 		})
 		.option("watch", {
 			default: true,
@@ -376,11 +371,6 @@ export const route: BuilderCallback<unknown, unknown> = (routeYargs: Argv) => {
 			"List the routes associated with a zone",
 			(yargs) => {
 				return yargs
-					.option("env", {
-						type: "string",
-						requiresArg: true,
-						describe: "Perform on a specific environment",
-					})
 					.option("zone", {
 						type: "string",
 						requiresArg: true,
@@ -416,11 +406,6 @@ export const route: BuilderCallback<unknown, unknown> = (routeYargs: Argv) => {
 						type: "string",
 						requiresArg: true,
 						describe: "zone id",
-					})
-					.option("env", {
-						type: "string",
-						requiresArg: true,
-						describe: "Perform on a specific environment",
 					});
 			},
 			() => {
@@ -442,7 +427,7 @@ export const routeHandler = () => {
 	throw new DeprecationError(`${deprecationNotice}\n${shouldDo}`);
 };
 
-export const subdomainOptions = (yargs: Argv) => {
+export const subdomainOptions = (yargs: Argv<CommonYargsOptions>) => {
 	return yargs.positional("name", { type: "string" });
 };
 

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -31,6 +31,7 @@ import type { Config, Environment } from "./config";
 import type { Route } from "./config/environment";
 import type { EnablePagesAssetsServiceBindingOptions } from "./miniflare-cli";
 import type { CfWorkerInit } from "./worker";
+import type { CommonYargsOptions } from "./yargs-types";
 import type { Argv, ArgumentsCamelCase } from "yargs";
 
 interface DevArgs {
@@ -79,7 +80,7 @@ interface DevArgs {
 	"test-scheduled"?: boolean;
 }
 
-export function devOptions(yargs: Argv): Argv<DevArgs> {
+export function devOptions(yargs: Argv<CommonYargsOptions>): Argv<DevArgs> {
 	return (
 		yargs
 			.positional("script", {
@@ -110,12 +111,6 @@ export function devOptions(yargs: Argv): Argv<DevArgs> {
 				describe: "Choose an entry type",
 				hidden: true,
 				deprecated: true,
-			})
-			.option("env", {
-				describe: "Perform on a specific environment",
-				type: "string",
-				requiresArg: true,
-				alias: "e",
 			})
 			.option("compatibility-date", {
 				describe: "Date to use for compatibility checks",
@@ -765,7 +760,7 @@ async function getBindingsAndAssetPaths(
 	const cliVars = collectKeyValues(args.var);
 
 	// now log all available bindings into the terminal
-	const bindings = await getBindings(configParam, {
+	const bindings = await getBindings(configParam, args.env, {
 		kv: args.kv,
 		vars: { ...args.vars, ...cliVars },
 		durableObjects: args.durableObjects,
@@ -794,6 +789,7 @@ async function getBindingsAndAssetPaths(
 
 async function getBindings(
 	configParam: Config,
+	env: string | undefined,
 	args: AdditionalDevProps
 ): Promise<CfWorkerInit["bindings"]> {
 	const bindings = {
@@ -823,7 +819,7 @@ async function getBindings(
 		],
 		// Use a copy of combinedVars since we're modifying it later
 		vars: {
-			...getVarsForDev(configParam),
+			...getVarsForDev(configParam, env),
 			...args.vars,
 		},
 		wasm_modules: configParam.wasm_modules,

--- a/packages/wrangler/src/dev/dev-vars.ts
+++ b/packages/wrangler/src/dev/dev-vars.ts
@@ -1,6 +1,5 @@
-import * as fs from "node:fs";
 import * as path from "node:path";
-import dotenv from "dotenv";
+import { loadDotEnv } from "../config";
 import { logger } from "../logger";
 import type { Config } from "../config";
 
@@ -14,21 +13,25 @@ import type { Config } from "../config";
  * It is useful during development, to provide these types of variable locally.
  * When running `wrangler dev` we will look for a file called `.dev.vars`, situated
  * next to the `wrangler.toml` file (or in the current working directory if there is no
- * `wrangler.toml`).
+ * `wrangler.toml`). If the `--env <env>` option is set, we'll first look for
+ * `.dev.vars.<env>`.
  *
  * Any values in this file, formatted like a `dotenv` file, will add to or override `vars`
  * bindings provided in the `wrangler.toml`.
  */
-export function getVarsForDev(config: Config): Config["vars"] {
+export function getVarsForDev(
+	config: Config,
+	env: string | undefined
+): Config["vars"] {
 	const configDir = path.resolve(path.dirname(config.configPath ?? "."));
 	const devVarsPath = path.resolve(configDir, ".dev.vars");
-	if (fs.existsSync(devVarsPath)) {
-		const devVarsRelativePath = path.relative(process.cwd(), devVarsPath);
+	const loaded = loadDotEnv(devVarsPath, env);
+	if (loaded !== undefined) {
+		const devVarsRelativePath = path.relative(process.cwd(), loaded.path);
 		logger.log(`Using vars defined in ${devVarsRelativePath}`);
-		const devVars = dotenv.parse(fs.readFileSync(devVarsPath, "utf8"));
 		return {
 			...config.vars,
-			...devVars,
+			...loaded.parsed,
 		};
 	} else {
 		return config.vars;

--- a/packages/wrangler/src/dispatch-namespace.ts
+++ b/packages/wrangler/src/dispatch-namespace.ts
@@ -5,6 +5,7 @@ import * as metrics from "./metrics";
 import { requireAuth } from "./user";
 import { printWranglerBanner } from ".";
 import type { ConfigPath } from ".";
+import type { CommonYargsOptions } from "./yargs-types";
 import type { Argv, CommandModule } from "yargs";
 
 type Namespace = {
@@ -105,9 +106,9 @@ async function renameWorkerNamespace(
 }
 
 export function workerNamespaceCommands(
-	workerNamespaceYargs: Argv,
-	subHelp: CommandModule
-): Argv {
+	workerNamespaceYargs: Argv<CommonYargsOptions>,
+	subHelp: CommandModule<CommonYargsOptions, CommonYargsOptions>
+) {
 	return workerNamespaceYargs
 		.command(subHelp)
 		.command("list", "List all dispatch namespaces", {}, async (args) => {

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -22,9 +22,10 @@ import type { Route, SimpleRoute } from "./config/environment";
 import type { WorkerMetadata } from "./create-worker-upload-form";
 import type { ConfigPath } from "./index";
 import type { PackageManager } from "./package-manager";
+import type { CommonYargsOptions } from "./yargs-types";
 import type { Argv, ArgumentsCamelCase } from "yargs";
 
-export async function initOptions(yargs: Argv) {
+export async function initOptions(yargs: Argv<CommonYargsOptions>) {
 	return yargs
 		.positional("name", {
 			describe: "The name of your worker",

--- a/packages/wrangler/src/kv/index.ts
+++ b/packages/wrangler/src/kv/index.ts
@@ -26,12 +26,11 @@ import {
 	unexpectedKVKeyValueProps,
 } from "./helpers";
 import type { ConfigPath } from "../index";
+import type { CommonYargsOptions } from "../yargs-types";
 import type { KeyValue } from "./helpers";
-import type { BuilderCallback, Argv } from "yargs";
+import type { Argv } from "yargs";
 
-export const kvNamespace: BuilderCallback<unknown, unknown> = (
-	kvYargs: Argv
-) => {
+export const kvNamespace = (kvYargs: Argv<CommonYargsOptions>) => {
 	return kvYargs
 		.command(
 			"create <namespace>",
@@ -42,12 +41,6 @@ export const kvNamespace: BuilderCallback<unknown, unknown> = (
 						describe: "The name of the new namespace",
 						type: "string",
 						demandOption: true,
-					})
-					.option("env", {
-						type: "string",
-						requiresArg: true,
-						describe: "Perform on a specific environment",
-						alias: "e",
 					})
 					.option("preview", {
 						type: "boolean",
@@ -133,12 +126,6 @@ export const kvNamespace: BuilderCallback<unknown, unknown> = (
 						describe: "The id of the namespace to delete",
 					})
 					.check(demandOneOfOption("binding", "namespace-id"))
-					.option("env", {
-						type: "string",
-						requiresArg: true,
-						describe: "Perform on a specific environment",
-						alias: "e",
-					})
 					.option("preview", {
 						type: "boolean",
 						describe: "Interact with a preview namespace",
@@ -187,7 +174,7 @@ export const kvNamespace: BuilderCallback<unknown, unknown> = (
 		);
 };
 
-export const kvKey: BuilderCallback<unknown, unknown> = (kvYargs: Argv) => {
+export const kvKey = (kvYargs: Argv<CommonYargsOptions>) => {
 	return kvYargs
 		.command(
 			"put <key> [value]",
@@ -214,12 +201,6 @@ export const kvKey: BuilderCallback<unknown, unknown> = (kvYargs: Argv) => {
 						describe: "The id of the namespace to write to",
 					})
 					.check(demandOneOfOption("binding", "namespace-id"))
-					.option("env", {
-						type: "string",
-						requiresArg: true,
-						describe: "Perform on a specific environment",
-						alias: "e",
-					})
 					.option("preview", {
 						type: "boolean",
 						describe: "Interact with a preview namespace",
@@ -302,12 +283,6 @@ export const kvKey: BuilderCallback<unknown, unknown> = (kvYargs: Argv) => {
 						describe: "The id of the namespace to list",
 					})
 					.check(demandOneOfOption("binding", "namespace-id"))
-					.option("env", {
-						type: "string",
-						requiresArg: true,
-						describe: "Perform on a specific environment",
-						alias: "e",
-					})
 					.option("preview", {
 						type: "boolean",
 						// In the case of listing keys we will default to non-preview mode
@@ -359,12 +334,6 @@ export const kvKey: BuilderCallback<unknown, unknown> = (kvYargs: Argv) => {
 						describe: "The id of the namespace to get from",
 					})
 					.check(demandOneOfOption("binding", "namespace-id"))
-					.option("env", {
-						type: "string",
-						requiresArg: true,
-						describe: "Perform on a specific environment",
-						alias: "e",
-					})
 					.option("preview", {
 						type: "boolean",
 						describe: "Interact with a preview namespace",
@@ -422,12 +391,6 @@ export const kvKey: BuilderCallback<unknown, unknown> = (kvYargs: Argv) => {
 						describe: "The id of the namespace to delete from",
 					})
 					.check(demandOneOfOption("binding", "namespace-id"))
-					.option("env", {
-						type: "string",
-						requiresArg: true,
-						describe: "Perform on a specific environment",
-						alias: "e",
-					})
 					.option("preview", {
 						type: "boolean",
 						describe: "Interact with a preview namespace",
@@ -450,7 +413,7 @@ export const kvKey: BuilderCallback<unknown, unknown> = (kvYargs: Argv) => {
 		);
 };
 
-export const kvBulk: BuilderCallback<unknown, unknown> = (kvYargs: Argv) => {
+export const kvBulk = (kvYargs: Argv<CommonYargsOptions>) => {
 	return kvYargs
 		.command(
 			"put <filename>",
@@ -473,12 +436,6 @@ export const kvBulk: BuilderCallback<unknown, unknown> = (kvYargs: Argv) => {
 						describe: "The id of the namespace to insert values into",
 					})
 					.check(demandOneOfOption("binding", "namespace-id"))
-					.option("env", {
-						type: "string",
-						requiresArg: true,
-						describe: "Perform on a specific environment",
-						alias: "e",
-					})
 					.option("preview", {
 						type: "boolean",
 						describe: "Interact with a preview namespace",
@@ -572,12 +529,6 @@ export const kvBulk: BuilderCallback<unknown, unknown> = (kvYargs: Argv) => {
 						describe: "The id of the namespace to delete from",
 					})
 					.check(demandOneOfOption("binding", "namespace-id"))
-					.option("env", {
-						type: "string",
-						requiresArg: true,
-						describe: "Perform on a specific environment",
-						alias: "e",
-					})
 					.option("preview", {
 						type: "boolean",
 						describe: "Interact with a preview namespace",

--- a/packages/wrangler/src/publish/index.ts
+++ b/packages/wrangler/src/publish/index.ts
@@ -14,18 +14,15 @@ import { requireAuth } from "../user";
 import { collectKeyValues } from "../utils/collectKeyValues";
 import publish from "./publish";
 import type { ConfigPath } from "../index";
-import type { YargsOptionsToInterface } from "../yargs-types";
+import type {
+	CommonYargsOptions,
+	YargsOptionsToInterface,
+} from "../yargs-types";
 import type { Argv, ArgumentsCamelCase } from "yargs";
 
-export function publishOptions(yargs: Argv) {
+export function publishOptions(yargs: Argv<CommonYargsOptions>) {
 	return (
 		yargs
-			.option("env", {
-				type: "string",
-				requiresArg: true,
-				describe: "Perform on a specific environment",
-				alias: "e",
-			})
 			.positional("script", {
 				describe: "The path to an entry point for your worker",
 				type: "string",

--- a/packages/wrangler/src/pubsub/pubsub-commands.tsx
+++ b/packages/wrangler/src/pubsub/pubsub-commands.tsx
@@ -7,11 +7,12 @@ import * as metrics from "../metrics";
 import { parseHumanDuration } from "../parse";
 import { requireAuth } from "../user";
 import * as pubsub from ".";
+import type { CommonYargsOptions } from "../yargs-types";
 import type { Argv, CommandModule } from "yargs";
 
 export function pubSubCommands(
-	pubsubYargs: Argv,
-	subHelp: CommandModule
+	pubsubYargs: Argv<CommonYargsOptions>,
+	subHelp: CommandModule<CommonYargsOptions, CommonYargsOptions>
 ): Argv {
 	return pubsubYargs
 		.command(subHelp)

--- a/packages/wrangler/src/queues/cli/commands/consumer/add.ts
+++ b/packages/wrangler/src/queues/cli/commands/consumer/add.ts
@@ -2,20 +2,20 @@ import { type Argv } from "yargs";
 import { readConfig } from "../../../../config";
 import { logger } from "../../../../logger";
 import { postConsumer } from "../../../client";
+import type { CommonYargsOptions } from "../../../../yargs-types";
 import type { PostConsumerBody } from "../../../client";
 
-interface Args {
+type Args = CommonYargsOptions & {
 	config?: string;
 	["queue-name"]: string;
 	["script-name"]: string;
-	["environment"]?: string;
 	["batch-size"]?: number;
 	["batch-timeout"]?: number;
 	["message-retries"]?: number;
 	["dead-letter-queue"]?: string;
-}
+};
 
-export function options(yargs: Argv): Argv<Args> {
+export function options(yargs: Argv<CommonYargsOptions>): Argv<Args> {
 	return yargs
 		.positional("queue-name", {
 			type: "string",
@@ -28,10 +28,6 @@ export function options(yargs: Argv): Argv<Args> {
 			description: "Name of the consumer script",
 		})
 		.options({
-			environment: {
-				type: "string",
-				describe: "Environment of the consumer script",
-			},
 			"batch-size": {
 				type: "number",
 				describe: "Maximum number of messages per batch",
@@ -58,7 +54,7 @@ export async function handler(args: Args) {
 	const body: PostConsumerBody = {
 		script_name: args["script-name"],
 		// TODO(soon) is this still the correct usage of the environment?
-		environment_name: args.environment || "", // API expects empty string as default
+		environment_name: args.env || "", // API expects empty string as default
 		settings: {
 			batch_size: args["batch-size"],
 			max_retries: args["message-retries"],

--- a/packages/wrangler/src/queues/cli/commands/consumer/index.ts
+++ b/packages/wrangler/src/queues/cli/commands/consumer/index.ts
@@ -1,8 +1,11 @@
 import { type BuilderCallback } from "yargs";
+import { type CommonYargsOptions } from "../../../../yargs-types";
 import { options as addOptions, handler as addHandler } from "./add";
 import { options as removeOptions, handler as removeHandler } from "./remove";
 
-export const consumers: BuilderCallback<unknown, unknown> = (yargs) => {
+export const consumers: BuilderCallback<CommonYargsOptions, unknown> = (
+	yargs
+) => {
 	yargs.command(
 		"add <queue-name> <script-name>",
 		"Add a Queue Consumer",

--- a/packages/wrangler/src/queues/cli/commands/consumer/remove.ts
+++ b/packages/wrangler/src/queues/cli/commands/consumer/remove.ts
@@ -2,15 +2,15 @@ import { type Argv } from "yargs";
 import { readConfig } from "../../../../config";
 import { logger } from "../../../../logger";
 import { deleteConsumer } from "../../../client";
+import type { CommonYargsOptions } from "../../../../yargs-types";
 
-interface Args {
+type Args = CommonYargsOptions & {
 	config?: string;
 	["queue-name"]: string;
 	["script-name"]: string;
-	["environment"]?: string;
-}
+};
 
-export function options(yargs: Argv): Argv<Args> {
+export function options(yargs: Argv<CommonYargsOptions>): Argv<Args> {
 	return yargs
 		.positional("queue-name", {
 			type: "string",
@@ -21,12 +21,6 @@ export function options(yargs: Argv): Argv<Args> {
 			type: "string",
 			demandOption: true,
 			description: "Name of the consumer script",
-		})
-		.options({
-			environment: {
-				type: "string",
-				describe: "Environment of the consumer script",
-			},
 		});
 }
 
@@ -38,7 +32,7 @@ export async function handler(args: Args) {
 		config,
 		args["queue-name"],
 		args["script-name"],
-		args["environment"]
+		args.env
 	);
 	logger.log(`Removed consumer from queue ${args["queue-name"]}.`);
 }

--- a/packages/wrangler/src/queues/cli/commands/index.ts
+++ b/packages/wrangler/src/queues/cli/commands/index.ts
@@ -1,11 +1,12 @@
 import { type BuilderCallback } from "yargs";
+import { type CommonYargsOptions } from "../../../yargs-types";
 import { consumers } from "./consumer";
 
 import { options as createOptions, handler as createHandler } from "./create";
 import { options as deleteOptions, handler as deleteHandler } from "./delete";
 import { options as listOptions, handler as listHandler } from "./list";
 
-export const queues: BuilderCallback<unknown, unknown> = (yargs) => {
+export const queues: BuilderCallback<CommonYargsOptions, unknown> = (yargs) => {
 	yargs.command("list", "List Queues", listOptions, listHandler);
 
 	yargs.command(

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -14,12 +14,13 @@ import { parseJSON, readFileSync } from "../parse";
 import { requireAuth } from "../user";
 
 import type { ConfigPath } from "../index";
-import type { YargsOptionsToInterface } from "../yargs-types";
-import type { Argv, BuilderCallback } from "yargs";
+import type {
+	CommonYargsOptions,
+	YargsOptionsToInterface,
+} from "../yargs-types";
+import type { Argv } from "yargs";
 
-export const secret: BuilderCallback<unknown, unknown> = (
-	secretYargs: Argv
-) => {
+export const secret = (secretYargs: Argv<CommonYargsOptions>) => {
 	return secretYargs
 		.option("legacy-env", {
 			type: "boolean",
@@ -39,13 +40,6 @@ export const secret: BuilderCallback<unknown, unknown> = (
 						describe: "Name of the Worker",
 						type: "string",
 						requiresArg: true,
-					})
-					.option("env", {
-						type: "string",
-						requiresArg: true,
-						describe:
-							"Binds the secret to the Worker of the specific environment",
-						alias: "e",
 					});
 			},
 			async (args) => {
@@ -173,13 +167,6 @@ export const secret: BuilderCallback<unknown, unknown> = (
 						describe: "Name of the Worker",
 						type: "string",
 						requiresArg: true,
-					})
-					.option("env", {
-						type: "string",
-						requiresArg: true,
-						describe:
-							"Binds the secret to the Worker of the specific environment",
-						alias: "e",
 					});
 			},
 			async (args) => {
@@ -226,19 +213,11 @@ export const secret: BuilderCallback<unknown, unknown> = (
 			"list",
 			"List all secrets for a Worker",
 			(yargs) => {
-				return yargs
-					.option("name", {
-						describe: "Name of the Worker",
-						type: "string",
-						requiresArg: true,
-					})
-					.option("env", {
-						type: "string",
-						requiresArg: true,
-						describe:
-							"Binds the secret to the Worker of the specific environment.",
-						alias: "e",
-					});
+				return yargs.option("name", {
+					describe: "Name of the Worker",
+					type: "string",
+					requiresArg: true,
+				});
 			},
 			async (args) => {
 				const config = readConfig(args.config as ConfigPath, args);
@@ -265,7 +244,7 @@ export const secret: BuilderCallback<unknown, unknown> = (
 		);
 };
 
-export const secretBulkOptions = (yargs: Argv) => {
+export const secretBulkOptions = (yargs: Argv<CommonYargsOptions>) => {
 	return yargs
 		.positional("json", {
 			describe: `The JSON file of key-value pairs to upload, in form {"key": value, ...}`,
@@ -276,12 +255,6 @@ export const secretBulkOptions = (yargs: Argv) => {
 			describe: "Name of the Worker",
 			type: "string",
 			requiresArg: true,
-		})
-		.option("env", {
-			type: "string",
-			requiresArg: true,
-			describe: "Binds the secret to the Worker of the specific environment.",
-			alias: "e",
 		});
 };
 

--- a/packages/wrangler/src/tail/index.ts
+++ b/packages/wrangler/src/tail/index.ts
@@ -21,12 +21,15 @@ import {
 } from "./createTail";
 import type { WorkerMetadata } from "../create-worker-upload-form";
 import type { ConfigPath } from "../index";
-import type { YargsOptionsToInterface } from "../yargs-types";
+import type {
+	CommonYargsOptions,
+	YargsOptionsToInterface,
+} from "../yargs-types";
 import type { TailCLIFilters } from "./createTail";
 import type { RawData } from "ws";
 import type { Argv } from "yargs";
 
-export function tailOptions(yargs: Argv) {
+export function tailOptions(yargs: Argv<CommonYargsOptions>) {
 	return yargs
 		.positional("worker", {
 			describe: "Name or route of the worker to tail",
@@ -68,12 +71,6 @@ export function tailOptions(yargs: Argv) {
 			describe:
 				'Filter by the IP address the request originates from. Use "self" to filter for your own IP',
 			array: true,
-		})
-		.option("env", {
-			type: "string",
-			requiresArg: true,
-			describe: "Perform on a specific environment",
-			alias: "e",
 		})
 		.option("debug", {
 			type: "boolean",

--- a/packages/wrangler/src/yargs-types.ts
+++ b/packages/wrangler/src/yargs-types.ts
@@ -1,7 +1,20 @@
 import type { ArgumentsCamelCase, Argv } from "yargs";
+
+/**
+ * Yargs options included in every wrangler command.
+ */
+export interface CommonYargsOptions {
+	v: boolean | undefined;
+	config: string | undefined;
+	env: string | undefined;
+}
+
 /**
  * Given some Yargs Options function factory, extract the interface
  * that corresponds to the yargs arguments
  */
-export type YargsOptionsToInterface<T extends (yargs: Argv) => Argv> =
-	T extends (yargs: Argv) => Argv<infer P> ? ArgumentsCamelCase<P> : never;
+export type YargsOptionsToInterface<
+	T extends (yargs: Argv<CommonYargsOptions>) => Argv
+> = T extends (yargs: Argv<CommonYargsOptions>) => Argv<infer P>
+	? ArgumentsCamelCase<P>
+	: never;


### PR DESCRIPTION
If `--env <env>` is specified, we'll now check `.env.<env>`/`.dev.vars.<env>` first. If they don't exist, we'll fallback to `.env`/`.dev.vars`.

`--env` is now a flag in every command, like `--config`.

Closes #1305.