### PR TITLE
fix: Upload filepath-routing configuration in wrangler pages publish

### DIFF
--- a/.changeset/wicked-rules-run.md
+++ b/.changeset/wicked-rules-run.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: Upload filepath-routing configuration in wrangler pages publish
+
+Publishing Pages projects containing a functions directory incorrectly did not upload the filepath-routing config so that the user can view it in Dash. This fixes that, making the generated routes viewable under `Routing configuration` in the `Functions` tab of a deployment.

--- a/packages/wrangler/src/__tests__/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages.test.ts
@@ -1209,27 +1209,23 @@ describe("pages", () => {
 						});
 
 						// Make sure the routing config is valid json
-						expect(() =>
-							JSON.parse(generatedFilepathRoutingConfig)
-						).not.toThrowError();
+						const parsedFilepathRoutingConfig = JSON.parse(
+							generatedFilepathRoutingConfig
+						);
 						// The actual shape doesn't matter that much since this
-						// is only used for display in Dash, but this snapshot
-						// is a good way to track unintentional changes.
-						expect(generatedFilepathRoutingConfig).toMatchInlineSnapshot(`
-				"{
-				  \\"routes\\": [
-				    {
-				      \\"routePath\\": \\"/hello\\",
-				      \\"mountPath\\": \\"/\\",
-				      \\"method\\": \\"\\",
-				      \\"module\\": [
-				        \\"hello.js:onRequest\\"
-				      ]
-				    }
-				  ],
-				  \\"baseURL\\": \\"/\\"
-				}"
-			`);
+						// is only used for display in Dash, but it's still useful for
+						// tracking unexpected changes to this config.
+						expect(parsedFilepathRoutingConfig).toStrictEqual({
+							routes: [
+								{
+									routePath: "/hello",
+									mountPath: "/",
+									method: "",
+									module: ["hello.js:onRequest"],
+								},
+							],
+							baseURL: "/",
+						});
 					});
 
 					return {

--- a/packages/wrangler/src/__tests__/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages.test.ts
@@ -1480,10 +1480,14 @@ describe("pages", () => {
 						const customRoutesJSON = await (
 							body.get("_routes.json") as Blob
 						).text();
+						const generatedFilepathRoutingConfig = await (
+							body.get("functions-filepath-routing-config.json") as Blob
+						).text();
 
 						// make sure this is all we uploaded
 						expect([...body.keys()]).toEqual([
 							"manifest",
+							"functions-filepath-routing-config.json",
 							"_worker.js",
 							"_routes.json",
 						]);
@@ -1504,6 +1508,32 @@ describe("pages", () => {
 							description: "Custom _routes.json file",
 							include: ["/hello"],
 							exclude: [],
+						});
+
+						// Make sure the routing config is valid json
+						const parsedFilepathRoutingConfig = JSON.parse(
+							generatedFilepathRoutingConfig
+						);
+						// The actual shape doesn't matter that much since this
+						// is only used for display in Dash, but it's still useful for
+						// tracking unexpected changes to this config.
+						console.log(generatedFilepathRoutingConfig);
+						expect(parsedFilepathRoutingConfig).toStrictEqual({
+							routes: [
+								{
+									routePath: "/goodbye",
+									mountPath: "/",
+									method: "",
+									module: ["goodbye.ts:onRequest"],
+								},
+								{
+									routePath: "/hello",
+									mountPath: "/",
+									method: "",
+									module: ["hello.js:onRequest"],
+								},
+							],
+							baseURL: "/",
 						});
 					});
 

--- a/packages/wrangler/src/__tests__/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages.test.ts
@@ -1165,16 +1165,21 @@ describe("pages", () => {
 						const body = init.body as FormData;
 						const manifest = JSON.parse(body.get("manifest") as string);
 
-						// for Functions projects, we auto-generate a `_worker.js` and `_routes.json`
+						// for Functions projects, we auto-generate a `_worker.js`,
+						// `functions-filepath-routing-config.json`, and `_routes.json`
 						// file, based on the contents of `/functions`
 						const generatedWorkerJS = body.get("_worker.js") as Blob;
 						const generatedRoutesJSON = await (
 							body.get("_routes.json") as Blob
 						).text();
+						const generatedFilepathRoutingConfig = await (
+							body.get("functions-filepath-routing-config.json") as Blob
+						).text();
 
 						// make sure this is all we uploaded
 						expect([...body.keys()]).toEqual([
 							"manifest",
+							"functions-filepath-routing-config.json",
 							"_worker.js",
 							"_routes.json",
 						]);
@@ -1202,6 +1207,29 @@ describe("pages", () => {
 							include: ["/hello"],
 							exclude: [],
 						});
+
+						// Make sure the routing config is valid json
+						expect(() =>
+							JSON.parse(generatedFilepathRoutingConfig)
+						).not.toThrowError();
+						// The actual shape doesn't matter that much since this
+						// is only used for display in Dash, but this snapshot
+						// is a good way to track unintentional changes.
+						expect(generatedFilepathRoutingConfig).toMatchInlineSnapshot(`
+				"{
+				  \\"routes\\": [
+				    {
+				      \\"routePath\\": \\"/hello\\",
+				      \\"mountPath\\": \\"/\\",
+				      \\"method\\": \\"\\",
+				      \\"module\\": [
+				        \\"hello.js:onRequest\\"
+				      ]
+				    }
+				  ],
+				  \\"baseURL\\": \\"/\\"
+				}"
+			`);
 					});
 
 					return {

--- a/packages/wrangler/src/pages/publish.tsx
+++ b/packages/wrangler/src/pages/publish.tsx
@@ -275,11 +275,20 @@ export const Handler = async ({
 		? join(tmpdir(), `_routes-${Math.random()}.json`)
 		: undefined;
 
+	// Routing configuration displayed in the Functions tab of a deployment in Dash
+	let filepathRoutingConfig: string | undefined;
+
 	if (!_workerJS && existsSync(functionsDirectory)) {
 		const outfile = join(tmpdir(), `./functionsWorker-${Math.random()}.js`);
+		const outputConfigPath = join(
+			tmpdir(),
+			`functions-filepath-routing-config-${Math.random()}.json`
+		);
+
 		try {
 			await buildFunctions({
 				outfile,
+				outputConfigPath,
 				functionsDirectory,
 				onEnd: () => {},
 				buildOutputDirectory: dirname(outfile),
@@ -292,6 +301,7 @@ export const Handler = async ({
 			});
 
 			builtFunctions = readFileSync(outfile, "utf-8");
+			filepathRoutingConfig = readFileSync(outputConfigPath, "utf-8");
 		} catch (e) {
 			if (e instanceof FunctionsNoRoutesError) {
 				logger.warn(
@@ -333,6 +343,16 @@ export const Handler = async ({
 	if (_redirects) {
 		formData.append("_redirects", new File([_redirects], "_redirects"));
 		logger.log(`✨ Uploading _redirects`);
+	}
+
+	if (filepathRoutingConfig) {
+		formData.append(
+			"functions-filepath-routing-config.json",
+			new File(
+				[filepathRoutingConfig],
+				"functions-filepath-routing-config.json"
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
Publishing Pages projects containing a functions directory incorrectly did not upload the filepath-routing config so that the user can view it in Dash. This fixes that, making the generated routes viewable under `Routing configuration` in the `Functions` tab of a deployment.
Testing:
- Added tests that show the file is being uploaded
- e2e tested