### PR TITLE
Add queue() handler support to the D1 beta facade shim

### DIFF
--- a/packages/wrangler/templates/d1-beta-facade.js
+++ b/packages/wrangler/templates/d1-beta-facade.js
@@ -170,5 +170,9 @@ var shim_default = {
 	async scheduled(controller, env, ctx) {
 		return worker.scheduled(controller, getMaskedEnv(env), ctx);
 	},
+
+	async queue(controller, env, ctx) {
+		return worker.queue(controller, getMaskedEnv(env), ctx);
+	},
 };
 export { shim_default as default };


### PR DESCRIPTION
So that the queue() handler can be invoked on a worker that binds to D1.

Fixes #2131

To be honest I didn't actually test this, but this so obviously looks to be what we need.

@geelen @jbw1991 