### PR TITLE
[Fix] `vars` string type

### DIFF
--- a/.changeset/yellow-files-argue.md
+++ b/.changeset/yellow-files-argue.md
@@ -1,0 +1,6 @@
+---
+"wrangler": patch
+---
+
+Fix Var string type:
+The type was not being coerced to a string, so TypeScript considered it a unresolved type.

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -100,8 +100,8 @@ describe("generateTypes()", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 		"interface Env {
 			TEST_KV_NAMESPACE: KVNamespace;
-			SOMETHING: asdasdfasdf;
-			ANOTHER: thing;
+			SOMETHING: \\"asdasdfasdf\\";
+			ANOTHER: \\"thing\\";
 			OBJECT_VAR: {\\"enterprise\\":\\"1701-D\\",\\"activeDuty\\":true,\\"captian\\":\\"Picard\\"};
 			DURABLE_TEST1: DurableObjectNamespace;
 			DURABLE_TEST2: DurableObjectNamespace;

--- a/packages/wrangler/src/type-generation.ts
+++ b/packages/wrangler/src/type-generation.ts
@@ -30,7 +30,7 @@ export async function generateTypes(
 				typeof varValue === "number" ||
 				typeof varValue === "boolean"
 			) {
-				envTypeStructure.push(`	${varName}: ${varValue};`);
+				envTypeStructure.push(`	${varName}: "${varValue}";`);
 			}
 			if (typeof varValue === "object" && varValue !== null) {
 				envTypeStructure.push(`	${varName}: ${JSON.stringify(varValue)};`);


### PR DESCRIPTION
The type was not being coerced to a string, so TypeScript considered it a unresolved type.