### PR TITLE
Remove experimental warning for dispatch namespaces

### DIFF
--- a/.changeset/long-wombats-refuse.md
+++ b/.changeset/long-wombats-refuse.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Remove the experimental binding warning from Dispatch Namespace since [it is GA](https://blog.cloudflare.com/workers-for-platforms-ga/).

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -2125,27 +2125,6 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[dispatch_namespaces]", () => {
-			it("should log an experimental warning when dispatch_namespaces is used", () => {
-				const { diagnostics } = normalizeAndValidateConfig(
-					{
-						dispatch_namespaces: [
-							{
-								binding: "BINDING_1",
-								namespace: "NAMESPACE_1",
-							},
-						],
-					} as unknown as RawConfig,
-					undefined,
-					{ env: undefined }
-				);
-				expect(diagnostics.hasWarnings()).toBe(true);
-				expect(diagnostics.hasErrors()).toBe(false);
-				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
-			"Processing wrangler configuration:
-			  - \\"dispatch_namespaces\\" fields are experimental and may change or break at any time."
-		`);
-			});
-
 			it("should error if dispatch_namespaces is not an array", () => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
@@ -2155,12 +2134,8 @@ describe("normalizeAndValidateConfig()", () => {
 					{ env: undefined }
 				);
 
-				expect(diagnostics.hasWarnings()).toBe(true);
+				expect(diagnostics.hasWarnings()).toBe(false);
 				expect(diagnostics.hasErrors()).toBe(true);
-				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
-			          "Processing wrangler configuration:
-			            - \\"dispatch_namespaces\\" fields are experimental and may change or break at any time."
-		        `);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 			"Processing wrangler configuration:
 			  - The field \\"dispatch_namespaces\\" should be an array but got \\"just a string\\"."
@@ -2199,12 +2174,8 @@ describe("normalizeAndValidateConfig()", () => {
 					undefined,
 					{ env: undefined }
 				);
-				expect(diagnostics.hasWarnings()).toBe(true);
+				expect(diagnostics.hasWarnings()).toBe(false);
 				expect(diagnostics.hasErrors()).toBe(true);
-				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
-			"Processing wrangler configuration:
-			  - \\"dispatch_namespaces\\" fields are experimental and may change or break at any time."
-		`);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 			"Processing wrangler configuration:
 			  - \\"dispatch_namespaces[0]\\" binding should be objects, but got \\"a string\\"

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -2114,7 +2114,7 @@ describe("init", () => {
 				type: "service",
 			},
 			{
-				type: "namespace",
+				type: "dispatch_namespace",
 				name: "name-namespace-mock",
 				namespace: "namespace-mock",
 			},

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -5846,7 +5846,7 @@ addEventListener('fetch', event => {});`
 				mockUploadWorkerRequest({
 					expectedBindings: [
 						{
-							type: "namespace",
+							type: "dispatch_namespace",
 							name: "foo",
 							namespace: "Foo",
 						},
@@ -5864,13 +5864,7 @@ addEventListener('fetch', event => {});`
 			Current Deployment ID: undefined"
 		`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
-				expect(std.warn).toMatchInlineSnapshot(`
-			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
-
-			    - \\"dispatch_namespaces\\" fields are experimental and may change or break at any time.
-
-			"
-		`);
+				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
 		});
 

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -909,7 +909,6 @@ function normalizeAndValidateEnvironment(
 
 	experimental(diagnostics, rawEnv, "unsafe");
 	experimental(diagnostics, rawEnv, "services");
-	experimental(diagnostics, rawEnv, "dispatch_namespaces");
 
 	const route = normalizeAndValidateRoute(diagnostics, topLevelEnv, rawEnv);
 

--- a/packages/wrangler/src/create-worker-upload-form.ts
+++ b/packages/wrangler/src/create-worker-upload-form.ts
@@ -44,7 +44,7 @@ type WorkerMetadataBinding =
 	| { type: "d1"; name: string; id: string; internalEnv?: string }
 	| { type: "service"; name: string; service: string; environment?: string }
 	| { type: "analytics_engine"; name: string; dataset?: string }
-	| { type: "namespace"; name: string; namespace: string }
+	| { type: "dispatch_namespace"; name: string; namespace: string }
 	| {
 			type: "logfwdr";
 			name: string;
@@ -161,7 +161,7 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
 	bindings.dispatch_namespaces?.forEach(({ binding, namespace }) => {
 		metadataBindings.push({
 			name: binding,
-			type: "namespace",
+			type: "dispatch_namespace",
 			namespace,
 		});
 	});

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -870,7 +870,7 @@ async function getWorkerConfig(
 						];
 					}
 					break;
-				case "namespace":
+				case "dispatch_namespace":
 					{
 						configObj.dispatch_namespaces = [
 							...(configObj.dispatch_namespaces ?? []),


### PR DESCRIPTION
- Remove experimental warning for dispatch namespaces since the [feature is GA](https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/get-started/configuration/).
- Update `namespace` to `dispatch_namespace` in upload form (the script upload API accepts both).

Tested with [Workers for Platforms Example Project](https://github.com/cloudflare/workers-for-platforms-example).
`npm start -w wrangler publish -- --config /path/to/workers-for-platforms-example-project/wrangler.toml`