### PR TITLE
Switch to using `Miniflare#setOptions` for experimental local

### DIFF
--- a/.changeset/friendly-adults-rush.md
+++ b/.changeset/friendly-adults-rush.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Reduce script reload times when using `wrangler dev --experimental-local`

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,40 @@
 				"node": ">=16.13.0"
 			}
 		},
+		"../miniflare3/packages/tre": {
+			"name": "@miniflare/tre",
+			"version": "3.0.0-next.3",
+			"extraneous": true,
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^8.8.0",
+				"acorn-walk": "^8.2.0",
+				"better-sqlite3": "^7.6.2",
+				"capnp-ts": "^0.7.0",
+				"exit-hook": "^2.2.1",
+				"get-port": "^5.1.1",
+				"glob-to-regexp": "^0.4.1",
+				"http-cache-semantics": "^4.1.0",
+				"kleur": "^4.1.5",
+				"stoppable": "^1.1.0",
+				"undici": "^5.10.0",
+				"workerd": "^1.20221111.4",
+				"ws": "^8.11.0",
+				"zod": "^3.18.0"
+			},
+			"devDependencies": {
+				"@types/better-sqlite3": "^7.6.2",
+				"@types/debug": "^4.1.7",
+				"@types/estree": "^1.0.0",
+				"@types/glob-to-regexp": "^0.4.1",
+				"@types/http-cache-semantics": "^4.0.1",
+				"@types/stoppable": "^1.1.1",
+				"@types/ws": "^8.5.3"
+			},
+			"engines": {
+				"node": ">=16.13"
+			}
+		},
 		"fixtures/external-durable-objects-app": {
 			"devDependencies": {
 				"@cloudflare/workers-types": "^3.14.1"
@@ -942,9 +976,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20220926.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20220926.0.tgz",
-			"integrity": "sha512-NbZ+NOviUvMHv4FLB2dlTIOp8Vh86qVCZEeQjaZ9NHjqKh9uyUEsKDuLIjea5XW+i9jHhyTlh3UQ4r2zcVhB3Q==",
+			"version": "1.20221111.5",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20221111.5.tgz",
+			"integrity": "sha512-Jl8uYpmpS1EO16JZEhCEemY5e1gHH2QxKP25HF6aoxvTwYytuTpjebMV7tAfdhe8U82tPnv57Or7mIdbXD7MAA==",
 			"cpu": [
 				"x64"
 			],
@@ -952,6 +986,55 @@
 			"optional": true,
 			"os": [
 				"darwin"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/workerd-darwin-arm64": {
+			"version": "1.20221111.5",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20221111.5.tgz",
+			"integrity": "sha512-Zw/acmQvd5QPHI5q1+TdiPCHgkp0+sVCGChqVZfZfS+S1HJTwDDAGrugGPZqcYmUehVTYTLx5x8iVnFPFBQ4bw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/workerd-linux-64": {
+			"version": "1.20221111.5",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20221111.5.tgz",
+			"integrity": "sha512-PRLYM2nsSyeNzxqOkByq7H4f3CtnA6PfivG8180OsCAiLfR1nmk9l4E6lYGBwmivL/R7cWu2y3a+hJUaFEdmqw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux",
+				"win32"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/workerd-linux-arm64": {
+			"version": "1.20221111.5",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20221111.5.tgz",
+			"integrity": "sha512-21IZ44ZnW6PvE6oT/UWstHazAF0nZOiprsbxu0NHnrLgsdSjSsKt7nWfLr/R/6DzKcYYdnQs8btgvKIvI8kChQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
 			],
 			"engines": {
 				"node": ">=16"
@@ -2805,21 +2888,24 @@
 			}
 		},
 		"node_modules/@miniflare/tre": {
-			"version": "3.0.0-next.2",
-			"resolved": "https://registry.npmjs.org/@miniflare/tre/-/tre-3.0.0-next.2.tgz",
-			"integrity": "sha512-P9dkNk2KDG56C7KOPZX1qD/nNESh1Srof/Kg8qutXhLNJPgI3igroE0q+XOvnwmlhmIrNxuUKQ/PZQo9WhUjNg==",
+			"version": "3.0.0-next.5",
+			"resolved": "https://registry.npmjs.org/@miniflare/tre/-/tre-3.0.0-next.5.tgz",
+			"integrity": "sha512-y48pai2IDaVKrqSoDRR8OLp285iPSMX6XaFsHXKb4+uzGQRoZtwqGU9g0lH9oW+JX/Vswy9YZamSDNex1bxB1w==",
 			"dev": true,
 			"dependencies": {
 				"acorn": "^8.8.0",
 				"acorn-walk": "^8.2.0",
+				"better-sqlite3": "^7.6.2",
 				"capnp-ts": "^0.7.0",
 				"exit-hook": "^2.2.1",
 				"get-port": "^5.1.1",
 				"glob-to-regexp": "^0.4.1",
+				"http-cache-semantics": "^4.1.0",
 				"kleur": "^4.1.5",
 				"stoppable": "^1.1.0",
-				"undici": "^5.10.0",
-				"workerd": "^1.20220926.3",
+				"undici": "^5.12.0",
+				"workerd": "^1.20221111.5",
+				"ws": "^8.11.0",
 				"zod": "^3.18.0"
 			},
 			"engines": {
@@ -2848,12 +2934,36 @@
 			}
 		},
 		"node_modules/@miniflare/tre/node_modules/undici": {
-			"version": "5.10.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.10.0.tgz",
-			"integrity": "sha512-c8HsD3IbwmjjbLvoZuRI26TZic+TSEe8FPMLLOkN1AfYRhdjnKBU6yL+IwcSCbdZiX4e5t0lfMDLDCqj4Sq70g==",
+			"version": "5.12.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.12.0.tgz",
+			"integrity": "sha512-zMLamCG62PGjd9HHMpo05bSLvvwWOZgGeiWlN/vlqu3+lRo3elxktVGEyLMX+IO7c2eflLjcW74AlkhEZm15mg==",
 			"dev": true,
+			"dependencies": {
+				"busboy": "^1.6.0"
+			},
 			"engines": {
 				"node": ">=12.18"
+			}
+		},
+		"node_modules/@miniflare/tre/node_modules/ws": {
+			"version": "8.11.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+			"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@miniflare/watcher": {
@@ -5044,6 +5154,17 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/better-sqlite3": {
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-7.6.2.tgz",
+			"integrity": "sha512-S5zIU1Hink2AH4xPsN0W43T1/AJ5jrPh7Oy07ocuW/AKYYY02GWzz9NH0nbSMn/gw6fDZ5jZ1QsHt1BXAwJ6Lg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"dependencies": {
+				"bindings": "^1.5.0",
+				"prebuild-install": "^7.1.0"
+			}
+		},
 		"node_modules/big.js": {
 			"version": "5.2.2",
 			"dev": true,
@@ -5063,7 +5184,6 @@
 			"version": "1.5.0",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
 			"dependencies": {
 				"file-uri-to-path": "1.0.0"
 			}
@@ -5541,9 +5661,9 @@
 			}
 		},
 		"node_modules/capnp-ts/node_modules/tslib": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
 			"dev": true
 		},
 		"node_modules/capture-exit": {
@@ -6765,6 +6885,15 @@
 		"node_modules/detect-indent": {
 			"version": "6.1.0",
 			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/detect-libc": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+			"integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -8013,6 +8142,15 @@
 			"version": "2.0.0",
 			"license": "MIT"
 		},
+		"node_modules/expand-template": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/expect": {
 			"version": "28.1.3",
 			"license": "MIT",
@@ -8462,8 +8600,7 @@
 		"node_modules/file-uri-to-path": {
 			"version": "1.0.0",
 			"dev": true,
-			"license": "MIT",
-			"optional": true
+			"license": "MIT"
 		},
 		"node_modules/fill-range": {
 			"version": "7.0.1",
@@ -8711,6 +8848,12 @@
 				"readable-stream": "^2.0.0"
 			}
 		},
+		"node_modules/fs-constants": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+			"dev": true
+		},
 		"node_modules/fs-extra": {
 			"version": "7.0.1",
 			"license": "MIT",
@@ -8875,6 +9018,12 @@
 			"funding": {
 				"url": "https://github.com/fisker/git-hooks-list?sponsor=1"
 			}
+		},
+		"node_modules/github-from-package": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+			"integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+			"dev": true
 		},
 		"node_modules/glob": {
 			"version": "7.2.0",
@@ -15845,6 +15994,12 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/mkdirp-classic": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+			"dev": true
+		},
 		"node_modules/mkdirp-infer-owner": {
 			"version": "2.0.0",
 			"dev": true,
@@ -16092,6 +16247,12 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/napi-build-utils": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+			"integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
+			"dev": true
+		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"license": "MIT"
@@ -16112,6 +16273,33 @@
 		"node_modules/nice-try": {
 			"version": "1.0.5",
 			"license": "MIT"
+		},
+		"node_modules/node-abi": {
+			"version": "3.28.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.28.0.tgz",
+			"integrity": "sha512-fRlDb4I0eLcQeUvGq7IY3xHrSb0c9ummdvDSYWfT9+LKP+3jCKw/tKoqaM7r1BAoiAC6GtwyjaGnOz6B3OtF+A==",
+			"dev": true,
+			"dependencies": {
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/node-abi/node_modules/semver": {
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/node-addon-api": {
 			"version": "1.7.2",
@@ -17130,6 +17318,32 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/prebuild-install": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
+			"integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+			"dev": true,
+			"dependencies": {
+				"detect-libc": "^2.0.0",
+				"expand-template": "^2.0.3",
+				"github-from-package": "0.0.0",
+				"minimist": "^1.2.3",
+				"mkdirp-classic": "^0.5.3",
+				"napi-build-utils": "^1.0.1",
+				"node-abi": "^3.3.0",
+				"pump": "^3.0.0",
+				"rc": "^1.2.7",
+				"simple-get": "^4.0.0",
+				"tar-fs": "^2.0.0",
+				"tunnel-agent": "^0.6.0"
+			},
+			"bin": {
+				"prebuild-install": "bin.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/preferred-pm": {
@@ -18779,6 +18993,51 @@
 			"version": "3.0.7",
 			"license": "ISC"
 		},
+		"node_modules/simple-concat": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/simple-get": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"decompress-response": "^6.0.0",
+				"once": "^1.3.1",
+				"simple-concat": "^1.0.0"
+			}
+		},
 		"node_modules/sisteransi": {
 			"version": "1.0.5",
 			"license": "MIT"
@@ -19715,6 +19974,54 @@
 				"node": ">= 10"
 			}
 		},
+		"node_modules/tar-fs": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+			"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+			"dev": true,
+			"dependencies": {
+				"chownr": "^1.1.1",
+				"mkdirp-classic": "^0.5.2",
+				"pump": "^3.0.0",
+				"tar-stream": "^2.1.4"
+			}
+		},
+		"node_modules/tar-fs/node_modules/chownr": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+			"dev": true
+		},
+		"node_modules/tar-stream": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+			"dev": true,
+			"dependencies": {
+				"bl": "^4.0.3",
+				"end-of-stream": "^1.4.1",
+				"fs-constants": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/tar-stream/node_modules/readable-stream": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/term-size": {
 			"version": "2.2.1",
 			"license": "MIT",
@@ -20254,6 +20561,18 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+			"dev": true,
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/type-check": {
@@ -21491,10 +21810,11 @@
 			}
 		},
 		"node_modules/workerd": {
-			"version": "1.20220926.3",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20220926.3.tgz",
-			"integrity": "sha512-/lmXRhgLixIkNNwsrFquPlT+qgFD71QbYJ8qroYQVL2hQVOuqw5N4TzMZS6gaNtVW+EUUnps+t/zbz98vjeuTg==",
+			"version": "1.20221111.5",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20221111.5.tgz",
+			"integrity": "sha512-cZVjhFaCYrNogLy52H20O2Y1Ld8orPRM5bt9fKCAwoGI0I2SZinPvcKb0QeK+EKrfQeWNcrd2MnEjP4sUDiWhA==",
 			"dev": true,
+			"hasInstallScript": true,
 			"bin": {
 				"workerd": "bin/workerd"
 			},
@@ -21502,10 +21822,10 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "^1.20220926.0",
-				"@cloudflare/workerd-darwin-arm64": "^1.20220926.0",
-				"@cloudflare/workerd-linux-64": "^1.20220926.0",
-				"@cloudflare/workerd-linux-arm64": "^1.20220926.0"
+				"@cloudflare/workerd-darwin-64": "1.20221111.5",
+				"@cloudflare/workerd-darwin-arm64": "1.20221111.5",
+				"@cloudflare/workerd-linux-64": "1.20221111.5",
+				"@cloudflare/workerd-linux-arm64": "1.20221111.5"
 			}
 		},
 		"node_modules/workers-chat-demo": {
@@ -21892,7 +22212,7 @@
 				"@databases/sql": "^3.2.0",
 				"@iarna/toml": "^3.0.0",
 				"@microsoft/api-extractor": "^7.28.3",
-				"@miniflare/tre": "3.0.0-next.2",
+				"@miniflare/tre": "^3.0.0-next.5",
 				"@types/better-sqlite3": "^7.6.0",
 				"@types/busboy": "^1.5.0",
 				"@types/command-exists": "^1.2.0",
@@ -23773,9 +24093,30 @@
 			}
 		},
 		"@cloudflare/workerd-darwin-64": {
-			"version": "1.20220926.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20220926.0.tgz",
-			"integrity": "sha512-NbZ+NOviUvMHv4FLB2dlTIOp8Vh86qVCZEeQjaZ9NHjqKh9uyUEsKDuLIjea5XW+i9jHhyTlh3UQ4r2zcVhB3Q==",
+			"version": "1.20221111.5",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20221111.5.tgz",
+			"integrity": "sha512-Jl8uYpmpS1EO16JZEhCEemY5e1gHH2QxKP25HF6aoxvTwYytuTpjebMV7tAfdhe8U82tPnv57Or7mIdbXD7MAA==",
+			"dev": true,
+			"optional": true
+		},
+		"@cloudflare/workerd-darwin-arm64": {
+			"version": "1.20221111.5",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20221111.5.tgz",
+			"integrity": "sha512-Zw/acmQvd5QPHI5q1+TdiPCHgkp0+sVCGChqVZfZfS+S1HJTwDDAGrugGPZqcYmUehVTYTLx5x8iVnFPFBQ4bw==",
+			"dev": true,
+			"optional": true
+		},
+		"@cloudflare/workerd-linux-64": {
+			"version": "1.20221111.5",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20221111.5.tgz",
+			"integrity": "sha512-PRLYM2nsSyeNzxqOkByq7H4f3CtnA6PfivG8180OsCAiLfR1nmk9l4E6lYGBwmivL/R7cWu2y3a+hJUaFEdmqw==",
+			"dev": true,
+			"optional": true
+		},
+		"@cloudflare/workerd-linux-arm64": {
+			"version": "1.20221111.5",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20221111.5.tgz",
+			"integrity": "sha512-21IZ44ZnW6PvE6oT/UWstHazAF0nZOiprsbxu0NHnrLgsdSjSsKt7nWfLr/R/6DzKcYYdnQs8btgvKIvI8kChQ==",
 			"dev": true,
 			"optional": true
 		},
@@ -25028,21 +25369,24 @@
 			}
 		},
 		"@miniflare/tre": {
-			"version": "3.0.0-next.2",
-			"resolved": "https://registry.npmjs.org/@miniflare/tre/-/tre-3.0.0-next.2.tgz",
-			"integrity": "sha512-P9dkNk2KDG56C7KOPZX1qD/nNESh1Srof/Kg8qutXhLNJPgI3igroE0q+XOvnwmlhmIrNxuUKQ/PZQo9WhUjNg==",
+			"version": "3.0.0-next.5",
+			"resolved": "https://registry.npmjs.org/@miniflare/tre/-/tre-3.0.0-next.5.tgz",
+			"integrity": "sha512-y48pai2IDaVKrqSoDRR8OLp285iPSMX6XaFsHXKb4+uzGQRoZtwqGU9g0lH9oW+JX/Vswy9YZamSDNex1bxB1w==",
 			"dev": true,
 			"requires": {
 				"acorn": "^8.8.0",
 				"acorn-walk": "^8.2.0",
+				"better-sqlite3": "^7.6.2",
 				"capnp-ts": "^0.7.0",
 				"exit-hook": "^2.2.1",
 				"get-port": "^5.1.1",
 				"glob-to-regexp": "^0.4.1",
+				"http-cache-semantics": "^4.1.0",
 				"kleur": "^4.1.5",
 				"stoppable": "^1.1.0",
-				"undici": "^5.10.0",
-				"workerd": "^1.20220926.3",
+				"undici": "^5.12.0",
+				"workerd": "^1.20221111.5",
+				"ws": "^8.11.0",
 				"zod": "^3.18.0"
 			},
 			"dependencies": {
@@ -25059,10 +25403,20 @@
 					"dev": true
 				},
 				"undici": {
-					"version": "5.10.0",
-					"resolved": "https://registry.npmjs.org/undici/-/undici-5.10.0.tgz",
-					"integrity": "sha512-c8HsD3IbwmjjbLvoZuRI26TZic+TSEe8FPMLLOkN1AfYRhdjnKBU6yL+IwcSCbdZiX4e5t0lfMDLDCqj4Sq70g==",
-					"dev": true
+					"version": "5.12.0",
+					"resolved": "https://registry.npmjs.org/undici/-/undici-5.12.0.tgz",
+					"integrity": "sha512-zMLamCG62PGjd9HHMpo05bSLvvwWOZgGeiWlN/vlqu3+lRo3elxktVGEyLMX+IO7c2eflLjcW74AlkhEZm15mg==",
+					"dev": true,
+					"requires": {
+						"busboy": "^1.6.0"
+					}
+				},
+				"ws": {
+					"version": "8.11.0",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+					"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+					"dev": true,
+					"requires": {}
 				}
 			}
 		},
@@ -26598,6 +26952,16 @@
 				"is-windows": "^1.0.0"
 			}
 		},
+		"better-sqlite3": {
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-7.6.2.tgz",
+			"integrity": "sha512-S5zIU1Hink2AH4xPsN0W43T1/AJ5jrPh7Oy07ocuW/AKYYY02GWzz9NH0nbSMn/gw6fDZ5jZ1QsHt1BXAwJ6Lg==",
+			"dev": true,
+			"requires": {
+				"bindings": "^1.5.0",
+				"prebuild-install": "^7.1.0"
+			}
+		},
 		"big.js": {
 			"version": "5.2.2",
 			"dev": true
@@ -26608,7 +26972,6 @@
 		"bindings": {
 			"version": "1.5.0",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"file-uri-to-path": "1.0.0"
 			}
@@ -26959,9 +27322,9 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+					"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
 					"dev": true
 				}
 			}
@@ -27725,6 +28088,12 @@
 		},
 		"detect-indent": {
 			"version": "6.1.0"
+		},
+		"detect-libc": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+			"integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+			"dev": true
 		},
 		"detect-newline": {
 			"version": "3.1.0"
@@ -28523,6 +28892,12 @@
 				}
 			}
 		},
+		"expand-template": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+			"dev": true
+		},
 		"expect": {
 			"version": "28.1.3",
 			"requires": {
@@ -28827,8 +29202,7 @@
 		},
 		"file-uri-to-path": {
 			"version": "1.0.0",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"fill-range": {
 			"version": "7.0.1",
@@ -29003,6 +29377,12 @@
 				"readable-stream": "^2.0.0"
 			}
 		},
+		"fs-constants": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+			"dev": true
+		},
 		"fs-extra": {
 			"version": "7.0.1",
 			"requires": {
@@ -29095,6 +29475,12 @@
 		},
 		"git-hooks-list": {
 			"version": "1.0.3"
+		},
+		"github-from-package": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+			"integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+			"dev": true
 		},
 		"glob": {
 			"version": "7.2.0",
@@ -33494,6 +33880,12 @@
 			"version": "1.0.4",
 			"dev": true
 		},
+		"mkdirp-classic": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+			"dev": true
+		},
 		"mkdirp-infer-owner": {
 			"version": "2.0.0",
 			"dev": true,
@@ -33662,6 +34054,12 @@
 				"to-regex": "^3.0.1"
 			}
 		},
+		"napi-build-utils": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+			"integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
+			"dev": true
+		},
 		"natural-compare": {
 			"version": "1.4.0"
 		},
@@ -33675,6 +34073,26 @@
 		},
 		"nice-try": {
 			"version": "1.0.5"
+		},
+		"node-abi": {
+			"version": "3.28.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.28.0.tgz",
+			"integrity": "sha512-fRlDb4I0eLcQeUvGq7IY3xHrSb0c9ummdvDSYWfT9+LKP+3jCKw/tKoqaM7r1BAoiAC6GtwyjaGnOz6B3OtF+A==",
+			"dev": true,
+			"requires": {
+				"semver": "^7.3.5"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.3.8",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				}
+			}
 		},
 		"node-addon-api": {
 			"version": "1.7.2",
@@ -34359,6 +34777,26 @@
 		},
 		"posix-character-classes": {
 			"version": "0.1.1"
+		},
+		"prebuild-install": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
+			"integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+			"dev": true,
+			"requires": {
+				"detect-libc": "^2.0.0",
+				"expand-template": "^2.0.3",
+				"github-from-package": "0.0.0",
+				"minimist": "^1.2.3",
+				"mkdirp-classic": "^0.5.3",
+				"napi-build-utils": "^1.0.1",
+				"node-abi": "^3.3.0",
+				"pump": "^3.0.0",
+				"rc": "^1.2.7",
+				"simple-get": "^4.0.0",
+				"tar-fs": "^2.0.0",
+				"tunnel-agent": "^0.6.0"
+			}
 		},
 		"preferred-pm": {
 			"version": "3.0.3",
@@ -35469,6 +35907,23 @@
 		"signal-exit": {
 			"version": "3.0.7"
 		},
+		"simple-concat": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+			"dev": true
+		},
+		"simple-get": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+			"dev": true,
+			"requires": {
+				"decompress-response": "^6.0.0",
+				"once": "^1.3.1",
+				"simple-concat": "^1.0.0"
+			}
+		},
 		"sisteransi": {
 			"version": "1.0.5"
 		},
@@ -36117,6 +36572,52 @@
 				"yallist": "^4.0.0"
 			}
 		},
+		"tar-fs": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+			"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+			"dev": true,
+			"requires": {
+				"chownr": "^1.1.1",
+				"mkdirp-classic": "^0.5.2",
+				"pump": "^3.0.0",
+				"tar-stream": "^2.1.4"
+			},
+			"dependencies": {
+				"chownr": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+					"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+					"dev": true
+				}
+			}
+		},
+		"tar-stream": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+			"dev": true,
+			"requires": {
+				"bl": "^4.0.3",
+				"end-of-stream": "^1.4.1",
+				"fs-constants": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
+		},
 		"term-size": {
 			"version": "2.2.1"
 		},
@@ -36481,6 +36982,15 @@
 						"yargs-parser": "^18.1.2"
 					}
 				}
+			}
+		},
+		"tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"type-check": {
@@ -37355,15 +37865,15 @@
 			}
 		},
 		"workerd": {
-			"version": "1.20220926.3",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20220926.3.tgz",
-			"integrity": "sha512-/lmXRhgLixIkNNwsrFquPlT+qgFD71QbYJ8qroYQVL2hQVOuqw5N4TzMZS6gaNtVW+EUUnps+t/zbz98vjeuTg==",
+			"version": "1.20221111.5",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20221111.5.tgz",
+			"integrity": "sha512-cZVjhFaCYrNogLy52H20O2Y1Ld8orPRM5bt9fKCAwoGI0I2SZinPvcKb0QeK+EKrfQeWNcrd2MnEjP4sUDiWhA==",
 			"dev": true,
 			"requires": {
-				"@cloudflare/workerd-darwin-64": "^1.20220926.0",
-				"@cloudflare/workerd-darwin-arm64": "^1.20220926.0",
-				"@cloudflare/workerd-linux-64": "^1.20220926.0",
-				"@cloudflare/workerd-linux-arm64": "^1.20220926.0"
+				"@cloudflare/workerd-darwin-64": "1.20221111.5",
+				"@cloudflare/workerd-darwin-arm64": "1.20221111.5",
+				"@cloudflare/workerd-linux-64": "1.20221111.5",
+				"@cloudflare/workerd-linux-arm64": "1.20221111.5"
 			}
 		},
 		"workers-chat-demo": {
@@ -37383,7 +37893,7 @@
 				"@miniflare/core": "2.10.0",
 				"@miniflare/d1": "2.10.0",
 				"@miniflare/durable-objects": "2.10.0",
-				"@miniflare/tre": "3.0.0-next.2",
+				"@miniflare/tre": "^3.0.0-next.5",
 				"@types/better-sqlite3": "^7.6.0",
 				"@types/busboy": "^1.5.0",
 				"@types/command-exists": "^1.2.0",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -119,7 +119,7 @@
 		"@databases/sql": "^3.2.0",
 		"@iarna/toml": "^3.0.0",
 		"@microsoft/api-extractor": "^7.28.3",
-		"@miniflare/tre": "3.0.0-next.2",
+		"@miniflare/tre": "^3.0.0-next.5",
 		"@types/better-sqlite3": "^7.6.0",
 		"@types/busboy": "^1.5.0",
 		"@types/command-exists": "^1.2.0",


### PR DESCRIPTION
Rather than recreating `Miniflare` instances on each reload, this PR switches to using `Miniflare#setOptions` on the existing instance if it exists. This retains internal Miniflare state, like the loopback server, which makes reloads much more efficient. This is also required for live-reload to work properly.