### PR TITLE
Update to CONTRIBUTING.md: we follow semver now

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -229,8 +229,8 @@ We should be consistent with the word that describes how we get a worker to the 
 
 We use the following guidelines to determine the kind of change for a PR:
 
-- Bugfixes are considered to be 'patch' changes.
-- New features (both experimental and stable) and new deprecation warnings for future breaking changes are considered as 'minor' changes. These changes shouldn't break existing code, but the deprecation warnings should suggest alternate solutions to not trigger the warning. If the new feature is experimental and its behaviour may functionally change, be sure to log warnings whenever they're used.
+- Bugfixes and experimental features are considered to be 'patch' changes. Be sure to log warnings when experimental features are used.
+- New stable features and new deprecation warnings for future breaking changes are considered as 'minor' changes. These changes shouldn't break existing code, but the deprecation warnings should suggest alternate solutions to not trigger the warning.
 - Breaking changes are considered to be 'major' changes. These are usually when deprecations take effect, or functional breaking behaviour is added with relevant logs (either as errors or warnings.)
 
 ## Miniflare Development

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -229,7 +229,7 @@ We should be consistent with the word that describes how we get a worker to the 
 
 We use the following guidelines to determine the kind of change for a PR:
 
-- Bugfixes are considered to be 'patch' changes. 
+- Bugfixes are considered to be 'patch' changes.
 - New features (both experimental and stable) and new deprecation warnings for future breaking changes are considered as 'minor' changes. These changes shouldn't break existing code, but the deprecation warnings should suggest alternate solutions to not trigger the warning. If the new feature is experimental and its behaviour may functionally change, be sure to log warnings whenever they're used.
 - Breaking changes are considered to be 'major' changes. These are usually when deprecations take effect, or functional breaking behaviour is added with relevant logs (either as errors or warnings.)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,12 +225,12 @@ fix: replace the word "deploy" with "publish" everywhere.
 We should be consistent with the word that describes how we get a worker to the edge. The command is `publish`, so let's use that everywhere.
 ```
 
-### Types of changes (and deviation from semver)
+### Types of changes
 
 We use the following guidelines to determine the kind of change for a PR:
 
-- Bugfixes and new features are considered to be 'patch' changes. If the new feature is experimental and its behaviour may functionally change, be sure to log warnings whenever they're used. (You'll note that this is where we deviate from semver, which otherwise suggests that behaviour/api changes should go into minor releases. We may revisit this in the future.)
-- New deprecation warnings for future breaking changes are considered as 'minor' changes. These changes shouldn't break existing code, but the deprecation warnings should suggest alternate solutions to not trigger the warning.
+- Bugfixes are considered to be 'patch' changes. 
+- New features (both experimental and stable) and new deprecation warnings for future breaking changes are considered as 'minor' changes. These changes shouldn't break existing code, but the deprecation warnings should suggest alternate solutions to not trigger the warning. If the new feature is experimental and its behaviour may functionally change, be sure to log warnings whenever they're used.
 - Breaking changes are considered to be 'major' changes. These are usually when deprecations take effect, or functional breaking behaviour is added with relevant logs (either as errors or warnings.)
 
 ## Miniflare Development

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,7 +230,7 @@ We should be consistent with the word that describes how we get a worker to the 
 We use the following guidelines to determine the kind of change for a PR:
 
 - Bugfixes and experimental features are considered to be 'patch' changes. Be sure to log warnings when experimental features are used.
-- New stable features and new deprecation warnings for future breaking changes are considered as 'minor' changes. These changes shouldn't break existing code, but the deprecation warnings should suggest alternate solutions to not trigger the warning.
+- New stable features and new deprecation warnings for future breaking changes are considered 'minor' changes. These changes shouldn't break existing code, but the deprecation warnings should suggest alternate solutions to not trigger the warning.
 - Breaking changes are considered to be 'major' changes. These are usually when deprecations take effect, or functional breaking behaviour is added with relevant logs (either as errors or warnings.)
 
 ## Miniflare Development


### PR DESCRIPTION
The team agreed we should be following semver for wrangler2's versions. See https://github.com/cloudflare/wrangler2/discussions/1820.

If you weren't in that meeting, or had a change of heart, feel free to disagree in the comments below.

This PR updates our CONTRIBUTING.md to reflect this decision.