### PR TITLE
Allow `--experimental-local` to cleanly exit on `x`/`CTRL-C`

### DIFF
--- a/.changeset/tasty-toes-drive.md
+++ b/.changeset/tasty-toes-drive.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Cleanly exit `wrangler dev --experimental-local` when pressing `x`/`q`/`CTRL-C`

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -519,14 +519,19 @@ export async function startDev(args: StartDevOptions) {
 		// mode enables raw mode on stdin which disables the built-in handler. The
 		// following line disconnects from the IPC channel when we press `x` or
 		// CTRL-C in interactive mode, ensuring no open handles, and allowing for a
-		// clean exit.
-		devReactElement.waitUntilExit().then(() => process.disconnect?.());
+		// clean exit. Note, if we called `stop()` using the dev API, we don't want
+		// to disconnect here, as the user may still need IPC.
+		let apiStopped = false;
+		devReactElement.waitUntilExit().then(() => {
+			if (!apiStopped) process.disconnect?.();
+		});
 
 		rerender = devReactElement.rerender;
 		return {
 			devReactElement,
 			watcher,
 			stop: async () => {
+				apiStopped = true;
 				devReactElement.unmount();
 				await watcher?.close();
 			},

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -512,6 +512,16 @@ export async function startDev(args: StartDevOptions) {
 			);
 		}
 		const devReactElement = render(await getDevReactElement(config));
+
+		// In the bootstrapper script `bin/wrangler.js`, we open an IPC channel, so
+		// IPC messages from this process are propagated through the bootstrapper.
+		// Normally, Node's SIGINT handler would close this for us, but interactive
+		// mode enables raw mode on stdin which disables the built-in handler. The
+		// following line disconnects from the IPC channel when we press `x` or
+		// CTRL-C in interactive mode, ensuring no open handles, and allowing for a
+		// clean exit.
+		devReactElement.waitUntilExit().then(() => process.disconnect?.());
+
 		rerender = devReactElement.rerender;
 		return {
 			devReactElement,

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -522,7 +522,7 @@ export async function startDev(args: StartDevOptions) {
 		// clean exit. Note, if we called `stop()` using the dev API, we don't want
 		// to disconnect here, as the user may still need IPC.
 		let apiStopped = false;
-		devReactElement.waitUntilExit().then(() => {
+		void devReactElement.waitUntilExit().then(() => {
 			if (!apiStopped) process.disconnect?.();
 		});
 

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -520,10 +520,12 @@ export async function startDev(args: StartDevOptions) {
 		// following line disconnects from the IPC channel when we press `x` or
 		// CTRL-C in interactive mode, ensuring no open handles, and allowing for a
 		// clean exit. Note, if we called `stop()` using the dev API, we don't want
-		// to disconnect here, as the user may still need IPC.
+		// to disconnect here, as the user may still need IPC. We also don't want
+		// to disconnect if this file was imported in Jest (not the case with E2E
+		// tests), as that would stop communication with the test runner.
 		let apiStopped = false;
 		void devReactElement.waitUntilExit().then(() => {
-			if (!apiStopped) process.disconnect?.();
+			if (!apiStopped && typeof jest === "undefined") process.disconnect?.();
 		});
 
 		rerender = devReactElement.rerender;


### PR DESCRIPTION
#### What this PR solves / how to test:

In the bootstrapper script `bin/wrangler.js`, we open an IPC channel, so IPC messages from the Wrangler process are propagated through the bootstrapper. Normally, Node's SIGINT handler would close this for us, but interactive mode enables raw mode on stdin which disables the built-in handler. This PR calls `process.disconnect()` to close this channel when we press `x` or CTRL-C, ensuring no open handles, and allowing for a clean exit.

This PR can be tested by running `wrangler dev --experimental-local` on a simple Worker script, then pressing, `x`, `q` and/or `CTRL-C`.

#### Associated docs issues/PR:

N/A

#### Author has included the following, where applicable:

- [ ] ~~Tests~~ (will make sure this is tested as part of https://github.com/cloudflare/wrangler2/pull/2365)
- [x] Changeset

#### Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes #2387
