### PR TITLE
Add an `await` when starting devRegistry

### DIFF
--- a/.changeset/afraid-tigers-lie.md
+++ b/.changeset/afraid-tigers-lie.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: resolve unstable_dev flakiness in tests by awaiting the dev registry

--- a/fixtures/local-mode-tests/tests/headers.test.ts
+++ b/fixtures/local-mode-tests/tests/headers.test.ts
@@ -3,7 +3,7 @@ import { unstable_dev } from "wrangler";
 import type { UnstableDevWorker } from "wrangler";
 
 // Disabled because of flakiness in CI
-describe.skip("worker", () => {
+describe("worker", () => {
 	let worker: UnstableDevWorker;
 	let resolveReadyPromise: (value: unknown) => void;
 	const readyPromise = new Promise((resolve) => {

--- a/fixtures/local-mode-tests/tests/headers.test.ts
+++ b/fixtures/local-mode-tests/tests/headers.test.ts
@@ -2,7 +2,6 @@ import path from "path";
 import { unstable_dev } from "wrangler";
 import type { UnstableDevWorker } from "wrangler";
 
-// Disabled because of flakiness in CI
 describe("worker", () => {
 	let worker: UnstableDevWorker;
 	let resolveReadyPromise: (value: unknown) => void;

--- a/packages/wrangler/src/__tests__/api-dev.test.ts
+++ b/packages/wrangler/src/__tests__/api-dev.test.ts
@@ -5,7 +5,7 @@ import { runInTempDir } from "./helpers/run-in-tmp";
 
 jest.unmock("undici");
 
-describe.skip("unstable_dev", () => {
+describe("unstable_dev", () => {
 	it("should return Hello World", async () => {
 		const worker = await unstable_dev(
 			"src/__tests__/helpers/worker-scripts/hello-world-worker.js",

--- a/packages/wrangler/src/__tests__/api-devregistry.test.js
+++ b/packages/wrangler/src/__tests__/api-devregistry.test.js
@@ -1,13 +1,13 @@
 import { unstable_dev } from "../api";
 import { fetch } from "undici";
 
-// jest.unmock("undici");
+jest.unmock("undici");
 
 /**
  * a huge caveat to how testing multi-worker scripts works:
  * you can't shutdown the first worker you spun up, or it'll kill the devRegistry
  */
-describe.skip("multi-worker testing", () => {
+describe("multi-worker testing", () => {
 	let childWorker;
 	let parentWorker;
 

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -62,18 +62,22 @@ export async function startDevServer(
 		}
 
 		//start the worker registry
-		startWorkerRegistry().catch((err) => {
-			logger.error("failed to start worker registry", err);
-		});
-		if (props.local) {
-			const boundRegisteredWorkers = await getBoundRegisteredWorkers({
-				services: props.bindings.services,
-				durableObjects: props.bindings.durable_objects,
-			});
+		try {
+			await startWorkerRegistry();
+			if (props.local) {
+				const boundRegisteredWorkers = await getBoundRegisteredWorkers({
+					services: props.bindings.services,
+					durableObjects: props.bindings.durable_objects,
+				});
 
-			if (!util.isDeepStrictEqual(boundRegisteredWorkers, workerDefinitions)) {
-				workerDefinitions = boundRegisteredWorkers || {};
+				if (
+					!util.isDeepStrictEqual(boundRegisteredWorkers, workerDefinitions)
+				) {
+					workerDefinitions = boundRegisteredWorkers || {};
+				}
 			}
+		} catch (err) {
+			logger.error("failed to start worker registry", err);
 		}
 
 		const betaD1Shims = props.bindings.d1_databases?.map((db) => db.binding);


### PR DESCRIPTION
**What this PR solves / how to test:**

`unstable_dev` tests seem to flake due to the dev registry not having started in time for the test to run.

An initial approach was to completely disable the dev registry, but I realised we never actually `await` when starting it - which could lead to the flakiness we've seen.

**Associated docs issues/PR:**

N/A

**Author has included the following, where applicable:**

- [x] Tests
- [x] Changeset

**Reviewer has performed the following, where applicable:**

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

