### PR TITLE
use 🇶  instead of 🆀 for queues

### DIFF
--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -42,7 +42,7 @@ describe("wrangler", () => {
 			  wrangler kv:key              🔑 Individually manage Workers KV key-value pairs
 			  wrangler kv:bulk             💪 Interact with multiple Workers KV key-value pairs at once
 			  wrangler pages               ⚡️ Configure Cloudflare Pages
-			  wrangler queues              🆀 Configure Workers Queues
+			  wrangler queues              🇶 Configure Workers Queues
 			  wrangler r2                  📦 Interact with an R2 store
 			  wrangler dispatch-namespace  📦 Interact with a dispatch namespace
 			  wrangler d1                  🗄  Interact with a D1 database
@@ -87,7 +87,7 @@ describe("wrangler", () => {
 			  wrangler kv:key              🔑 Individually manage Workers KV key-value pairs
 			  wrangler kv:bulk             💪 Interact with multiple Workers KV key-value pairs at once
 			  wrangler pages               ⚡️ Configure Cloudflare Pages
-			  wrangler queues              🆀 Configure Workers Queues
+			  wrangler queues              🇶 Configure Workers Queues
 			  wrangler r2                  📦 Interact with an R2 store
 			  wrangler dispatch-namespace  📦 Interact with a dispatch namespace
 			  wrangler d1                  🗄  Interact with a D1 database

--- a/packages/wrangler/src/__tests__/queues.test.ts
+++ b/packages/wrangler/src/__tests__/queues.test.ts
@@ -22,7 +22,7 @@ describe("wrangler", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 			"wrangler queues
 
-			🆀 Configure Workers Queues
+			🇶 Configure Workers Queues
 
 			Commands:
 			  wrangler queues list           List Queues

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -398,7 +398,7 @@ export function createCLIParser(argv: string[]) {
 	});
 
 	// queues
-	wrangler.command("queues", "🆀 Configure Workers Queues", (queuesYargs) => {
+	wrangler.command("queues", "🇶 Configure Workers Queues", (queuesYargs) => {
 		return queues(queuesYargs.command(subHelp));
 	});
 


### PR DESCRIPTION
Quality assurance reporting for duty. This is critical.