### PR TITLE
Make a better error message when creating a d1 db fails

### DIFF
--- a/packages/wrangler/src/d1/create.tsx
+++ b/packages/wrangler/src/d1/create.tsx
@@ -23,17 +23,26 @@ export async function Handler({
 	name,
 }: ArgumentsCamelCase<CreateArgs>): Promise<void> {
 	const accountId = await requireAuth({});
+
 	logger.log(d1BetaWarning);
 
-	const db: Database = await fetchResult(`/accounts/${accountId}/d1/database`, {
-		method: "POST",
-		headers: {
-			"Content-Type": "application/json",
-		},
-		body: JSON.stringify({
-			name,
-		}),
-	});
+	let db: Database;
+	try {
+		db = await fetchResult(`/accounts/${accountId}/d1/database`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				name,
+			}),
+		});
+	} catch (e) {
+		if ((e as { code: number }).code === 7502) {
+			throw new Error("A database with that name already exists");
+		}
+		throw e;
+	}
 
 	render(
 		<Box flexDirection="column">


### PR DESCRIPTION
Before:
```
✘ [ERROR] A request to the Cloudflare API (/accounts/f7f78ebb28c2a224a9a46a3007350b7a/d1/database) failed.

  Internal error [code: 7502]

  If you think this is a bug, please open an issue at:
  https://github.com/cloudflare/wrangler2/issues/new/choose
```

After:
```
✘ [ERROR] A database with that name already exists


If you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose
```