### PR TITLE
XDG compliant metrics directory

### DIFF
--- a/.changeset/brown-beers-cheat.md
+++ b/.changeset/brown-beers-cheat.md
@@ -2,8 +2,6 @@
 "wrangler": patch
 ---
 
-XDG compliant metrics directory
-When metrics was implemented the XDG compliant pathing was done in parrelel,
-this bring metrics directory into XDG compliance with other Wrangler root config.
+This change makes the metrics directory XDG compliant
 
 resolves #2075

--- a/.changeset/brown-beers-cheat.md
+++ b/.changeset/brown-beers-cheat.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+XDG compliant metrics directory
+When metrics was implemented the XDG compliant pathing was done in parrelel,
+this bring metrics directory into XDG compliance with other Wrangler root config.
+
+resolves #2075

--- a/packages/wrangler/src/__tests__/metrics.test.ts
+++ b/packages/wrangler/src/__tests__/metrics.test.ts
@@ -364,7 +364,7 @@ describe("metrics", () => {
 
 				expect(std.out).toMatchInlineSnapshot(`
 			"Usage metrics tracking has changed since you last granted permission.
-			Your choice has been saved in the following file: home/.wrangler/config/metrics.json.
+			Your choice has been saved in the following file: test-xdg-config/metrics.json.
 
 			  You can override the user level setting for a project in \`wrangler.toml\`:
 

--- a/packages/wrangler/src/metrics/metrics-config.ts
+++ b/packages/wrangler/src/metrics/metrics-config.ts
@@ -6,6 +6,7 @@ import { fetchResult } from "../cfetch";
 import { getConfigCache, saveToConfigCache } from "../config-cache";
 import { confirm } from "../dialogs";
 import { getEnvironmentVariableFactory } from "../environment-variables";
+import { getGlobalWranglerConfigPath } from "../global-wrangler-config-path";
 import { CI } from "../is-ci";
 import isInteractive from "../is-interactive";
 import { logger } from "../logger";
@@ -167,7 +168,7 @@ export function readMetricsConfig(): MetricsConfigFile {
  * Get the path to the metrics config file.
  */
 function getMetricsConfigPath(): string {
-	return path.resolve(os.homedir(), ".wrangler/config/metrics.json");
+	return path.resolve(getGlobalWranglerConfigPath(), "metrics.json");
 }
 
 /**

--- a/packages/wrangler/src/metrics/metrics-config.ts
+++ b/packages/wrangler/src/metrics/metrics-config.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
 import { readFileSync, mkdirSync, writeFileSync } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { fetchResult } from "../cfetch";
 import { getConfigCache, saveToConfigCache } from "../config-cache";


### PR DESCRIPTION
When metrics was implemented the XDG compliant pathing was done in parrelel, this bring metrics directory into XDG compliance with other Wrangler root config.

resolves #2075