### PR TITLE
use the `main` field instead of `browser` if `node-compat` is enabled

### DIFF
--- a/.changeset/slimy-parents-itch.md
+++ b/.changeset/slimy-parents-itch.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+---
+
+Use the `main` entrypoint for dependencies when `node_compat` is enabled.
+
+Previously, we would use the `"browser"` or `"worker"` entrypoint in a depedency's `package.json` for bundling.
+Now, if the user enables Node compatability, we target the `"main"` entrypoint.

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -304,7 +304,7 @@ export async function bundleWorker(
 		sourceRoot: destination,
 		minify,
 		metafile: true,
-		conditions: ["worker", "browser"],
+		conditions: nodeCompat ? ["main", "module"] : ["worker", "browser"],
 		...(process.env.NODE_ENV && {
 			define: {
 				// use process.env["NODE_ENV" + ""] so that esbuild doesn't replace it


### PR DESCRIPTION
Use the `main` entrypoint for dependencies when `node_compat` is enabled.

Previously, we would use the `"browser"` or `"worker"` entrypoint in a depedency's `package.json` for bundling.
Now, if the user enables Node compatability, we target the `"main"` entrypoint.

Closes #2157
