### PR TITLE
Trigger login flow if a user runs `wrangler dev` while logged out

### DIFF
--- a/.changeset/bright-donkeys-pay.md
+++ b/.changeset/bright-donkeys-pay.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+---
+
+Trigger login flow if a user runs `wrangler dev` while logged out
+
+Previously, we would just error if a user logged out and then ran `wrangler dev`.
+Now, we kick them to the OAuth flow and suggest running `wrangler dev --local` if
+the login fails.
+
+Closes [#2147](https://github.com/cloudflare/wrangler2/issues/2147)

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -13,7 +13,7 @@ import { getEntry } from "./entry";
 import { logger } from "./logger";
 import * as metrics from "./metrics";
 import { getAssetPaths, getSiteAssetPaths } from "./sites";
-import { getAccountFromCache } from "./user";
+import { getAccountFromCache, loginOrRefreshIfRequired } from "./user";
 import { collectKeyValues } from "./utils/collectKeyValues";
 import { identifyD1BindingsAsBeta } from "./worker";
 import { getHostFromRoute, getZoneForRoute, getZoneIdFromHost } from "./zones";
@@ -303,6 +303,15 @@ export function devOptions(yargs: Argv<CommonYargsOptions>): Argv<DevArgs> {
 }
 
 export async function devHandler(args: ArgumentsCamelCase<DevArgs>) {
+	if (!args.local) {
+		const isLoggedIn = await loginOrRefreshIfRequired();
+		if (!isLoggedIn) {
+			throw new Error(
+				"You must be logged in to use wrangler dev in remote mode. Try logging in, or run wrangler dev --local."
+			);
+		}
+	}
+
 	let watcher;
 	try {
 		const devInstance = await startDev(args);


### PR DESCRIPTION
Previously, we would just error if a user logged out and then ran `wrangler dev`.
Now, we kick them to the OAuth flow and suggest running `wrangler dev --local` if
the login fails.

Closes [#2147](https://github.com/cloudflare/wrangler2/issues/2147)
