### PR TITLE
Use latest ubuntu for all tests

### DIFF
--- a/.github/workflows/codecov-context.yml
+++ b/.github/workflows/codecov-context.yml
@@ -8,7 +8,7 @@ jobs:
   codecov:
     if: ${{ github.repository_owner == 'cloudflare' }}
     name: CodeCov Main Branch Updater
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/create-pullrequest-prerelease.yml
+++ b/.github/workflows/create-pullrequest-prerelease.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     if: ${{ github.repository_owner == 'cloudflare' }}
     name: Build & Publish a Prerelease to the Adhoc Registry
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/d1.yml
+++ b/.github/workflows/d1.yml
@@ -8,7 +8,7 @@ jobs:
   release:
     if: ${{ github.repository_owner == 'cloudflare' }}
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/experimental-wasm-release.yml
+++ b/.github/workflows/experimental-wasm-release.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     if: ${{ github.repository_owner == 'cloudflare' }}
     name: Build and release `wrangler@wasm` to NPM
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   add-to-project:
     name: Add issue to project
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/add-to-project@v0.3.0
         with:

--- a/.github/workflows/prereleases.yml
+++ b/.github/workflows/prereleases.yml
@@ -8,7 +8,7 @@ jobs:
   prerelease:
     if: ${{ github.repository_owner == 'cloudflare' }}
     name: Build & Publish a beta release to NPM
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Repo
@@ -54,7 +54,7 @@ jobs:
     if: ${{ github.repository_owner == 'cloudflare' }}
     name: Publish Prerelease Registry
     needs: prerelease
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -5,7 +5,7 @@ on: pull_request
 jobs:
   check:
     name: "Checks"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -43,7 +43,7 @@ jobs:
     name: "Tests"
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-22.04, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repo

--- a/.github/workflows/queues.yml
+++ b/.github/workflows/queues.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     if: ${{ github.repository_owner == 'cloudflare' }}
     name: Build and release `wrangler@queues` to NPM
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   release:
     if: ${{ github.repository_owner == 'cloudflare' }}
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/test-old-node-error.yml
+++ b/.github/workflows/test-old-node-error.yml
@@ -7,7 +7,7 @@ jobs:
     name: "Checks"
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-22.04, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repo

--- a/.github/workflows/write-prerelease-comment.yml
+++ b/.github/workflows/write-prerelease-comment.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   comment:
     if: ${{ github.repository_owner == 'cloudflare' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Write comment to the PR
     steps:
       - name: "Put PR and workflow ID on the environment"


### PR DESCRIPTION
Due to changes in `workerd`, and issues with `libc++` in ubuntu 20, use `ubuntu-22.04` instead of `ubuntu-latest` in CI