### PR TITLE
chore: export devoptions as UnstableDevOptions

### DIFF
--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -6,7 +6,7 @@ import type { Environment } from "../config";
 import type { EnablePagesAssetsServiceBindingOptions } from "../miniflare-cli/types";
 import type { RequestInit, Response, RequestInfo } from "undici";
 
-interface DevOptions {
+export interface UnstableDevOptions {
 	config?: string;
 	env?: string;
 	ip?: string;

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -75,7 +75,7 @@ export interface UnstableDevWorker {
  */
 export async function unstable_dev(
 	script: string,
-	options?: DevOptions,
+	options?: UnstableDevOptions,
 	apiOptions?: unknown
 ): Promise<UnstableDevWorker> {
 	const {

--- a/packages/wrangler/src/api/index.ts
+++ b/packages/wrangler/src/api/index.ts
@@ -1,2 +1,2 @@
 export { unstable_dev } from "./dev";
-export type { UnstableDevWorker } from "./dev";
+export type { UnstableDevWorker, UnstableDevOptions } from "./dev";

--- a/packages/wrangler/src/cli.ts
+++ b/packages/wrangler/src/cli.ts
@@ -4,7 +4,7 @@ import { unstable_dev } from "./api";
 import { FatalError } from "./errors";
 import { main } from ".";
 
-import type { UnstableDevWorker } from "./api";
+import type { UnstableDevWorker, UnstableDevOptions } from "./api";
 /**
  * The main entrypoint for the CLI.
  * main only gets called when the script is run directly, not when it's imported as a module.
@@ -25,4 +25,4 @@ if (typeof jest === "undefined" && require.main === module) {
  * and call wrangler.unstable_dev().
  */
 export { unstable_dev };
-export type { UnstableDevWorker };
+export type { UnstableDevWorker, UnstableDevOptions };


### PR DESCRIPTION
Just exporting DevOptions for easier typing - called it `UnstableDevOptions` to make it clear it'll change