### PR TITLE
Allow calling fetch() in new worker templates

### DIFF
--- a/packages/wrangler/templates/new-worker.js
+++ b/packages/wrangler/templates/new-worker.js
@@ -8,8 +8,10 @@
  * Learn more at https://developers.cloudflare.com/workers/
  */
 
+async function handleFetch(request, env, ctx) {
+	return new Response("Hello World!");
+};
+
 export default {
-	async fetch(request, env, ctx) {
-		return new Response("Hello World!");
-	},
+	fetch: handleFetch,
 };

--- a/packages/wrangler/templates/new-worker.ts
+++ b/packages/wrangler/templates/new-worker.ts
@@ -19,12 +19,14 @@ export interface Env {
 	// MY_BUCKET: R2Bucket;
 }
 
+async function handleFetch(
+	request: Request,
+	env: Env,
+	ctx: ExecutionContext
+): Promise<Response> {
+	return new Response("Hello World!");
+};
+
 export default {
-	async fetch(
-		request: Request,
-		env: Env,
-		ctx: ExecutionContext
-	): Promise<Response> {
-		return new Response("Hello World!");
-	},
+	fetch: handleFetch,
 };


### PR DESCRIPTION
The new-worker templates contain a function called `fetch()`, which overrides the global `fetch()`. As a result you can't call fetch API without a workaround like `globalThis.fetch()`, or by renaming the function.

This MR renames the function.