### PR TITLE
Install `libc++1` in GitHub actions jobs

### DIFF
--- a/.github/workflows/codecov-context.yml
+++ b/.github/workflows/codecov-context.yml
@@ -22,6 +22,13 @@ jobs:
           node-version: 16.13
           cache: "npm" # cache ~/.npm in case 'npm ci' needs to run
 
+      - name: Install workerd Dependencies
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update
+          sudo apt-get install -y libc++1
+
       - name: Install NPM Dependencies
         run: npm ci
 

--- a/.github/workflows/create-pullrequest-prerelease.yml
+++ b/.github/workflows/create-pullrequest-prerelease.yml
@@ -20,6 +20,13 @@ jobs:
           node-version: 16.13
           cache: "npm" # cache ~/.npm in case 'npm ci' needs to run
 
+      - name: Install workerd Dependencies
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update
+          sudo apt-get install -y libc++1
+
       - name: Install NPM Dependencies
         run: npm ci
 

--- a/.github/workflows/d1.yml
+++ b/.github/workflows/d1.yml
@@ -22,6 +22,13 @@ jobs:
           node-version: 16.13
           cache: "npm" # cache ~/.npm in case 'npm ci' needs to run
 
+      - name: Install workerd Dependencies
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update
+          sudo apt-get install -y libc++1
+
       - name: Install NPM Dependencies
         run: npm ci
 

--- a/.github/workflows/experimental-wasm-release.yml
+++ b/.github/workflows/experimental-wasm-release.yml
@@ -21,6 +21,13 @@ jobs:
           node-version: 16.13
           cache: "npm" # cache ~/.npm in case 'npm ci' needs to run
 
+      - name: Install workerd Dependencies
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update
+          sudo apt-get install -y libc++1
+
       - name: Install NPM Dependencies
         run: npm ci
 

--- a/.github/workflows/prereleases.yml
+++ b/.github/workflows/prereleases.yml
@@ -22,6 +22,13 @@ jobs:
           node-version: 16.13
           cache: "npm" # cache ~/.npm in case 'npm ci' needs to run
 
+      - name: Install workerd Dependencies
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update
+          sudo apt-get install -y libc++1
+
       - name: Install NPM Dependencies
         run: npm ci
 
@@ -60,6 +67,13 @@ jobs:
         with:
           node-version: 16.13
           cache: "npm" # cache ~/.npm in case 'npm ci' needs to run
+
+      - name: Install workerd Dependencies
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update
+          sudo apt-get install -y libc++1
 
       - name: Install NPM Dependencies
         run: npm ci

--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -26,6 +26,13 @@ jobs:
             tsconfig.tsbuildinfo
           key: ${{ matrix.os }}-eslint-tsbuildinfo-${{ hashFiles('**/*.ts','**/*.js', 'package.json', 'tsconfig.json') }}
 
+      - name: Install workerd Dependencies
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update
+          sudo apt-get install -y libc++1
+
       - name: Install NPM Dependencies
         run: npm ci
 
@@ -49,6 +56,13 @@ jobs:
         with:
           node-version: 16.13
           cache: "npm" # cache ~/.npm in case 'npm ci' needs to run
+
+      - name: Install workerd Dependencies
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update
+          sudo apt-get install -y libc++1
 
       - name: Install NPM Dependencies
         run: npm ci

--- a/.github/workflows/queues.yml
+++ b/.github/workflows/queues.yml
@@ -22,6 +22,13 @@ jobs:
           node-version: 16.13
           cache: "npm" # cache ~/.npm in case 'npm ci' needs to run
 
+      - name: Install workerd Dependencies
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update
+          sudo apt-get install -y libc++1
+
       - name: Install NPM Dependencies
         run: npm ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,13 @@ jobs:
           node-version: 16.13
           cache: "npm" # cache ~/.npm in case 'npm ci' needs to run
 
+      - name: Install workerd Dependencies
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update
+          sudo apt-get install -y libc++1
+
       - name: Install NPM Dependencies
         run: npm ci
 


### PR DESCRIPTION
This is required by `workerd` at runtime. It also looks like this is indirectly required by `workerd`'s install script, so we need to install this any time we call `npm ci`.