### PR TITLE
pubsub: fix typo in log output

### DIFF
--- a/packages/wrangler/src/pubsub/pubsub-commands.tsx
+++ b/packages/wrangler/src/pubsub/pubsub-commands.tsx
@@ -49,7 +49,7 @@ export function pubSubCommands(
 								namespace.description = args.description;
 							}
 
-							logger.log(`Creating Pub/SubNamespace ${args.name}...`);
+							logger.log(`Creating Pub/Sub Namespace ${args.name}...`);
 							await pubsub.createPubSubNamespace(accountId, namespace);
 							logger.log(`Success! Created Pub/Sub Namespace ${args.name}`);
 							await metrics.sendMetricsEvent("create pubsub namespace", {


### PR DESCRIPTION
Fixes:
```
➜  wrangler pubsub namespace create hello-namespace                             
Creating Pub/SubNamespace hello-namespace...
Success! Created Pub/Sub Namespace hello-namespace
```

Note the missing space between `Pub/Sub` and `Namespace`.