### PR TITLE
Fallback to `zone_name` on invalid URL error

### DIFF
--- a/packages/wrangler/src/__tests__/helpers/msw/handlers/zones.ts
+++ b/packages/wrangler/src/__tests__/helpers/msw/handlers/zones.ts
@@ -1,0 +1,22 @@
+import { rest } from "msw";
+
+export default [
+	rest.get("*/zones", ({ url: { searchParams } }, res, context) => {
+		return res(
+			context.status(200),
+			context.json({
+				success: true,
+				errors: [],
+				messages: [],
+				result:
+					searchParams.get("name") === "exists.com"
+						? [
+								{
+									id: "exists-com",
+								},
+						  ]
+						: [],
+			})
+		);
+	}),
+];

--- a/packages/wrangler/src/__tests__/helpers/msw/index.ts
+++ b/packages/wrangler/src/__tests__/helpers/msw/index.ts
@@ -4,8 +4,8 @@ import { mswSuccessNamespacesHandlers } from "./handlers/namespaces";
 import { mswSuccessOauthHandlers } from "./handlers/oauth";
 import { mswSuccessR2handlers } from "./handlers/r2";
 import { default as mswSucessScriptHandlers } from "./handlers/script";
-import { default as mswZoneHandlers } from "./handlers/zones";
 import { mswSuccessUserHandlers } from "./handlers/user";
+import { default as mswZoneHandlers } from "./handlers/zones";
 export const msw = setupServer();
 
 export {
@@ -15,4 +15,5 @@ export {
 	mswSuccessNamespacesHandlers,
 	mswSucessScriptHandlers,
 	mswZoneHandlers,
+	mswSuccessDeployments,
 };

--- a/packages/wrangler/src/__tests__/helpers/msw/index.ts
+++ b/packages/wrangler/src/__tests__/helpers/msw/index.ts
@@ -4,6 +4,7 @@ import { mswSuccessNamespacesHandlers } from "./handlers/namespaces";
 import { mswSuccessOauthHandlers } from "./handlers/oauth";
 import { mswSuccessR2handlers } from "./handlers/r2";
 import { default as mswSucessScriptHandlers } from "./handlers/script";
+import { default as mswZoneHandlers } from "./handlers/zones";
 import { mswSuccessUserHandlers } from "./handlers/user";
 export const msw = setupServer();
 
@@ -13,5 +14,5 @@ export {
 	mswSuccessOauthHandlers,
 	mswSuccessNamespacesHandlers,
 	mswSucessScriptHandlers,
-	mswSuccessDeployments,
+	mswZoneHandlers,
 };


### PR DESCRIPTION
Closes #2094 and #2095

Falls back to `zone_name` when the hostname can't be inferred from a route pattern (essentially only for the wildcard pattern `*/*`