### PR TITLE
fix: lowering limit for bulk upload to avoid API error

### DIFF
--- a/.changeset/thin-candles-hang.md
+++ b/.changeset/thin-candles-hang.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+lowering limit for bulk upload to avoid API error

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -2624,14 +2624,14 @@ addEventListener('fetch', event => {});`
 
 			// We expect this to be uploaded in 4 batches
 
-			// The first batch has 11 files
-			expect(requests[0].uploads.length).toEqual(11);
-			// The next batch has 5 files
-			expect(requests[1].uploads.length).toEqual(5);
+			// The first batch has 10 files
+			expect(requests[0].uploads.length).toEqual(10);
+			// The next batch has 4 files
+			expect(requests[1].uploads.length).toEqual(4);
 			// And the next one has 3 files
 			expect(requests[2].uploads.length).toEqual(3);
-			// And just 1 in the last batch
-			expect(requests[3].uploads.length).toEqual(1);
+			// And 3 more in the last batch
+			expect(requests[3].uploads.length).toEqual(3);
 
 			let assetIndex = 0;
 			for (const request of requests) {

--- a/packages/wrangler/src/sites.tsx
+++ b/packages/wrangler/src/sites.tsx
@@ -177,7 +177,7 @@ export async function syncAssets(
 
 			// Check if adding this asset to the bucket would
 			// push it over the 98 MiB limit KV bulk API limit
-			if (uploadBucketSize + assetSize > 98 * 1000 * 1000) {
+			if (uploadBucketSize + assetSize > 80 * 1000 * 1000) {
 				// If so, move the current bucket into the batch,
 				// and reset the counter/bucket
 				uploadBuckets.push(uploadBucket);


### PR DESCRIPTION
I had to lower this limit in order to successfully publish my worker.

This is a solution for #2104