### PR TITLE
chore: run fixture tests first

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
 	"license": "MIT OR Apache-2.0",
 	"author": "wrangler@cloudflare.com",
 	"workspaces": [
-		"packages/*",
-		"fixtures/*"
+		"fixtures/*",
+		"packages/*"
 	],
 	"scripts": {
 		"build": "npm run build --workspace=wrangler --workspace=jest-environment-wrangler --workspace=pages-plugin-example --workspace=wranglerjs-compat-webpack-plugin",


### PR DESCRIPTION
While the unstable_dev tests are flaky, ideally we should run them first so we don't have to wait for them to flake after all the other tests pass