### PR TITLE
Fix `--(experimental)-local` on Linux

### DIFF
--- a/.changeset/healthy-peaches-drive.md
+++ b/.changeset/healthy-peaches-drive.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix script reloads, and allow clean exits, when using `--experimental-local` on Linux

--- a/.changeset/unlucky-cars-shout.md
+++ b/.changeset/unlucky-cars-shout.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix DevTools inspector support when using `--(experimental-)local`

--- a/package-lock.json
+++ b/package-lock.json
@@ -2918,9 +2918,9 @@
 			}
 		},
 		"node_modules/@miniflare/tre": {
-			"version": "3.0.0-next.7",
-			"resolved": "https://registry.npmjs.org/@miniflare/tre/-/tre-3.0.0-next.7.tgz",
-			"integrity": "sha512-Gdr2vBAeFM2k/dgIMi7SQbcoOZsTudhkDP6NXxQkIPwUj3hTOEOjG2pi9D1ALgA4nxzpcIrxrxlnKkH+pqdt4w==",
+			"version": "3.0.0-next.8",
+			"resolved": "https://registry.npmjs.org/@miniflare/tre/-/tre-3.0.0-next.8.tgz",
+			"integrity": "sha512-ISrxERQTTanh8Sp1yuJCN0k+nFmuu1sOweCpCfSLDQ3Te4yJdrr1fp+OFuKbgzLn5eXK2NjxcQxP/J1eJfBIOQ==",
 			"dev": true,
 			"dependencies": {
 				"acorn": "^8.8.0",
@@ -22320,7 +22320,7 @@
 				"@databases/sql": "^3.2.0",
 				"@iarna/toml": "^3.0.0",
 				"@microsoft/api-extractor": "^7.28.3",
-				"@miniflare/tre": "^3.0.0-next.7",
+				"@miniflare/tre": "^3.0.0-next.8",
 				"@types/better-sqlite3": "^7.6.0",
 				"@types/busboy": "^1.5.0",
 				"@types/command-exists": "^1.2.0",
@@ -25477,9 +25477,9 @@
 			}
 		},
 		"@miniflare/tre": {
-			"version": "3.0.0-next.7",
-			"resolved": "https://registry.npmjs.org/@miniflare/tre/-/tre-3.0.0-next.7.tgz",
-			"integrity": "sha512-Gdr2vBAeFM2k/dgIMi7SQbcoOZsTudhkDP6NXxQkIPwUj3hTOEOjG2pi9D1ALgA4nxzpcIrxrxlnKkH+pqdt4w==",
+			"version": "3.0.0-next.8",
+			"resolved": "https://registry.npmjs.org/@miniflare/tre/-/tre-3.0.0-next.8.tgz",
+			"integrity": "sha512-ISrxERQTTanh8Sp1yuJCN0k+nFmuu1sOweCpCfSLDQ3Te4yJdrr1fp+OFuKbgzLn5eXK2NjxcQxP/J1eJfBIOQ==",
 			"dev": true,
 			"requires": {
 				"acorn": "^8.8.0",
@@ -38088,7 +38088,7 @@
 				"@miniflare/core": "2.10.0",
 				"@miniflare/d1": "2.10.0",
 				"@miniflare/durable-objects": "2.10.0",
-				"@miniflare/tre": "^3.0.0-next.7",
+				"@miniflare/tre": "^3.0.0-next.8",
 				"@types/better-sqlite3": "^7.6.0",
 				"@types/busboy": "^1.5.0",
 				"@types/command-exists": "^1.2.0",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -119,7 +119,7 @@
 		"@databases/sql": "^3.2.0",
 		"@iarna/toml": "^3.0.0",
 		"@microsoft/api-extractor": "^7.28.3",
-		"@miniflare/tre": "^3.0.0-next.7",
+		"@miniflare/tre": "^3.0.0-next.8",
 		"@types/better-sqlite3": "^7.6.0",
 		"@types/busboy": "^1.5.0",
 		"@types/command-exists": "^1.2.0",

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -164,13 +164,6 @@ function useLocalWorker({
 		async function startLocalWorker() {
 			if (!bundle || !format) return;
 
-			// port for the worker
-			await waitForPortToBeAvailable(initialPort, {
-				retryPeriod: 200,
-				timeout: 2000,
-				abortSignal: abortController.signal,
-			});
-
 			// In local mode, we want to copy all referenced modules into
 			// the output bundle directory before starting up
 			for (const module of bundle.modules) {
@@ -302,6 +295,15 @@ function useLocalWorker({
 
 				return;
 			}
+
+			// Wait for the Worker port to be available. We don't want to do this in experimental local
+			// mode, as we only `dispose()` the Miniflare 3 instance, and shutdown the server when
+			// unmounting the component, not when props change. If we did, we'd just timeout every time.
+			await waitForPortToBeAvailable(initialPort, {
+				retryPeriod: 200,
+				timeout: 2000,
+				abortSignal: abortController.signal,
+			});
 
 			const nodeOptions = setupNodeOptions({
 				inspect,
@@ -890,5 +892,5 @@ export async function getMiniflare3(): Promise<
 	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 	typeof import("@miniflare/tre")
 > {
-	return (miniflare3Module ??= await npxImport("@miniflare/tre@3.0.0-next.7"));
+	return (miniflare3Module ??= await npxImport("@miniflare/tre@3.0.0-next.8"));
 }

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -4,6 +4,7 @@ import { realpathSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import chalk from "chalk";
+import getPort from "get-port";
 import { npxImport } from "npx-import";
 import { useState, useEffect, useRef } from "react";
 import onExit from "signal-exit";
@@ -110,7 +111,6 @@ function useLocalWorker({
 	workerDefinitions,
 	assetPaths,
 	initialPort,
-	inspectorPort,
 	rules,
 	localPersistencePath,
 	liveReload,
@@ -133,6 +133,11 @@ function useLocalWorker({
 	const removeSignalExitListener = useRef<() => void>();
 	const removeExperimentalLocalSignalExitListener = useRef<() => void>();
 	const [inspectorUrl, setInspectorUrl] = useState<string | undefined>();
+
+	// Our inspector proxy server will be binding to `LocalProps`'s `inspectorPort`.
+	// If we attempted to bind Node.js/workerd to the same inspector port, we'd get a port already in use error.
+	// Therefore, generate a new random port for our runtime's to bind their inspector service to.
+	const runtimeInspectorPortRef = useRef<number>();
 
 	useEffect(() => {
 		if (bindings.services && bindings.services.length > 0) {
@@ -197,6 +202,9 @@ function useLocalWorker({
 				bundle,
 			});
 
+			runtimeInspectorPortRef.current ??= await getPort();
+			const runtimeInspectorPort = runtimeInspectorPortRef.current;
+
 			const { forkOptions, miniflareCLIPath, options } = setupMiniflareOptions({
 				workerName,
 				port: initialPort,
@@ -240,7 +248,7 @@ function useLocalWorker({
 					r2Buckets: bindings?.r2_buckets,
 					authenticatedAccountId: accountId,
 					kvRemote: experimentalLocalRemoteKv,
-					inspectorPort,
+					inspectorPort: runtimeInspectorPort,
 				});
 
 				const current = experimentalLocalRef.current;
@@ -268,7 +276,7 @@ function useLocalWorker({
 				try {
 					// fetch the inspector JSON response from the DevTools Inspector protocol
 					const inspectorJSONArr = (await (
-						await fetch(`http://127.0.0.1:${inspectorPort}/json`)
+						await fetch(`http://127.0.0.1:${runtimeInspectorPort}/json`)
 					).json()) as InspectorJSON;
 
 					const foundInspectorURL = inspectorJSONArr?.find((inspectorJSON) =>
@@ -297,8 +305,7 @@ function useLocalWorker({
 
 			const nodeOptions = setupNodeOptions({
 				inspect,
-				ip: initialIp,
-				inspectorPort,
+				inspectorPort: runtimeInspectorPort,
 			});
 			logger.log("⎔ Starting a local server...");
 
@@ -404,7 +411,6 @@ function useLocalWorker({
 		workerName,
 		format,
 		initialPort,
-		inspectorPort,
 		initialIp,
 		queueConsumers,
 		bindings.queues,
@@ -733,11 +739,9 @@ export function setupMiniflareOptions({
 
 export function setupNodeOptions({
 	inspect,
-	ip,
 	inspectorPort,
 }: {
 	inspect: boolean;
-	ip: string;
 	inspectorPort: number;
 }) {
 	const nodeOptions = [
@@ -746,7 +750,7 @@ export function setupNodeOptions({
 		// "--log=VERBOSE", // uncomment this to Miniflare to log "everything"!
 	];
 	if (inspect) {
-		nodeOptions.push("--inspect=" + `${ip}:${inspectorPort}`); // start Miniflare listening for a debugger to attach
+		nodeOptions.push("--inspect=" + `127.0.0.1:${inspectorPort}`); // start Miniflare listening for a debugger to attach
 	}
 	return nodeOptions;
 }

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -395,7 +395,13 @@ function useLocalWorker({
 		}
 
 		startLocalWorker().catch((err) => {
-			logger.error("local worker:", err);
+			if (err.code === "ERR_RUNTIME_FAILURE") {
+				// Don't log a full verbose stack-trace when Miniflare 3's workerd instance fails to start.
+				// workerd will log its own errors, and our stack trace won't have any useful information.
+				logger.error(err.message);
+			} else {
+				logger.error("local worker:", err);
+			}
 		});
 
 		return () => {

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -426,11 +426,7 @@ export async function startLocalServer({
 			return;
 		}
 
-		const nodeOptions = setupNodeOptions({
-			inspect,
-			ip: initialIp,
-			inspectorPort,
-		});
+		const nodeOptions = setupNodeOptions({ inspect, inspectorPort });
 		logger.log("⎔ Starting a local server...");
 
 		const child = (local = fork(miniflareCLIPath, forkOptions, {


### PR DESCRIPTION
Previously, the Wrangler proxy and Node.js/workerd inspector servers were listening on the same port. This somehow worked on macOS, but gives a port already in use error on Linux.

Additionally, the Node.js inspector was configured to listen on `0.0.0.0:<port>`. Aside from the security risk of opening an inspector server on all interfaces, Node.js was logging `0.0.0.0:<port>` to the console. Our RegExp to extract the debugger URL was looking for `127.0.0.1:<port>` though, so we never actually connected to the inspector.

We also had an issue where calling `setOptions()`/`dispose()` on Miniflare 3 instances, wouldn't actually clean-up the previous `workerd` instance. This has been fixed in `@miniflare/tre@3.0.0-next.8`.