### PR TITLE
Always log when delegating to local `wrangler` install

### DIFF
--- a/.changeset/rotten-dragons-notice.md
+++ b/.changeset/rotten-dragons-notice.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+---
+
+Always log when delegating to local `wrangler` install.
+
+When a global `wrangler` command is executed in a package directory with `wrangler` installed locally, the command is redirected to the local `wrangler` install.
+We now always log a message when this happens, so you know what's going on.

--- a/packages/wrangler/bin/wrangler.js
+++ b/packages/wrangler/bin/wrangler.js
@@ -93,7 +93,15 @@ function runDelegatedWrangler() {
 	} = JSON.parse(fs.readFileSync(packageJsonPath));
 	const resolvedBinaryPath = path.resolve(packageJsonPath, "..", binaryPath);
 
-	debug(`Delegating to locally-installed version of wrangler @ v${version}`);
+	// Make sure the user knows we're delegating to a different installation
+	const currentPackageJsonPath = path.resolve(__dirname, "..", "package.json");
+	const currentPackage = JSON.parse(fs.readFileSync(currentPackageJsonPath));
+	const argv = process.argv.slice(2).join(" ");
+	console.log(
+		`Delegating to locally-installed wrangler@${version} over global wrangler@${currentPackage.version}...
+Run \`npx wrangler ${argv}\` to use the local version directly.
+`
+	);
 
 	// this call to `spawn` is simpler because the delegated version will do all
 	// of the other work.


### PR DESCRIPTION
Closes #2302.

When a global `wrangler` command is executed in a package directory with `wrangler` installed locally, the command is redirected to the local `wrangler` install. Whilst sometimes useful, this behaviour is contrary to most other `npm` CLI packages (and `npx wrangler ...` should already call the local version if detected). It also makes debugging issues more confusing, as it's not clear which `wrangler` version is being called. This PR replaces a debug log we already had for this with a regular log, so users (and `wrangler` developers 😅) know what's going on.