### PR TITLE
Add `failOpen` property to the deployment metadata

### DIFF
--- a/.changeset/pretty-lemons-prove.md
+++ b/.changeset/pretty-lemons-prove.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/pages-shared": patch
+---
+
+feat: Add a `failOpen` prop to the deployment metadata.

--- a/packages/pages-shared/asset-server/metadata.ts
+++ b/packages/pages-shared/asset-server/metadata.ts
@@ -63,4 +63,5 @@ export type Metadata = {
 		token: string;
 	};
 	deploymentId?: string;
+	failOpen?: boolean;
 };

--- a/packages/pages-shared/metadata-generator/createMetadataObject.ts
+++ b/packages/pages-shared/metadata-generator/createMetadataObject.ts
@@ -19,12 +19,14 @@ export function createMetadataObject({
 	headers,
 	webAnalyticsToken,
 	deploymentId,
+	failOpen,
 	logger = (_message: string) => {},
 }: {
 	redirects?: ParsedRedirects;
 	headers?: ParsedHeaders;
 	webAnalyticsToken?: string;
 	deploymentId?: string;
+	failOpen?: boolean;
 	logger?: Logger;
 }): Metadata {
 	return {
@@ -32,6 +34,7 @@ export function createMetadataObject({
 		...constructHeaders({ headers, logger }),
 		...constructWebAnalytics({ webAnalyticsToken, logger }),
 		deploymentId,
+		failOpen,
 	};
 }
 

--- a/packages/pages-shared/metadata-generator/types.ts
+++ b/packages/pages-shared/metadata-generator/types.ts
@@ -84,6 +84,7 @@ export type Metadata = {
 		token: string;
 	};
 	deploymentId?: string;
+	failOpen?: boolean;
 };
 
 export type Logger = (message: string) => void;


### PR DESCRIPTION
feat: Add a `failOpen` prop to the deployment metadata
