### PR TITLE
Update error code for queue_not_found

### DIFF
--- a/.changeset/violet-dancers-fix.md
+++ b/.changeset/violet-dancers-fix.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Check for the correct API error code when attempting to detect missing Queues.

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -7607,7 +7607,7 @@ function mockGetQueueMissing(expectedQueueName: string) {
 		`/accounts/:accountId/workers/queues/${expectedQueueName}`,
 		"GET",
 		([_url, _accountId]) => {
-			throw { code: 100123 };
+			throw { code: 11000 };
 		}
 	);
 	return requests;

--- a/packages/wrangler/src/publish/publish.ts
+++ b/packages/wrangler/src/publish/publish.ts
@@ -997,7 +997,7 @@ async function ensureQueuesExist(config: Config) {
 			await getQueue(config, queue);
 		} catch (err) {
 			const queueErr = err as FetchError;
-			if (queueErr.code === 100123) {
+			if (queueErr.code === 11000) {
 				// queue_not_found
 				throw new Error(
 					`Queue "${queue}" does not exist. To create it, run: wrangler queues create ${queue}`


### PR DESCRIPTION
The API error codes for queues are being updated.

This PR updates the error code for handling missing queues.