### PR TITLE
fix: call readConfig like the rest of the examples

### DIFF
--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -26,8 +26,8 @@ export type {
  * Get the Wrangler configuration; read it from the give `configPath` if available.
  */
 export function readConfig(
-	configPath?: string | undefined,
-	args?: unknown
+	configPath: string | undefined,
+	args: unknown
 ): Config {
 	let rawConfig: RawConfig = {};
 	if (!configPath) {

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -286,7 +286,7 @@ export function createCLIParser(argv: string[]) {
 				"https://developers.cloudflare.com/workers/wrangler/commands/";
 			logger.log(`Opening a link in your default browser: ${urlToOpen}`);
 			await openInBrowser(urlToOpen);
-			const config = readConfig();
+			const config = readConfig(undefined, {});
 			await metrics.sendMetricsEvent("view docs", {
 				sendMetrics: config.send_metrics,
 			});


### PR DESCRIPTION
This PR removes the:
```
✘ [ERROR] Cannot read properties of undefined (reading 'legacy-env')
```
message that appears 