### PR TITLE
Fix: Missing Worker name using `--from-dash`

### DIFF
--- a/.changeset/large-dingos-try.md
+++ b/.changeset/large-dingos-try.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Fix: Missing Worker name using `--from-dash`
+Added the `--from-dash` name as a fallback when no name is provided in the `wrangler init` command.
+Additionally added a checks to the `std.out` to ensure that the name is provided.
+
+resolves #1853

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -2379,6 +2379,8 @@ describe("init", () => {
 				"init isolinear-optical-chip --from-dash memory-crystal"
 			);
 
+			expect(std.out).toContain("cd isolinear-optical-chip");
+
 			checkFiles({
 				items: {
 					"isolinear-optical-chip/src/index.js": false,
@@ -2513,6 +2515,7 @@ describe("init", () => {
 			data = 1_337
 			"
 		`);
+			expect(std.out).toContain("cd isolinear-optical-chip");
 
 			checkFiles({
 				items: {

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -417,7 +417,7 @@ export async function initHandler(args: ArgumentsCamelCase<InitArgs>) {
 			);
 			instructions.push(
 				`\nTo start developing your Worker, run \`${
-					isNamedWorker ? `cd ${args.name} && ` : ""
+					isNamedWorker ? `cd ${args.name || fromDashScriptName} && ` : ""
 				}npm start\``
 			);
 			if (isAddingTestScripts) {


### PR DESCRIPTION
Added the fromDashName provided as a fallback when no name is provided in the `wrangler init` command. Additionally added a checks to the `std.out` to ensure that the name is provided.

resolves #1853