### PR TITLE
Validate object size for wrangler r2 put

### DIFF
--- a/.changeset/old-doors-enjoy.md
+++ b/.changeset/old-doors-enjoy.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Validate object size for wrangler r2 put

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -295,10 +295,12 @@ describe("r2", () => {
 			fs.writeFileSync("wormhole-img.png", Buffer.alloc(TOO_BIG_FILE_SIZE));
 			await expect(
 				runWrangler(
-				`r2 object put bucketName-object-test/wormhole-img.png --file ./wormhole-img.png`
+					`r2 object put bucketName-object-test/wormhole-img.png --file ./wormhole-img.png`
 				)
 			).rejects.toThrowErrorMatchingInlineSnapshot(`
-			"Error: Wrangler only supports uploading files up to ${prettyBytes(MAX_UPLOAD_SIZE)} in size
+			"Error: Wrangler only supports uploading files up to ${prettyBytes(
+				MAX_UPLOAD_SIZE
+			)} in size
 			wormhole-img.png is ${prettyBytes(TOO_BIG_FILE_SIZE)} in size"
 		`);
 		});

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import { rest } from "msw";
 import prettyBytes from "pretty-bytes";
-import { MAX_UPLOAD_SIZE } from "../r2/helpers"
+import { MAX_UPLOAD_SIZE } from "../r2/constants";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { msw, mswSuccessR2handlers } from "./helpers/msw";

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -299,7 +299,7 @@ describe("r2", () => {
 				)
 			).rejects.toThrowErrorMatchingInlineSnapshot(`
 			"Error: Wrangler only supports uploading files up to ${prettyBytes(MAX_UPLOAD_SIZE)} in size
-			wormhole-img.png is ${prettyBytes(TEST_FILE_SIZE)} in size"
+			wormhole-img.png is ${prettyBytes(TOO_BIG_FILE_SIZE)} in size"
 		`);
 		});
 

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -291,8 +291,8 @@ describe("r2", () => {
 		});
 
 		it("should fail to upload R2 object to bucket if too large", async () => {
-			const TEST_FILE_SIZE = MAX_UPLOAD_SIZE + 1024 * 1024;
-			fs.writeFileSync("wormhole-img.png", Buffer.alloc(TEST_FILE_SIZE));
+			const TOO_BIG_FILE_SIZE = MAX_UPLOAD_SIZE + 1024 * 1024;
+			fs.writeFileSync("wormhole-img.png", Buffer.alloc(TOO_BIG_FILE_SIZE));
 			await expect(
 				runWrangler(
 				`r2 object put bucketName-object-test/wormhole-img.png --file ./wormhole-img.png`

--- a/packages/wrangler/src/r2/constants.ts
+++ b/packages/wrangler/src/r2/constants.ts
@@ -1,0 +1,4 @@
+/**
+ * The maximum file size we can upload using the V4 API.
+ */
+export const MAX_UPLOAD_SIZE = 300 * 1024 * 1024;

--- a/packages/wrangler/src/r2/helpers.ts
+++ b/packages/wrangler/src/r2/helpers.ts
@@ -4,6 +4,11 @@ import { fetchR2Objects } from "../cfetch/internal";
 import type { HeadersInit } from "undici";
 
 /**
+ * The maximum file size we can upload using the V4 API.
+ */
+export const MAX_UPLOAD_SIZE = 300 * 1024 * 1024;
+
+/**
  * Information about a bucket, returned from `listR2Buckets()`.
  */
 export interface R2BucketInfo {

--- a/packages/wrangler/src/r2/helpers.ts
+++ b/packages/wrangler/src/r2/helpers.ts
@@ -4,11 +4,6 @@ import { fetchR2Objects } from "../cfetch/internal";
 import type { HeadersInit } from "undici";
 
 /**
- * The maximum file size we can upload using the V4 API.
- */
-export const MAX_UPLOAD_SIZE = 300 * 1024 * 1024;
-
-/**
  * Information about a bucket, returned from `listR2Buckets()`.
  */
 export interface R2BucketInfo {

--- a/packages/wrangler/src/r2/index.ts
+++ b/packages/wrangler/src/r2/index.ts
@@ -22,7 +22,7 @@ import type { ConfigPath } from "../index";
 import type { Readable } from "node:stream";
 import type { BuilderCallback } from "yargs";
 
-export const MAX_UPLOAD_SIZE = 300 * 1024 * 1024;
+const MAX_UPLOAD_SIZE = 300 * 1024 * 1024;
 
 export const r2: BuilderCallback<unknown, unknown> = (r2Yargs) => {
 	return r2Yargs

--- a/packages/wrangler/src/r2/index.ts
+++ b/packages/wrangler/src/r2/index.ts
@@ -9,6 +9,7 @@ import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { requireAuth } from "../user";
 import {
+	MAX_UPLOAD_SIZE,
 	bucketAndKeyFromObjectPath,
 	createR2Bucket,
 	deleteR2Bucket,
@@ -21,8 +22,6 @@ import {
 import type { ConfigPath } from "../index";
 import type { Readable } from "node:stream";
 import type { BuilderCallback } from "yargs";
-
-const MAX_UPLOAD_SIZE = 300 * 1024 * 1024;
 
 export const r2: BuilderCallback<unknown, unknown> = (r2Yargs) => {
 	return r2Yargs

--- a/packages/wrangler/src/r2/index.ts
+++ b/packages/wrangler/src/r2/index.ts
@@ -9,7 +9,9 @@ import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { requireAuth } from "../user";
 import {
-	MAX_UPLOAD_SIZE,
+	MAX_UPLOAD_SIZE
+} from "./constants";
+import {
 	bucketAndKeyFromObjectPath,
 	createR2Bucket,
 	deleteR2Bucket,

--- a/packages/wrangler/src/r2/index.ts
+++ b/packages/wrangler/src/r2/index.ts
@@ -3,14 +3,12 @@ import * as stream from "node:stream";
 
 import prettyBytes from "pretty-bytes";
 import { readConfig } from "../config";
-import {FatalError} from "../errors";
+import { FatalError } from "../errors";
 import { CommandLineArgsError, printWranglerBanner } from "../index";
 import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { requireAuth } from "../user";
-import {
-	MAX_UPLOAD_SIZE
-} from "./constants";
+import { MAX_UPLOAD_SIZE } from "./constants";
 import {
 	bucketAndKeyFromObjectPath,
 	createR2Bucket,


### PR DESCRIPTION
Closes https://github.com/cloudflare/wrangler2/issues/2171

Uses the `key` provided since there won't always be a `file` name, in the event it's using piped data.

Before:

```sh
➜  ~ npx wrangler r2 object put sdk-example/test.tmp -f ./test.tmp
 ⛅️ wrangler 2.2.1
-------------------
Creating object "test.tmp" in bucket "sdk-example".

✘ [ERROR] Failed to fetch /accounts/134a5a2c0ba47b38eada4b9c8ead10b6/r2/buckets/sdk-example/objects/test.tmp - 413: Request Entity Too Large);


If you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose
```

After:

```sh
> node -r esbuild-register scripts/bundle.ts

 ⛅️ wrangler 2.2.1 
-------------------

✘ [ERROR] Error: Wrangler only supports uploading files up to 315 MB in size

  test.tmp is 316 MB in size


If you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose
```

## To-Do

What's the most efficient way to demonstrate this in tests? Since `objectSize` is calculated by `fs.statSync` or `byteLength` of the stream, it seems like it'd be horribly inefficient to just create a 301MB asset during the tests - or is that fine? 🤷 

Also, I think we should mention the S3 API can be used to upload larger files. Do we link to the documentation directly or just mention to use it?