### PR TITLE
 Update esbuild to 0.15.18

### DIFF
--- a/.changeset/wicked-tools-remain.md
+++ b/.changeset/wicked-tools-remain.md
@@ -1,0 +1,6 @@
+---
+"wrangler": patch
+"wranglerjs-compat-webpack-plugin": patch
+---
+
+Bump esbuild to version 0.15.15

--- a/.changeset/wicked-tools-remain.md
+++ b/.changeset/wicked-tools-remain.md
@@ -3,4 +3,4 @@
 "wranglerjs-compat-webpack-plugin": patch
 ---
 
-Bump esbuild to version 0.15.15
+Bump esbuild to version 0.15.18

--- a/package-lock.json
+++ b/package-lock.json
@@ -9701,9 +9701,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.15.15",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.15.tgz",
-			"integrity": "sha512-TEw/lwK4Zzld9x3FedV6jy8onOUHqcEX3ADFk4k+gzPUwrxn8nWV62tH0udo8jOtjFodlEfc4ypsqX3e+WWO6w==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.18.tgz",
+			"integrity": "sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==",
 			"hasInstallScript": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
@@ -9712,28 +9712,28 @@
 				"node": ">=12"
 			},
 			"optionalDependencies": {
-				"@esbuild/android-arm": "0.15.15",
-				"@esbuild/linux-loong64": "0.15.15",
-				"esbuild-android-64": "0.15.15",
-				"esbuild-android-arm64": "0.15.15",
-				"esbuild-darwin-64": "0.15.15",
-				"esbuild-darwin-arm64": "0.15.15",
-				"esbuild-freebsd-64": "0.15.15",
-				"esbuild-freebsd-arm64": "0.15.15",
-				"esbuild-linux-32": "0.15.15",
-				"esbuild-linux-64": "0.15.15",
-				"esbuild-linux-arm": "0.15.15",
-				"esbuild-linux-arm64": "0.15.15",
-				"esbuild-linux-mips64le": "0.15.15",
-				"esbuild-linux-ppc64le": "0.15.15",
-				"esbuild-linux-riscv64": "0.15.15",
-				"esbuild-linux-s390x": "0.15.15",
-				"esbuild-netbsd-64": "0.15.15",
-				"esbuild-openbsd-64": "0.15.15",
-				"esbuild-sunos-64": "0.15.15",
-				"esbuild-windows-32": "0.15.15",
-				"esbuild-windows-64": "0.15.15",
-				"esbuild-windows-arm64": "0.15.15"
+				"@esbuild/android-arm": "0.15.18",
+				"@esbuild/linux-loong64": "0.15.18",
+				"esbuild-android-64": "0.15.18",
+				"esbuild-android-arm64": "0.15.18",
+				"esbuild-darwin-64": "0.15.18",
+				"esbuild-darwin-arm64": "0.15.18",
+				"esbuild-freebsd-64": "0.15.18",
+				"esbuild-freebsd-arm64": "0.15.18",
+				"esbuild-linux-32": "0.15.18",
+				"esbuild-linux-64": "0.15.18",
+				"esbuild-linux-arm": "0.15.18",
+				"esbuild-linux-arm64": "0.15.18",
+				"esbuild-linux-mips64le": "0.15.18",
+				"esbuild-linux-ppc64le": "0.15.18",
+				"esbuild-linux-riscv64": "0.15.18",
+				"esbuild-linux-s390x": "0.15.18",
+				"esbuild-netbsd-64": "0.15.18",
+				"esbuild-openbsd-64": "0.15.18",
+				"esbuild-sunos-64": "0.15.18",
+				"esbuild-windows-32": "0.15.18",
+				"esbuild-windows-64": "0.15.18",
+				"esbuild-windows-arm64": "0.15.18"
 			}
 		},
 		"node_modules/esbuild-android-64": {
@@ -10076,9 +10076,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/@esbuild/android-arm": {
-			"version": "0.15.15",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.15.tgz",
-			"integrity": "sha512-JJjZjJi2eBL01QJuWjfCdZxcIgot+VoK6Fq7eKF9w4YHm9hwl7nhBR1o2Wnt/WcANk5l9SkpvrldW1PLuXxcbw==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.18.tgz",
+			"integrity": "sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==",
 			"cpu": [
 				"arm"
 			],
@@ -10091,9 +10091,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
-			"version": "0.15.15",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.15.tgz",
-			"integrity": "sha512-lhz6UNPMDXUhtXSulw8XlFAtSYO26WmHQnCi2Lg2p+/TMiJKNLtZCYUxV4wG6rZMzXmr8InGpNwk+DLT2Hm0PA==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.18.tgz",
+			"integrity": "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==",
 			"cpu": [
 				"loong64"
 			],
@@ -10106,9 +10106,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-android-64": {
-			"version": "0.15.15",
-			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.15.tgz",
-			"integrity": "sha512-F+WjjQxO+JQOva3tJWNdVjouFMLK6R6i5gjDvgUthLYJnIZJsp1HlF523k73hELY20WPyEO8xcz7aaYBVkeg5Q==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.18.tgz",
+			"integrity": "sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==",
 			"cpu": [
 				"x64"
 			],
@@ -10121,9 +10121,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-android-arm64": {
-			"version": "0.15.15",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.15.tgz",
-			"integrity": "sha512-attlyhD6Y22jNyQ0fIIQ7mnPvDWKw7k6FKnsXlBvQE6s3z6s6cuEHcSgoirquQc7TmZgVCK5fD/2uxmRN+ZpcQ==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.18.tgz",
+			"integrity": "sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -10136,9 +10136,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-darwin-64": {
-			"version": "0.15.15",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.15.tgz",
-			"integrity": "sha512-ohZtF8W1SHJ4JWldsPVdk8st0r9ExbAOSrBOh5L+Mq47i696GVwv1ab/KlmbUoikSTNoXEhDzVpxUR/WIO19FQ==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.18.tgz",
+			"integrity": "sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==",
 			"cpu": [
 				"x64"
 			],
@@ -10151,9 +10151,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-darwin-arm64": {
-			"version": "0.15.15",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.15.tgz",
-			"integrity": "sha512-P8jOZ5zshCNIuGn+9KehKs/cq5uIniC+BeCykvdVhx/rBXSxmtj3CUIKZz4sDCuESMbitK54drf/2QX9QHG5Ag==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.18.tgz",
+			"integrity": "sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==",
 			"cpu": [
 				"arm64"
 			],
@@ -10166,9 +10166,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-freebsd-64": {
-			"version": "0.15.15",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.15.tgz",
-			"integrity": "sha512-KkTg+AmDXz1IvA9S1gt8dE24C8Thx0X5oM0KGF322DuP+P3evwTL9YyusHAWNsh4qLsR80nvBr/EIYs29VSwuA==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.18.tgz",
+			"integrity": "sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==",
 			"cpu": [
 				"x64"
 			],
@@ -10181,9 +10181,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-freebsd-arm64": {
-			"version": "0.15.15",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.15.tgz",
-			"integrity": "sha512-FUcML0DRsuyqCMfAC+HoeAqvWxMeq0qXvclZZ/lt2kLU6XBnDA5uKTLUd379WYEyVD4KKFctqWd9tTuk8C/96g==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.18.tgz",
+			"integrity": "sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==",
 			"cpu": [
 				"arm64"
 			],
@@ -10196,9 +10196,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-linux-32": {
-			"version": "0.15.15",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.15.tgz",
-			"integrity": "sha512-q28Qn5pZgHNqug02aTkzw5sW9OklSo96b5nm17Mq0pDXrdTBcQ+M6Q9A1B+dalFeynunwh/pvfrNucjzwDXj+Q==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.18.tgz",
+			"integrity": "sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==",
 			"cpu": [
 				"ia32"
 			],
@@ -10211,9 +10211,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-linux-64": {
-			"version": "0.15.15",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.15.tgz",
-			"integrity": "sha512-217KPmWMirkf8liO+fj2qrPwbIbhNTGNVtvqI1TnOWJgcMjUWvd677Gq3fTzXEjilkx2yWypVnTswM2KbXgoAg==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.18.tgz",
+			"integrity": "sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==",
 			"cpu": [
 				"x64"
 			],
@@ -10226,9 +10226,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-linux-arm": {
-			"version": "0.15.15",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.15.tgz",
-			"integrity": "sha512-RYVW9o2yN8yM7SB1yaWr378CwrjvGCyGybX3SdzPHpikUHkME2AP55Ma20uNwkNyY2eSYFX9D55kDrfQmQBR4w==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.18.tgz",
+			"integrity": "sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==",
 			"cpu": [
 				"arm"
 			],
@@ -10241,9 +10241,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-linux-arm64": {
-			"version": "0.15.15",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.15.tgz",
-			"integrity": "sha512-/ltmNFs0FivZkYsTzAsXIfLQX38lFnwJTWCJts0IbCqWZQe+jjj0vYBNbI0kmXLb3y5NljiM5USVAO1NVkdh2g==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.18.tgz",
+			"integrity": "sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==",
 			"cpu": [
 				"arm64"
 			],
@@ -10256,9 +10256,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-linux-mips64le": {
-			"version": "0.15.15",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.15.tgz",
-			"integrity": "sha512-PksEPb321/28GFFxtvL33yVPfnMZihxkEv5zME2zapXGp7fA1X2jYeiTUK+9tJ/EGgcNWuwvtawPxJG7Mmn86A==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.18.tgz",
+			"integrity": "sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==",
 			"cpu": [
 				"mips64el"
 			],
@@ -10271,9 +10271,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-linux-ppc64le": {
-			"version": "0.15.15",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.15.tgz",
-			"integrity": "sha512-ek8gJBEIhcpGI327eAZigBOHl58QqrJrYYIZBWQCnH3UnXoeWMrMZLeeZL8BI2XMBhP+sQ6ERctD5X+ajL/AIA==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.18.tgz",
+			"integrity": "sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==",
 			"cpu": [
 				"ppc64"
 			],
@@ -10286,9 +10286,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-linux-riscv64": {
-			"version": "0.15.15",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.15.tgz",
-			"integrity": "sha512-H5ilTZb33/GnUBrZMNJtBk7/OXzDHDXjIzoLXHSutwwsLxSNaLxzAaMoDGDd/keZoS+GDBqNVxdCkpuiRW4OSw==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.18.tgz",
+			"integrity": "sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==",
 			"cpu": [
 				"riscv64"
 			],
@@ -10301,9 +10301,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-linux-s390x": {
-			"version": "0.15.15",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.15.tgz",
-			"integrity": "sha512-jKaLUg78mua3rrtrkpv4Or2dNTJU7bgHN4bEjT4OX4GR7nLBSA9dfJezQouTxMmIW7opwEC5/iR9mpC18utnxQ==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.18.tgz",
+			"integrity": "sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==",
 			"cpu": [
 				"s390x"
 			],
@@ -10316,9 +10316,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-netbsd-64": {
-			"version": "0.15.15",
-			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.15.tgz",
-			"integrity": "sha512-aOvmF/UkjFuW6F36HbIlImJTTx45KUCHJndtKo+KdP8Dhq3mgLRKW9+6Ircpm8bX/RcS3zZMMmaBLkvGY06Gvw==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.18.tgz",
+			"integrity": "sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==",
 			"cpu": [
 				"x64"
 			],
@@ -10331,9 +10331,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-openbsd-64": {
-			"version": "0.15.15",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.15.tgz",
-			"integrity": "sha512-HFFX+WYedx1w2yJ1VyR1Dfo8zyYGQZf1cA69bLdrHzu9svj6KH6ZLK0k3A1/LFPhcEY9idSOhsB2UyU0tHPxgQ==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.18.tgz",
+			"integrity": "sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==",
 			"cpu": [
 				"x64"
 			],
@@ -10346,9 +10346,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-sunos-64": {
-			"version": "0.15.15",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.15.tgz",
-			"integrity": "sha512-jOPBudffG4HN8yJXcK9rib/ZTFoTA5pvIKbRrt3IKAGMq1EpBi4xoVoSRrq/0d4OgZLaQbmkHp8RO9eZIn5atA==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.18.tgz",
+			"integrity": "sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==",
 			"cpu": [
 				"x64"
 			],
@@ -10361,9 +10361,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-windows-32": {
-			"version": "0.15.15",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.15.tgz",
-			"integrity": "sha512-MDkJ3QkjnCetKF0fKxCyYNBnOq6dmidcwstBVeMtXSgGYTy8XSwBeIE4+HuKiSsG6I/mXEb++px3IGSmTN0XiA==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.18.tgz",
+			"integrity": "sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -10376,9 +10376,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-windows-64": {
-			"version": "0.15.15",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.15.tgz",
-			"integrity": "sha512-xaAUIB2qllE888SsMU3j9nrqyLbkqqkpQyWVkfwSil6BBPgcPk3zOFitTTncEKCLTQy3XV9RuH7PDj3aJDljWA==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.18.tgz",
+			"integrity": "sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==",
 			"cpu": [
 				"x64"
 			],
@@ -10391,9 +10391,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-windows-arm64": {
-			"version": "0.15.15",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.15.tgz",
-			"integrity": "sha512-ttuoCYCIJAFx4UUKKWYnFdrVpoXa3+3WWkXVI6s09U+YjhnyM5h96ewTq/WgQj9LFSIlABQvadHSOQyAVjW5xQ==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.18.tgz",
+			"integrity": "sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -27267,7 +27267,7 @@
 				"@miniflare/durable-objects": "2.10.0",
 				"blake3-wasm": "^2.1.5",
 				"chokidar": "^3.5.3",
-				"esbuild": "0.15.15",
+				"esbuild": "0.15.18",
 				"miniflare": "2.10.0",
 				"nanoid": "^3.3.3",
 				"path-to-regexp": "^6.2.0",
@@ -27533,7 +27533,7 @@
 				"@types/rimraf": "^3.0.2",
 				"@types/tar": "^6.1.1",
 				"@types/webpack": "^4.41.32",
-				"esbuild": "^0.15.15",
+				"esbuild": "^0.15.18",
 				"execa": "^6.1.0",
 				"jest": "^27.5.1",
 				"jest-fetch-mock": "^3.0.3",
@@ -27543,38 +27543,6 @@
 				"typescript": "^4.6.3",
 				"undici": "^5.9.1",
 				"webpack": "^4.46.0"
-			}
-		},
-		"packages/wranglerjs-compat-webpack-plugin/node_modules/@esbuild/android-arm": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.18.tgz",
-			"integrity": "sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"packages/wranglerjs-compat-webpack-plugin/node_modules/@esbuild/linux-loong64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.18.tgz",
-			"integrity": "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"packages/wranglerjs-compat-webpack-plugin/node_modules/@jest/console": {
@@ -27969,363 +27937,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sindresorhus/emittery?sponsor=1"
-			}
-		},
-		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.18.tgz",
-			"integrity": "sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==",
-			"dev": true,
-			"hasInstallScript": true,
-			"bin": {
-				"esbuild": "bin/esbuild"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"optionalDependencies": {
-				"@esbuild/android-arm": "0.15.18",
-				"@esbuild/linux-loong64": "0.15.18",
-				"esbuild-android-64": "0.15.18",
-				"esbuild-android-arm64": "0.15.18",
-				"esbuild-darwin-64": "0.15.18",
-				"esbuild-darwin-arm64": "0.15.18",
-				"esbuild-freebsd-64": "0.15.18",
-				"esbuild-freebsd-arm64": "0.15.18",
-				"esbuild-linux-32": "0.15.18",
-				"esbuild-linux-64": "0.15.18",
-				"esbuild-linux-arm": "0.15.18",
-				"esbuild-linux-arm64": "0.15.18",
-				"esbuild-linux-mips64le": "0.15.18",
-				"esbuild-linux-ppc64le": "0.15.18",
-				"esbuild-linux-riscv64": "0.15.18",
-				"esbuild-linux-s390x": "0.15.18",
-				"esbuild-netbsd-64": "0.15.18",
-				"esbuild-openbsd-64": "0.15.18",
-				"esbuild-sunos-64": "0.15.18",
-				"esbuild-windows-32": "0.15.18",
-				"esbuild-windows-64": "0.15.18",
-				"esbuild-windows-arm64": "0.15.18"
-			}
-		},
-		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-android-64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.18.tgz",
-			"integrity": "sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-android-arm64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.18.tgz",
-			"integrity": "sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-darwin-64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.18.tgz",
-			"integrity": "sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-darwin-arm64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.18.tgz",
-			"integrity": "sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-freebsd-64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.18.tgz",
-			"integrity": "sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-freebsd-arm64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.18.tgz",
-			"integrity": "sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-linux-32": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.18.tgz",
-			"integrity": "sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-linux-64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.18.tgz",
-			"integrity": "sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-linux-arm": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.18.tgz",
-			"integrity": "sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-linux-arm64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.18.tgz",
-			"integrity": "sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-linux-mips64le": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.18.tgz",
-			"integrity": "sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==",
-			"cpu": [
-				"mips64el"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-linux-ppc64le": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.18.tgz",
-			"integrity": "sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-linux-riscv64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.18.tgz",
-			"integrity": "sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-linux-s390x": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.18.tgz",
-			"integrity": "sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-netbsd-64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.18.tgz",
-			"integrity": "sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-openbsd-64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.18.tgz",
-			"integrity": "sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-sunos-64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.18.tgz",
-			"integrity": "sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"sunos"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-windows-32": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.18.tgz",
-			"integrity": "sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-windows-64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.18.tgz",
-			"integrity": "sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-windows-arm64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.18.tgz",
-			"integrity": "sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"packages/wranglerjs-compat-webpack-plugin/node_modules/expect": {
@@ -35792,164 +35403,164 @@
 			}
 		},
 		"esbuild": {
-			"version": "0.15.15",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.15.tgz",
-			"integrity": "sha512-TEw/lwK4Zzld9x3FedV6jy8onOUHqcEX3ADFk4k+gzPUwrxn8nWV62tH0udo8jOtjFodlEfc4ypsqX3e+WWO6w==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.18.tgz",
+			"integrity": "sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==",
 			"requires": {
-				"@esbuild/android-arm": "0.15.15",
-				"@esbuild/linux-loong64": "0.15.15",
-				"esbuild-android-64": "0.15.15",
-				"esbuild-android-arm64": "0.15.15",
-				"esbuild-darwin-64": "0.15.15",
-				"esbuild-darwin-arm64": "0.15.15",
-				"esbuild-freebsd-64": "0.15.15",
-				"esbuild-freebsd-arm64": "0.15.15",
-				"esbuild-linux-32": "0.15.15",
-				"esbuild-linux-64": "0.15.15",
-				"esbuild-linux-arm": "0.15.15",
-				"esbuild-linux-arm64": "0.15.15",
-				"esbuild-linux-mips64le": "0.15.15",
-				"esbuild-linux-ppc64le": "0.15.15",
-				"esbuild-linux-riscv64": "0.15.15",
-				"esbuild-linux-s390x": "0.15.15",
-				"esbuild-netbsd-64": "0.15.15",
-				"esbuild-openbsd-64": "0.15.15",
-				"esbuild-sunos-64": "0.15.15",
-				"esbuild-windows-32": "0.15.15",
-				"esbuild-windows-64": "0.15.15",
-				"esbuild-windows-arm64": "0.15.15"
+				"@esbuild/android-arm": "0.15.18",
+				"@esbuild/linux-loong64": "0.15.18",
+				"esbuild-android-64": "0.15.18",
+				"esbuild-android-arm64": "0.15.18",
+				"esbuild-darwin-64": "0.15.18",
+				"esbuild-darwin-arm64": "0.15.18",
+				"esbuild-freebsd-64": "0.15.18",
+				"esbuild-freebsd-arm64": "0.15.18",
+				"esbuild-linux-32": "0.15.18",
+				"esbuild-linux-64": "0.15.18",
+				"esbuild-linux-arm": "0.15.18",
+				"esbuild-linux-arm64": "0.15.18",
+				"esbuild-linux-mips64le": "0.15.18",
+				"esbuild-linux-ppc64le": "0.15.18",
+				"esbuild-linux-riscv64": "0.15.18",
+				"esbuild-linux-s390x": "0.15.18",
+				"esbuild-netbsd-64": "0.15.18",
+				"esbuild-openbsd-64": "0.15.18",
+				"esbuild-sunos-64": "0.15.18",
+				"esbuild-windows-32": "0.15.18",
+				"esbuild-windows-64": "0.15.18",
+				"esbuild-windows-arm64": "0.15.18"
 			},
 			"dependencies": {
 				"@esbuild/android-arm": {
-					"version": "0.15.15",
-					"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.15.tgz",
-					"integrity": "sha512-JJjZjJi2eBL01QJuWjfCdZxcIgot+VoK6Fq7eKF9w4YHm9hwl7nhBR1o2Wnt/WcANk5l9SkpvrldW1PLuXxcbw==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.18.tgz",
+					"integrity": "sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==",
 					"optional": true
 				},
 				"@esbuild/linux-loong64": {
-					"version": "0.15.15",
-					"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.15.tgz",
-					"integrity": "sha512-lhz6UNPMDXUhtXSulw8XlFAtSYO26WmHQnCi2Lg2p+/TMiJKNLtZCYUxV4wG6rZMzXmr8InGpNwk+DLT2Hm0PA==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.18.tgz",
+					"integrity": "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==",
 					"optional": true
 				},
 				"esbuild-android-64": {
-					"version": "0.15.15",
-					"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.15.tgz",
-					"integrity": "sha512-F+WjjQxO+JQOva3tJWNdVjouFMLK6R6i5gjDvgUthLYJnIZJsp1HlF523k73hELY20WPyEO8xcz7aaYBVkeg5Q==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.18.tgz",
+					"integrity": "sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==",
 					"optional": true
 				},
 				"esbuild-android-arm64": {
-					"version": "0.15.15",
-					"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.15.tgz",
-					"integrity": "sha512-attlyhD6Y22jNyQ0fIIQ7mnPvDWKw7k6FKnsXlBvQE6s3z6s6cuEHcSgoirquQc7TmZgVCK5fD/2uxmRN+ZpcQ==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.18.tgz",
+					"integrity": "sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==",
 					"optional": true
 				},
 				"esbuild-darwin-64": {
-					"version": "0.15.15",
-					"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.15.tgz",
-					"integrity": "sha512-ohZtF8W1SHJ4JWldsPVdk8st0r9ExbAOSrBOh5L+Mq47i696GVwv1ab/KlmbUoikSTNoXEhDzVpxUR/WIO19FQ==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.18.tgz",
+					"integrity": "sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==",
 					"optional": true
 				},
 				"esbuild-darwin-arm64": {
-					"version": "0.15.15",
-					"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.15.tgz",
-					"integrity": "sha512-P8jOZ5zshCNIuGn+9KehKs/cq5uIniC+BeCykvdVhx/rBXSxmtj3CUIKZz4sDCuESMbitK54drf/2QX9QHG5Ag==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.18.tgz",
+					"integrity": "sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==",
 					"optional": true
 				},
 				"esbuild-freebsd-64": {
-					"version": "0.15.15",
-					"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.15.tgz",
-					"integrity": "sha512-KkTg+AmDXz1IvA9S1gt8dE24C8Thx0X5oM0KGF322DuP+P3evwTL9YyusHAWNsh4qLsR80nvBr/EIYs29VSwuA==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.18.tgz",
+					"integrity": "sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==",
 					"optional": true
 				},
 				"esbuild-freebsd-arm64": {
-					"version": "0.15.15",
-					"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.15.tgz",
-					"integrity": "sha512-FUcML0DRsuyqCMfAC+HoeAqvWxMeq0qXvclZZ/lt2kLU6XBnDA5uKTLUd379WYEyVD4KKFctqWd9tTuk8C/96g==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.18.tgz",
+					"integrity": "sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==",
 					"optional": true
 				},
 				"esbuild-linux-32": {
-					"version": "0.15.15",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.15.tgz",
-					"integrity": "sha512-q28Qn5pZgHNqug02aTkzw5sW9OklSo96b5nm17Mq0pDXrdTBcQ+M6Q9A1B+dalFeynunwh/pvfrNucjzwDXj+Q==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.18.tgz",
+					"integrity": "sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==",
 					"optional": true
 				},
 				"esbuild-linux-64": {
-					"version": "0.15.15",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.15.tgz",
-					"integrity": "sha512-217KPmWMirkf8liO+fj2qrPwbIbhNTGNVtvqI1TnOWJgcMjUWvd677Gq3fTzXEjilkx2yWypVnTswM2KbXgoAg==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.18.tgz",
+					"integrity": "sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==",
 					"optional": true
 				},
 				"esbuild-linux-arm": {
-					"version": "0.15.15",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.15.tgz",
-					"integrity": "sha512-RYVW9o2yN8yM7SB1yaWr378CwrjvGCyGybX3SdzPHpikUHkME2AP55Ma20uNwkNyY2eSYFX9D55kDrfQmQBR4w==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.18.tgz",
+					"integrity": "sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==",
 					"optional": true
 				},
 				"esbuild-linux-arm64": {
-					"version": "0.15.15",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.15.tgz",
-					"integrity": "sha512-/ltmNFs0FivZkYsTzAsXIfLQX38lFnwJTWCJts0IbCqWZQe+jjj0vYBNbI0kmXLb3y5NljiM5USVAO1NVkdh2g==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.18.tgz",
+					"integrity": "sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==",
 					"optional": true
 				},
 				"esbuild-linux-mips64le": {
-					"version": "0.15.15",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.15.tgz",
-					"integrity": "sha512-PksEPb321/28GFFxtvL33yVPfnMZihxkEv5zME2zapXGp7fA1X2jYeiTUK+9tJ/EGgcNWuwvtawPxJG7Mmn86A==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.18.tgz",
+					"integrity": "sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==",
 					"optional": true
 				},
 				"esbuild-linux-ppc64le": {
-					"version": "0.15.15",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.15.tgz",
-					"integrity": "sha512-ek8gJBEIhcpGI327eAZigBOHl58QqrJrYYIZBWQCnH3UnXoeWMrMZLeeZL8BI2XMBhP+sQ6ERctD5X+ajL/AIA==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.18.tgz",
+					"integrity": "sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==",
 					"optional": true
 				},
 				"esbuild-linux-riscv64": {
-					"version": "0.15.15",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.15.tgz",
-					"integrity": "sha512-H5ilTZb33/GnUBrZMNJtBk7/OXzDHDXjIzoLXHSutwwsLxSNaLxzAaMoDGDd/keZoS+GDBqNVxdCkpuiRW4OSw==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.18.tgz",
+					"integrity": "sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==",
 					"optional": true
 				},
 				"esbuild-linux-s390x": {
-					"version": "0.15.15",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.15.tgz",
-					"integrity": "sha512-jKaLUg78mua3rrtrkpv4Or2dNTJU7bgHN4bEjT4OX4GR7nLBSA9dfJezQouTxMmIW7opwEC5/iR9mpC18utnxQ==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.18.tgz",
+					"integrity": "sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==",
 					"optional": true
 				},
 				"esbuild-netbsd-64": {
-					"version": "0.15.15",
-					"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.15.tgz",
-					"integrity": "sha512-aOvmF/UkjFuW6F36HbIlImJTTx45KUCHJndtKo+KdP8Dhq3mgLRKW9+6Ircpm8bX/RcS3zZMMmaBLkvGY06Gvw==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.18.tgz",
+					"integrity": "sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==",
 					"optional": true
 				},
 				"esbuild-openbsd-64": {
-					"version": "0.15.15",
-					"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.15.tgz",
-					"integrity": "sha512-HFFX+WYedx1w2yJ1VyR1Dfo8zyYGQZf1cA69bLdrHzu9svj6KH6ZLK0k3A1/LFPhcEY9idSOhsB2UyU0tHPxgQ==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.18.tgz",
+					"integrity": "sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==",
 					"optional": true
 				},
 				"esbuild-sunos-64": {
-					"version": "0.15.15",
-					"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.15.tgz",
-					"integrity": "sha512-jOPBudffG4HN8yJXcK9rib/ZTFoTA5pvIKbRrt3IKAGMq1EpBi4xoVoSRrq/0d4OgZLaQbmkHp8RO9eZIn5atA==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.18.tgz",
+					"integrity": "sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==",
 					"optional": true
 				},
 				"esbuild-windows-32": {
-					"version": "0.15.15",
-					"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.15.tgz",
-					"integrity": "sha512-MDkJ3QkjnCetKF0fKxCyYNBnOq6dmidcwstBVeMtXSgGYTy8XSwBeIE4+HuKiSsG6I/mXEb++px3IGSmTN0XiA==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.18.tgz",
+					"integrity": "sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==",
 					"optional": true
 				},
 				"esbuild-windows-64": {
-					"version": "0.15.15",
-					"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.15.tgz",
-					"integrity": "sha512-xaAUIB2qllE888SsMU3j9nrqyLbkqqkpQyWVkfwSil6BBPgcPk3zOFitTTncEKCLTQy3XV9RuH7PDj3aJDljWA==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.18.tgz",
+					"integrity": "sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==",
 					"optional": true
 				},
 				"esbuild-windows-arm64": {
-					"version": "0.15.15",
-					"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.15.tgz",
-					"integrity": "sha512-ttuoCYCIJAFx4UUKKWYnFdrVpoXa3+3WWkXVI6s09U+YjhnyM5h96ewTq/WgQj9LFSIlABQvadHSOQyAVjW5xQ==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.18.tgz",
+					"integrity": "sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==",
 					"optional": true
 				}
 			}
@@ -47684,7 +47295,7 @@
 				"concurrently": "^7.2.2",
 				"devtools-protocol": "^0.0.955664",
 				"dotenv": "^16.0.0",
-				"esbuild": "0.15.15",
+				"esbuild": "0.15.18",
 				"execa": "^6.1.0",
 				"express": "^4.18.1",
 				"finalhandler": "^1.2.0",
@@ -47830,7 +47441,7 @@
 				"@types/rimraf": "^3.0.2",
 				"@types/tar": "^6.1.1",
 				"@types/webpack": "^4.41.32",
-				"esbuild": "^0.15.15",
+				"esbuild": "^0.15.18",
 				"execa": "^6.1.0",
 				"jest": "^27.5.1",
 				"jest-fetch-mock": "^3.0.3",
@@ -47843,20 +47454,6 @@
 				"webpack": "^4.46.0"
 			},
 			"dependencies": {
-				"@esbuild/android-arm": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.18.tgz",
-					"integrity": "sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==",
-					"dev": true,
-					"optional": true
-				},
-				"@esbuild/linux-loong64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.18.tgz",
-					"integrity": "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==",
-					"dev": true,
-					"optional": true
-				},
 				"@jest/console": {
 					"version": "27.5.1",
 					"resolved": "https://registry.npmjs.org/@jest/console/-/console-27.5.1.tgz",
@@ -48159,176 +47756,6 @@
 					"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.8.1.tgz",
 					"integrity": "sha512-uDfvUjVrfGJJhymx/kz6prltenw1u7WrCg1oa94zYY8xxVpLLUu045LAT0dhDZdXG58/EpPL/5kA180fQ/qudg==",
 					"dev": true
-				},
-				"esbuild": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.18.tgz",
-					"integrity": "sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==",
-					"dev": true,
-					"requires": {
-						"@esbuild/android-arm": "0.15.18",
-						"@esbuild/linux-loong64": "0.15.18",
-						"esbuild-android-64": "0.15.18",
-						"esbuild-android-arm64": "0.15.18",
-						"esbuild-darwin-64": "0.15.18",
-						"esbuild-darwin-arm64": "0.15.18",
-						"esbuild-freebsd-64": "0.15.18",
-						"esbuild-freebsd-arm64": "0.15.18",
-						"esbuild-linux-32": "0.15.18",
-						"esbuild-linux-64": "0.15.18",
-						"esbuild-linux-arm": "0.15.18",
-						"esbuild-linux-arm64": "0.15.18",
-						"esbuild-linux-mips64le": "0.15.18",
-						"esbuild-linux-ppc64le": "0.15.18",
-						"esbuild-linux-riscv64": "0.15.18",
-						"esbuild-linux-s390x": "0.15.18",
-						"esbuild-netbsd-64": "0.15.18",
-						"esbuild-openbsd-64": "0.15.18",
-						"esbuild-sunos-64": "0.15.18",
-						"esbuild-windows-32": "0.15.18",
-						"esbuild-windows-64": "0.15.18",
-						"esbuild-windows-arm64": "0.15.18"
-					}
-				},
-				"esbuild-android-64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.18.tgz",
-					"integrity": "sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==",
-					"dev": true,
-					"optional": true
-				},
-				"esbuild-android-arm64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.18.tgz",
-					"integrity": "sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==",
-					"dev": true,
-					"optional": true
-				},
-				"esbuild-darwin-64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.18.tgz",
-					"integrity": "sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==",
-					"dev": true,
-					"optional": true
-				},
-				"esbuild-darwin-arm64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.18.tgz",
-					"integrity": "sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==",
-					"dev": true,
-					"optional": true
-				},
-				"esbuild-freebsd-64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.18.tgz",
-					"integrity": "sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==",
-					"dev": true,
-					"optional": true
-				},
-				"esbuild-freebsd-arm64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.18.tgz",
-					"integrity": "sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==",
-					"dev": true,
-					"optional": true
-				},
-				"esbuild-linux-32": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.18.tgz",
-					"integrity": "sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==",
-					"dev": true,
-					"optional": true
-				},
-				"esbuild-linux-64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.18.tgz",
-					"integrity": "sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==",
-					"dev": true,
-					"optional": true
-				},
-				"esbuild-linux-arm": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.18.tgz",
-					"integrity": "sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==",
-					"dev": true,
-					"optional": true
-				},
-				"esbuild-linux-arm64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.18.tgz",
-					"integrity": "sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==",
-					"dev": true,
-					"optional": true
-				},
-				"esbuild-linux-mips64le": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.18.tgz",
-					"integrity": "sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==",
-					"dev": true,
-					"optional": true
-				},
-				"esbuild-linux-ppc64le": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.18.tgz",
-					"integrity": "sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==",
-					"dev": true,
-					"optional": true
-				},
-				"esbuild-linux-riscv64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.18.tgz",
-					"integrity": "sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==",
-					"dev": true,
-					"optional": true
-				},
-				"esbuild-linux-s390x": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.18.tgz",
-					"integrity": "sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==",
-					"dev": true,
-					"optional": true
-				},
-				"esbuild-netbsd-64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.18.tgz",
-					"integrity": "sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==",
-					"dev": true,
-					"optional": true
-				},
-				"esbuild-openbsd-64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.18.tgz",
-					"integrity": "sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==",
-					"dev": true,
-					"optional": true
-				},
-				"esbuild-sunos-64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.18.tgz",
-					"integrity": "sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==",
-					"dev": true,
-					"optional": true
-				},
-				"esbuild-windows-32": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.18.tgz",
-					"integrity": "sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==",
-					"dev": true,
-					"optional": true
-				},
-				"esbuild-windows-64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.18.tgz",
-					"integrity": "sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==",
-					"dev": true,
-					"optional": true
-				},
-				"esbuild-windows-arm64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.18.tgz",
-					"integrity": "sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==",
-					"dev": true,
-					"optional": true
 				},
 				"expect": {
 					"version": "27.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 				"@typescript-eslint/parser": "^5.46.0",
 				"cross-env": "^7.0.3",
 				"esbuild-jest": "0.5.0",
-				"esbuild-register": "^3.3.2",
+				"esbuild-register": "^3.4.2",
 				"eslint": "^8.13.0",
 				"eslint-plugin-import": "^2.26.0",
 				"eslint-plugin-react": "^7.29.4",
@@ -2665,6 +2665,141 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.12.tgz",
+			"integrity": "sha512-0LacmiIW+X0/LOLMZqYtZ7d4uY9fxYABAYhSSOu+OGQVBqH4N5eIYgkT7bBFnR4Nm3qo6qS3RpHKVrDASqj/uQ==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.12.tgz",
+			"integrity": "sha512-sS5CR3XBKQXYpSGMM28VuiUnbX83Z+aWPZzClW+OB2JquKqxoiwdqucJ5qvXS8pM6Up3RtJfDnRQZkz3en2z5g==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.12.tgz",
+			"integrity": "sha512-Dpe5hOAQiQRH20YkFAg+wOpcd4PEuXud+aGgKBQa/VriPJA8zuVlgCOSTwna1CgYl05lf6o5els4dtuyk1qJxQ==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.12.tgz",
+			"integrity": "sha512-ApGRA6X5txIcxV0095X4e4KKv87HAEXfuDRcGTniDWUUN+qPia8sl/BqG/0IomytQWajnUn4C7TOwHduk/FXBQ==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.12.tgz",
+			"integrity": "sha512-AMdK2gA9EU83ccXCWS1B/KcWYZCj4P3vDofZZkl/F/sBv/fphi2oUqUTox/g5GMcIxk8CF1CVYTC82+iBSyiUg==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.12.tgz",
+			"integrity": "sha512-KUKB9w8G/xaAbD39t6gnRBuhQ8vIYYlxGT2I+mT6UGRnCGRr1+ePFIGBQmf5V16nxylgUuuWVW1zU2ktKkf6WQ==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.12.tgz",
+			"integrity": "sha512-vhDdIv6z4eL0FJyNVfdr3C/vdd/Wc6h1683GJsFoJzfKb92dU/v88FhWdigg0i6+3TsbSDeWbsPUXb4dif2abg==",
+			"cpu": [
+				"arm"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.12.tgz",
+			"integrity": "sha512-29HXMLpLklDfmw7T2buGqq3HImSUaZ1ArmrPOMaNiZZQptOSZs32SQtOHEl8xWX5vfdwZqrBfNf8Te4nArVzKQ==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.12.tgz",
+			"integrity": "sha512-JFDuNDTTfgD1LJg7wHA42o2uAO/9VzHYK0leAVnCQE/FdMB599YMH73ux+nS0xGr79pv/BK+hrmdRin3iLgQjg==",
+			"cpu": [
+				"ia32"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@esbuild/linux-loong64": {
 			"version": "0.15.12",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.12.tgz",
@@ -2676,6 +2811,171 @@
 			"optional": true,
 			"os": [
 				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.12.tgz",
+			"integrity": "sha512-zI1cNgHa3Gol+vPYjIYHzKhU6qMyOQrvZ82REr5Fv7rlh5PG6SkkuCoH7IryPqR+BK2c/7oISGsvPJPGnO2bHQ==",
+			"cpu": [
+				"mips64el"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.12.tgz",
+			"integrity": "sha512-/C8OFXExoMmvTDIOAM54AhtmmuDHKoedUd0Otpfw3+AuuVGemA1nQK99oN909uZbLEU6Bi+7JheFMG3xGfZluQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.12.tgz",
+			"integrity": "sha512-qeouyyc8kAGV6Ni6Isz8hUsKMr00EHgVwUKWNp1r4l88fHEoNTDB8mmestvykW6MrstoGI7g2EAsgr0nxmuGYg==",
+			"cpu": [
+				"riscv64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.12.tgz",
+			"integrity": "sha512-s9AyI/5vz1U4NNqnacEGFElqwnHusWa81pskAf8JNDM2eb6b2E6PpBmT8RzeZv6/TxE6/TADn2g9bb0jOUmXwQ==",
+			"cpu": [
+				"s390x"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.12.tgz",
+			"integrity": "sha512-e8YA7GQGLWhvakBecLptUiKxOk4E/EPtSckS1i0MGYctW8ouvNUoh7xnU15PGO2jz7BYl8q1R6g0gE5HFtzpqQ==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.12.tgz",
+			"integrity": "sha512-z2+kUxmOqBS+6SRVd57iOLIHE8oGOoEnGVAmwjm2aENSP35HPS+5cK+FL1l+rhrsJOFIPrNHqDUNechpuG96Sg==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.12.tgz",
+			"integrity": "sha512-PAonw4LqIybwn2/vJujhbg1N9W2W8lw9RtXIvvZoyzoA/4rA4CpiuahVbASmQohiytRsixbNoIOUSjRygKXpyA==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.12.tgz",
+			"integrity": "sha512-+wr1tkt1RERi+Zi/iQtkzmMH4nS8+7UIRxjcyRz7lur84wCkAITT50Olq/HiT4JN2X2bjtlOV6vt7ptW5Gw60Q==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.12.tgz",
+			"integrity": "sha512-XEjeUSHmjsAOJk8+pXJu9pFY2O5KKQbHXZWQylJzQuIBeiGrpMeq9sTVrHefHxMOyxUgoKQTcaTS+VK/K5SviA==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.12.tgz",
+			"integrity": "sha512-eRKPM7e0IecUAUYr2alW7JGDejrFJXmpjt4MlfonmQ5Rz9HWpKFGCjuuIRgKO7W9C/CWVFXdJ2GjddsBXqQI4A==",
+			"cpu": [
+				"ia32"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.12.tgz",
+			"integrity": "sha512-iPYKN78t3op2+erv2frW568j1q0RpqX6JOLZ7oPPaAV1VaF7dDstOrNw37PVOYoTWE11pV4A1XUitpdEFNIsPg==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
 			],
 			"engines": {
 				"node": ">=12"
@@ -9701,9 +10001,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.18.tgz",
-			"integrity": "sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==",
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.12.tgz",
+			"integrity": "sha512-eq5KcuXajf2OmivCl4e89AD3j8fbV+UTE9vczEzq5haA07U9oOTzBWlh3+6ZdjJR7Rz2QfWZ2uxZyhZxBgJ4+g==",
 			"hasInstallScript": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
@@ -9712,28 +10012,28 @@
 				"node": ">=12"
 			},
 			"optionalDependencies": {
-				"@esbuild/android-arm": "0.15.18",
-				"@esbuild/linux-loong64": "0.15.18",
-				"esbuild-android-64": "0.15.18",
-				"esbuild-android-arm64": "0.15.18",
-				"esbuild-darwin-64": "0.15.18",
-				"esbuild-darwin-arm64": "0.15.18",
-				"esbuild-freebsd-64": "0.15.18",
-				"esbuild-freebsd-arm64": "0.15.18",
-				"esbuild-linux-32": "0.15.18",
-				"esbuild-linux-64": "0.15.18",
-				"esbuild-linux-arm": "0.15.18",
-				"esbuild-linux-arm64": "0.15.18",
-				"esbuild-linux-mips64le": "0.15.18",
-				"esbuild-linux-ppc64le": "0.15.18",
-				"esbuild-linux-riscv64": "0.15.18",
-				"esbuild-linux-s390x": "0.15.18",
-				"esbuild-netbsd-64": "0.15.18",
-				"esbuild-openbsd-64": "0.15.18",
-				"esbuild-sunos-64": "0.15.18",
-				"esbuild-windows-32": "0.15.18",
-				"esbuild-windows-64": "0.15.18",
-				"esbuild-windows-arm64": "0.15.18"
+				"@esbuild/android-arm": "0.16.12",
+				"@esbuild/android-arm64": "0.16.12",
+				"@esbuild/android-x64": "0.16.12",
+				"@esbuild/darwin-arm64": "0.16.12",
+				"@esbuild/darwin-x64": "0.16.12",
+				"@esbuild/freebsd-arm64": "0.16.12",
+				"@esbuild/freebsd-x64": "0.16.12",
+				"@esbuild/linux-arm": "0.16.12",
+				"@esbuild/linux-arm64": "0.16.12",
+				"@esbuild/linux-ia32": "0.16.12",
+				"@esbuild/linux-loong64": "0.16.12",
+				"@esbuild/linux-mips64el": "0.16.12",
+				"@esbuild/linux-ppc64": "0.16.12",
+				"@esbuild/linux-riscv64": "0.16.12",
+				"@esbuild/linux-s390x": "0.16.12",
+				"@esbuild/linux-x64": "0.16.12",
+				"@esbuild/netbsd-x64": "0.16.12",
+				"@esbuild/openbsd-x64": "0.16.12",
+				"@esbuild/sunos-x64": "0.16.12",
+				"@esbuild/win32-arm64": "0.16.12",
+				"@esbuild/win32-ia32": "0.16.12",
+				"@esbuild/win32-x64": "0.16.12"
 			}
 		},
 		"node_modules/esbuild-android-64": {
@@ -10005,8 +10305,12 @@
 			}
 		},
 		"node_modules/esbuild-register": {
-			"version": "3.3.2",
-			"license": "MIT",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.4.2.tgz",
+			"integrity": "sha512-kG/XyTDyz6+YDuyfB9ZoSIOOmgyFCH+xPRtsCa8W85HLRV5Csp+o3jWVbOSHgSLfyLc5DmP+KFDNwty4mEjC+Q==",
+			"dependencies": {
+				"debug": "^4.3.4"
+			},
 			"peerDependencies": {
 				"esbuild": ">=0.12 <1"
 			}
@@ -10076,9 +10380,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/@esbuild/android-arm": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.18.tgz",
-			"integrity": "sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==",
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.12.tgz",
+			"integrity": "sha512-CTWgMJtpCyCltrvipZrrcjjRu+rzm6pf9V8muCsJqtKujR3kPmU4ffbckvugNNaRmhxAF1ZI3J+0FUIFLFg8KA==",
 			"cpu": [
 				"arm"
 			],
@@ -10091,315 +10395,15 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.18.tgz",
-			"integrity": "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==",
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.12.tgz",
+			"integrity": "sha512-xTGzVPqm6WKfCC0iuj1fryIWr1NWEM8DMhAIo+4rFgUtwy/lfHl+Obvus4oddzRDbBetLLmojfVZGmt/g/g+Rw==",
 			"cpu": [
 				"loong64"
 			],
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-android-64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.18.tgz",
-			"integrity": "sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-android-arm64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.18.tgz",
-			"integrity": "sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-darwin-64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.18.tgz",
-			"integrity": "sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-darwin-arm64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.18.tgz",
-			"integrity": "sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-freebsd-64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.18.tgz",
-			"integrity": "sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-freebsd-arm64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.18.tgz",
-			"integrity": "sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-linux-32": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.18.tgz",
-			"integrity": "sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==",
-			"cpu": [
-				"ia32"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-linux-64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.18.tgz",
-			"integrity": "sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-linux-arm": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.18.tgz",
-			"integrity": "sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==",
-			"cpu": [
-				"arm"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-linux-arm64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.18.tgz",
-			"integrity": "sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-linux-mips64le": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.18.tgz",
-			"integrity": "sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==",
-			"cpu": [
-				"mips64el"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-linux-ppc64le": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.18.tgz",
-			"integrity": "sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==",
-			"cpu": [
-				"ppc64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-linux-riscv64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.18.tgz",
-			"integrity": "sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==",
-			"cpu": [
-				"riscv64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-linux-s390x": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.18.tgz",
-			"integrity": "sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==",
-			"cpu": [
-				"s390x"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-netbsd-64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.18.tgz",
-			"integrity": "sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-openbsd-64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.18.tgz",
-			"integrity": "sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-sunos-64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.18.tgz",
-			"integrity": "sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"sunos"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-windows-32": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.18.tgz",
-			"integrity": "sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==",
-			"cpu": [
-				"ia32"
-			],
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-windows-64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.18.tgz",
-			"integrity": "sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-windows-arm64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.18.tgz",
-			"integrity": "sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"win32"
 			],
 			"engines": {
 				"node": ">=12"
@@ -27267,7 +27271,7 @@
 				"@miniflare/durable-objects": "2.10.0",
 				"blake3-wasm": "^2.1.5",
 				"chokidar": "^3.5.3",
-				"esbuild": "0.15.18",
+				"esbuild": "0.16.12",
 				"miniflare": "2.10.0",
 				"nanoid": "^3.3.3",
 				"path-to-regexp": "^6.2.0",
@@ -27533,7 +27537,7 @@
 				"@types/rimraf": "^3.0.2",
 				"@types/tar": "^6.1.1",
 				"@types/webpack": "^4.41.32",
-				"esbuild": "^0.15.18",
+				"esbuild": "^0.16.12",
 				"execa": "^6.1.0",
 				"jest": "^27.5.1",
 				"jest-fetch-mock": "^3.0.3",
@@ -30337,11 +30341,131 @@
 			"dev": true,
 			"optional": true
 		},
+		"@esbuild/android-arm64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.12.tgz",
+			"integrity": "sha512-0LacmiIW+X0/LOLMZqYtZ7d4uY9fxYABAYhSSOu+OGQVBqH4N5eIYgkT7bBFnR4Nm3qo6qS3RpHKVrDASqj/uQ==",
+			"optional": true
+		},
+		"@esbuild/android-x64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.12.tgz",
+			"integrity": "sha512-sS5CR3XBKQXYpSGMM28VuiUnbX83Z+aWPZzClW+OB2JquKqxoiwdqucJ5qvXS8pM6Up3RtJfDnRQZkz3en2z5g==",
+			"optional": true
+		},
+		"@esbuild/darwin-arm64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.12.tgz",
+			"integrity": "sha512-Dpe5hOAQiQRH20YkFAg+wOpcd4PEuXud+aGgKBQa/VriPJA8zuVlgCOSTwna1CgYl05lf6o5els4dtuyk1qJxQ==",
+			"optional": true
+		},
+		"@esbuild/darwin-x64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.12.tgz",
+			"integrity": "sha512-ApGRA6X5txIcxV0095X4e4KKv87HAEXfuDRcGTniDWUUN+qPia8sl/BqG/0IomytQWajnUn4C7TOwHduk/FXBQ==",
+			"optional": true
+		},
+		"@esbuild/freebsd-arm64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.12.tgz",
+			"integrity": "sha512-AMdK2gA9EU83ccXCWS1B/KcWYZCj4P3vDofZZkl/F/sBv/fphi2oUqUTox/g5GMcIxk8CF1CVYTC82+iBSyiUg==",
+			"optional": true
+		},
+		"@esbuild/freebsd-x64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.12.tgz",
+			"integrity": "sha512-KUKB9w8G/xaAbD39t6gnRBuhQ8vIYYlxGT2I+mT6UGRnCGRr1+ePFIGBQmf5V16nxylgUuuWVW1zU2ktKkf6WQ==",
+			"optional": true
+		},
+		"@esbuild/linux-arm": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.12.tgz",
+			"integrity": "sha512-vhDdIv6z4eL0FJyNVfdr3C/vdd/Wc6h1683GJsFoJzfKb92dU/v88FhWdigg0i6+3TsbSDeWbsPUXb4dif2abg==",
+			"optional": true
+		},
+		"@esbuild/linux-arm64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.12.tgz",
+			"integrity": "sha512-29HXMLpLklDfmw7T2buGqq3HImSUaZ1ArmrPOMaNiZZQptOSZs32SQtOHEl8xWX5vfdwZqrBfNf8Te4nArVzKQ==",
+			"optional": true
+		},
+		"@esbuild/linux-ia32": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.12.tgz",
+			"integrity": "sha512-JFDuNDTTfgD1LJg7wHA42o2uAO/9VzHYK0leAVnCQE/FdMB599YMH73ux+nS0xGr79pv/BK+hrmdRin3iLgQjg==",
+			"optional": true
+		},
 		"@esbuild/linux-loong64": {
 			"version": "0.15.12",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.12.tgz",
 			"integrity": "sha512-tZEowDjvU7O7I04GYvWQOS4yyP9E/7YlsB0jjw1Ycukgr2ycEzKyIk5tms5WnLBymaewc6VmRKnn5IJWgK4eFw==",
 			"dev": true,
+			"optional": true
+		},
+		"@esbuild/linux-mips64el": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.12.tgz",
+			"integrity": "sha512-zI1cNgHa3Gol+vPYjIYHzKhU6qMyOQrvZ82REr5Fv7rlh5PG6SkkuCoH7IryPqR+BK2c/7oISGsvPJPGnO2bHQ==",
+			"optional": true
+		},
+		"@esbuild/linux-ppc64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.12.tgz",
+			"integrity": "sha512-/C8OFXExoMmvTDIOAM54AhtmmuDHKoedUd0Otpfw3+AuuVGemA1nQK99oN909uZbLEU6Bi+7JheFMG3xGfZluQ==",
+			"optional": true
+		},
+		"@esbuild/linux-riscv64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.12.tgz",
+			"integrity": "sha512-qeouyyc8kAGV6Ni6Isz8hUsKMr00EHgVwUKWNp1r4l88fHEoNTDB8mmestvykW6MrstoGI7g2EAsgr0nxmuGYg==",
+			"optional": true
+		},
+		"@esbuild/linux-s390x": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.12.tgz",
+			"integrity": "sha512-s9AyI/5vz1U4NNqnacEGFElqwnHusWa81pskAf8JNDM2eb6b2E6PpBmT8RzeZv6/TxE6/TADn2g9bb0jOUmXwQ==",
+			"optional": true
+		},
+		"@esbuild/linux-x64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.12.tgz",
+			"integrity": "sha512-e8YA7GQGLWhvakBecLptUiKxOk4E/EPtSckS1i0MGYctW8ouvNUoh7xnU15PGO2jz7BYl8q1R6g0gE5HFtzpqQ==",
+			"optional": true
+		},
+		"@esbuild/netbsd-x64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.12.tgz",
+			"integrity": "sha512-z2+kUxmOqBS+6SRVd57iOLIHE8oGOoEnGVAmwjm2aENSP35HPS+5cK+FL1l+rhrsJOFIPrNHqDUNechpuG96Sg==",
+			"optional": true
+		},
+		"@esbuild/openbsd-x64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.12.tgz",
+			"integrity": "sha512-PAonw4LqIybwn2/vJujhbg1N9W2W8lw9RtXIvvZoyzoA/4rA4CpiuahVbASmQohiytRsixbNoIOUSjRygKXpyA==",
+			"optional": true
+		},
+		"@esbuild/sunos-x64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.12.tgz",
+			"integrity": "sha512-+wr1tkt1RERi+Zi/iQtkzmMH4nS8+7UIRxjcyRz7lur84wCkAITT50Olq/HiT4JN2X2bjtlOV6vt7ptW5Gw60Q==",
+			"optional": true
+		},
+		"@esbuild/win32-arm64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.12.tgz",
+			"integrity": "sha512-XEjeUSHmjsAOJk8+pXJu9pFY2O5KKQbHXZWQylJzQuIBeiGrpMeq9sTVrHefHxMOyxUgoKQTcaTS+VK/K5SviA==",
+			"optional": true
+		},
+		"@esbuild/win32-ia32": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.12.tgz",
+			"integrity": "sha512-eRKPM7e0IecUAUYr2alW7JGDejrFJXmpjt4MlfonmQ5Rz9HWpKFGCjuuIRgKO7W9C/CWVFXdJ2GjddsBXqQI4A==",
+			"optional": true
+		},
+		"@esbuild/win32-x64": {
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.12.tgz",
+			"integrity": "sha512-iPYKN78t3op2+erv2frW568j1q0RpqX6JOLZ7oPPaAV1VaF7dDstOrNw37PVOYoTWE11pV4A1XUitpdEFNIsPg==",
 			"optional": true
 		},
 		"@eslint/eslintrc": {
@@ -35403,164 +35527,44 @@
 			}
 		},
 		"esbuild": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.18.tgz",
-			"integrity": "sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==",
+			"version": "0.16.12",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.12.tgz",
+			"integrity": "sha512-eq5KcuXajf2OmivCl4e89AD3j8fbV+UTE9vczEzq5haA07U9oOTzBWlh3+6ZdjJR7Rz2QfWZ2uxZyhZxBgJ4+g==",
 			"requires": {
-				"@esbuild/android-arm": "0.15.18",
-				"@esbuild/linux-loong64": "0.15.18",
-				"esbuild-android-64": "0.15.18",
-				"esbuild-android-arm64": "0.15.18",
-				"esbuild-darwin-64": "0.15.18",
-				"esbuild-darwin-arm64": "0.15.18",
-				"esbuild-freebsd-64": "0.15.18",
-				"esbuild-freebsd-arm64": "0.15.18",
-				"esbuild-linux-32": "0.15.18",
-				"esbuild-linux-64": "0.15.18",
-				"esbuild-linux-arm": "0.15.18",
-				"esbuild-linux-arm64": "0.15.18",
-				"esbuild-linux-mips64le": "0.15.18",
-				"esbuild-linux-ppc64le": "0.15.18",
-				"esbuild-linux-riscv64": "0.15.18",
-				"esbuild-linux-s390x": "0.15.18",
-				"esbuild-netbsd-64": "0.15.18",
-				"esbuild-openbsd-64": "0.15.18",
-				"esbuild-sunos-64": "0.15.18",
-				"esbuild-windows-32": "0.15.18",
-				"esbuild-windows-64": "0.15.18",
-				"esbuild-windows-arm64": "0.15.18"
+				"@esbuild/android-arm": "0.16.12",
+				"@esbuild/android-arm64": "0.16.12",
+				"@esbuild/android-x64": "0.16.12",
+				"@esbuild/darwin-arm64": "0.16.12",
+				"@esbuild/darwin-x64": "0.16.12",
+				"@esbuild/freebsd-arm64": "0.16.12",
+				"@esbuild/freebsd-x64": "0.16.12",
+				"@esbuild/linux-arm": "0.16.12",
+				"@esbuild/linux-arm64": "0.16.12",
+				"@esbuild/linux-ia32": "0.16.12",
+				"@esbuild/linux-loong64": "0.16.12",
+				"@esbuild/linux-mips64el": "0.16.12",
+				"@esbuild/linux-ppc64": "0.16.12",
+				"@esbuild/linux-riscv64": "0.16.12",
+				"@esbuild/linux-s390x": "0.16.12",
+				"@esbuild/linux-x64": "0.16.12",
+				"@esbuild/netbsd-x64": "0.16.12",
+				"@esbuild/openbsd-x64": "0.16.12",
+				"@esbuild/sunos-x64": "0.16.12",
+				"@esbuild/win32-arm64": "0.16.12",
+				"@esbuild/win32-ia32": "0.16.12",
+				"@esbuild/win32-x64": "0.16.12"
 			},
 			"dependencies": {
 				"@esbuild/android-arm": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.18.tgz",
-					"integrity": "sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==",
+					"version": "0.16.12",
+					"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.12.tgz",
+					"integrity": "sha512-CTWgMJtpCyCltrvipZrrcjjRu+rzm6pf9V8muCsJqtKujR3kPmU4ffbckvugNNaRmhxAF1ZI3J+0FUIFLFg8KA==",
 					"optional": true
 				},
 				"@esbuild/linux-loong64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.18.tgz",
-					"integrity": "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==",
-					"optional": true
-				},
-				"esbuild-android-64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.18.tgz",
-					"integrity": "sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==",
-					"optional": true
-				},
-				"esbuild-android-arm64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.18.tgz",
-					"integrity": "sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==",
-					"optional": true
-				},
-				"esbuild-darwin-64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.18.tgz",
-					"integrity": "sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==",
-					"optional": true
-				},
-				"esbuild-darwin-arm64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.18.tgz",
-					"integrity": "sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==",
-					"optional": true
-				},
-				"esbuild-freebsd-64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.18.tgz",
-					"integrity": "sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==",
-					"optional": true
-				},
-				"esbuild-freebsd-arm64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.18.tgz",
-					"integrity": "sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==",
-					"optional": true
-				},
-				"esbuild-linux-32": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.18.tgz",
-					"integrity": "sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==",
-					"optional": true
-				},
-				"esbuild-linux-64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.18.tgz",
-					"integrity": "sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==",
-					"optional": true
-				},
-				"esbuild-linux-arm": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.18.tgz",
-					"integrity": "sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==",
-					"optional": true
-				},
-				"esbuild-linux-arm64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.18.tgz",
-					"integrity": "sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==",
-					"optional": true
-				},
-				"esbuild-linux-mips64le": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.18.tgz",
-					"integrity": "sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==",
-					"optional": true
-				},
-				"esbuild-linux-ppc64le": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.18.tgz",
-					"integrity": "sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==",
-					"optional": true
-				},
-				"esbuild-linux-riscv64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.18.tgz",
-					"integrity": "sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==",
-					"optional": true
-				},
-				"esbuild-linux-s390x": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.18.tgz",
-					"integrity": "sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==",
-					"optional": true
-				},
-				"esbuild-netbsd-64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.18.tgz",
-					"integrity": "sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==",
-					"optional": true
-				},
-				"esbuild-openbsd-64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.18.tgz",
-					"integrity": "sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==",
-					"optional": true
-				},
-				"esbuild-sunos-64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.18.tgz",
-					"integrity": "sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==",
-					"optional": true
-				},
-				"esbuild-windows-32": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.18.tgz",
-					"integrity": "sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==",
-					"optional": true
-				},
-				"esbuild-windows-64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.18.tgz",
-					"integrity": "sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==",
-					"optional": true
-				},
-				"esbuild-windows-arm64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.18.tgz",
-					"integrity": "sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==",
+					"version": "0.16.12",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.12.tgz",
+					"integrity": "sha512-xTGzVPqm6WKfCC0iuj1fryIWr1NWEM8DMhAIo+4rFgUtwy/lfHl+Obvus4oddzRDbBetLLmojfVZGmt/g/g+Rw==",
 					"optional": true
 				}
 			}
@@ -35686,8 +35690,12 @@
 			"optional": true
 		},
 		"esbuild-register": {
-			"version": "3.3.2",
-			"requires": {}
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.4.2.tgz",
+			"integrity": "sha512-kG/XyTDyz6+YDuyfB9ZoSIOOmgyFCH+xPRtsCa8W85HLRV5Csp+o3jWVbOSHgSLfyLc5DmP+KFDNwty4mEjC+Q==",
+			"requires": {
+				"debug": "^4.3.4"
+			}
 		},
 		"esbuild-sunos-64": {
 			"version": "0.15.12",
@@ -47295,7 +47303,7 @@
 				"concurrently": "^7.2.2",
 				"devtools-protocol": "^0.0.955664",
 				"dotenv": "^16.0.0",
-				"esbuild": "0.15.18",
+				"esbuild": "0.16.12",
 				"execa": "^6.1.0",
 				"express": "^4.18.1",
 				"finalhandler": "^1.2.0",
@@ -47441,7 +47449,7 @@
 				"@types/rimraf": "^3.0.2",
 				"@types/tar": "^6.1.1",
 				"@types/webpack": "^4.41.32",
-				"esbuild": "^0.15.18",
+				"esbuild": "^0.16.12",
 				"execa": "^6.1.0",
 				"jest": "^27.5.1",
 				"jest-fetch-mock": "^3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9701,9 +9701,10 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.14.51",
+			"version": "0.15.15",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.15.tgz",
+			"integrity": "sha512-TEw/lwK4Zzld9x3FedV6jy8onOUHqcEX3ADFk4k+gzPUwrxn8nWV62tH0udo8jOtjFodlEfc4ypsqX3e+WWO6w==",
 			"hasInstallScript": true,
-			"license": "MIT",
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
@@ -9711,26 +9712,28 @@
 				"node": ">=12"
 			},
 			"optionalDependencies": {
-				"esbuild-android-64": "0.14.51",
-				"esbuild-android-arm64": "0.14.51",
-				"esbuild-darwin-64": "0.14.51",
-				"esbuild-darwin-arm64": "0.14.51",
-				"esbuild-freebsd-64": "0.14.51",
-				"esbuild-freebsd-arm64": "0.14.51",
-				"esbuild-linux-32": "0.14.51",
-				"esbuild-linux-64": "0.14.51",
-				"esbuild-linux-arm": "0.14.51",
-				"esbuild-linux-arm64": "0.14.51",
-				"esbuild-linux-mips64le": "0.14.51",
-				"esbuild-linux-ppc64le": "0.14.51",
-				"esbuild-linux-riscv64": "0.14.51",
-				"esbuild-linux-s390x": "0.14.51",
-				"esbuild-netbsd-64": "0.14.51",
-				"esbuild-openbsd-64": "0.14.51",
-				"esbuild-sunos-64": "0.14.51",
-				"esbuild-windows-32": "0.14.51",
-				"esbuild-windows-64": "0.14.51",
-				"esbuild-windows-arm64": "0.14.51"
+				"@esbuild/android-arm": "0.15.15",
+				"@esbuild/linux-loong64": "0.15.15",
+				"esbuild-android-64": "0.15.15",
+				"esbuild-android-arm64": "0.15.15",
+				"esbuild-darwin-64": "0.15.15",
+				"esbuild-darwin-arm64": "0.15.15",
+				"esbuild-freebsd-64": "0.15.15",
+				"esbuild-freebsd-arm64": "0.15.15",
+				"esbuild-linux-32": "0.15.15",
+				"esbuild-linux-64": "0.15.15",
+				"esbuild-linux-arm": "0.15.15",
+				"esbuild-linux-arm64": "0.15.15",
+				"esbuild-linux-mips64le": "0.15.15",
+				"esbuild-linux-ppc64le": "0.15.15",
+				"esbuild-linux-riscv64": "0.15.15",
+				"esbuild-linux-s390x": "0.15.15",
+				"esbuild-netbsd-64": "0.15.15",
+				"esbuild-openbsd-64": "0.15.15",
+				"esbuild-sunos-64": "0.15.15",
+				"esbuild-windows-32": "0.15.15",
+				"esbuild-windows-64": "0.15.15",
+				"esbuild-windows-arm64": "0.15.15"
 			}
 		},
 		"node_modules/esbuild-android-64": {
@@ -10072,10 +10075,40 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/esbuild/node_modules/@esbuild/android-arm": {
+			"version": "0.15.15",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.15.tgz",
+			"integrity": "sha512-JJjZjJi2eBL01QJuWjfCdZxcIgot+VoK6Fq7eKF9w4YHm9hwl7nhBR1o2Wnt/WcANk5l9SkpvrldW1PLuXxcbw==",
+			"cpu": [
+				"arm"
+			],
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
+			"version": "0.15.15",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.15.tgz",
+			"integrity": "sha512-lhz6UNPMDXUhtXSulw8XlFAtSYO26WmHQnCi2Lg2p+/TMiJKNLtZCYUxV4wG6rZMzXmr8InGpNwk+DLT2Hm0PA==",
+			"cpu": [
+				"loong64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/esbuild/node_modules/esbuild-android-64": {
-			"version": "0.14.51",
-			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.51.tgz",
-			"integrity": "sha512-6FOuKTHnC86dtrKDmdSj2CkcKF8PnqkaIXqvgydqfJmqBazCPdw+relrMlhGjkvVdiiGV70rpdnyFmA65ekBCQ==",
+			"version": "0.15.15",
+			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.15.tgz",
+			"integrity": "sha512-F+WjjQxO+JQOva3tJWNdVjouFMLK6R6i5gjDvgUthLYJnIZJsp1HlF523k73hELY20WPyEO8xcz7aaYBVkeg5Q==",
 			"cpu": [
 				"x64"
 			],
@@ -10088,9 +10121,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-android-arm64": {
-			"version": "0.14.51",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.51.tgz",
-			"integrity": "sha512-vBtp//5VVkZWmYYvHsqBRCMMi1MzKuMIn5XDScmnykMTu9+TD9v0NMEDqQxvtFToeYmojdo5UCV2vzMQWJcJ4A==",
+			"version": "0.15.15",
+			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.15.tgz",
+			"integrity": "sha512-attlyhD6Y22jNyQ0fIIQ7mnPvDWKw7k6FKnsXlBvQE6s3z6s6cuEHcSgoirquQc7TmZgVCK5fD/2uxmRN+ZpcQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -10103,11 +10136,12 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-darwin-64": {
-			"version": "0.14.51",
+			"version": "0.15.15",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.15.tgz",
+			"integrity": "sha512-ohZtF8W1SHJ4JWldsPVdk8st0r9ExbAOSrBOh5L+Mq47i696GVwv1ab/KlmbUoikSTNoXEhDzVpxUR/WIO19FQ==",
 			"cpu": [
 				"x64"
 			],
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -10117,9 +10151,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-darwin-arm64": {
-			"version": "0.14.51",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.51.tgz",
-			"integrity": "sha512-juYD0QnSKwAMfzwKdIF6YbueXzS6N7y4GXPDeDkApz/1RzlT42mvX9jgNmyOlWKN7YzQAYbcUEJmZJYQGdf2ow==",
+			"version": "0.15.15",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.15.tgz",
+			"integrity": "sha512-P8jOZ5zshCNIuGn+9KehKs/cq5uIniC+BeCykvdVhx/rBXSxmtj3CUIKZz4sDCuESMbitK54drf/2QX9QHG5Ag==",
 			"cpu": [
 				"arm64"
 			],
@@ -10132,9 +10166,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-freebsd-64": {
-			"version": "0.14.51",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.51.tgz",
-			"integrity": "sha512-cLEI/aXjb6vo5O2Y8rvVSQ7smgLldwYY5xMxqh/dQGfWO+R1NJOFsiax3IS4Ng300SVp7Gz3czxT6d6qf2cw0g==",
+			"version": "0.15.15",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.15.tgz",
+			"integrity": "sha512-KkTg+AmDXz1IvA9S1gt8dE24C8Thx0X5oM0KGF322DuP+P3evwTL9YyusHAWNsh4qLsR80nvBr/EIYs29VSwuA==",
 			"cpu": [
 				"x64"
 			],
@@ -10147,9 +10181,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-freebsd-arm64": {
-			"version": "0.14.51",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.51.tgz",
-			"integrity": "sha512-TcWVw/rCL2F+jUgRkgLa3qltd5gzKjIMGhkVybkjk6PJadYInPtgtUBp1/hG+mxyigaT7ib+od1Xb84b+L+1Mg==",
+			"version": "0.15.15",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.15.tgz",
+			"integrity": "sha512-FUcML0DRsuyqCMfAC+HoeAqvWxMeq0qXvclZZ/lt2kLU6XBnDA5uKTLUd379WYEyVD4KKFctqWd9tTuk8C/96g==",
 			"cpu": [
 				"arm64"
 			],
@@ -10162,9 +10196,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-linux-32": {
-			"version": "0.14.51",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.51.tgz",
-			"integrity": "sha512-RFqpyC5ChyWrjx8Xj2K0EC1aN0A37H6OJfmUXIASEqJoHcntuV3j2Efr9RNmUhMfNE6yEj2VpYuDteZLGDMr0w==",
+			"version": "0.15.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.15.tgz",
+			"integrity": "sha512-q28Qn5pZgHNqug02aTkzw5sW9OklSo96b5nm17Mq0pDXrdTBcQ+M6Q9A1B+dalFeynunwh/pvfrNucjzwDXj+Q==",
 			"cpu": [
 				"ia32"
 			],
@@ -10177,9 +10211,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-linux-64": {
-			"version": "0.14.51",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.51.tgz",
-			"integrity": "sha512-dxjhrqo5i7Rq6DXwz5v+MEHVs9VNFItJmHBe1CxROWNf4miOGoQhqSG8StStbDkQ1Mtobg6ng+4fwByOhoQoeA==",
+			"version": "0.15.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.15.tgz",
+			"integrity": "sha512-217KPmWMirkf8liO+fj2qrPwbIbhNTGNVtvqI1TnOWJgcMjUWvd677Gq3fTzXEjilkx2yWypVnTswM2KbXgoAg==",
 			"cpu": [
 				"x64"
 			],
@@ -10192,9 +10226,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-linux-arm": {
-			"version": "0.14.51",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.51.tgz",
-			"integrity": "sha512-LsJynDxYF6Neg7ZC7748yweCDD+N8ByCv22/7IAZglIEniEkqdF4HCaa49JNDLw1UQGlYuhOB8ZT/MmcSWzcWg==",
+			"version": "0.15.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.15.tgz",
+			"integrity": "sha512-RYVW9o2yN8yM7SB1yaWr378CwrjvGCyGybX3SdzPHpikUHkME2AP55Ma20uNwkNyY2eSYFX9D55kDrfQmQBR4w==",
 			"cpu": [
 				"arm"
 			],
@@ -10207,9 +10241,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-linux-arm64": {
-			"version": "0.14.51",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.51.tgz",
-			"integrity": "sha512-D9rFxGutoqQX3xJPxqd6o+kvYKeIbM0ifW2y0bgKk5HPgQQOo2k9/2Vpto3ybGYaFPCE5qTGtqQta9PoP6ZEzw==",
+			"version": "0.15.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.15.tgz",
+			"integrity": "sha512-/ltmNFs0FivZkYsTzAsXIfLQX38lFnwJTWCJts0IbCqWZQe+jjj0vYBNbI0kmXLb3y5NljiM5USVAO1NVkdh2g==",
 			"cpu": [
 				"arm64"
 			],
@@ -10222,9 +10256,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-linux-mips64le": {
-			"version": "0.14.51",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.51.tgz",
-			"integrity": "sha512-vS54wQjy4IinLSlb5EIlLoln8buh1yDgliP4CuEHumrPk4PvvP4kTRIG4SzMXm6t19N0rIfT4bNdAxzJLg2k6A==",
+			"version": "0.15.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.15.tgz",
+			"integrity": "sha512-PksEPb321/28GFFxtvL33yVPfnMZihxkEv5zME2zapXGp7fA1X2jYeiTUK+9tJ/EGgcNWuwvtawPxJG7Mmn86A==",
 			"cpu": [
 				"mips64el"
 			],
@@ -10237,9 +10271,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-linux-ppc64le": {
-			"version": "0.14.51",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.51.tgz",
-			"integrity": "sha512-xcdd62Y3VfGoyphNP/aIV9LP+RzFw5M5Z7ja+zdpQHHvokJM7d0rlDRMN+iSSwvUymQkqZO+G/xjb4/75du8BQ==",
+			"version": "0.15.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.15.tgz",
+			"integrity": "sha512-ek8gJBEIhcpGI327eAZigBOHl58QqrJrYYIZBWQCnH3UnXoeWMrMZLeeZL8BI2XMBhP+sQ6ERctD5X+ajL/AIA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -10252,9 +10286,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-linux-riscv64": {
-			"version": "0.14.51",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.51.tgz",
-			"integrity": "sha512-syXHGak9wkAnFz0gMmRBoy44JV0rp4kVCEA36P5MCeZcxFq8+fllBC2t6sKI23w3qd8Vwo9pTADCgjTSf3L3rA==",
+			"version": "0.15.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.15.tgz",
+			"integrity": "sha512-H5ilTZb33/GnUBrZMNJtBk7/OXzDHDXjIzoLXHSutwwsLxSNaLxzAaMoDGDd/keZoS+GDBqNVxdCkpuiRW4OSw==",
 			"cpu": [
 				"riscv64"
 			],
@@ -10267,9 +10301,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-linux-s390x": {
-			"version": "0.14.51",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.51.tgz",
-			"integrity": "sha512-kFAJY3dv+Wq8o28K/C7xkZk/X34rgTwhknSsElIqoEo8armCOjMJ6NsMxm48KaWY2h2RUYGtQmr+RGuUPKBhyw==",
+			"version": "0.15.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.15.tgz",
+			"integrity": "sha512-jKaLUg78mua3rrtrkpv4Or2dNTJU7bgHN4bEjT4OX4GR7nLBSA9dfJezQouTxMmIW7opwEC5/iR9mpC18utnxQ==",
 			"cpu": [
 				"s390x"
 			],
@@ -10282,9 +10316,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-netbsd-64": {
-			"version": "0.14.51",
-			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.51.tgz",
-			"integrity": "sha512-ZZBI7qrR1FevdPBVHz/1GSk1x5GDL/iy42Zy8+neEm/HA7ma+hH/bwPEjeHXKWUDvM36CZpSL/fn1/y9/Hb+1A==",
+			"version": "0.15.15",
+			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.15.tgz",
+			"integrity": "sha512-aOvmF/UkjFuW6F36HbIlImJTTx45KUCHJndtKo+KdP8Dhq3mgLRKW9+6Ircpm8bX/RcS3zZMMmaBLkvGY06Gvw==",
 			"cpu": [
 				"x64"
 			],
@@ -10297,9 +10331,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-openbsd-64": {
-			"version": "0.14.51",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.51.tgz",
-			"integrity": "sha512-7R1/p39M+LSVQVgDVlcY1KKm6kFKjERSX1lipMG51NPcspJD1tmiZSmmBXoY5jhHIu6JL1QkFDTx94gMYK6vfA==",
+			"version": "0.15.15",
+			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.15.tgz",
+			"integrity": "sha512-HFFX+WYedx1w2yJ1VyR1Dfo8zyYGQZf1cA69bLdrHzu9svj6KH6ZLK0k3A1/LFPhcEY9idSOhsB2UyU0tHPxgQ==",
 			"cpu": [
 				"x64"
 			],
@@ -10312,9 +10346,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-sunos-64": {
-			"version": "0.14.51",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.51.tgz",
-			"integrity": "sha512-HoHaCswHxLEYN8eBTtyO0bFEWvA3Kdb++hSQ/lLG7TyKF69TeSG0RNoBRAs45x/oCeWaTDntEZlYwAfQlhEtJA==",
+			"version": "0.15.15",
+			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.15.tgz",
+			"integrity": "sha512-jOPBudffG4HN8yJXcK9rib/ZTFoTA5pvIKbRrt3IKAGMq1EpBi4xoVoSRrq/0d4OgZLaQbmkHp8RO9eZIn5atA==",
 			"cpu": [
 				"x64"
 			],
@@ -10327,9 +10361,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-windows-32": {
-			"version": "0.14.51",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.51.tgz",
-			"integrity": "sha512-4rtwSAM35A07CBt1/X8RWieDj3ZUHQqUOaEo5ZBs69rt5WAFjP4aqCIobdqOy4FdhYw1yF8Z0xFBTyc9lgPtEg==",
+			"version": "0.15.15",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.15.tgz",
+			"integrity": "sha512-MDkJ3QkjnCetKF0fKxCyYNBnOq6dmidcwstBVeMtXSgGYTy8XSwBeIE4+HuKiSsG6I/mXEb++px3IGSmTN0XiA==",
 			"cpu": [
 				"ia32"
 			],
@@ -10342,9 +10376,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-windows-64": {
-			"version": "0.14.51",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.51.tgz",
-			"integrity": "sha512-HoN/5HGRXJpWODprGCgKbdMvrC3A2gqvzewu2eECRw2sYxOUoh2TV1tS+G7bHNapPGI79woQJGV6pFH7GH7qnA==",
+			"version": "0.15.15",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.15.tgz",
+			"integrity": "sha512-xaAUIB2qllE888SsMU3j9nrqyLbkqqkpQyWVkfwSil6BBPgcPk3zOFitTTncEKCLTQy3XV9RuH7PDj3aJDljWA==",
 			"cpu": [
 				"x64"
 			],
@@ -10357,9 +10391,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-windows-arm64": {
-			"version": "0.14.51",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.51.tgz",
-			"integrity": "sha512-JQDqPjuOH7o+BsKMSddMfmVJXrnYZxXDHsoLHc0xgmAZkOOCflRmC43q31pk79F9xuyWY45jDBPolb5ZgGOf9g==",
+			"version": "0.15.15",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.15.tgz",
+			"integrity": "sha512-ttuoCYCIJAFx4UUKKWYnFdrVpoXa3+3WWkXVI6s09U+YjhnyM5h96ewTq/WgQj9LFSIlABQvadHSOQyAVjW5xQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -27233,7 +27267,7 @@
 				"@miniflare/durable-objects": "2.10.0",
 				"blake3-wasm": "^2.1.5",
 				"chokidar": "^3.5.3",
-				"esbuild": "0.14.51",
+				"esbuild": "0.15.15",
 				"miniflare": "2.10.0",
 				"nanoid": "^3.3.3",
 				"path-to-regexp": "^6.2.0",
@@ -27499,7 +27533,7 @@
 				"@types/rimraf": "^3.0.2",
 				"@types/tar": "^6.1.1",
 				"@types/webpack": "^4.41.32",
-				"esbuild": "^0.14.51",
+				"esbuild": "^0.15.15",
 				"execa": "^6.1.0",
 				"jest": "^27.5.1",
 				"jest-fetch-mock": "^3.0.3",
@@ -27509,6 +27543,38 @@
 				"typescript": "^4.6.3",
 				"undici": "^5.9.1",
 				"webpack": "^4.46.0"
+			}
+		},
+		"packages/wranglerjs-compat-webpack-plugin/node_modules/@esbuild/android-arm": {
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.18.tgz",
+			"integrity": "sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"packages/wranglerjs-compat-webpack-plugin/node_modules/@esbuild/linux-loong64": {
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.18.tgz",
+			"integrity": "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"packages/wranglerjs-compat-webpack-plugin/node_modules/@jest/console": {
@@ -27903,6 +27969,363 @@
 			},
 			"funding": {
 				"url": "https://github.com/sindresorhus/emittery?sponsor=1"
+			}
+		},
+		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild": {
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.18.tgz",
+			"integrity": "sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==",
+			"dev": true,
+			"hasInstallScript": true,
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"optionalDependencies": {
+				"@esbuild/android-arm": "0.15.18",
+				"@esbuild/linux-loong64": "0.15.18",
+				"esbuild-android-64": "0.15.18",
+				"esbuild-android-arm64": "0.15.18",
+				"esbuild-darwin-64": "0.15.18",
+				"esbuild-darwin-arm64": "0.15.18",
+				"esbuild-freebsd-64": "0.15.18",
+				"esbuild-freebsd-arm64": "0.15.18",
+				"esbuild-linux-32": "0.15.18",
+				"esbuild-linux-64": "0.15.18",
+				"esbuild-linux-arm": "0.15.18",
+				"esbuild-linux-arm64": "0.15.18",
+				"esbuild-linux-mips64le": "0.15.18",
+				"esbuild-linux-ppc64le": "0.15.18",
+				"esbuild-linux-riscv64": "0.15.18",
+				"esbuild-linux-s390x": "0.15.18",
+				"esbuild-netbsd-64": "0.15.18",
+				"esbuild-openbsd-64": "0.15.18",
+				"esbuild-sunos-64": "0.15.18",
+				"esbuild-windows-32": "0.15.18",
+				"esbuild-windows-64": "0.15.18",
+				"esbuild-windows-arm64": "0.15.18"
+			}
+		},
+		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-android-64": {
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.18.tgz",
+			"integrity": "sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-android-arm64": {
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.18.tgz",
+			"integrity": "sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-darwin-64": {
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.18.tgz",
+			"integrity": "sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-darwin-arm64": {
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.18.tgz",
+			"integrity": "sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-freebsd-64": {
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.18.tgz",
+			"integrity": "sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-freebsd-arm64": {
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.18.tgz",
+			"integrity": "sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-linux-32": {
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.18.tgz",
+			"integrity": "sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-linux-64": {
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.18.tgz",
+			"integrity": "sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-linux-arm": {
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.18.tgz",
+			"integrity": "sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-linux-arm64": {
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.18.tgz",
+			"integrity": "sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-linux-mips64le": {
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.18.tgz",
+			"integrity": "sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-linux-ppc64le": {
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.18.tgz",
+			"integrity": "sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-linux-riscv64": {
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.18.tgz",
+			"integrity": "sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-linux-s390x": {
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.18.tgz",
+			"integrity": "sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-netbsd-64": {
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.18.tgz",
+			"integrity": "sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-openbsd-64": {
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.18.tgz",
+			"integrity": "sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-sunos-64": {
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.18.tgz",
+			"integrity": "sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-windows-32": {
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.18.tgz",
+			"integrity": "sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-windows-64": {
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.18.tgz",
+			"integrity": "sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"packages/wranglerjs-compat-webpack-plugin/node_modules/esbuild-windows-arm64": {
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.18.tgz",
+			"integrity": "sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"packages/wranglerjs-compat-webpack-plugin/node_modules/expect": {
@@ -35369,146 +35792,164 @@
 			}
 		},
 		"esbuild": {
-			"version": "0.14.51",
+			"version": "0.15.15",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.15.tgz",
+			"integrity": "sha512-TEw/lwK4Zzld9x3FedV6jy8onOUHqcEX3ADFk4k+gzPUwrxn8nWV62tH0udo8jOtjFodlEfc4ypsqX3e+WWO6w==",
 			"requires": {
-				"esbuild-android-64": "0.14.51",
-				"esbuild-android-arm64": "0.14.51",
-				"esbuild-darwin-64": "0.14.51",
-				"esbuild-darwin-arm64": "0.14.51",
-				"esbuild-freebsd-64": "0.14.51",
-				"esbuild-freebsd-arm64": "0.14.51",
-				"esbuild-linux-32": "0.14.51",
-				"esbuild-linux-64": "0.14.51",
-				"esbuild-linux-arm": "0.14.51",
-				"esbuild-linux-arm64": "0.14.51",
-				"esbuild-linux-mips64le": "0.14.51",
-				"esbuild-linux-ppc64le": "0.14.51",
-				"esbuild-linux-riscv64": "0.14.51",
-				"esbuild-linux-s390x": "0.14.51",
-				"esbuild-netbsd-64": "0.14.51",
-				"esbuild-openbsd-64": "0.14.51",
-				"esbuild-sunos-64": "0.14.51",
-				"esbuild-windows-32": "0.14.51",
-				"esbuild-windows-64": "0.14.51",
-				"esbuild-windows-arm64": "0.14.51"
+				"@esbuild/android-arm": "0.15.15",
+				"@esbuild/linux-loong64": "0.15.15",
+				"esbuild-android-64": "0.15.15",
+				"esbuild-android-arm64": "0.15.15",
+				"esbuild-darwin-64": "0.15.15",
+				"esbuild-darwin-arm64": "0.15.15",
+				"esbuild-freebsd-64": "0.15.15",
+				"esbuild-freebsd-arm64": "0.15.15",
+				"esbuild-linux-32": "0.15.15",
+				"esbuild-linux-64": "0.15.15",
+				"esbuild-linux-arm": "0.15.15",
+				"esbuild-linux-arm64": "0.15.15",
+				"esbuild-linux-mips64le": "0.15.15",
+				"esbuild-linux-ppc64le": "0.15.15",
+				"esbuild-linux-riscv64": "0.15.15",
+				"esbuild-linux-s390x": "0.15.15",
+				"esbuild-netbsd-64": "0.15.15",
+				"esbuild-openbsd-64": "0.15.15",
+				"esbuild-sunos-64": "0.15.15",
+				"esbuild-windows-32": "0.15.15",
+				"esbuild-windows-64": "0.15.15",
+				"esbuild-windows-arm64": "0.15.15"
 			},
 			"dependencies": {
+				"@esbuild/android-arm": {
+					"version": "0.15.15",
+					"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.15.tgz",
+					"integrity": "sha512-JJjZjJi2eBL01QJuWjfCdZxcIgot+VoK6Fq7eKF9w4YHm9hwl7nhBR1o2Wnt/WcANk5l9SkpvrldW1PLuXxcbw==",
+					"optional": true
+				},
+				"@esbuild/linux-loong64": {
+					"version": "0.15.15",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.15.tgz",
+					"integrity": "sha512-lhz6UNPMDXUhtXSulw8XlFAtSYO26WmHQnCi2Lg2p+/TMiJKNLtZCYUxV4wG6rZMzXmr8InGpNwk+DLT2Hm0PA==",
+					"optional": true
+				},
 				"esbuild-android-64": {
-					"version": "0.14.51",
-					"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.51.tgz",
-					"integrity": "sha512-6FOuKTHnC86dtrKDmdSj2CkcKF8PnqkaIXqvgydqfJmqBazCPdw+relrMlhGjkvVdiiGV70rpdnyFmA65ekBCQ==",
+					"version": "0.15.15",
+					"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.15.tgz",
+					"integrity": "sha512-F+WjjQxO+JQOva3tJWNdVjouFMLK6R6i5gjDvgUthLYJnIZJsp1HlF523k73hELY20WPyEO8xcz7aaYBVkeg5Q==",
 					"optional": true
 				},
 				"esbuild-android-arm64": {
-					"version": "0.14.51",
-					"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.51.tgz",
-					"integrity": "sha512-vBtp//5VVkZWmYYvHsqBRCMMi1MzKuMIn5XDScmnykMTu9+TD9v0NMEDqQxvtFToeYmojdo5UCV2vzMQWJcJ4A==",
+					"version": "0.15.15",
+					"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.15.tgz",
+					"integrity": "sha512-attlyhD6Y22jNyQ0fIIQ7mnPvDWKw7k6FKnsXlBvQE6s3z6s6cuEHcSgoirquQc7TmZgVCK5fD/2uxmRN+ZpcQ==",
 					"optional": true
 				},
 				"esbuild-darwin-64": {
-					"version": "0.14.51",
+					"version": "0.15.15",
+					"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.15.tgz",
+					"integrity": "sha512-ohZtF8W1SHJ4JWldsPVdk8st0r9ExbAOSrBOh5L+Mq47i696GVwv1ab/KlmbUoikSTNoXEhDzVpxUR/WIO19FQ==",
 					"optional": true
 				},
 				"esbuild-darwin-arm64": {
-					"version": "0.14.51",
-					"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.51.tgz",
-					"integrity": "sha512-juYD0QnSKwAMfzwKdIF6YbueXzS6N7y4GXPDeDkApz/1RzlT42mvX9jgNmyOlWKN7YzQAYbcUEJmZJYQGdf2ow==",
+					"version": "0.15.15",
+					"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.15.tgz",
+					"integrity": "sha512-P8jOZ5zshCNIuGn+9KehKs/cq5uIniC+BeCykvdVhx/rBXSxmtj3CUIKZz4sDCuESMbitK54drf/2QX9QHG5Ag==",
 					"optional": true
 				},
 				"esbuild-freebsd-64": {
-					"version": "0.14.51",
-					"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.51.tgz",
-					"integrity": "sha512-cLEI/aXjb6vo5O2Y8rvVSQ7smgLldwYY5xMxqh/dQGfWO+R1NJOFsiax3IS4Ng300SVp7Gz3czxT6d6qf2cw0g==",
+					"version": "0.15.15",
+					"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.15.tgz",
+					"integrity": "sha512-KkTg+AmDXz1IvA9S1gt8dE24C8Thx0X5oM0KGF322DuP+P3evwTL9YyusHAWNsh4qLsR80nvBr/EIYs29VSwuA==",
 					"optional": true
 				},
 				"esbuild-freebsd-arm64": {
-					"version": "0.14.51",
-					"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.51.tgz",
-					"integrity": "sha512-TcWVw/rCL2F+jUgRkgLa3qltd5gzKjIMGhkVybkjk6PJadYInPtgtUBp1/hG+mxyigaT7ib+od1Xb84b+L+1Mg==",
+					"version": "0.15.15",
+					"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.15.tgz",
+					"integrity": "sha512-FUcML0DRsuyqCMfAC+HoeAqvWxMeq0qXvclZZ/lt2kLU6XBnDA5uKTLUd379WYEyVD4KKFctqWd9tTuk8C/96g==",
 					"optional": true
 				},
 				"esbuild-linux-32": {
-					"version": "0.14.51",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.51.tgz",
-					"integrity": "sha512-RFqpyC5ChyWrjx8Xj2K0EC1aN0A37H6OJfmUXIASEqJoHcntuV3j2Efr9RNmUhMfNE6yEj2VpYuDteZLGDMr0w==",
+					"version": "0.15.15",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.15.tgz",
+					"integrity": "sha512-q28Qn5pZgHNqug02aTkzw5sW9OklSo96b5nm17Mq0pDXrdTBcQ+M6Q9A1B+dalFeynunwh/pvfrNucjzwDXj+Q==",
 					"optional": true
 				},
 				"esbuild-linux-64": {
-					"version": "0.14.51",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.51.tgz",
-					"integrity": "sha512-dxjhrqo5i7Rq6DXwz5v+MEHVs9VNFItJmHBe1CxROWNf4miOGoQhqSG8StStbDkQ1Mtobg6ng+4fwByOhoQoeA==",
+					"version": "0.15.15",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.15.tgz",
+					"integrity": "sha512-217KPmWMirkf8liO+fj2qrPwbIbhNTGNVtvqI1TnOWJgcMjUWvd677Gq3fTzXEjilkx2yWypVnTswM2KbXgoAg==",
 					"optional": true
 				},
 				"esbuild-linux-arm": {
-					"version": "0.14.51",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.51.tgz",
-					"integrity": "sha512-LsJynDxYF6Neg7ZC7748yweCDD+N8ByCv22/7IAZglIEniEkqdF4HCaa49JNDLw1UQGlYuhOB8ZT/MmcSWzcWg==",
+					"version": "0.15.15",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.15.tgz",
+					"integrity": "sha512-RYVW9o2yN8yM7SB1yaWr378CwrjvGCyGybX3SdzPHpikUHkME2AP55Ma20uNwkNyY2eSYFX9D55kDrfQmQBR4w==",
 					"optional": true
 				},
 				"esbuild-linux-arm64": {
-					"version": "0.14.51",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.51.tgz",
-					"integrity": "sha512-D9rFxGutoqQX3xJPxqd6o+kvYKeIbM0ifW2y0bgKk5HPgQQOo2k9/2Vpto3ybGYaFPCE5qTGtqQta9PoP6ZEzw==",
+					"version": "0.15.15",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.15.tgz",
+					"integrity": "sha512-/ltmNFs0FivZkYsTzAsXIfLQX38lFnwJTWCJts0IbCqWZQe+jjj0vYBNbI0kmXLb3y5NljiM5USVAO1NVkdh2g==",
 					"optional": true
 				},
 				"esbuild-linux-mips64le": {
-					"version": "0.14.51",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.51.tgz",
-					"integrity": "sha512-vS54wQjy4IinLSlb5EIlLoln8buh1yDgliP4CuEHumrPk4PvvP4kTRIG4SzMXm6t19N0rIfT4bNdAxzJLg2k6A==",
+					"version": "0.15.15",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.15.tgz",
+					"integrity": "sha512-PksEPb321/28GFFxtvL33yVPfnMZihxkEv5zME2zapXGp7fA1X2jYeiTUK+9tJ/EGgcNWuwvtawPxJG7Mmn86A==",
 					"optional": true
 				},
 				"esbuild-linux-ppc64le": {
-					"version": "0.14.51",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.51.tgz",
-					"integrity": "sha512-xcdd62Y3VfGoyphNP/aIV9LP+RzFw5M5Z7ja+zdpQHHvokJM7d0rlDRMN+iSSwvUymQkqZO+G/xjb4/75du8BQ==",
+					"version": "0.15.15",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.15.tgz",
+					"integrity": "sha512-ek8gJBEIhcpGI327eAZigBOHl58QqrJrYYIZBWQCnH3UnXoeWMrMZLeeZL8BI2XMBhP+sQ6ERctD5X+ajL/AIA==",
 					"optional": true
 				},
 				"esbuild-linux-riscv64": {
-					"version": "0.14.51",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.51.tgz",
-					"integrity": "sha512-syXHGak9wkAnFz0gMmRBoy44JV0rp4kVCEA36P5MCeZcxFq8+fllBC2t6sKI23w3qd8Vwo9pTADCgjTSf3L3rA==",
+					"version": "0.15.15",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.15.tgz",
+					"integrity": "sha512-H5ilTZb33/GnUBrZMNJtBk7/OXzDHDXjIzoLXHSutwwsLxSNaLxzAaMoDGDd/keZoS+GDBqNVxdCkpuiRW4OSw==",
 					"optional": true
 				},
 				"esbuild-linux-s390x": {
-					"version": "0.14.51",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.51.tgz",
-					"integrity": "sha512-kFAJY3dv+Wq8o28K/C7xkZk/X34rgTwhknSsElIqoEo8armCOjMJ6NsMxm48KaWY2h2RUYGtQmr+RGuUPKBhyw==",
+					"version": "0.15.15",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.15.tgz",
+					"integrity": "sha512-jKaLUg78mua3rrtrkpv4Or2dNTJU7bgHN4bEjT4OX4GR7nLBSA9dfJezQouTxMmIW7opwEC5/iR9mpC18utnxQ==",
 					"optional": true
 				},
 				"esbuild-netbsd-64": {
-					"version": "0.14.51",
-					"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.51.tgz",
-					"integrity": "sha512-ZZBI7qrR1FevdPBVHz/1GSk1x5GDL/iy42Zy8+neEm/HA7ma+hH/bwPEjeHXKWUDvM36CZpSL/fn1/y9/Hb+1A==",
+					"version": "0.15.15",
+					"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.15.tgz",
+					"integrity": "sha512-aOvmF/UkjFuW6F36HbIlImJTTx45KUCHJndtKo+KdP8Dhq3mgLRKW9+6Ircpm8bX/RcS3zZMMmaBLkvGY06Gvw==",
 					"optional": true
 				},
 				"esbuild-openbsd-64": {
-					"version": "0.14.51",
-					"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.51.tgz",
-					"integrity": "sha512-7R1/p39M+LSVQVgDVlcY1KKm6kFKjERSX1lipMG51NPcspJD1tmiZSmmBXoY5jhHIu6JL1QkFDTx94gMYK6vfA==",
+					"version": "0.15.15",
+					"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.15.tgz",
+					"integrity": "sha512-HFFX+WYedx1w2yJ1VyR1Dfo8zyYGQZf1cA69bLdrHzu9svj6KH6ZLK0k3A1/LFPhcEY9idSOhsB2UyU0tHPxgQ==",
 					"optional": true
 				},
 				"esbuild-sunos-64": {
-					"version": "0.14.51",
-					"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.51.tgz",
-					"integrity": "sha512-HoHaCswHxLEYN8eBTtyO0bFEWvA3Kdb++hSQ/lLG7TyKF69TeSG0RNoBRAs45x/oCeWaTDntEZlYwAfQlhEtJA==",
+					"version": "0.15.15",
+					"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.15.tgz",
+					"integrity": "sha512-jOPBudffG4HN8yJXcK9rib/ZTFoTA5pvIKbRrt3IKAGMq1EpBi4xoVoSRrq/0d4OgZLaQbmkHp8RO9eZIn5atA==",
 					"optional": true
 				},
 				"esbuild-windows-32": {
-					"version": "0.14.51",
-					"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.51.tgz",
-					"integrity": "sha512-4rtwSAM35A07CBt1/X8RWieDj3ZUHQqUOaEo5ZBs69rt5WAFjP4aqCIobdqOy4FdhYw1yF8Z0xFBTyc9lgPtEg==",
+					"version": "0.15.15",
+					"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.15.tgz",
+					"integrity": "sha512-MDkJ3QkjnCetKF0fKxCyYNBnOq6dmidcwstBVeMtXSgGYTy8XSwBeIE4+HuKiSsG6I/mXEb++px3IGSmTN0XiA==",
 					"optional": true
 				},
 				"esbuild-windows-64": {
-					"version": "0.14.51",
-					"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.51.tgz",
-					"integrity": "sha512-HoN/5HGRXJpWODprGCgKbdMvrC3A2gqvzewu2eECRw2sYxOUoh2TV1tS+G7bHNapPGI79woQJGV6pFH7GH7qnA==",
+					"version": "0.15.15",
+					"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.15.tgz",
+					"integrity": "sha512-xaAUIB2qllE888SsMU3j9nrqyLbkqqkpQyWVkfwSil6BBPgcPk3zOFitTTncEKCLTQy3XV9RuH7PDj3aJDljWA==",
 					"optional": true
 				},
 				"esbuild-windows-arm64": {
-					"version": "0.14.51",
-					"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.51.tgz",
-					"integrity": "sha512-JQDqPjuOH7o+BsKMSddMfmVJXrnYZxXDHsoLHc0xgmAZkOOCflRmC43q31pk79F9xuyWY45jDBPolb5ZgGOf9g==",
+					"version": "0.15.15",
+					"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.15.tgz",
+					"integrity": "sha512-ttuoCYCIJAFx4UUKKWYnFdrVpoXa3+3WWkXVI6s09U+YjhnyM5h96ewTq/WgQj9LFSIlABQvadHSOQyAVjW5xQ==",
 					"optional": true
 				}
 			}
@@ -47243,7 +47684,7 @@
 				"concurrently": "^7.2.2",
 				"devtools-protocol": "^0.0.955664",
 				"dotenv": "^16.0.0",
-				"esbuild": "0.14.51",
+				"esbuild": "0.15.15",
 				"execa": "^6.1.0",
 				"express": "^4.18.1",
 				"finalhandler": "^1.2.0",
@@ -47389,7 +47830,7 @@
 				"@types/rimraf": "^3.0.2",
 				"@types/tar": "^6.1.1",
 				"@types/webpack": "^4.41.32",
-				"esbuild": "^0.14.51",
+				"esbuild": "^0.15.15",
 				"execa": "^6.1.0",
 				"jest": "^27.5.1",
 				"jest-fetch-mock": "^3.0.3",
@@ -47402,6 +47843,20 @@
 				"webpack": "^4.46.0"
 			},
 			"dependencies": {
+				"@esbuild/android-arm": {
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.18.tgz",
+					"integrity": "sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==",
+					"dev": true,
+					"optional": true
+				},
+				"@esbuild/linux-loong64": {
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.18.tgz",
+					"integrity": "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==",
+					"dev": true,
+					"optional": true
+				},
 				"@jest/console": {
 					"version": "27.5.1",
 					"resolved": "https://registry.npmjs.org/@jest/console/-/console-27.5.1.tgz",
@@ -47704,6 +48159,176 @@
 					"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.8.1.tgz",
 					"integrity": "sha512-uDfvUjVrfGJJhymx/kz6prltenw1u7WrCg1oa94zYY8xxVpLLUu045LAT0dhDZdXG58/EpPL/5kA180fQ/qudg==",
 					"dev": true
+				},
+				"esbuild": {
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.18.tgz",
+					"integrity": "sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==",
+					"dev": true,
+					"requires": {
+						"@esbuild/android-arm": "0.15.18",
+						"@esbuild/linux-loong64": "0.15.18",
+						"esbuild-android-64": "0.15.18",
+						"esbuild-android-arm64": "0.15.18",
+						"esbuild-darwin-64": "0.15.18",
+						"esbuild-darwin-arm64": "0.15.18",
+						"esbuild-freebsd-64": "0.15.18",
+						"esbuild-freebsd-arm64": "0.15.18",
+						"esbuild-linux-32": "0.15.18",
+						"esbuild-linux-64": "0.15.18",
+						"esbuild-linux-arm": "0.15.18",
+						"esbuild-linux-arm64": "0.15.18",
+						"esbuild-linux-mips64le": "0.15.18",
+						"esbuild-linux-ppc64le": "0.15.18",
+						"esbuild-linux-riscv64": "0.15.18",
+						"esbuild-linux-s390x": "0.15.18",
+						"esbuild-netbsd-64": "0.15.18",
+						"esbuild-openbsd-64": "0.15.18",
+						"esbuild-sunos-64": "0.15.18",
+						"esbuild-windows-32": "0.15.18",
+						"esbuild-windows-64": "0.15.18",
+						"esbuild-windows-arm64": "0.15.18"
+					}
+				},
+				"esbuild-android-64": {
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.18.tgz",
+					"integrity": "sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-android-arm64": {
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.18.tgz",
+					"integrity": "sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-darwin-64": {
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.18.tgz",
+					"integrity": "sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-darwin-arm64": {
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.18.tgz",
+					"integrity": "sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-freebsd-64": {
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.18.tgz",
+					"integrity": "sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-freebsd-arm64": {
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.18.tgz",
+					"integrity": "sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-32": {
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.18.tgz",
+					"integrity": "sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-64": {
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.18.tgz",
+					"integrity": "sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-arm": {
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.18.tgz",
+					"integrity": "sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-arm64": {
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.18.tgz",
+					"integrity": "sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-mips64le": {
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.18.tgz",
+					"integrity": "sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-ppc64le": {
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.18.tgz",
+					"integrity": "sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-riscv64": {
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.18.tgz",
+					"integrity": "sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-s390x": {
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.18.tgz",
+					"integrity": "sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-netbsd-64": {
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.18.tgz",
+					"integrity": "sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-openbsd-64": {
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.18.tgz",
+					"integrity": "sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-sunos-64": {
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.18.tgz",
+					"integrity": "sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-windows-32": {
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.18.tgz",
+					"integrity": "sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-windows-64": {
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.18.tgz",
+					"integrity": "sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-windows-arm64": {
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.18.tgz",
+					"integrity": "sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==",
+					"dev": true,
+					"optional": true
 				},
 				"expect": {
 					"version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"@typescript-eslint/parser": "^5.46.0",
 		"cross-env": "^7.0.3",
 		"esbuild-jest": "0.5.0",
-		"esbuild-register": "^3.3.2",
+		"esbuild-register": "^3.4.2",
 		"eslint": "^8.13.0",
 		"eslint-plugin-import": "^2.26.0",
 		"eslint-plugin-react": "^7.29.4",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -105,7 +105,7 @@
 		"@miniflare/durable-objects": "2.10.0",
 		"blake3-wasm": "^2.1.5",
 		"chokidar": "^3.5.3",
-		"esbuild": "0.14.51",
+		"esbuild": "0.15.15",
 		"miniflare": "2.10.0",
 		"nanoid": "^3.3.3",
 		"path-to-regexp": "^6.2.0",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -105,7 +105,7 @@
 		"@miniflare/durable-objects": "2.10.0",
 		"blake3-wasm": "^2.1.5",
 		"chokidar": "^3.5.3",
-		"esbuild": "0.15.15",
+		"esbuild": "0.15.18",
 		"miniflare": "2.10.0",
 		"nanoid": "^3.3.3",
 		"path-to-regexp": "^6.2.0",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -105,7 +105,7 @@
 		"@miniflare/durable-objects": "2.10.0",
 		"blake3-wasm": "^2.1.5",
 		"chokidar": "^3.5.3",
-		"esbuild": "0.15.18",
+		"esbuild": "0.16.12",
 		"miniflare": "2.10.0",
 		"nanoid": "^3.3.3",
 		"path-to-regexp": "^6.2.0",

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -2,8 +2,8 @@ import assert from "node:assert";
 import * as fs from "node:fs";
 import { builtinModules } from "node:module";
 import * as path from "node:path";
-import NodeGlobalsPolyfills from "@esbuild-plugins/node-globals-polyfill";
-import NodeModulesPolyfills from "@esbuild-plugins/node-modules-polyfill";
+import { NodeGlobalsPolyfillPlugin } from "@esbuild-plugins/node-globals-polyfill";
+import { NodeModulesPolyfillPlugin } from "@esbuild-plugins/node-modules-polyfill";
 import * as esbuild from "esbuild";
 import tmp from "tmp-promise";
 import createModuleCollector from "./module-collection";
@@ -352,7 +352,10 @@ export async function bundleWorker(
 		plugins: [
 			moduleCollector.plugin,
 			...(nodeCompat
-				? [NodeGlobalsPolyfills({ buffer: true }), NodeModulesPolyfills()]
+				? [
+						NodeGlobalsPolyfillPlugin({ buffer: true }),
+						NodeModulesPolyfillPlugin(),
+				  ]
 				: []),
 			...(plugins || []),
 		],

--- a/packages/wranglerjs-compat-webpack-plugin/package.json
+++ b/packages/wranglerjs-compat-webpack-plugin/package.json
@@ -55,7 +55,7 @@
 		"@types/rimraf": "^3.0.2",
 		"@types/tar": "^6.1.1",
 		"@types/webpack": "^4.41.32",
-		"esbuild": "^0.15.15",
+		"esbuild": "^0.15.18",
 		"execa": "^6.1.0",
 		"jest": "^27.5.1",
 		"jest-fetch-mock": "^3.0.3",

--- a/packages/wranglerjs-compat-webpack-plugin/package.json
+++ b/packages/wranglerjs-compat-webpack-plugin/package.json
@@ -55,7 +55,7 @@
 		"@types/rimraf": "^3.0.2",
 		"@types/tar": "^6.1.1",
 		"@types/webpack": "^4.41.32",
-		"esbuild": "^0.15.18",
+		"esbuild": "^0.16.12",
 		"execa": "^6.1.0",
 		"jest": "^27.5.1",
 		"jest-fetch-mock": "^3.0.3",

--- a/packages/wranglerjs-compat-webpack-plugin/package.json
+++ b/packages/wranglerjs-compat-webpack-plugin/package.json
@@ -55,7 +55,7 @@
 		"@types/rimraf": "^3.0.2",
 		"@types/tar": "^6.1.1",
 		"@types/webpack": "^4.41.32",
-		"esbuild": "^0.14.51",
+		"esbuild": "^0.15.15",
 		"execa": "^6.1.0",
 		"jest": "^27.5.1",
 		"jest-fetch-mock": "^3.0.3",


### PR DESCRIPTION
**What this PR solves / how to test:**

The current esbuild version used in wrangler is 0.14.51 and does not support the satisfies operator.
This is now supported [since esbuild 0.15.14](https://github.com/evanw/esbuild/blob/master/CHANGELOG.md#01514).

This PR updated esbuild version to the latest, 0.15.18.

**Associated docs issues/PR:**

- https://github.com/evanw/esbuild/blob/master/CHANGELOG.md#01514

**Author has included the following, where applicable:**

- [x] Tests
- [x] Changeset

**Reviewer has performed the following, where applicable:**

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes #1971  .
