### PR TITLE
fix: don't throw if versions isn't available

### DIFF
--- a/packages/wrangler/src/publish/publish.ts
+++ b/packages/wrangler/src/publish/publish.ts
@@ -819,11 +819,18 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		logger.log("No publish targets for", workerName, formatTime(deployMs));
 	}
 
-	const deploymentsList = await fetchResult<DeploymentListRes>(
-		`/accounts/${accountId}/workers/versions/by-script/${scriptTag}`
-	);
+	try {
+		const deploymentsList = await fetchResult<DeploymentListRes>(
+			`/accounts/${accountId}/workers/versions/by-script/${scriptTag}`
+		);
 
-	logger.log("Current Version:", deploymentsList.latest.number);
+		logger.log("Current Version:", deploymentsList.latest.number);
+	} catch (e) {
+		if ((e as { code: number }).code === 10023) {
+			// TODO: remove this try/catch once versions is completely rolled out
+		}
+		throw e;
+	}
 }
 
 function formatTime(duration: number) {


### PR DESCRIPTION
We're currently throwing this error to everyone while versions isn't fully rolled out - this PR suppresses the error.
```
✘ [ERROR] A request to the Cloudflare API (/accounts/xxx/workers/versions/by-script/xxx) failed.

  workers.api.error.unauthorized [code: 10023]
  
  If you think this is a bug, please open an issue at: https://github.com/cloudflare/wrangler2/issues/new/choose
```