### PR TITLE
fix: d1 - don't backup prod db when applying migrations locally

### DIFF
--- a/.changeset/lovely-bears-sort.md
+++ b/.changeset/lovely-bears-sort.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: d1 - don't backup prod db when applying migrations locally

--- a/.changeset/lovely-bears-sort.md
+++ b/.changeset/lovely-bears-sort.md
@@ -3,3 +3,5 @@
 ---
 
 fix: d1 - don't backup prod db when applying migrations locally
+
+Closes #2336

--- a/packages/wrangler/src/d1/migrations/apply.tsx
+++ b/packages/wrangler/src/d1/migrations/apply.tsx
@@ -102,8 +102,11 @@ export const ApplyHandler = withConfig<BaseSqlExecuteArgs>(
 			if (!ok) return;
 		}
 
-		render(<Text>🕒 Creating backup...</Text>);
-		await createBackup(accountId, databaseInfo.uuid);
+		// don't backup prod db when applying migrations locally
+		if (!local) {
+			render(<Text>🕒 Creating backup...</Text>);
+			await createBackup(accountId, databaseInfo.uuid);
+		}
 
 		for (const migration of unappliedMigrations) {
 			let query = fs.readFileSync(


### PR DESCRIPTION
Closes https://github.com/cloudflare/wrangler2/issues/2336