### PR TITLE
fix(wrangler): do not login or read wrangler.toml when applying D1 migrations in local mode.

### DIFF
--- a/.changeset/beige-snails-complain.md
+++ b/.changeset/beige-snails-complain.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix(wrangler): do not login or read wrangler.toml when applying D1 migrations in local mode.
+
+When applying D1 migrations to a deployed database, it is important that we are logged in
+and that we have the database ID from the wrangler.toml.
+This is not needed for `--local` mode where we are just writing to a local SQLite file.

--- a/packages/wrangler/src/__tests__/d1.test.ts
+++ b/packages/wrangler/src/__tests__/d1.test.ts
@@ -1,6 +1,9 @@
-import { mockAccountId } from "./helpers/mock-account-id";
+import { cwd } from "process";
 import { mockConsoleMethods } from "./helpers/mock-console";
+import { useMockIsTTY } from "./helpers/mock-istty";
+import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
+import writeWranglerToml from "./helpers/write-wrangler-toml";
 
 function endEventLoop() {
 	return new Promise((resolve) => setImmediate(resolve));
@@ -8,8 +11,8 @@ function endEventLoop() {
 
 describe("d1", () => {
 	const std = mockConsoleMethods();
-
-	mockAccountId();
+	runInTempDir();
+	const { setIsTTY } = useMockIsTTY();
 
 	it("should show help when no argument is passed", async () => {
 		await runWrangler("d1");
@@ -76,5 +79,45 @@ describe("d1", () => {
 		To request features, visit https://community.cloudflare.com/c/developers/d1.
 		To give feedback, visit https://discord.gg/cloudflaredev"
 	`);
+	});
+
+	describe("migrate", () => {
+		describe("apply", () => {
+			it("should not attempt to login in local mode", async () => {
+				setIsTTY(false);
+				writeWranglerToml({
+					d1_databases: [
+						{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
+					],
+				});
+				// If we get to the point where we are checking for migrations then we have not been asked to log in.
+				await expect(
+					runWrangler("d1 migrations apply --local DATABASE")
+				).rejects.toThrowError(
+					`No migrations present at ${cwd().replaceAll("\\", "/")}/migrations.`
+				);
+			});
+
+			it("should try to read D1 config from wrangler.toml", async () => {
+				setIsTTY(false);
+				writeWranglerToml();
+				await expect(
+					runWrangler("d1 migrations apply DATABASE")
+				).rejects.toThrowError(
+					"Can't find a DB with name/binding 'DATABASE' in local config. Check info in wrangler.toml..."
+				);
+			});
+
+			it("should not try to read wrangler.toml in local mode", async () => {
+				setIsTTY(false);
+				writeWranglerToml();
+				// If we get to the point where we are checking for migrations then we have not checked wrangler.toml.
+				await expect(
+					runWrangler("d1 migrations apply --local DATABASE")
+				).rejects.toThrowError(
+					`No migrations present at ${cwd().replaceAll("\\", "/")}/migrations.`
+				);
+			});
+		});
 	});
 });

--- a/packages/wrangler/src/d1/migrations/apply.tsx
+++ b/packages/wrangler/src/d1/migrations/apply.tsx
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import fs from "node:fs";
 import path from "path";
 import { Box, render, Text } from "ink";
@@ -10,6 +11,7 @@ import isInteractive from "../../is-interactive";
 import { logger } from "../../logger";
 import { requireAuth } from "../../user";
 import { createBackup } from "../backups";
+import { DEFAULT_MIGRATION_PATH, DEFAULT_MIGRATION_TABLE } from "../constants";
 import { executeSql } from "../execute";
 import { d1BetaWarning, getDatabaseInfoFromConfig } from "../utils";
 import {
@@ -28,11 +30,10 @@ export function ApplyOptions(yargs: Argv): Argv<BaseSqlExecuteArgs> {
 
 export const ApplyHandler = withConfig<BaseSqlExecuteArgs>(
 	async ({ config, database, local, persistTo }): Promise<void> => {
-		const accountId = await requireAuth({});
 		logger.log(d1BetaWarning);
 
 		const databaseInfo = await getDatabaseInfoFromConfig(config, database);
-		if (!databaseInfo) {
+		if (!databaseInfo && !local) {
 			throw new Error(
 				`Can't find a DB with name/binding '${database}' in local config. Check info in wrangler.toml...`
 			);
@@ -44,11 +45,14 @@ export const ApplyHandler = withConfig<BaseSqlExecuteArgs>(
 
 		const migrationsPath = await getMigrationsPath(
 			path.dirname(config.configPath),
-			databaseInfo.migrationsFolderPath,
+			databaseInfo?.migrationsFolderPath ?? DEFAULT_MIGRATION_PATH,
 			false
 		);
+
+		const migrationTableName =
+			databaseInfo?.migrationsTableName ?? DEFAULT_MIGRATION_TABLE;
 		await initMigrationsTable(
-			databaseInfo.migrationsTableName,
+			migrationTableName,
 			local,
 			config,
 			database,
@@ -57,7 +61,7 @@ export const ApplyHandler = withConfig<BaseSqlExecuteArgs>(
 
 		const unappliedMigrations = (
 			await getUnappliedMigrations(
-				databaseInfo.migrationsTableName,
+				migrationTableName,
 				migrationsPath,
 				local,
 				config,
@@ -104,7 +108,12 @@ export const ApplyHandler = withConfig<BaseSqlExecuteArgs>(
 
 		// don't backup prod db when applying migrations locally
 		if (!local) {
+			assert(
+				databaseInfo,
+				"In non-local mode `databaseInfo` should be defined."
+			);
 			render(<Text>🕒 Creating backup...</Text>);
+			const accountId = await requireAuth({});
 			await createBackup(accountId, databaseInfo.uuid);
 		}
 
@@ -114,7 +123,7 @@ export const ApplyHandler = withConfig<BaseSqlExecuteArgs>(
 				"utf8"
 			);
 			query += `
-								INSERT INTO ${databaseInfo.migrationsTableName} (name)
+								INSERT INTO ${migrationTableName} (name)
 								values ('${migration.Name}');
 						`;
 


### PR DESCRIPTION
What this PR solves / how to test:

When applying D1 migrations to a deployed database, it is important that we are logged in and that we have the database ID from the wrangler.toml. This is not needed for `--local` mode where we are just writing to a local SQLite file.

Unit tests have been added but to manually test this cd into `fixtures/worker-app` and run

```
npx wrangler logout
npx wrangler d1 migrations apply --local DATABASE
```

If Wrangler attempts to log you in, it is broken.
If Wrangler complains that you have not specified any D1 database bindings in wrangler.toml, it is broken.
The expected behaviour is that it complains that there are no migration files.

Author has included the following, where applicable:

- [x] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [x] Checked for inclusion of relevant tests
- [x] Checked for inclusion of a relevant changeset
- [x] Checked for creation of associated docs updates
- [x] Manually pulled down the changes and spot-tested

Fixes a problem with an internal project using D1.
