### PR TITLE
Fix `wrangler dev --local` and its lazy imports of `@miniflare/tre`

### DIFF
--- a/.changeset/breezy-bears-hang.md
+++ b/.changeset/breezy-bears-hang.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/pages-shared": patch
+"wrangler": patch
+---
+
+fix: `wrangler dev --local` now correctly lazy-imports `@miniflare/tre`
+
+Previously, we introduced a bug where we were incorrectly requiring `@miniflare/tre`, even when not using the `workerd`/`--experimental-local` mode.

--- a/fixtures/worker-app/package.json
+++ b/fixtures/worker-app/package.json
@@ -5,5 +5,21 @@
 	"description": "",
 	"license": "ISC",
 	"author": "",
-	"main": "src/index.js"
+	"main": "src/index.js",
+	"jest": {
+		"restoreMocks": true,
+		"testRegex": ".*.(test|spec)\\.[jt]sx?$",
+		"testTimeout": 30000,
+		"transform": {
+			"^.+\\.c?(t|j)sx?$": [
+				"esbuild-jest",
+				{
+					"sourcemap": true
+				}
+			]
+		},
+		"transformIgnorePatterns": [
+			"node_modules/(?!find-up|locate-path|p-locate|p-limit|yocto-queue|path-exists|execa|strip-final-newline|npm-run-path|path-key|onetime|mimic-fn|human-signals|is-stream)"
+		]
+	}
 }

--- a/fixtures/worker-app/tests/index.test.ts
+++ b/fixtures/worker-app/tests/index.test.ts
@@ -1,0 +1,52 @@
+import { fork } from "child_process";
+import * as path from "path";
+import { fetch } from "undici";
+import type { ChildProcess } from "child_process";
+
+describe("'wrangler dev' correctly renders pages", () => {
+	let wranglerProcess: ChildProcess;
+	let ip: string;
+	let port: number;
+	let resolveReadyPromise: (value: unknown) => void;
+	const readyPromise = new Promise((resolve) => {
+		resolveReadyPromise = resolve;
+	});
+
+	// const std = mockConsoleMethods();
+	beforeAll(() => {
+		wranglerProcess = fork(
+			path.join("..", "..", "packages", "wrangler", "bin", "wrangler.js"),
+			["dev", "--local", "--port=0"],
+			{
+				stdio: ["inherit", "inherit", "inherit", "ipc"],
+				cwd: path.resolve(__dirname, ".."),
+			}
+		).on("message", (message) => {
+			const parsedMessage = JSON.parse(message.toString());
+			ip = parsedMessage.ip;
+			port = parsedMessage.port;
+			resolveReadyPromise(undefined);
+		});
+	});
+
+	afterAll(async () => {
+		await readyPromise;
+		await new Promise((resolve, reject) => {
+			wranglerProcess.once("exit", (code) => {
+				if (!code) {
+					resolve(code);
+				} else {
+					reject(code);
+				}
+			});
+			wranglerProcess.kill("SIGTERM");
+		});
+	});
+
+	it.concurrent("renders ", async () => {
+		await readyPromise;
+		const response = await fetch(`http://${ip}:${port}/`);
+		const text = await response.text();
+		expect(text).toContain(`http://${ip}:${port}/`);
+	});
+});

--- a/packages/pages-shared/environment-polyfills/miniflare-tre.ts
+++ b/packages/pages-shared/environment-polyfills/miniflare-tre.ts
@@ -1,14 +1,12 @@
-import {
-	fetch as miniflareFetch,
-	Headers as MiniflareHeaders,
-	Request as MiniflareRequest,
-	Response as MiniflareResponse,
-} from "@miniflare/tre";
 import { polyfill } from ".";
 
-polyfill({
-	fetch: miniflareFetch,
-	Headers: MiniflareHeaders,
-	Request: MiniflareRequest,
-	Response: MiniflareResponse,
-});
+export default async () => {
+	const mf = await import("@miniflare/tre");
+
+	polyfill({
+		fetch: mf.fetch,
+		Headers: mf.Headers,
+		Request: mf.Request,
+		Response: mf.Response,
+	});
+};

--- a/packages/pages-shared/environment-polyfills/miniflare.ts
+++ b/packages/pages-shared/environment-polyfills/miniflare.ts
@@ -1,14 +1,12 @@
-import {
-	fetch as miniflareFetch,
-	Headers as MiniflareHeaders,
-	Request as MiniflareRequest,
-	Response as MiniflareResponse,
-} from "@miniflare/core";
 import { polyfill } from ".";
 
-polyfill({
-	fetch: miniflareFetch,
-	Headers: MiniflareHeaders,
-	Request: MiniflareRequest,
-	Response: MiniflareResponse,
-});
+export default async () => {
+	const mf = await import("@miniflare/core");
+
+	polyfill({
+		fetch: mf.fetch,
+		Headers: mf.Headers,
+		Request: mf.Request,
+		Response: mf.Response,
+	});
+};

--- a/packages/wrangler/src/miniflare-cli/assets.ts
+++ b/packages/wrangler/src/miniflare-cli/assets.ts
@@ -89,13 +89,17 @@ async function generateAssetsFetch(
 	tre: boolean
 ): Promise<typeof fetch> {
 	// Defer importing miniflare until we really need it
-	if (tre) {
-		await import(
-			"@cloudflare/pages-shared/environment-polyfills/miniflare-tre"
-		);
-	} else {
-		await import("@cloudflare/pages-shared/environment-polyfills/miniflare");
-	}
+
+	const polyfill = tre
+		? (
+				await import(
+					"@cloudflare/pages-shared/environment-polyfills/miniflare-tre"
+				)
+		  ).default
+		: (await import("@cloudflare/pages-shared/environment-polyfills/miniflare"))
+				.default;
+
+	await polyfill();
 
 	const miniflare = tre
 		? await import("@miniflare/tre")


### PR DESCRIPTION
The `await import()` of the environment polyfills seemed to break out of the `if (tre) {}` check. This made the`miniflare-cli` dist look like:

```ts
import { ... } from "@miniflare/tre"
```

When the `@miniflare/tre` package was missing, this broke `wrangler dev --local` for users.

By wrapping the polyfill logic in a function like this, we can avoid this top-level import.