### PR TITLE
Log pages upload error

### DIFF
--- a/.changeset/green-icons-end.md
+++ b/.changeset/green-icons-end.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Added error logging for pages upload

--- a/packages/wrangler/src/pages/upload.tsx
+++ b/packages/wrangler/src/pages/upload.tsx
@@ -317,7 +317,9 @@ export const upload = async (
 				(error) => {
 					return Promise.reject(
 						new FatalError(
-							`Failed to upload files. Please try again. Error: ${JSON.stringify(error)})`,
+							`Failed to upload files. Please try again. Error: ${JSON.stringify(
+								error
+							)})`,
 							error.code || 1
 						)
 					);

--- a/packages/wrangler/src/pages/upload.tsx
+++ b/packages/wrangler/src/pages/upload.tsx
@@ -317,7 +317,7 @@ export const upload = async (
 				(error) => {
 					return Promise.reject(
 						new FatalError(
-							"Failed to upload files. Please try again.",
+							`Failed to upload files. Please try again. Error: ${JSON.stringify(error)})`,
 							error.code || 1
 						)
 					);


### PR DESCRIPTION
Log error when we exhaust retries for Pages upload. This is to support better troubleshooting with publishing issues.