### PR TITLE
Use the user's preferred default branch name if set in .gitconfig

### DIFF
--- a/.changeset/gentle-rocks-sneeze.md
+++ b/.changeset/gentle-rocks-sneeze.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+---
+
+Use the user's preferred default branch name if set in .gitconfig.
+
+Previously, we would initialize new workers with `main` as the name of the default branch.
+Now, we see if the user has a custom setting in .gitconfig for `init.defaultBranch`, and use
+that if it exists.
+
+Closes #2112

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -529,7 +529,7 @@ describe("init", () => {
 			        }
 		      `);
 			expect((await execa("git", ["branch", "--show-current"])).stdout).toEqual(
-				"main"
+				getDefaultBranchName()
 			);
 		});
 
@@ -598,7 +598,7 @@ describe("init", () => {
 			"should not offer to initialize a git repo if git is not installed"
 		);
 
-		it("should initialize git repo with `main` default branch", async () => {
+		it("should initialize git repo with the user's default branch", async () => {
 			mockConfirm(
 				{
 					text: "Would you like to use git to manage this Worker?",
@@ -621,7 +621,7 @@ describe("init", () => {
 		      `);
 
 			expect(execaSync("git", ["symbolic-ref", "HEAD"]).stdout).toEqual(
-				"refs/heads/main"
+				`refs/heads/${getDefaultBranchName()}`
 			);
 		});
 	});
@@ -2809,6 +2809,20 @@ describe("init", () => {
 		});
 	});
 });
+
+function getDefaultBranchName() {
+	try {
+		const { stdout: defaultBranchName } = execaSync("git", [
+			"config",
+			"--get",
+			"init.defaultBranch",
+		]);
+
+		return defaultBranchName;
+	} catch {
+		return "main";
+	}
+}
 
 /**
  * Change the current working directory, ensuring that this exists.

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -2820,7 +2820,8 @@ function getDefaultBranchName() {
 
 		return defaultBranchName;
 	} catch {
-		return "main";
+		// ew
+		return "master";
 	}
 }
 

--- a/packages/wrangler/src/git-client.ts
+++ b/packages/wrangler/src/git-client.ts
@@ -42,10 +42,21 @@ export async function getGitVersioon(): Promise<string | null> {
  */
 export async function initializeGit(cwd: string) {
 	try {
-		// Try to create the repository with the HEAD branch of `main`.
-		await execa("git", ["init", "--initial-branch", "main"], {
-			cwd,
-		});
+		// Get the default init branch name
+		const { stdout: defaultBranchName } = await execa("git", [
+			"config",
+			"--get",
+			"init.defaultBranch",
+		]);
+
+		// Try to create the repository with the HEAD branch of defaultBranchName ?? `main`.
+		await execa(
+			"git",
+			["init", "--initial-branch", defaultBranchName.trim() ?? "main"],
+			{
+				cwd,
+			}
+		);
 	} catch {
 		// Unable to create the repo with a HEAD branch name, so just fall back to the default.
 		await execa("git", ["init"], {


### PR DESCRIPTION
Previously, we would initialize new workers with `main` as the name of the default branch.
Now, we see if the user has a custom setting in .gitconfig for `init.defaultBranch`, and use
that if it exists.

Closes #2112
