### PR TITLE
feat: delete site/assets namespace when a worker is deleted

### DIFF
--- a/.changeset/poor-cycles-grow.md
+++ b/.changeset/poor-cycles-grow.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+feat: delete site/assets namespace when a worker is deleted
+
+This patch deletes any site/asset kv namespaces associated with a worker when `wrangler delete` is used. It finds the namespace associated with a worker by using the names it would have otherwise used, and deletes it. It also does the same for the preview namespace that's used with `wrangler dev`.

--- a/packages/wrangler/src/delete.ts
+++ b/packages/wrangler/src/delete.ts
@@ -1,9 +1,11 @@
+import assert from "assert";
 import path from "path";
 import { fetchResult } from "./cfetch";
 import { findWranglerToml, readConfig } from "./config";
 import { confirm } from "./dialogs";
 import { CI } from "./is-ci";
 import isInteractive from "./is-interactive";
+import { deleteKVNamespace, listKVNamespaces } from "./kv/helpers";
 import { logger } from "./logger";
 import * as metrics from "./metrics";
 import { requireAuth } from "./user";
@@ -60,10 +62,17 @@ export async function deleteHandler(args: ArgumentsCamelCase<DeleteArgs>) {
 
 	const scriptName = getScriptName(args, config);
 
+	assert(
+		scriptName,
+		"A worker name must be defined, either via --name, or in wrangler.toml"
+	);
+
 	if (args.dryRun) {
 		logger.log(`--dry-run: exiting now.`);
 		return;
 	}
+
+	assert(accountId, "Missing accountId");
 
 	let confirmed = true;
 	if (isInteractive() || !CI.isCI()) {
@@ -79,8 +88,24 @@ export async function deleteHandler(args: ArgumentsCamelCase<DeleteArgs>) {
 			new URLSearchParams({ force: "true" })
 		);
 
+		await deleteSiteNamespaceIfExisting(scriptName, accountId);
+
 		logger.log("Successfully deleted", scriptName);
 	}
+}
 
-	// TODO: maybe delete sites/assets kv namespace as well?
+async function deleteSiteNamespaceIfExisting(
+	scriptName: string,
+	accountId: string
+): Promise<void> {
+	const title = `__${scriptName}-workers_sites_assets`;
+	const previewTitle = `__${scriptName}-workers_sites_assets_preview`;
+	const allNamespaces = await listKVNamespaces(accountId);
+	const namespacesToDelete = allNamespaces.filter(
+		(ns) => ns.title === title || ns.title === previewTitle
+	);
+	for (const ns of namespacesToDelete) {
+		await deleteKVNamespace(accountId, ns.id);
+		logger.log(`🌀 Deleted asset namespace for Workers Site "${ns.title}"`);
+	}
 }

--- a/packages/wrangler/src/sites.tsx
+++ b/packages/wrangler/src/sites.tsx
@@ -77,7 +77,7 @@ async function createKVNamespaceIfNotAlreadyExisting(
 	// check if it already exists
 	// TODO: this is super inefficient, should be made better
 	const namespaces = await listKVNamespaces(accountId);
-	const found = namespaces.find((x) => x.title === title);
+	const found = namespaces.find((ns) => ns.title === title);
 	if (found) {
 		return { created: false, id: found.id };
 	}


### PR DESCRIPTION
This patch deletes any site/asset kv namespaces associated with a worker when `wrangler delete` is used. It finds the namespace associated with a worker by using the names it would have otherwise used, and deletes it. It also does the same for the preview namespace that's used with `wrangler dev`.