### PR TITLE
test: set `LC_ALL` to `en` to fix the language thrown by Yargs

### DIFF
--- a/packages/wrangler/src/__tests__/jest.setup.ts
+++ b/packages/wrangler/src/__tests__/jest.setup.ts
@@ -29,6 +29,9 @@ import { msw } from "./helpers/msw";
 	global as unknown as { __RELATIVE_PACKAGE_PATH__: string }
 ).__RELATIVE_PACKAGE_PATH__ = "..";
 
+// Set `LC_ALL` to fix the language as English for the messages thrown by Yargs.
+process.env.LC_ALL = "en";
+
 // Mock out getPort since we don't actually care about what ports are open in unit tests.
 jest.mock("get-port", () => {
 	return {


### PR DESCRIPTION
### What this PR solves / how to test:

I ran the tests in my environment, and the tests failed with messages like the following:

<img width="777" alt="SS" src="https://user-images.githubusercontent.com/10682/208233295-3bbf9623-6e75-4eb1-b9fe-04bc4c4b7f5b.png">

This is caused by the setting of the language to Japanese in my environment.

```
$ echo $LC_ALL
ja_JP.UTF-8
```

`Yargs` throws errors in Japanese, not English, since `Yargs` looks up an environment variable to decide which language to use.

There are several ways to fix it. I couldn't decide which way would work best for us, so this PR will propose one of the solutions.

In `jest.setup.ts`, I've set the `LC_ALL` to fix the language as English for the messages thrown by `Yargs`. If there is a better way, let's go with it.

### Associated docs issues/PR:

Nothing

### Author has included the following, where applicable:

- [ ] Tests
- [ ] Changeset

### Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes # [insert issue number].
