### PR TITLE
fix: make generated types prettier

### DIFF
--- a/packages/wrangler/src/type-generation.ts
+++ b/packages/wrangler/src/type-generation.ts
@@ -156,11 +156,11 @@ function writeDTSFile({
 	if (formatType === "modules") {
 		combinedTypeStrings += `interface Env {\n${envTypeStructure
 			.map((value) => `\t${value}`)
-			.join("\n")} \n}\n${modulesTypeStructure.join("\n")}`;
+			.join("\n")}\n}\n${modulesTypeStructure.join("\n")}`;
 	} else {
 		combinedTypeStrings += `export {};\ndeclare global {\n${envTypeStructure
 			.map((value) => `\tconst ${value}`)
-			.join("\n")} \n}\n${modulesTypeStructure.join("\n")}`;
+			.join("\n")}\n}\n${modulesTypeStructure.join("\n")}`;
 	}
 
 	if (envTypeStructure.length || modulesTypeStructure.length) {


### PR DESCRIPTION
This PR makes `prettier --check` pass on the generated `worker-configuration.d.ts` file by removing trailing whitespaces and replacing tabs with 4 whitespaces.

```diff
// Generated by Wrangler on Mon Nov 28 2022 09:15:37 GMT-0800 (Pacific Standard Time)
interface Env {
-	DB: D1Database; 
+    DB: D1Database;
}
```