### PR TITLE
fix: don't ask for preview_database_id in --local

### DIFF
--- a/.changeset/clean-rules-peel.md
+++ b/.changeset/clean-rules-peel.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: don't ask for preview_database_id in --local

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -166,7 +166,8 @@ export function printBindings(bindings: CfWorkerInit["bindings"]) {
 					if (database_name) {
 						databaseValue = `${database_name} (${database_id})`;
 					}
-					if (preview_database_id) {
+					//database_id is local when running `wrangler dev --local`
+					if (preview_database_id && database_id !== "local") {
 						databaseValue += `, Preview: (${preview_database_id})`;
 					}
 					return {

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -906,7 +906,10 @@ function getBindings(
 			...(configParam.d1_databases ?? []).map((d1Db) => {
 				//in local dev, bindings don't matter
 				if (local) {
-					return d1Db;
+					return {
+						...d1Db,
+						database_id: "local",
+					};
 				}
 				if (!d1Db.preview_database_id) {
 					throw new Error(

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -442,7 +442,7 @@ export async function startDev(args: StartDevOptions) {
 
 		// eslint-disable-next-line no-inner-declarations
 		async function getDevReactElement(configParam: Config) {
-			const { assetPaths, bindings } = await getBindingsAndAssetPaths(
+			const { assetPaths, bindings } = getBindingsAndAssetPaths(
 				args,
 				configParam
 			);
@@ -559,7 +559,7 @@ export async function startApiDev(args: StartDevOptions) {
 
 	// eslint-disable-next-line no-inner-declarations
 	async function getDevServer(configParam: Config) {
-		const { assetPaths, bindings } = await getBindingsAndAssetPaths(
+		const { assetPaths, bindings } = getBindingsAndAssetPaths(
 			args,
 			configParam
 		);
@@ -798,14 +798,11 @@ async function validateDevServerSettings(
 	};
 }
 
-async function getBindingsAndAssetPaths(
-	args: StartDevOptions,
-	configParam: Config
-) {
+function getBindingsAndAssetPaths(args: StartDevOptions, configParam: Config) {
 	const cliVars = collectKeyValues(args.var);
 
 	// now log all available bindings into the terminal
-	const bindings = await getBindings(configParam, args.env, {
+	const bindings = getBindings(configParam, args.env, args.local ?? false, {
 		kv: args.kv,
 		vars: { ...args.vars, ...cliVars },
 		durableObjects: args.durableObjects,
@@ -832,11 +829,12 @@ async function getBindingsAndAssetPaths(
 	return { assetPaths, bindings };
 }
 
-async function getBindings(
+function getBindings(
 	configParam: Config,
 	env: string | undefined,
+	local: boolean,
 	args: AdditionalDevProps
-): Promise<CfWorkerInit["bindings"]> {
+): CfWorkerInit["bindings"] {
 	const bindings = {
 		kv_namespaces: [
 			...(configParam.kv_namespaces || []).map(
@@ -906,6 +904,10 @@ async function getBindings(
 		logfwdr: configParam.logfwdr,
 		d1_databases: identifyD1BindingsAsBeta([
 			...(configParam.d1_databases ?? []).map((d1Db) => {
+				//in local dev, bindings don't matter
+				if (local) {
+					return d1Db;
+				}
 				if (!d1Db.preview_database_id) {
 					throw new Error(
 						`In development, you should use a separate D1 database than the one you'd use in production. Please create a new D1 database with "wrangler d1 create <name>" and add its id as preview_database_id to the d1_database "${d1Db.binding}" in your wrangler.toml`


### PR DESCRIPTION
With `--local` enabled this now prints:
```
Your worker has access to the following bindings:
- D1 Databases:
  - DB: test3 (local)
 ```

Otherwise:

```
Your worker has access to the following bindings:
- D1 Databases:
  - DB: test3 (9bcfcc3b-e25f-4088-8ef3-959ffe5e2665), Preview: (9bcfcc3b-e25f-4088-8ef3-959ffe5e2665)
```

Closes https://github.com/cloudflare/wrangler2/issues/2354