### PR TITLE
Fix `mockPrompt` error message

### DIFF
--- a/packages/wrangler/src/__tests__/helpers/mock-dialogs.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-dialogs.ts
@@ -78,7 +78,7 @@ export function mockPrompt(...expectations: PromptExpectation[]) {
 					return Promise.resolve(expectation.result);
 				}
 			}
-			throw new Error(`Unexpected confirmation message: ${text}`);
+			throw new Error(`Unexpected prompt message: ${text}`);
 		}
 	);
 	return () => {


### PR DESCRIPTION
What this PR solves / how to test:
`mockPrompt` throws an Error with the message `Unexpected confirmation message`. This message should be `Unexpected prompt message` instead.

Associated docs issues/PR:

- [insert associated docs issue(s)/PR(s)]

Author has included the following, where applicable:

- [x] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [x] Checked for inclusion of relevant tests
- [x] Checked for inclusion of a relevant changeset
- [x] Checked for creation of associated docs updates
- [x] Manually pulled down the changes and spot-tested

Fixes # [insert issue number].
