### PR TITLE
fix: use XDG PATH for metrics config

### DIFF
--- a/.changeset/good-geckos-call.md
+++ b/.changeset/good-geckos-call.md
@@ -1,0 +1,10 @@
+---
+"wrangler": patch
+---
+
+fix: use XDG PATH for metrics config
+
+Use `getGlobalWranglerConfigPath` to get the config directory
+which previously added support for XDG Paths.
+
+resolves #2075

--- a/packages/wrangler/src/__tests__/metrics.test.ts
+++ b/packages/wrangler/src/__tests__/metrics.test.ts
@@ -364,7 +364,7 @@ describe("metrics", () => {
 
 				expect(std.out).toMatchInlineSnapshot(`
 			"Usage metrics tracking has changed since you last granted permission.
-			Your choice has been saved in the following file: home/.wrangler/config/metrics.json.
+			Your choice has been saved in the following file: test-xdg-config/config/metrics.json.
 
 			  You can override the user level setting for a project in \`wrangler.toml\`:
 

--- a/packages/wrangler/src/metrics/metrics-config.ts
+++ b/packages/wrangler/src/metrics/metrics-config.ts
@@ -6,6 +6,7 @@ import { fetchResult } from "../cfetch";
 import { getConfigCache, saveToConfigCache } from "../config-cache";
 import { confirm } from "../dialogs";
 import { getEnvironmentVariableFactory } from "../environment-variables";
+import { getGlobalWranglerConfigPath } from "../global-wrangler-config-path"
 import { CI } from "../is-ci";
 import isInteractive from "../is-interactive";
 import { logger } from "../logger";
@@ -167,7 +168,7 @@ export function readMetricsConfig(): MetricsConfigFile {
  * Get the path to the metrics config file.
  */
 function getMetricsConfigPath(): string {
-	return path.resolve(os.homedir(), ".wrangler/config/metrics.json");
+	return path.join(getGlobalWranglerConfigPath(), "config/metrics.json");
 }
 
 /**


### PR DESCRIPTION
Use `getGlobalWranglerConfigPath` to get the config directory which previously added support for XDG Paths.

resolves #2075