### PR TITLE
Add first class Analytics Engine bindings

### DIFF
--- a/.changeset/lazy-wolves-sing.md
+++ b/.changeset/lazy-wolves-sing.md
@@ -5,6 +5,7 @@
 feat: Add support for Analytics Engine bindings.
 
 For example:
+
 ```
 analytics_engine_datasets = [
     { binding = "ANALYTICS", dataset = "my_dataset" }

--- a/.changeset/lazy-wolves-sing.md
+++ b/.changeset/lazy-wolves-sing.md
@@ -1,0 +1,12 @@
+---
+"wrangler": minor
+---
+
+feat: Add support for Analytics Engine bindings.
+
+For example:
+```
+analytics_engine_datasets = [
+    { binding = "ANALYTICS", dataset = "my_dataset" }
+]
+```

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -55,6 +55,7 @@ describe("normalizeAndValidateConfig()", () => {
 			},
 			r2_buckets: [],
 			services: [],
+			analytics_engine_datasets: [],
 			route: undefined,
 			routes: undefined,
 			rules: [],
@@ -914,6 +915,15 @@ describe("normalizeAndValidateConfig()", () => {
 						service: "SERVICE_TYPE_1",
 						environment: "SERVICE_BINDING_ENVIRONMENT_1",
 					},
+				],
+				analytics_engine_datasets: [
+					{
+						binding: "AE_BINDING_1",
+						dataset: "DATASET_1",
+					},
+					{
+						binding: "AE_BINDING_2",
+					}
 				],
 				unsafe: {
 					bindings: [
@@ -2028,6 +2038,92 @@ describe("normalizeAndValidateConfig()", () => {
 			});
 		});
 
+		describe("[analytics_engine_datasets]", () => {
+			it("should error if analytics_engine_datasets is an object", () => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{ analytics_engine_datasets: {} } as unknown as RawConfig,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+			                  "Processing wrangler configuration:
+			                    - The field \\"analytics_engine_datasets\\" should be an array but got {}."
+		              `);
+			});
+
+			it("should error if analytics_engine_datasets is a string", () => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{ analytics_engine_datasets: "BAD" } as unknown as RawConfig,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+			                  "Processing wrangler configuration:
+			                    - The field \\"analytics_engine_datasets\\" should be an array but got \\"BAD\\"."
+		              `);
+			});
+
+			it("should error if analytics_engine_datasets is a number", () => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{ analytics_engine_datasets: 999 } as unknown as RawConfig,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+			                  "Processing wrangler configuration:
+			                    - The field \\"analytics_engine_datasets\\" should be an array but got 999."
+		              `);
+			});
+
+			it("should error if analytics_engine_datasets is null", () => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{ analytics_engine_datasets: null } as unknown as RawConfig,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+			                  "Processing wrangler configuration:
+			                    - The field \\"analytics_engine_datasets\\" should be an array but got null."
+		              `);
+			});
+
+			it("should error if analytics_engine_datasets.bindings are not valid", () => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						analytics_engine_datasets: [
+							{},
+							{ binding: 2333, dataset: 2444 },
+							{
+								binding: "AE_BINDING_2",
+								dataset: 2555,
+							},
+							{ binding: "AE_BINDING_1", dataset: "" },
+						],
+					} as unknown as RawConfig,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+			          "Processing wrangler configuration:
+			            - \\"analytics_engine_datasets[0]\\" bindings should have a string \\"binding\\" field but got {}.
+			            - \\"analytics_engine_datasets[1]\\" bindings should have a string \\"binding\\" field but got {\\"binding\\":2333,\\"dataset\\":2444}.
+			            - \\"analytics_engine_datasets[1]\\" bindings should, optionally, have a string \\"dataset\\" field but got {\\"binding\\":2333,\\"dataset\\":2444}.
+			            - \\"analytics_engine_datasets[2]\\" bindings should, optionally, have a string \\"dataset\\" field but got {\\"binding\\":\\"AE_BINDING_2\\",\\"dataset\\":2555}.
+			            - \\"analytics_engine_datasets[3]\\" bindings should, optionally, have a string \\"dataset\\" field but got {\\"binding\\":\\"AE_BINDING_1\\",\\"dataset\\":\\"\\"}."
+		        `);
+			});
+		});
+
 		describe("[dispatch_namespaces]", () => {
 			it("should log an experimental warning when dispatch_namespaces is used", () => {
 				const { diagnostics } = normalizeAndValidateConfig(
@@ -2697,6 +2793,7 @@ describe("normalizeAndValidateConfig()", () => {
 			};
 			const kv_namespaces: RawConfig["kv_namespaces"] = [];
 			const r2_buckets: RawConfig["r2_buckets"] = [];
+			const analytics_engine_datasets: RawConfig["analytics_engine_datasets"] = [];
 			const unsafe: RawConfig["unsafe"] = { bindings: [] };
 			const rawConfig: RawConfig = {
 				define,
@@ -2704,6 +2801,7 @@ describe("normalizeAndValidateConfig()", () => {
 				durable_objects,
 				kv_namespaces,
 				r2_buckets,
+				analytics_engine_datasets,
 				unsafe,
 				env: {
 					ENV1: {},
@@ -2723,6 +2821,7 @@ describe("normalizeAndValidateConfig()", () => {
 					durable_objects,
 					kv_namespaces,
 					r2_buckets,
+					analytics_engine_datasets,
 					unsafe,
 				})
 			);
@@ -2746,6 +2845,9 @@ describe("normalizeAndValidateConfig()", () => {
 			    - \\"r2_buckets\\" exists at the top level, but not on \\"env.ENV1\\".
 			      This is not what you probably want, since \\"r2_buckets\\" is not inherited by environments.
 			      Please add \\"r2_buckets\\" to \\"env.ENV1\\".
+			    - \\"analytics_engine_datasets\\" exists at the top level, but not on \\"env.ENV1\\".
+			      This is not what you probably want, since \\"analytics_engine_datasets\\" is not inherited by environments.
+			      Please add \\"analytics_engine_datasets\\" to \\"env.ENV1\\".
 			    - \\"unsafe\\" exists at the top level, but not on \\"env.ENV1\\".
 			      This is not what you probably want, since \\"unsafe\\" is not inherited by environments.
 			      Please add \\"unsafe\\" to \\"env.ENV1\\"."
@@ -3443,6 +3545,106 @@ describe("normalizeAndValidateConfig()", () => {
 			              - \\"env.ENV1.r2_buckets[2]\\" bindings should have a string \\"binding\\" field but got {\\"binding\\":2333,\\"bucket_name\\":2444}.
 			              - \\"env.ENV1.r2_buckets[2]\\" bindings should have a string \\"bucket_name\\" field but got {\\"binding\\":2333,\\"bucket_name\\":2444}.
 			              - \\"env.ENV1.r2_buckets[3]\\" bindings should, optionally, have a string \\"preview_bucket_name\\" field but got {\\"binding\\":\\"R2_BINDING_2\\",\\"bucket_name\\":\\"R2_BUCKET_2\\",\\"preview_bucket_name\\":2555}."
+		        `);
+			});
+		});
+
+		describe("[analytics_engine_datasets]", () => {
+			it("should error if analytics_engine_datasets is an object", () => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{ env: { ENV1: { analytics_engine_datasets: {} } } } as unknown as RawConfig,
+					undefined,
+					{ env: "ENV1" }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+			          "Processing wrangler configuration:
+
+			            - \\"env.ENV1\\" environment configuration
+			              - The field \\"env.ENV1.analytics_engine_datasets\\" should be an array but got {}."
+		        `);
+			});
+
+			it("should error if analytics_engine_datasets is a string", () => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{ env: { ENV1: { analytics_engine_datasets: "BAD" } } } as unknown as RawConfig,
+					undefined,
+					{ env: "ENV1" }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+			          "Processing wrangler configuration:
+
+			            - \\"env.ENV1\\" environment configuration
+			              - The field \\"env.ENV1.analytics_engine_datasets\\" should be an array but got \\"BAD\\"."
+		        `);
+			});
+
+			it("should error if analytics_engine_datasets is a number", () => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{ env: { ENV1: { analytics_engine_datasets: 999 } } } as unknown as RawConfig,
+					undefined,
+					{ env: "ENV1" }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+			          "Processing wrangler configuration:
+
+			            - \\"env.ENV1\\" environment configuration
+			              - The field \\"env.ENV1.analytics_engine_datasets\\" should be an array but got 999."
+		        `);
+			});
+
+			it("should error if analytics_engine_datasets is null", () => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{ env: { ENV1: { analytics_engine_datasets: null } } } as unknown as RawConfig,
+					undefined,
+					{ env: "ENV1" }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+			          "Processing wrangler configuration:
+
+			            - \\"env.ENV1\\" environment configuration
+			              - The field \\"env.ENV1.analytics_engine_datasets\\" should be an array but got null."
+		        `);
+			});
+
+			it("should error if analytics_engine_datasets.bindings are not valid", () => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						env: {
+							ENV1: {
+								analytics_engine_datasets: [
+									{},
+									{ binding: 2333, dataset: 2444 },
+									{
+										binding: "AE_BINDING_2",
+										dataset: 2555,
+									},
+									{ binding: "AE_BINDING_1", dataset: "" },
+								],
+							},
+						},
+					} as unknown as RawConfig,
+					undefined,
+					{ env: "ENV1" }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+			          "Processing wrangler configuration:
+
+			            - \\"env.ENV1\\" environment configuration
+			              - \\"env.ENV1.analytics_engine_datasets[0]\\" bindings should have a string \\"binding\\" field but got {}.
+			              - \\"env.ENV1.analytics_engine_datasets[1]\\" bindings should have a string \\"binding\\" field but got {\\"binding\\":2333,\\"dataset\\":2444}.
+			              - \\"env.ENV1.analytics_engine_datasets[1]\\" bindings should, optionally, have a string \\"dataset\\" field but got {\\"binding\\":2333,\\"dataset\\":2444}.
+			              - \\"env.ENV1.analytics_engine_datasets[2]\\" bindings should, optionally, have a string \\"dataset\\" field but got {\\"binding\\":\\"AE_BINDING_2\\",\\"dataset\\":2555}.
+			              - \\"env.ENV1.analytics_engine_datasets[3]\\" bindings should, optionally, have a string \\"dataset\\" field but got {\\"binding\\":\\"AE_BINDING_1\\",\\"dataset\\":\\"\\"}."
 		        `);
 			});
 		});

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -923,7 +923,7 @@ describe("normalizeAndValidateConfig()", () => {
 					},
 					{
 						binding: "AE_BINDING_2",
-					}
+					},
 				],
 				unsafe: {
 					bindings: [
@@ -2793,7 +2793,8 @@ describe("normalizeAndValidateConfig()", () => {
 			};
 			const kv_namespaces: RawConfig["kv_namespaces"] = [];
 			const r2_buckets: RawConfig["r2_buckets"] = [];
-			const analytics_engine_datasets: RawConfig["analytics_engine_datasets"] = [];
+			const analytics_engine_datasets: RawConfig["analytics_engine_datasets"] =
+				[];
 			const unsafe: RawConfig["unsafe"] = { bindings: [] };
 			const rawConfig: RawConfig = {
 				define,
@@ -3552,7 +3553,9 @@ describe("normalizeAndValidateConfig()", () => {
 		describe("[analytics_engine_datasets]", () => {
 			it("should error if analytics_engine_datasets is an object", () => {
 				const { diagnostics } = normalizeAndValidateConfig(
-					{ env: { ENV1: { analytics_engine_datasets: {} } } } as unknown as RawConfig,
+					{
+						env: { ENV1: { analytics_engine_datasets: {} } },
+					} as unknown as RawConfig,
 					undefined,
 					{ env: "ENV1" }
 				);
@@ -3568,7 +3571,9 @@ describe("normalizeAndValidateConfig()", () => {
 
 			it("should error if analytics_engine_datasets is a string", () => {
 				const { diagnostics } = normalizeAndValidateConfig(
-					{ env: { ENV1: { analytics_engine_datasets: "BAD" } } } as unknown as RawConfig,
+					{
+						env: { ENV1: { analytics_engine_datasets: "BAD" } },
+					} as unknown as RawConfig,
 					undefined,
 					{ env: "ENV1" }
 				);
@@ -3584,7 +3589,9 @@ describe("normalizeAndValidateConfig()", () => {
 
 			it("should error if analytics_engine_datasets is a number", () => {
 				const { diagnostics } = normalizeAndValidateConfig(
-					{ env: { ENV1: { analytics_engine_datasets: 999 } } } as unknown as RawConfig,
+					{
+						env: { ENV1: { analytics_engine_datasets: 999 } },
+					} as unknown as RawConfig,
 					undefined,
 					{ env: "ENV1" }
 				);
@@ -3600,7 +3607,9 @@ describe("normalizeAndValidateConfig()", () => {
 
 			it("should error if analytics_engine_datasets is null", () => {
 				const { diagnostics } = normalizeAndValidateConfig(
-					{ env: { ENV1: { analytics_engine_datasets: null } } } as unknown as RawConfig,
+					{
+						env: { ENV1: { analytics_engine_datasets: null } },
+					} as unknown as RawConfig,
 					undefined,
 					{ env: "ENV1" }
 				);

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -4497,6 +4497,10 @@ addEventListener('fetch', event => {});`
 					{ binding: "R2_BUCKET_ONE", bucket_name: "r2-bucket-one-name" },
 					{ binding: "R2_BUCKET_TWO", bucket_name: "r2-bucket-two-name" },
 				],
+				analytics_engine_datasets: [
+					{ binding: "AE_DATASET_ONE", dataset: "ae-dataset-one-name" },
+					{ binding: "AE_DATASET_TWO", dataset: "ae-dataset-two-name" },
+				],
 				text_blobs: {
 					TEXT_BLOB_ONE: "./my-entire-app-depends-on-this.cfg",
 					TEXT_BLOB_TWO: "./the-entirety-of-human-knowledge.txt",
@@ -4599,6 +4603,16 @@ addEventListener('fetch', event => {});`
 						type: "r2_bucket",
 					},
 					{
+						dataset: "ae-dataset-one-name",
+						name: "AE_DATASET_ONE",
+						type: "analytics_engine",
+					},
+					{
+						dataset: "ae-dataset-two-name",
+						name: "AE_DATASET_TWO",
+						type: "analytics_engine",
+					},
+					{
 						name: "httplogs",
 						type: "logfwdr",
 						destination: "httplogs",
@@ -4656,6 +4670,9 @@ addEventListener('fetch', event => {});`
 			- logfwdr:
 			  - httplogs: httplogs
 			  - trace: trace
+			- Analytics Engine Datasets:
+			  - AE_DATASET_ONE: ae-dataset-one-name
+			  - AE_DATASET_TWO: ae-dataset-two-name
 			- Text Blobs:
 			  - TEXT_BLOB_ONE: my-entire-app-depends-on-this.cfg
 			  - TEXT_BLOB_TWO: the-entirety-of-human-knowledge.txt
@@ -4713,6 +4730,12 @@ addEventListener('fetch', event => {});`
 						bucket_name: "r2-bucket-two-name",
 					},
 				],
+				analytics_engine_datasets: [
+					{
+						binding: "CONFLICTING_NAME_FOUR",
+						dataset: "analytics-engine-dataset-name",
+					},
+				],
 				text_blobs: {
 					CONFLICTING_NAME_THREE: "./my-entire-app-depends-on-this.cfg",
 					CONFLICTING_NAME_FOUR: "./the-entirety-of-human-knowledge.txt",
@@ -4760,7 +4783,7 @@ addEventListener('fetch', event => {});`
 						                - CONFLICTING_NAME_ONE assigned to Durable Object, KV Namespace, and R2 Bucket bindings.
 						                - CONFLICTING_NAME_TWO assigned to Durable Object and KV Namespace bindings.
 						                - CONFLICTING_NAME_THREE assigned to R2 Bucket, Text Blob, Unsafe, Environment Variable, WASM Module, and Data Blob bindings.
-						                - CONFLICTING_NAME_FOUR assigned to Text Blob and Unsafe bindings.
+						                - CONFLICTING_NAME_FOUR assigned to Analytics Engine Dataset, Text Blob, and Unsafe bindings.
 						                - Bindings must have unique names, so that they can all be referenced in the worker.
 						                  Please change your bindings to have unique names.]
 					            `);
@@ -4775,7 +4798,7 @@ addEventListener('fetch', event => {});`
 			            - CONFLICTING_NAME_TWO assigned to Durable Object and KV Namespace bindings.
 			            - CONFLICTING_NAME_THREE assigned to R2 Bucket, Text Blob, Unsafe, Environment Variable, WASM
 			          Module, and Data Blob bindings.
-			            - CONFLICTING_NAME_FOUR assigned to Text Blob and Unsafe bindings.
+			            - CONFLICTING_NAME_FOUR assigned to Analytics Engine Dataset, Text Blob, and Unsafe bindings.
 			            - Bindings must have unique names, so that they can all be referenced in the worker.
 			              Please change your bindings to have unique names.
 
@@ -4820,6 +4843,16 @@ addEventListener('fetch', event => {});`
 						bucket_name: "r2-bucket-two-name",
 					},
 				],
+				analytics_engine_datasets: [
+					{
+						binding: "CONFLICTING_AE_DATASET_NAME",
+						dataset: "ae-dataset-one-name",
+					},
+					{
+						binding: "CONFLICTING_AE_DATASET_NAME",
+						dataset: "ae-dataset-two-name",
+					},
+				],
 				unsafe: {
 					bindings: [
 						{
@@ -4859,6 +4892,7 @@ addEventListener('fetch', event => {});`
 						                - CONFLICTING_DURABLE_OBJECT_NAME assigned to multiple Durable Object bindings.
 						                - CONFLICTING_KV_NAMESPACE_NAME assigned to multiple KV Namespace bindings.
 						                - CONFLICTING_R2_BUCKET_NAME assigned to multiple R2 Bucket bindings.
+						                - CONFLICTING_AE_DATASET_NAME assigned to multiple Analytics Engine Dataset bindings.
 						                - CONFLICTING_UNSAFE_NAME assigned to multiple Unsafe bindings.
 						                - Bindings must have unique names, so that they can all be referenced in the worker.
 						                  Please change your bindings to have unique names.]
@@ -4873,6 +4907,7 @@ addEventListener('fetch', event => {});`
 			            - CONFLICTING_DURABLE_OBJECT_NAME assigned to multiple Durable Object bindings.
 			            - CONFLICTING_KV_NAMESPACE_NAME assigned to multiple KV Namespace bindings.
 			            - CONFLICTING_R2_BUCKET_NAME assigned to multiple R2 Bucket bindings.
+			            - CONFLICTING_AE_DATASET_NAME assigned to multiple Analytics Engine Dataset bindings.
 			            - CONFLICTING_UNSAFE_NAME assigned to multiple Unsafe bindings.
 			            - Bindings must have unique names, so that they can all be referenced in the worker.
 			              Please change your bindings to have unique names.
@@ -4934,6 +4969,24 @@ addEventListener('fetch', event => {});`
 						bucket_name: "r2-bucket-four-name",
 					},
 				],
+				analytics_engine_datasets: [
+					{
+						binding: "CONFLICTING_AE_DATASET_NAME",
+						dataset: "ae-dataset-one-name",
+					},
+					{
+						binding: "CONFLICTING_AE_DATASET_NAME",
+						dataset: "ae-dataset-two-name",
+					},
+					{
+						binding: "CONFLICTING_NAME_THREE",
+						dataset: "ae-dataset-three-name",
+					},
+					{
+						binding: "CONFLICTING_NAME_FOUR",
+						dataset: "ae-dataset-four-name",
+					},
+				],
 				text_blobs: {
 					CONFLICTING_NAME_THREE: "./my-entire-app-depends-on-this.cfg",
 					CONFLICTING_NAME_FOUR: "./the-entirety-of-human-knowledge.txt",
@@ -4991,8 +5044,9 @@ addEventListener('fetch', event => {});`
 						                - CONFLICTING_DURABLE_OBJECT_NAME assigned to multiple Durable Object bindings.
 						                - CONFLICTING_KV_NAMESPACE_NAME assigned to multiple KV Namespace bindings.
 						                - CONFLICTING_R2_BUCKET_NAME assigned to multiple R2 Bucket bindings.
-						                - CONFLICTING_NAME_THREE assigned to R2 Bucket, Text Blob, Unsafe, Environment Variable, WASM Module, and Data Blob bindings.
-						                - CONFLICTING_NAME_FOUR assigned to R2 Bucket, Text Blob, and Unsafe bindings.
+						                - CONFLICTING_NAME_THREE assigned to R2 Bucket, Analytics Engine Dataset, Text Blob, Unsafe, Environment Variable, WASM Module, and Data Blob bindings.
+						                - CONFLICTING_NAME_FOUR assigned to R2 Bucket, Analytics Engine Dataset, Text Blob, and Unsafe bindings.
+						                - CONFLICTING_AE_DATASET_NAME assigned to multiple Analytics Engine Dataset bindings.
 						                - CONFLICTING_UNSAFE_NAME assigned to multiple Unsafe bindings.
 						                - Bindings must have unique names, so that they can all be referenced in the worker.
 						                  Please change your bindings to have unique names.]
@@ -5007,9 +5061,11 @@ addEventListener('fetch', event => {});`
 			            - CONFLICTING_DURABLE_OBJECT_NAME assigned to multiple Durable Object bindings.
 			            - CONFLICTING_KV_NAMESPACE_NAME assigned to multiple KV Namespace bindings.
 			            - CONFLICTING_R2_BUCKET_NAME assigned to multiple R2 Bucket bindings.
-			            - CONFLICTING_NAME_THREE assigned to R2 Bucket, Text Blob, Unsafe, Environment Variable, WASM
-			          Module, and Data Blob bindings.
-			            - CONFLICTING_NAME_FOUR assigned to R2 Bucket, Text Blob, and Unsafe bindings.
+			            - CONFLICTING_NAME_THREE assigned to R2 Bucket, Analytics Engine Dataset, Text Blob, Unsafe,
+			          Environment Variable, WASM Module, and Data Blob bindings.
+			            - CONFLICTING_NAME_FOUR assigned to R2 Bucket, Analytics Engine Dataset, Text Blob, and Unsafe
+			          bindings.
+			            - CONFLICTING_AE_DATASET_NAME assigned to multiple Analytics Engine Dataset bindings.
 			            - CONFLICTING_UNSAFE_NAME assigned to multiple Unsafe bindings.
 			            - Bindings must have unique names, so that they can all be referenced in the worker.
 			              Please change your bindings to have unique names.
@@ -5741,6 +5797,35 @@ addEventListener('fetch', event => {});`
 
 			          "
 		        `);
+			});
+		});
+
+		describe("[analytics_engine_datasets]", () => {
+			it("should support analytics engine bindings", async () => {
+				writeWranglerToml({
+					analytics_engine_datasets: [{ binding: "FOO", dataset: "foo-dataset" }],
+				});
+				writeWorkerSource();
+				mockSubDomainRequest();
+				mockUploadWorkerRequest({
+					expectedBindings: [
+						{ dataset: "foo-dataset", name: "FOO", type: "analytics_engine" },
+					],
+				});
+
+				await runWrangler("publish index.js");
+				expect(std.out).toMatchInlineSnapshot(`
+			"Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- Analytics Engine Datasets:
+			  - FOO: foo-dataset
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev
+			Current Version: 2"
+		`);
+				expect(std.err).toMatchInlineSnapshot(`""`);
+				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
 		});
 

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -5803,7 +5803,9 @@ addEventListener('fetch', event => {});`
 		describe("[analytics_engine_datasets]", () => {
 			it("should support analytics engine bindings", async () => {
 				writeWranglerToml({
-					analytics_engine_datasets: [{ binding: "FOO", dataset: "foo-dataset" }],
+					analytics_engine_datasets: [
+						{ binding: "FOO", dataset: "foo-dataset" },
+					],
 				});
 				writeWorkerSource();
 				mockSubDomainRequest();

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -5824,7 +5824,7 @@ addEventListener('fetch', event => {});`
 			Uploaded test-name (TIMINGS)
 			Published test-name (TIMINGS)
 			  https://test-name.test-sub-domain.workers.dev
-			Current Version: 2"
+			Current Deployment ID: undefined"
 		`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -122,7 +122,7 @@ describe("generateTypes()", () => {
 			R2_BUCKET_BINDING: R2Bucket;
 			D1_TESTING_SOMETHING: D1Database;
 			SERVICE_BINDING: Fetcher;
-			AE_DATASET_BINDING: Dataset;
+			AE_DATASET_BINDING: AnalyticsEngineDataset;
 			NAMESPACE_BINDING: any;
 			LOGFWDR_SCHEMA: any;
 			SOME_DATA_BLOB1: ArrayBuffer;

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -52,6 +52,12 @@ const bindingsConfigMock: Partial<Config> = {
 		},
 	],
 	services: [{ binding: "SERVICE_BINDING", service: "SERVICE_NAME" }],
+	analytics_engine_datasets: [
+		{
+			binding: "AE_DATASET_BINDING",
+			dataset: "AE_DATASET_TEST",
+		},
+	],
 	dispatch_namespaces: [
 		{ binding: "NAMESPACE_BINDING", namespace: "NAMESPACE_ID" },
 	],
@@ -116,6 +122,7 @@ describe("generateTypes()", () => {
 			R2_BUCKET_BINDING: R2Bucket;
 			D1_TESTING_SOMETHING: D1Database;
 			SERVICE_BINDING: Fetcher;
+			AE_DATASET_BINDING: Dataset;
 			NAMESPACE_BINDING: any;
 			LOGFWDR_SCHEMA: any;
 			SOME_DATA_BLOB1: ArrayBuffer;

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -440,6 +440,22 @@ interface EnvironmentNonInheritable {
 		| undefined;
 
 	/**
+	 * Specifies analytics engine datasets that are bound to this Worker environment.
+	 *
+	 * NOTE: This field is not automatically inherited from the top level environment,
+	 * and so must be specified in every named environment.
+	 *
+	 * @default `[]`
+	 * @nonInheritable
+	 */
+	analytics_engine_datasets: {
+		/** The binding name used to refer to the dataset in the worker. */
+		binding: string;
+		/** The name of this dataset to write to. */
+		dataset?: string;
+	}[];
+
+	/**
 	 * "Unsafe" tables for features that aren't directly supported by wrangler.
 	 *
 	 * NOTE: This field is not automatically inherited from the top level environment,

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -221,7 +221,7 @@ export function printBindings(bindings: CfWorkerInit["bindings"]) {
 			entries: analytics_engine_datasets.map(({ binding, dataset }) => {
 				return {
 					key: binding,
-					value: dataset || binding,
+					value: dataset ?? binding,
 				};
 			}),
 		});

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -93,6 +93,7 @@ export function printBindings(bindings: CfWorkerInit["bindings"]) {
 		r2_buckets,
 		logfwdr,
 		services,
+		analytics_engine_datasets,
 		text_blobs,
 		unsafe,
 		vars,
@@ -206,6 +207,18 @@ export function printBindings(bindings: CfWorkerInit["bindings"]) {
 				return {
 					key: binding,
 					value,
+				};
+			}),
+		});
+	}
+
+	if (analytics_engine_datasets !== undefined && analytics_engine_datasets.length > 0) {
+		output.push({
+			type: "Analytics Engine Datasets",
+			entries: analytics_engine_datasets.map(({ binding, dataset }) => {
+				return {
+					key: binding,
+					value: dataset || binding,
 				};
 			}),
 		});

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -212,7 +212,10 @@ export function printBindings(bindings: CfWorkerInit["bindings"]) {
 		});
 	}
 
-	if (analytics_engine_datasets !== undefined && analytics_engine_datasets.length > 0) {
+	if (
+		analytics_engine_datasets !== undefined &&
+		analytics_engine_datasets.length > 0
+	) {
 		output.push({
 			type: "Analytics Engine Datasets",
 			entries: analytics_engine_datasets.map(({ binding, dataset }) => {

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -1115,6 +1115,16 @@ function normalizeAndValidateEnvironment(
 			validateBindingArray(envName, validateServiceBinding),
 			[]
 		),
+		analytics_engine_datasets: notInheritable(
+			diagnostics,
+			topLevelEnv,
+			rawConfig,
+			rawEnv,
+			envName,
+			"analytics_engine_datasets",
+			validateBindingArray(envName, validateAnalyticsEngineBinding),
+			[]
+		),
 		dispatch_namespaces: notInheritable(
 			diagnostics,
 			topLevelEnv,
@@ -1834,6 +1844,7 @@ const validateBindingsHaveUniqueNames = (
 		durable_objects,
 		kv_namespaces,
 		r2_buckets,
+		analytics_engine_datasets,
 		text_blobs,
 		unsafe,
 		vars,
@@ -1848,6 +1859,7 @@ const validateBindingsHaveUniqueNames = (
 		"Durable Object": getBindingNames(durable_objects),
 		"KV Namespace": getBindingNames(kv_namespaces),
 		"R2 Bucket": getBindingNames(r2_buckets),
+		"Analytics Engine Dataset": getBindingNames(analytics_engine_datasets),
 		"Text Blob": getBindingNames(text_blobs),
 		Unsafe: getBindingNames(unsafe),
 		"Environment Variable": getBindingNames(vars),
@@ -1948,6 +1960,35 @@ const validateServiceBinding: ValidatorFn = (diagnostics, field, value) => {
 	if (!isOptionalProperty(value, "environment", "string")) {
 		diagnostics.errors.push(
 			`"${field}" bindings should have a string "environment" field but got ${JSON.stringify(
+				value
+			)}.`
+		);
+		isValid = false;
+	}
+	return isValid;
+};
+
+const validateAnalyticsEngineBinding: ValidatorFn = (diagnostics, field, value) => {
+	if (typeof value !== "object" || value === null) {
+		diagnostics.errors.push(
+			`"analytics_engine" bindings should be objects, but got ${JSON.stringify(value)}`
+		);
+		return false;
+	}
+	let isValid = true;
+	// Service bindings must have a binding and optional dataset.
+	if (!isRequiredProperty(value, "binding", "string")) {
+		diagnostics.errors.push(
+			`"${field}" bindings should have a string "binding" field but got ${JSON.stringify(
+				value
+			)}.`
+		);
+		isValid = false;
+	}
+	if (!isOptionalProperty(value, "dataset", "string") ||
+		(value as { dataset: string }).dataset?.length === 0) {
+		diagnostics.errors.push(
+			`"${field}" bindings should, optionally, have a string "dataset" field but got ${JSON.stringify(
 				value
 			)}.`
 		);

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -1968,10 +1968,16 @@ const validateServiceBinding: ValidatorFn = (diagnostics, field, value) => {
 	return isValid;
 };
 
-const validateAnalyticsEngineBinding: ValidatorFn = (diagnostics, field, value) => {
+const validateAnalyticsEngineBinding: ValidatorFn = (
+	diagnostics,
+	field,
+	value
+) => {
 	if (typeof value !== "object" || value === null) {
 		diagnostics.errors.push(
-			`"analytics_engine" bindings should be objects, but got ${JSON.stringify(value)}`
+			`"analytics_engine" bindings should be objects, but got ${JSON.stringify(
+				value
+			)}`
 		);
 		return false;
 	}
@@ -1985,8 +1991,10 @@ const validateAnalyticsEngineBinding: ValidatorFn = (diagnostics, field, value) 
 		);
 		isValid = false;
 	}
-	if (!isOptionalProperty(value, "dataset", "string") ||
-		(value as { dataset: string }).dataset?.length === 0) {
+	if (
+		!isOptionalProperty(value, "dataset", "string") ||
+		(value as { dataset: string }).dataset?.length === 0
+	) {
 		diagnostics.errors.push(
 			`"${field}" bindings should, optionally, have a string "dataset" field but got ${JSON.stringify(
 				value

--- a/packages/wrangler/src/create-worker-upload-form.ts
+++ b/packages/wrangler/src/create-worker-upload-form.ts
@@ -43,7 +43,7 @@ type WorkerMetadataBinding =
 	| { type: "r2_bucket"; name: string; bucket_name: string }
 	| { type: "d1"; name: string; id: string; internalEnv?: string }
 	| { type: "service"; name: string; service: string; environment?: string }
-	| { type: "analytics_engine"; name: string, dataset?: string }
+	| { type: "analytics_engine"; name: string; dataset?: string }
 	| { type: "namespace"; name: string; namespace: string }
 	| {
 			type: "logfwdr";

--- a/packages/wrangler/src/create-worker-upload-form.ts
+++ b/packages/wrangler/src/create-worker-upload-form.ts
@@ -43,6 +43,7 @@ type WorkerMetadataBinding =
 	| { type: "r2_bucket"; name: string; bucket_name: string }
 	| { type: "d1"; name: string; id: string; internalEnv?: string }
 	| { type: "service"; name: string; service: string; environment?: string }
+	| { type: "analytics_engine"; name: string, dataset?: string }
 	| { type: "namespace"; name: string; namespace: string }
 	| {
 			type: "logfwdr";
@@ -146,6 +147,14 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
 			type: "service",
 			service,
 			...(environment && { environment }),
+		});
+	});
+
+	bindings.analytics_engine_datasets?.forEach(({ binding, dataset }) => {
+		metadataBindings.push({
+			name: binding,
+			type: "analytics_engine",
+			dataset,
 		});
 	});
 

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -901,6 +901,7 @@ async function getBindings(
 		],
 		dispatch_namespaces: configParam.dispatch_namespaces,
 		services: configParam.services,
+		analytics_engine_datasets: configParam.analytics_engine_datasets,
 		unsafe: configParam.unsafe?.bindings,
 		logfwdr: configParam.logfwdr,
 		d1_databases: identifyD1BindingsAsBeta([

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -543,6 +543,7 @@ export function createCLIParser(argv: string[]) {
 				r2_buckets: config.r2_buckets,
 				d1_databases: config.d1_databases,
 				services: config.services,
+				analytics_engine_datasets: config.analytics_engine_datasets,
 				dispatch_namespaces: config.dispatch_namespaces,
 				logfwdr: config.logfwdr,
 				unsafe: { bindings: config.unsafe?.bindings },

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -862,6 +862,14 @@ async function getWorkerConfig(
 						];
 					}
 					break;
+				case "analytics_engine":
+					{
+						configObj.analytics_engine_datasets = [
+							...(configObj.analytics_engine_datasets ?? []),
+							{ binding: binding.name, dataset: binding.dataset },
+						];
+					}
+					break;
 				case "namespace":
 					{
 						configObj.dispatch_namespaces = [

--- a/packages/wrangler/src/publish/publish.ts
+++ b/packages/wrangler/src/publish/publish.ts
@@ -540,6 +540,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			r2_buckets: config.r2_buckets,
 			d1_databases: identifyD1BindingsAsBeta(config.d1_databases),
 			services: config.services,
+			analytics_engine_datasets: config.analytics_engine_datasets,
 			dispatch_namespaces: config.dispatch_namespaces,
 			logfwdr: config.logfwdr,
 			unsafe: config.unsafe?.bindings,

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -108,6 +108,7 @@ export const secret = (secretYargs: Argv<CommonYargsOptions>) => {
 									r2_buckets: [],
 									d1_databases: [],
 									services: [],
+									analytics_engine_datasets: [],
 									wasm_modules: {},
 									text_blobs: {},
 									data_blobs: {},

--- a/packages/wrangler/src/type-generation.ts
+++ b/packages/wrangler/src/type-generation.ts
@@ -59,6 +59,12 @@ export async function generateTypes(
 		}
 	}
 
+	if (configToDTS.analytics_engine_datasets) {
+		for (const analyticsEngine of configToDTS.analytics_engine_datasets) {
+			envTypeStructure.push(`	${analyticsEngine.binding}: Dataset;`);
+		}
+	}
+
 	if (configToDTS.dispatch_namespaces) {
 		for (const namespace of configToDTS.dispatch_namespaces) {
 			envTypeStructure.push(`${namespace.binding}: any;`);

--- a/packages/wrangler/src/type-generation.ts
+++ b/packages/wrangler/src/type-generation.ts
@@ -61,7 +61,7 @@ export async function generateTypes(
 
 	if (configToDTS.analytics_engine_datasets) {
 		for (const analyticsEngine of configToDTS.analytics_engine_datasets) {
-			envTypeStructure.push(`	${analyticsEngine.binding}: Dataset;`);
+			envTypeStructure.push(`	${analyticsEngine.binding}: AnalyticsEngineDataset;`);
 		}
 	}
 

--- a/packages/wrangler/src/type-generation.ts
+++ b/packages/wrangler/src/type-generation.ts
@@ -62,7 +62,7 @@ export async function generateTypes(
 	if (configToDTS.analytics_engine_datasets) {
 		for (const analyticsEngine of configToDTS.analytics_engine_datasets) {
 			envTypeStructure.push(
-				`	${analyticsEngine.binding}: AnalyticsEngineDataset;`
+				`${analyticsEngine.binding}: AnalyticsEngineDataset;`
 			);
 		}
 	}

--- a/packages/wrangler/src/type-generation.ts
+++ b/packages/wrangler/src/type-generation.ts
@@ -61,7 +61,9 @@ export async function generateTypes(
 
 	if (configToDTS.analytics_engine_datasets) {
 		for (const analyticsEngine of configToDTS.analytics_engine_datasets) {
-			envTypeStructure.push(`	${analyticsEngine.binding}: AnalyticsEngineDataset;`);
+			envTypeStructure.push(
+				`	${analyticsEngine.binding}: AnalyticsEngineDataset;`
+			);
 		}
 	}
 

--- a/packages/wrangler/src/worker.ts
+++ b/packages/wrangler/src/worker.ts
@@ -144,6 +144,11 @@ interface CfService {
 	environment?: string;
 }
 
+interface CfAnalyticsEngineDataset {
+	binding: string;
+	dataset?: string;
+}
+
 interface CfDispatchNamespace {
 	binding: string;
 	namespace: string;
@@ -207,6 +212,7 @@ export interface CfWorkerInit {
 		r2_buckets: CfR2Bucket[] | undefined;
 		d1_databases: CfD1Database[] | undefined;
 		services: CfService[] | undefined;
+		analytics_engine_datasets: CfAnalyticsEngineDataset[] | undefined;
 		dispatch_namespaces: CfDispatchNamespace[] | undefined;
 		logfwdr: CfLogfwdr | undefined;
 		unsafe: CfUnsafeBinding[] | undefined;


### PR DESCRIPTION
I've tried to add support for an `analytics_engine_datasets` section in wrangler.toml. To avoid having to use unsafe bindings.