### PR TITLE
Refactor unstable_dev to have a single `option` object

### DIFF
--- a/.changeset/warm-phones-knock.md
+++ b/.changeset/warm-phones-knock.md
@@ -1,0 +1,23 @@
+---
+"wrangler": patch
+---
+
+BREAKING CHANGE: refactor unstable_dev to use an experimental object, instead of a second options object
+
+Before, if you wanted to disable the experimental warning, you would run:
+
+```js
+worker = await unstable_dev(
+	"src/index.js",
+	{},
+	{ disableExperimentalWarning: true }
+);
+```
+
+After this change, you'll need to do this instead:
+
+```js
+worker = await unstable_dev("src/index.js", {
+	experimental: { disableExperimentalWarning: true },
+});
+```

--- a/fixtures/local-mode-tests/tests/headers.test.ts
+++ b/fixtures/local-mode-tests/tests/headers.test.ts
@@ -12,8 +12,7 @@ describe("worker", () => {
 	beforeAll(async () => {
 		worker = await unstable_dev(
 			path.resolve(__dirname, "..", "src", "headers.ts"),
-			{},
-			{ disableExperimentalWarning: true }
+			{ experimental: { disableExperimentalWarning: true } }
 		);
 
 		resolveReadyPromise(undefined);

--- a/fixtures/local-mode-tests/tests/module.test.ts
+++ b/fixtures/local-mode-tests/tests/module.test.ts
@@ -22,8 +22,8 @@ describe("worker", () => {
 			{
 				config: path.resolve(__dirname, "..", "src", "wrangler.module.toml"),
 				vars: { VAR4: "https://google.com" },
-			},
-			{ disableExperimentalWarning: true }
+				experimental: { disableExperimentalWarning: true },
+			}
 		);
 
 		resolveReadyPromise(undefined);

--- a/fixtures/local-mode-tests/tests/nodeBuiltinPackage.test.ts
+++ b/fixtures/local-mode-tests/tests/nodeBuiltinPackage.test.ts
@@ -12,10 +12,7 @@ describe("worker", () => {
 	beforeAll(async () => {
 		worker = await unstable_dev(
 			path.resolve(__dirname, "..", "src", "nodeBuiltinPackage.ts"),
-			{},
-			{
-				disableExperimentalWarning: true,
-			}
+			{ experimental: { disableExperimentalWarning: true } }
 		);
 
 		resolveReadyPromise(undefined);

--- a/fixtures/local-mode-tests/tests/ports.test.ts
+++ b/fixtures/local-mode-tests/tests/ports.test.ts
@@ -13,46 +13,30 @@ describe("worker", () => {
 		//since the script is invoked from the directory above, need to specify index.js is in src/
 
 		workers = await Promise.all([
-			unstable_dev(
-				path.resolve(__dirname, "..", "src", "basicModule.ts"),
-				{},
-				{ disableExperimentalWarning: true }
-			),
-			unstable_dev(
-				path.resolve(__dirname, "..", "src", "basicModule.ts"),
-				{},
-				{ disableExperimentalWarning: true }
-			),
-			unstable_dev(
-				path.resolve(__dirname, "..", "src", "basicModule.ts"),
-				{},
-				{ disableExperimentalWarning: true }
-			),
-			unstable_dev(
-				path.resolve(__dirname, "..", "src", "basicModule.ts"),
-				{},
-				{ disableExperimentalWarning: true }
-			),
-			unstable_dev(
-				path.resolve(__dirname, "..", "src", "basicModule.ts"),
-				{},
-				{ disableExperimentalWarning: true }
-			),
-			unstable_dev(
-				path.resolve(__dirname, "..", "src", "basicModule.ts"),
-				{},
-				{ disableExperimentalWarning: true }
-			),
-			unstable_dev(
-				path.resolve(__dirname, "..", "src", "basicModule.ts"),
-				{},
-				{ disableExperimentalWarning: true }
-			),
-			unstable_dev(
-				path.resolve(__dirname, "..", "src", "basicModule.ts"),
-				{},
-				{ disableExperimentalWarning: true }
-			),
+			unstable_dev(path.resolve(__dirname, "..", "src", "basicModule.ts"), {
+				experimental: { disableExperimentalWarning: true },
+			}),
+			unstable_dev(path.resolve(__dirname, "..", "src", "basicModule.ts"), {
+				experimental: { disableExperimentalWarning: true },
+			}),
+			unstable_dev(path.resolve(__dirname, "..", "src", "basicModule.ts"), {
+				experimental: { disableExperimentalWarning: true },
+			}),
+			unstable_dev(path.resolve(__dirname, "..", "src", "basicModule.ts"), {
+				experimental: { disableExperimentalWarning: true },
+			}),
+			unstable_dev(path.resolve(__dirname, "..", "src", "basicModule.ts"), {
+				experimental: { disableExperimentalWarning: true },
+			}),
+			unstable_dev(path.resolve(__dirname, "..", "src", "basicModule.ts"), {
+				experimental: { disableExperimentalWarning: true },
+			}),
+			unstable_dev(path.resolve(__dirname, "..", "src", "basicModule.ts"), {
+				experimental: { disableExperimentalWarning: true },
+			}),
+			unstable_dev(path.resolve(__dirname, "..", "src", "basicModule.ts"), {
+				experimental: { disableExperimentalWarning: true },
+			}),
 		]);
 
 		resolveReadyPromise(undefined);

--- a/fixtures/local-mode-tests/tests/sw.test.ts
+++ b/fixtures/local-mode-tests/tests/sw.test.ts
@@ -17,13 +17,10 @@ describe("worker", () => {
 		process.env.NODE_ENV = "local-testing";
 
 		//since the script is invoked from the directory above, need to specify index.js is in src/
-		worker = await unstable_dev(
-			path.resolve(__dirname, "..", "src", "sw.ts"),
-			{
-				config: path.resolve(__dirname, "..", "src", "wrangler.sw.toml"),
-			},
-			{ disableExperimentalWarning: true }
-		);
+		worker = await unstable_dev(path.resolve(__dirname, "..", "src", "sw.ts"), {
+			config: path.resolve(__dirname, "..", "src", "wrangler.sw.toml"),
+			experimental: { disableExperimentalWarning: true },
+		});
 
 		resolveReadyPromise(undefined);
 	});

--- a/fixtures/local-mode-tests/tests/unstableDev.test.ts
+++ b/fixtures/local-mode-tests/tests/unstableDev.test.ts
@@ -20,8 +20,8 @@ describe("worker in local mode", () => {
 				ip: "127.0.0.1",
 				port: 1337,
 				local: true,
-			},
-			{ disableExperimentalWarning: true }
+				experimental: { disableExperimentalWarning: true },
+			}
 		);
 
 		resolveReadyPromise(undefined);
@@ -68,8 +68,8 @@ describe.skip("worker in remote mode", () => {
 				ip: "127.0.0.1",
 				port: 1337,
 				local: false,
-			},
-			{ disableExperimentalWarning: true }
+				experimental: { disableExperimentalWarning: true },
+			}
 		);
 
 		resolveReadyPromise(undefined);

--- a/packages/wrangler/src/__tests__/api-dev.test.ts
+++ b/packages/wrangler/src/__tests__/api-dev.test.ts
@@ -9,8 +9,7 @@ describe("unstable_dev", () => {
 	it("should return Hello World", async () => {
 		const worker = await unstable_dev(
 			"src/__tests__/helpers/worker-scripts/hello-world-worker.js",
-			{},
-			{ disableExperimentalWarning: true }
+			{ experimental: { disableExperimentalWarning: true } }
 		);
 		const resp = await worker.fetch();
 		if (resp) {
@@ -23,8 +22,7 @@ describe("unstable_dev", () => {
 	it("should return the port that the server started on (1)", async () => {
 		const worker = await unstable_dev(
 			"src/__tests__/helpers/worker-scripts/hello-world-worker.js",
-			{},
-			{ disableExperimentalWarning: true }
+			{ experimental: { disableExperimentalWarning: true } }
 		);
 		expect(worker.port).toBeGreaterThan(0);
 		await worker.stop();
@@ -33,8 +31,7 @@ describe("unstable_dev", () => {
 	it("should return the port that the server started on (2)", async () => {
 		const worker = await unstable_dev(
 			"src/__tests__/helpers/worker-scripts/hello-world-worker.js",
-			{ port: 9191 },
-			{ disableExperimentalWarning: true }
+			{ port: 9191, experimental: { disableExperimentalWarning: true } }
 		);
 		expect(worker.port).toBe(9191);
 		await worker.stop();
@@ -45,8 +42,10 @@ describe("unstable dev fetch input protocol", () => {
 	it("should use http localProtocol", async () => {
 		const worker = await unstable_dev(
 			"src/__tests__/helpers/worker-scripts/hello-world-worker.js",
-			{ localProtocol: "http" },
-			{ disableExperimentalWarning: true }
+			{
+				localProtocol: "http",
+				experimental: { disableExperimentalWarning: true },
+			}
 		);
 		const res = await worker.fetch();
 		if (res) {
@@ -59,8 +58,10 @@ describe("unstable dev fetch input protocol", () => {
 	it("should use undefined localProtocol", async () => {
 		const worker = await unstable_dev(
 			"src/__tests__/helpers/worker-scripts/hello-world-worker.js",
-			{ localProtocol: undefined },
-			{ disableExperimentalWarning: true }
+			{
+				localProtocol: undefined,
+				experimental: { disableExperimentalWarning: true },
+			}
 		);
 		const res = await worker.fetch();
 		if (res) {
@@ -91,11 +92,10 @@ describe("unstable dev fetch input parsing", () => {
 	`;
 		fs.writeFileSync("index.js", scriptContent);
 		const port = 21213;
-		const worker = await unstable_dev(
-			"index.js",
-			{ port },
-			{ disableExperimentalWarning: true }
-		);
+		const worker = await unstable_dev("index.js", {
+			port,
+			experimental: { disableExperimentalWarning: true },
+		});
 		const req = new Request("http://0.0.0.0:21213/test", {
 			method: "POST",
 		});
@@ -119,11 +119,9 @@ describe("unstable dev fetch input parsing", () => {
 	};
 	`;
 		fs.writeFileSync("index.js", scriptContent);
-		const worker = await unstable_dev(
-			"index.js",
-			{},
-			{ disableExperimentalWarning: true }
-		);
+		const worker = await unstable_dev("index.js", {
+			experimental: { disableExperimentalWarning: true },
+		});
 		const url = new URL("http://localhost:80/test");
 		const resp = await worker.fetch(url);
 		let text;
@@ -145,11 +143,9 @@ describe("unstable dev fetch input parsing", () => {
 	};
 	`;
 		fs.writeFileSync("index.js", scriptContent);
-		const worker = await unstable_dev(
-			"index.js",
-			{},
-			{ disableExperimentalWarning: true }
-		);
+		const worker = await unstable_dev("index.js", {
+			experimental: { disableExperimentalWarning: true },
+		});
 		const resp = await worker.fetch("http://example.com/test");
 		let text;
 		if (resp) text = await resp.text();
@@ -170,11 +166,9 @@ describe("unstable dev fetch input parsing", () => {
 	};
 	`;
 		fs.writeFileSync("index.js", scriptContent);
-		const worker = await unstable_dev(
-			"index.js",
-			{},
-			{ disableExperimentalWarning: true }
-		);
+		const worker = await unstable_dev("index.js", {
+			experimental: { disableExperimentalWarning: true },
+		});
 		const resp = await worker.fetch("/test");
 		let text;
 		if (resp) text = await resp.text();
@@ -195,11 +189,9 @@ describe("unstable dev fetch input parsing", () => {
 	};
 	`;
 		fs.writeFileSync("index.js", scriptContent);
-		const worker = await unstable_dev(
-			"index.js",
-			{},
-			{ disableExperimentalWarning: true }
-		);
+		const worker = await unstable_dev("index.js", {
+			experimental: { disableExperimentalWarning: true },
+		});
 		const resp = await worker.fetch("");
 		let text;
 		if (resp) text = await resp.text();

--- a/packages/wrangler/src/__tests__/api-devregistry.test.js
+++ b/packages/wrangler/src/__tests__/api-devregistry.test.js
@@ -14,13 +14,17 @@ describe("multi-worker testing", () => {
 	beforeAll(async () => {
 		childWorker = await unstable_dev(
 			"src/__tests__/helpers/worker-scripts/hello-world-worker.js",
-			{ config: "src/__tests__/helpers/worker-scripts/child-wrangler.toml" },
-			{ disableExperimentalWarning: true }
+			{
+				config: "src/__tests__/helpers/worker-scripts/child-wrangler.toml",
+				experimental: { disableExperimentalWarning: true },
+			}
 		);
 		parentWorker = await unstable_dev(
 			"src/__tests__/helpers/worker-scripts/parent-worker.js",
-			{ config: "src/__tests__/helpers/worker-scripts/parent-wrangler.toml" },
-			{ disableExperimentalWarning: true }
+			{
+				config: "src/__tests__/helpers/worker-scripts/parent-wrangler.toml",
+				experimental: { disableExperimentalWarning: true },
+			}
 		);
 	});
 

--- a/packages/wrangler/src/__tests__/middleware.scheduled.test.ts
+++ b/packages/wrangler/src/__tests__/middleware.scheduled.test.ts
@@ -27,11 +27,9 @@ describe("run scheduled events with middleware", () => {
 		});
 
 		it("should not intercept when middleware is not enabled", async () => {
-			const worker = await unstable_dev(
-				"index.js",
-				{},
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch("/__scheduled");
 			let text;
@@ -41,11 +39,10 @@ describe("run scheduled events with middleware", () => {
 		});
 
 		it("should intercept when middleware is enabled", async () => {
-			const worker = await unstable_dev(
-				"index.js",
-				{ testScheduled: true },
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				testScheduled: true,
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch("/__scheduled");
 			let text;
@@ -55,11 +52,10 @@ describe("run scheduled events with middleware", () => {
 		});
 
 		it("should not trigger scheduled event on wrong route", async () => {
-			const worker = await unstable_dev(
-				"index.js",
-				{ testScheduled: true },
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				testScheduled: true,
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch("/test");
 			let text;
@@ -91,11 +87,9 @@ describe("run scheduled events with middleware", () => {
 		});
 
 		it("should not intercept when middleware is not enabled", async () => {
-			const worker = await unstable_dev(
-				"index.js",
-				{},
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch("/__scheduled");
 			let text;
@@ -105,11 +99,10 @@ describe("run scheduled events with middleware", () => {
 		});
 
 		it("should intercept when middleware is enabled", async () => {
-			const worker = await unstable_dev(
-				"index.js",
-				{ testScheduled: true },
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				testScheduled: true,
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch("/__scheduled");
 			let text;
@@ -119,11 +112,10 @@ describe("run scheduled events with middleware", () => {
 		});
 
 		it("should not trigger scheduled event on wrong route", async () => {
-			const worker = await unstable_dev(
-				"index.js",
-				{ testScheduled: true },
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				testScheduled: true,
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch("/test");
 			let text;

--- a/packages/wrangler/src/__tests__/middleware.test.ts
+++ b/packages/wrangler/src/__tests__/middleware.test.ts
@@ -27,11 +27,9 @@ describe("workers change behaviour with middleware with wrangler dev", () => {
 			`;
 			fs.writeFileSync("index.js", scriptContent);
 
-			const worker = await unstable_dev(
-				"index.js",
-				{},
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch();
 			let text;
@@ -57,11 +55,9 @@ describe("workers change behaviour with middleware with wrangler dev", () => {
 
 			fs.writeFileSync("index.js", scriptContent);
 
-			const worker = await unstable_dev(
-				"index.js",
-				{},
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch();
 			let text;
@@ -90,11 +86,9 @@ describe("workers change behaviour with middleware with wrangler dev", () => {
 
 			fs.writeFileSync("index.js", scriptContent);
 
-			const worker = await unstable_dev(
-				"index.js",
-				{},
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch();
 			let text;
@@ -121,11 +115,9 @@ describe("workers change behaviour with middleware with wrangler dev", () => {
 			`;
 			fs.writeFileSync("index.js", scriptContent);
 
-			const worker = await unstable_dev(
-				"index.js",
-				{},
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch();
 			let text;
@@ -150,11 +142,9 @@ describe("workers change behaviour with middleware with wrangler dev", () => {
 			`;
 			fs.writeFileSync("index.js", scriptContent);
 
-			const worker = await unstable_dev(
-				"index.js",
-				{},
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch();
 			let text;
@@ -179,11 +169,9 @@ describe("workers change behaviour with middleware with wrangler dev", () => {
 
 			fs.writeFileSync("index.js", scriptContent);
 
-			const worker = await unstable_dev(
-				"index.js",
-				{},
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch();
 			let text;
@@ -211,11 +199,9 @@ describe("workers change behaviour with middleware with wrangler dev", () => {
 
 			fs.writeFileSync("index.js", scriptContent);
 
-			const worker = await unstable_dev(
-				"index.js",
-				{},
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch();
 			let text;
@@ -242,11 +228,9 @@ describe("unchanged functionality when wrapping with middleware", () => {
 			`;
 			fs.writeFileSync("index.js", scriptContent);
 
-			const worker = await unstable_dev(
-				"index.js",
-				{},
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch();
 			if (resp) {
@@ -267,11 +251,9 @@ describe("unchanged functionality when wrapping with middleware", () => {
 			`;
 			fs.writeFileSync("index.js", scriptContent);
 
-			const worker = await unstable_dev(
-				"index.js",
-				{},
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch();
 			let text;
@@ -295,11 +277,9 @@ describe("unchanged functionality when wrapping with middleware", () => {
 			`;
 			fs.writeFileSync("index.js", scriptContent);
 
-			const worker = await unstable_dev(
-				"index.js",
-				{},
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch();
 			if (resp) {
@@ -328,11 +308,9 @@ describe("unchanged functionality when wrapping with middleware", () => {
 			`;
 			fs.writeFileSync("index.js", scriptContent);
 
-			const worker = await unstable_dev(
-				"index.js",
-				{},
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch();
 			let text;
@@ -356,11 +334,9 @@ describe("unchanged functionality when wrapping with middleware", () => {
 			`;
 			fs.writeFileSync("index.js", scriptContent);
 
-			const worker = await unstable_dev(
-				"index.js",
-				{},
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch();
 			const status = resp?.status;
@@ -396,11 +372,9 @@ describe("unchanged functionality when wrapping with middleware", () => {
 			`;
 			fs.writeFileSync("index.js", scriptContent);
 
-			const worker = await unstable_dev(
-				"index.js",
-				{},
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch();
 			let text;
@@ -419,11 +393,9 @@ describe("unchanged functionality when wrapping with middleware", () => {
 			`;
 			fs.writeFileSync("index.js", scriptContent);
 
-			const worker = await unstable_dev(
-				"index.js",
-				{},
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch();
 			if (resp) {
@@ -443,11 +415,9 @@ describe("unchanged functionality when wrapping with middleware", () => {
 			`;
 			fs.writeFileSync("index.js", scriptContent);
 
-			const worker = await unstable_dev(
-				"index.js",
-				{},
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch();
 			let text;
@@ -470,11 +440,9 @@ describe("unchanged functionality when wrapping with middleware", () => {
 			`;
 			fs.writeFileSync("index.js", scriptContent);
 
-			const worker = await unstable_dev(
-				"index.js",
-				{},
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch();
 			if (resp) {
@@ -502,11 +470,9 @@ describe("unchanged functionality when wrapping with middleware", () => {
 			`;
 			fs.writeFileSync("index.js", scriptContent);
 
-			const worker = await unstable_dev(
-				"index.js",
-				{},
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch();
 			let text;
@@ -532,11 +498,9 @@ describe("unchanged functionality when wrapping with middleware", () => {
 			`;
 			fs.writeFileSync("index.js", scriptContent);
 
-			const worker = await unstable_dev(
-				"index.js",
-				{},
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch();
 			let text;
@@ -563,11 +527,9 @@ describe("unchanged functionality when wrapping with middleware", () => {
 			`;
 			fs.writeFileSync("index.js", scriptContent);
 
-			const worker = await unstable_dev(
-				"index.js",
-				{},
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch();
 			let text;
@@ -593,11 +555,9 @@ describe("unchanged functionality when wrapping with middleware", () => {
 			`;
 			fs.writeFileSync("index.js", scriptContent);
 
-			const worker = await unstable_dev(
-				"index.js",
-				{},
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch();
 			let text;
@@ -624,11 +584,9 @@ describe("unchanged functionality when wrapping with middleware", () => {
 			`;
 			fs.writeFileSync("index.js", scriptContent);
 
-			const worker = await unstable_dev(
-				"index.js",
-				{},
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch();
 			let text;
@@ -649,11 +607,9 @@ describe("unchanged functionality when wrapping with middleware", () => {
 			`;
 			fs.writeFileSync("index.js", scriptContent);
 
-			const worker = await unstable_dev(
-				"index.js",
-				{},
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch();
 			const status = resp?.status;
@@ -680,11 +636,9 @@ describe("unchanged functionality when wrapping with middleware", () => {
 			`;
 			fs.writeFileSync("index.js", scriptContent);
 
-			const worker = await unstable_dev(
-				"index.js",
-				{},
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch();
 			let text;
@@ -710,11 +664,9 @@ describe("unchanged functionality when wrapping with middleware", () => {
 			`;
 			fs.writeFileSync("index.js", scriptContent);
 
-			const worker = await unstable_dev(
-				"index.js",
-				{},
-				{ disableExperimentalWarning: true }
-			);
+			const worker = await unstable_dev("index.js", {
+				experimental: { disableExperimentalWarning: true },
+			});
 
 			const resp = await worker.fetch();
 			let text;

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -80,7 +80,7 @@ export async function unstable_dev(
 	const { testMode = true, disableExperimentalWarning = false } =
 		options?.experimental ?? {};
 	if (apiOptions) {
-		throw logger.error(
+		logger.error(
 			"unstable_dev's third argument (apiOptions) has been deprecated in favor of an `experimental` property within the second argument (options).\nPlease update your code from:\n`await unstable_dev('...', {...}, {...});`\nto:\n`await unstable_dev('...', {..., experimental: {...}});`"
 		);
 	}

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -76,7 +76,9 @@ export async function unstable_dev(
 	script: string,
 	options?: DevOptions
 ): Promise<UnstableDevWorker> {
-	if (!options?.experimental?.disableExperimentalWarning) {
+	const { testMode = true, disableExperimentalWarning = false } =
+		options?.experimental ?? {};
+	if (!disableExperimentalWarning) {
 		logger.warn(
 			`unstable_dev() is experimental\nunstable_dev()'s behaviour will likely change in future releases`
 		);
@@ -84,7 +86,7 @@ export async function unstable_dev(
 	let readyPort: number;
 	let readyAddress: string;
 	//due to Pages adoption of unstable_dev, we can't *just* disable rebuilds and watching. instead, we'll have two versions of startDev, which will converge.
-	if (options?.experimental?.testMode) {
+	if (testMode) {
 		//in testMode, we can run multiple wranglers in parallel, but rebuilds might not work out of the box
 		return new Promise<UnstableDevWorker>((resolve) => {
 			//lmao

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -52,8 +52,6 @@ interface DevOptions {
 	local?: boolean;
 	forceLocal?: boolean;
 	enablePagesAssetsServiceBinding?: EnablePagesAssetsServiceBindingOptions;
-	_?: (string | number)[]; //yargs wants this
-	$0?: string; //yargs wants this
 	testScheduled?: boolean;
 	experimentalLocal?: boolean;
 	accountId?: string;
@@ -78,7 +76,7 @@ export async function unstable_dev(
 	script: string,
 	options?: DevOptions
 ): Promise<UnstableDevWorker> {
-	if (!options?.experimental.disableExperimentalWarning) {
+	if (!options?.experimental?.disableExperimentalWarning) {
 		logger.warn(
 			`unstable_dev() is experimental\nunstable_dev()'s behaviour will likely change in future releases`
 		);

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -74,10 +74,17 @@ export interface UnstableDevWorker {
  */
 export async function unstable_dev(
 	script: string,
-	options?: DevOptions
+	options?: DevOptions,
+	apiOptions?: unknown
 ): Promise<UnstableDevWorker> {
 	const { testMode = true, disableExperimentalWarning = false } =
 		options?.experimental ?? {};
+	if (apiOptions) {
+		throw logger.error(
+			"unstable_dev's third argument (apiOptions) has been deprecated in favor of an `experimental` property within the second argument (options).\nPlease update your code from:\n`await unstable_dev('...', {...}, {...});`\nto:\n`await unstable_dev('...', {..., experimental: {...}});`"
+		);
+	}
+
 	if (!disableExperimentalWarning) {
 		logger.warn(
 			`unstable_dev() is experimental\nunstable_dev()'s behaviour will likely change in future releases`

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -58,11 +58,10 @@ interface DevOptions {
 	experimentalLocal?: boolean;
 	accountId?: string;
 	experimentalLocalRemoteKv?: boolean;
-}
-
-interface DevApiOptions {
-	testMode?: boolean;
-	disableExperimentalWarning?: boolean;
+	experimental: {
+		testMode?: boolean;
+		disableExperimentalWarning?: boolean;
+	};
 }
 
 export interface UnstableDevWorker {
@@ -77,12 +76,9 @@ export interface UnstableDevWorker {
  */
 export async function unstable_dev(
 	script: string,
-	options?: DevOptions,
-	apiOptions?: DevApiOptions
+	options?: DevOptions
 ): Promise<UnstableDevWorker> {
-	const { testMode = true, disableExperimentalWarning = false } =
-		apiOptions || {};
-	if (!disableExperimentalWarning) {
+	if (!options?.experimental.disableExperimentalWarning) {
 		logger.warn(
 			`unstable_dev() is experimental\nunstable_dev()'s behaviour will likely change in future releases`
 		);
@@ -90,7 +86,7 @@ export async function unstable_dev(
 	let readyPort: number;
 	let readyAddress: string;
 	//due to Pages adoption of unstable_dev, we can't *just* disable rebuilds and watching. instead, we'll have two versions of startDev, which will converge.
-	if (testMode) {
+	if (options?.experimental?.testMode) {
 		//in testMode, we can run multiple wranglers in parallel, but rebuilds might not work out of the box
 		return new Promise<UnstableDevWorker>((resolve) => {
 			//lmao

--- a/packages/wrangler/src/pages/dev.tsx
+++ b/packages/wrangler/src/pages/dev.tsx
@@ -470,73 +470,70 @@ export const Handler = async ({
 		}
 	}
 
-	const { stop, waitUntilExit } = await unstable_dev(
-		entrypoint,
-		{
-			ip,
-			port,
-			inspectorPort,
-			watch: true,
-			localProtocol,
-			liveReload,
-			compatibilityDate,
-			compatibilityFlags,
-			nodeCompat,
-			experimentalLocal,
-			vars: Object.fromEntries(
-				bindings
-					.map((binding) => binding.toString().split("="))
-					.map(([key, ...values]) => [key, values.join("=")])
-			),
-			kv: kvs.map((binding) => ({
-				binding: binding.toString(),
-				id: "",
-			})),
-			durableObjects: durableObjects
-				.map((durableObject) => {
-					const { binding, className, scriptName } =
-						DURABLE_OBJECTS_BINDING_REGEXP.exec(durableObject.toString())
-							?.groups || {};
+	const { stop, waitUntilExit } = await unstable_dev(entrypoint, {
+		ip,
+		port,
+		inspectorPort,
+		watch: true,
+		localProtocol,
+		liveReload,
+		compatibilityDate,
+		compatibilityFlags,
+		nodeCompat,
+		experimentalLocal,
+		vars: Object.fromEntries(
+			bindings
+				.map((binding) => binding.toString().split("="))
+				.map(([key, ...values]) => [key, values.join("=")])
+		),
+		kv: kvs.map((binding) => ({
+			binding: binding.toString(),
+			id: "",
+		})),
+		durableObjects: durableObjects
+			.map((durableObject) => {
+				const { binding, className, scriptName } =
+					DURABLE_OBJECTS_BINDING_REGEXP.exec(durableObject.toString())
+						?.groups || {};
 
-					if (!binding || !className) {
-						logger.warn(
-							"Could not parse Durable Object binding:",
-							durableObject.toString()
-						);
-						return;
-					}
+				if (!binding || !className) {
+					logger.warn(
+						"Could not parse Durable Object binding:",
+						durableObject.toString()
+					);
+					return;
+				}
 
-					return {
-						name: binding,
-						class_name: className,
-						script_name: scriptName,
-					};
-				})
-				.filter(Boolean) as AdditionalDevProps["durableObjects"],
-			r2: r2s.map((binding) => {
-				return { binding: binding.toString(), bucket_name: "" };
-			}),
+				return {
+					name: binding,
+					class_name: className,
+					script_name: scriptName,
+				};
+			})
+			.filter(Boolean) as AdditionalDevProps["durableObjects"],
+		r2: r2s.map((binding) => {
+			return { binding: binding.toString(), bucket_name: "" };
+		}),
 
-			d1Databases: d1s.map((binding) => ({
-				binding: binding.toString(),
-				database_id: "", // Required for types, but unused by dev
-				database_name: `local-${binding}`,
-			})),
+		d1Databases: d1s.map((binding) => ({
+			binding: binding.toString(),
+			database_id: "", // Required for types, but unused by dev
+			database_name: `local-${binding}`,
+		})),
 
-			enablePagesAssetsServiceBinding: {
-				proxyPort,
-				directory,
-			},
-			forceLocal: true,
-			persist,
-			persistTo,
-			showInteractiveDevSession: undefined,
-			inspect: undefined,
-			logPrefix: "pages",
-			logLevel: logLevel ?? "warn",
+		enablePagesAssetsServiceBinding: {
+			proxyPort,
+			directory,
 		},
-		{ testMode: false, disableExperimentalWarning: true }
-	);
+		forceLocal: true,
+		persist,
+		persistTo,
+		showInteractiveDevSession: undefined,
+		inspect: undefined,
+		logPrefix: "pages",
+		logLevel: logLevel ?? "warn",
+		experimental: { testMode: false, disableExperimentalWarning: true },
+	});
 	await metrics.sendMetricsEvent("run pages dev");
 
 	CLEANUP_CALLBACKS.push(stop);

--- a/packages/wrangler/templates/init-tests/test-jest-new-worker.js
+++ b/packages/wrangler/templates/init-tests/test-jest-new-worker.js
@@ -4,11 +4,9 @@ describe("Worker", () => {
 	let worker;
 
 	beforeAll(async () => {
-		worker = await unstable_dev(
-			"src/index.js",
-			{},
-			{ disableExperimentalWarning: true }
-		);
+		worker = await unstable_dev("src/index.js", {
+			experimental: { disableExperimentalWarning: true },
+		});
 	});
 
 	afterAll(async () => {

--- a/packages/wrangler/templates/init-tests/test-vitest-new-worker.js
+++ b/packages/wrangler/templates/init-tests/test-vitest-new-worker.js
@@ -5,11 +5,9 @@ describe("Worker", () => {
 	let worker;
 
 	beforeAll(async () => {
-		worker = await unstable_dev(
-			"src/index.js",
-			{},
-			{ disableExperimentalWarning: true }
-		);
+		worker = await unstable_dev("src/index.js", {
+			experimental: { disableExperimentalWarning: true },
+		});
 	});
 
 	afterAll(async () => {


### PR DESCRIPTION
What this PR solves / how to test:

This PR refactors `unstable_dev` to use a single `options` object, which contains an `experimental` object for things we're still trying out. 

A follow-up PR will want to move more options to `experimental` - I believe @Skye-31 / @GregBrimble  / @WalshyDev would know if there are Pages-only props passed to `unstable_dev` that we might want to put in there


Associated docs issues/PR:

- https://github.com/cloudflare/wrangler2/issues/2344
- https://github.com/cloudflare/cloudflare-docs/pull/7113

Author has included the following, where applicable:

- [x] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [x] Checked for inclusion of relevant tests
- [x] Checked for inclusion of a relevant changeset
- [x] Checked for creation of associated docs updates
- [x] Manually pulled down the changes and spot-tested


