### PR TITLE
Add a `passThroughOnException()` handler to Pages Functions

### DIFF
--- a/.changeset/dirty-gifts-breathe.md
+++ b/.changeset/dirty-gifts-breathe.md
@@ -1,0 +1,19 @@
+---
+"wrangler": patch
+---
+
+feat: Add a `passThroughOnException()` handler in Pages Functions
+
+This `passThroughOnException()` handler is not as good as the built-in for Workers. We're just adding it now as a stop-gap until we can do the behind-the-scenes plumbing required to make the built-in function work properly.
+
+We wrap your Pages Functions code in a `try/catch` and on failure, if you call `passThroughOnException()` we defer to the static assets of your project.
+
+For example:
+
+```ts
+export const onRequest = ({ passThroughOnException }) => {
+	passThroughOnException();
+
+	x; // Would ordinarily throw an error, but instead, static assets are served.
+};
+```

--- a/fixtures/pages-functions-app/functions/passThroughOnException/_middleware.ts
+++ b/fixtures/pages-functions-app/functions/passThroughOnException/_middleware.ts
@@ -1,0 +1,5 @@
+export const onRequest = ({ passThroughOnException, next }) => {
+	passThroughOnException();
+
+	return next();
+};

--- a/fixtures/pages-functions-app/functions/passThroughOnException/nested.ts
+++ b/fixtures/pages-functions-app/functions/passThroughOnException/nested.ts
@@ -1,0 +1,3 @@
+export const onRequest = ({ passThroughOnException }) => {
+	x;
+};

--- a/fixtures/pages-functions-app/functions/passThroughOnExceptionClosed.ts
+++ b/fixtures/pages-functions-app/functions/passThroughOnExceptionClosed.ts
@@ -1,0 +1,3 @@
+export const onRequest = ({ passThroughOnException }) => {
+	x;
+};

--- a/fixtures/pages-functions-app/functions/passThroughOnExceptionOpen.ts
+++ b/fixtures/pages-functions-app/functions/passThroughOnExceptionOpen.ts
@@ -1,0 +1,5 @@
+export const onRequest = ({ passThroughOnException }) => {
+	passThroughOnException();
+
+	x;
+};

--- a/fixtures/pages-functions-app/functions/passThroughOnExceptionWithCapture/_middleware.ts
+++ b/fixtures/pages-functions-app/functions/passThroughOnExceptionWithCapture/_middleware.ts
@@ -1,0 +1,13 @@
+export const onRequest = async ({ request, passThroughOnException, next }) => {
+	passThroughOnException();
+
+	try {
+		return await next();
+	} catch (e) {
+		if (new URL(request.url).searchParams.has("catch")) {
+			return new Response(`Manually caught error: ${e}`);
+		}
+
+		throw e;
+	}
+};

--- a/fixtures/pages-functions-app/functions/passThroughOnExceptionWithCapture/nested.ts
+++ b/fixtures/pages-functions-app/functions/passThroughOnExceptionWithCapture/nested.ts
@@ -1,0 +1,3 @@
+export const onRequest = ({ passThroughOnException }) => {
+	x;
+};

--- a/fixtures/pages-functions-app/tests/index.test.ts
+++ b/fixtures/pages-functions-app/tests/index.test.ts
@@ -232,4 +232,51 @@ describe("Pages Functions", () => {
 			expect(response.headers.get("A-Header")).toEqual("New-Value");
 		});
 	});
+
+	describe("passThroughOnException", () => {
+		it("works on a single handler", async () => {
+			const response = await waitUntilReady(
+				"http://localhost:8789/passThroughOnExceptionOpen"
+			);
+
+			expect(response.status).toEqual(200);
+			expect(await response.text()).toContain("Hello, world!");
+		});
+
+		it("defaults closed", async () => {
+			const response = await waitUntilReady(
+				"http://localhost:8789/passThroughOnExceptionClosed"
+			);
+
+			expect(response.status).toEqual(500);
+			expect(await response.text()).not.toContain("Hello, world!");
+		});
+
+		it("works for nested handlers", async () => {
+			const response = await waitUntilReady(
+				"http://localhost:8789/passThroughOnException/nested"
+			);
+
+			expect(response.status).toEqual(200);
+			expect(await response.text()).toContain("Hello, world!");
+		});
+
+		it("allows errors to still be manually caught in middleware", async () => {
+			let response = await waitUntilReady(
+				"http://localhost:8789/passThroughOnExceptionWithCapture/nested"
+			);
+
+			expect(response.status).toEqual(200);
+			expect(await response.text()).toContain("Hello, world!");
+
+			response = await waitUntilReady(
+				"http://localhost:8789/passThroughOnExceptionWithCapture/nested?catch"
+			);
+
+			expect(response.status).toEqual(200);
+			expect(await response.text()).toMatchInlineSnapshot(
+				`"Manually caught error: ReferenceError: x is not defined"`
+			);
+		});
+	});
 });

--- a/packages/wrangler/templates/pages-template-plugin.ts
+++ b/packages/wrangler/templates/pages-template-plugin.ts
@@ -19,6 +19,7 @@ type EventContext<Env, P extends string, Data> = {
 	request: Request;
 	functionPath: string;
 	waitUntil: (promise: Promise<unknown>) => void;
+	passThroughOnException: () => void;
 	next: (input?: Request | string, init?: RequestInit) => Promise<Response>;
 	env: Env & { ASSETS: { fetch: typeof fetch } };
 	params: Params<P>;
@@ -29,6 +30,7 @@ type EventPluginContext<Env, P extends string, Data, PluginArgs> = {
 	request: Request;
 	functionPath: string;
 	waitUntil: (promise: Promise<unknown>) => void;
+	passThroughOnException: () => void;
 	next: (input?: Request | string, init?: RequestInit) => Promise<Response>;
 	env: Env & { ASSETS: { fetch: typeof fetch } };
 	params: Params<P>;
@@ -146,6 +148,8 @@ export default function (pluginArgs) {
 					pluginArgs,
 					env,
 					waitUntil: workerContext.waitUntil.bind(workerContext),
+					passThroughOnException:
+						workerContext.passThroughOnException.bind(workerContext),
 				};
 
 				const response = await handler(context);


### PR DESCRIPTION
Workers Types PR: https://github.com/cloudflare/workers-types/pull/314

feat: Add a `passThroughOnException()` handler in Pages Functions

This `passThroughOnException()` handler is not as good as the built-in for Workers. We're just adding it now as a stop-gap until we can do the behind-the-scenes plumbing required to make the built-in function work properly.

We wrap your Pages Functions code in a `try/catch` and on failure, if you call `passThroughOnException()` we defer to the static assets of your project.

For example:

```ts
export const onRequest = ({ passThroughOnException }) => {
	passThroughOnException();
	x; // Would ordinarily throw an error, but instead, static assets are served.
};
```