### PR TITLE
Warn for scripts larger than 1MB compressed

### DIFF
--- a/.changeset/metal-news-tap.md
+++ b/.changeset/metal-news-tap.md
@@ -1,0 +1,14 @@
+---
+"wrangler": minor
+---
+
+feature: Add warnings around bundle sizes for large scripts
+
+Prints a warning for scripts > 1MB compressed, encouraging smaller
+script sizes. This warning can be silenced by setting the
+NO_SCRIPT_SIZE_WARNING env variable
+
+If a publish fails with either a script size error or a validator error
+on script startup (CPU or memory), we print out the largest 5
+dependencies in your bundle. This is accomplished by using the esbuild
+generated metafile.

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -6561,6 +6561,28 @@ addEventListener('fetch', event => {});`
 		`);
 			});
 
+			test("should not warn about bundle sizes when NO_SCRIPT_SIZE_WARNING is set", async () => {
+				const previousValue = process.env.NO_SCRIPT_SIZE_WARNING;
+				process.env.NO_SCRIPT_SIZE_WARNING = "true";
+
+				const bigModule = Buffer.alloc(10_000_000);
+				randomFillSync(bigModule);
+				await printBundleSize({ name: "index.js", content: "" }, [
+					{ name: "index.js", content: bigModule, type: "buffer" },
+				]);
+
+				expect(std).toMatchInlineSnapshot(`
+			Object {
+			  "debug": "",
+			  "err": "",
+			  "out": "Total Upload: xx KiB / gzip: xx KiB",
+			  "warn": "",
+			}
+		`);
+
+				process.env.NO_SCRIPT_SIZE_WARNING = previousValue;
+			});
+
 			test("should print the top biggest dependencies in the bundle when upload fails", () => {
 				const deps = {
 					"node_modules/a-mod/module.js": { bytesInOutput: 450 },

--- a/packages/wrangler/src/bundle-reporter.tsx
+++ b/packages/wrangler/src/bundle-reporter.tsx
@@ -2,6 +2,10 @@ import { Blob } from "node:buffer";
 import { gzipSync } from "node:zlib";
 import { logger } from "./logger";
 import type { CfModule } from "./worker";
+import type { Metafile } from "esbuild";
+
+const ONE_KIB_BYTES = 1024;
+const ONE_MIB_BYTES = ONE_KIB_BYTES * 1024;
 
 async function getSize(modules: CfModule[]) {
 	const gzipSize = gzipSync(
@@ -21,9 +25,44 @@ export async function printBundleSize(
 ) {
 	const { size, gzipSize } = await getSize([...modules, main]);
 
-	const bundleReport = `${(size / 1024).toFixed(2)} KiB / gzip: ${(
-		gzipSize / 1024
+	const bundleReport = `${(size / ONE_KIB_BYTES).toFixed(2)} KiB / gzip: ${(
+		gzipSize / ONE_KIB_BYTES
 	).toFixed(2)} KiB`;
 
 	logger.log(`Total Upload: ${bundleReport}`);
+
+	if (gzipSize > ONE_MIB_BYTES) {
+		logger.warn(
+			"We recommend keeping your script less than 1MiB (1024 KiB) after gzip. Exceeding past this can affect cold start time"
+		);
+	}
+}
+
+export function printOffendingDependencies(
+	dependencies: Metafile["outputs"][string]["inputs"]
+) {
+	const warning: string[] = [];
+
+	const dependenciesSorted = Object.entries(dependencies);
+	dependenciesSorted.sort(
+		([_adep, aData], [_bdep, bData]) =>
+			bData.bytesInOutput - aData.bytesInOutput
+	);
+	const topLargest = dependenciesSorted.slice(0, 5);
+
+	if (topLargest.length > 0) {
+		warning.push(
+			`Here are the ${topLargest.length} largest dependencies included in your script:`
+		);
+
+		for (const [dep, data] of topLargest) {
+			warning.push(
+				`- ${dep} - ${(data.bytesInOutput / ONE_KIB_BYTES).toFixed(2)} KiB`
+			);
+		}
+
+		warning.push("If these are unnecessary, consider removing them");
+
+		logger.warn(warning.join("\n"));
+	}
 }

--- a/packages/wrangler/src/bundle-reporter.tsx
+++ b/packages/wrangler/src/bundle-reporter.tsx
@@ -31,7 +31,7 @@ export async function printBundleSize(
 
 	logger.log(`Total Upload: ${bundleReport}`);
 
-	if (gzipSize > ONE_MIB_BYTES) {
+	if (gzipSize > ONE_MIB_BYTES && !process.env.NO_SCRIPT_SIZE_WARNING) {
 		logger.warn(
 			"We recommend keeping your script less than 1MiB (1024 KiB) after gzip. Exceeding past this can affect cold start time"
 		);

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -15,6 +15,7 @@ import type { CfModule } from "./worker";
 
 type BundleResult = {
 	modules: CfModule[];
+	dependencies: esbuild.Metafile["outputs"][string]["inputs"];
 	resolvedEntryPointPath: string;
 	bundleType: "esm" | "commonjs";
 	stop: (() => void) | undefined;
@@ -332,7 +333,8 @@ export async function bundleWorker(
 			listEntryPoints(entryPointOutputs)
 	);
 
-	const entryPointExports = entryPointOutputs[0][1].exports;
+	const { exports: entryPointExports, inputs: dependencies } =
+		entryPointOutputs[0][1];
 	const bundleType = entryPointExports.length > 0 ? "esm" : "commonjs";
 
 	const sourceMapPath = Object.keys(result.metafile.outputs).filter((_path) =>
@@ -341,6 +343,7 @@ export async function bundleWorker(
 
 	return {
 		modules: moduleCollector.modules,
+		dependencies,
 		resolvedEntryPointPath: path.resolve(
 			entry.directory,
 			entryPointOutputs[0][0]

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -226,10 +226,12 @@ async function runEsbuild({
 		resolvedEntryPointPath,
 		bundleType,
 		modules,
+		dependencies,
 		sourceMapPath,
 	}: Awaited<ReturnType<typeof bundleWorker>> = noBundle
 		? {
 				modules: [],
+				dependencies: {},
 				resolvedEntryPointPath: entry.file,
 				bundleType: entry.format === "modules" ? "esm" : "commonjs",
 				stop: undefined,
@@ -265,6 +267,7 @@ async function runEsbuild({
 		path: resolvedEntryPointPath,
 		type: bundleType,
 		modules,
+		dependencies,
 		sourceMapPath,
 	};
 }

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -8,7 +8,7 @@ import type { Config } from "../config";
 import type { WorkerRegistry } from "../dev-registry";
 import type { Entry } from "../entry";
 import type { CfModule } from "../worker";
-import type { WatchMode } from "esbuild";
+import type { WatchMode, Metafile } from "esbuild";
 
 export type EsbuildBundle = {
 	id: number;
@@ -16,6 +16,7 @@ export type EsbuildBundle = {
 	entry: Entry;
 	type: "esm" | "commonjs";
 	modules: CfModule[];
+	dependencies: Metafile["outputs"][string]["inputs"];
 	sourceMapPath: string | undefined;
 };
 
@@ -100,11 +101,13 @@ export function useEsbuild({
 				resolvedEntryPointPath,
 				bundleType,
 				modules,
+				dependencies,
 				stop,
 				sourceMapPath,
 			}: Awaited<ReturnType<typeof bundleWorker>> = noBundle
 				? {
 						modules: [],
+						dependencies: {},
 						resolvedEntryPointPath: entry.file,
 						bundleType: entry.format === "modules" ? "esm" : "commonjs",
 						stop: undefined,
@@ -158,6 +161,7 @@ export function useEsbuild({
 				path: resolvedEntryPointPath,
 				type: bundleType,
 				modules,
+				dependencies,
 				sourceMapPath,
 			});
 		}


### PR DESCRIPTION
Uses the esbuild-generated metafile to see which dependencies are heaviest and points out the top 5, as well as a message encouraging a smaller script