### PR TITLE
Tweaking display of d1 execute (for large files in particular)

### DIFF
--- a/.changeset/loud-toys-guess.md
+++ b/.changeset/loud-toys-guess.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: truncate lines longer than 70 chars when executing d1 sql

--- a/packages/wrangler/src/d1/execute.tsx
+++ b/packages/wrangler/src/d1/execute.tsx
@@ -142,7 +142,7 @@ export const Handler = withConfig<ExecuteArgs>(
 	}): Promise<void> => {
 		logger.log(d1BetaWarning);
 		if (file && command)
-			return console.error(`Error: can't provide both --command and --file.`);
+			return logger.error(`Error: can't provide both --command and --file.`);
 
 		const isInteractive = process.stdout.isTTY;
 		const response: QueryResult[] | null = await executeSql(
@@ -181,7 +181,7 @@ export const Handler = withConfig<ExecuteArgs>(
 				</Static>
 			);
 		} else {
-			console.log(JSON.stringify(response, null, 2));
+			logger.log(JSON.stringify(response, null, 2));
 		}
 	}
 );
@@ -251,7 +251,7 @@ async function executeRemotely(
 			if (!ok) return null;
 			logger.log(`🌀 Let's go`);
 		} else {
-			console.error(warning);
+			logger.error(warning);
 		}
 	}
 
@@ -268,13 +268,13 @@ async function executeRemotely(
 		// Don't output if shouldPrompt is undefined
 	} else if (shouldPrompt !== undefined) {
 		// Pipe to error so we don't break jq
-		console.error(`Executing on ${name} (${db.uuid}):`);
+		logger.error(`Executing on ${name} (${db.uuid}):`);
 	}
 
 	const results: QueryResult[] = [];
 	for (const sql of batches) {
 		if (multiple_batches)
-			console.log(
+			logger.log(
 				chalk.gray(`  ${sql.slice(0, 70)}${sql.length > 70 ? "..." : ""}`)
 			);
 


### PR DESCRIPTION
Takes some lines out when the commands fit in a single batch, and gives the user some context about where each batch starts if there are multiple, e.g.

<img width="710" alt="image" src="https://user-images.githubusercontent.com/23264/202170019-00b58b95-d641-4660-ba92-0314a3e0fbb4.png">
