### PR TITLE
chore: move spicy options under experimental in unstable_dev

### DIFF
--- a/.changeset/rotten-tigers-clean.md
+++ b/.changeset/rotten-tigers-clean.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+BREAKING CHANGE: move experimental options under the experimental object for unstable_dev

--- a/fixtures/local-mode-tests/tests/ports.test.ts
+++ b/fixtures/local-mode-tests/tests/ports.test.ts
@@ -2,7 +2,9 @@ import path from "path";
 import { unstable_dev } from "wrangler";
 import type { UnstableDevWorker } from "wrangler";
 
-describe("worker", () => {
+// Okay this test is seriously flaky, even without devRegistry enabled
+// TODO: figure out why we can't run 8 wranglers at once
+describe.skip("worker", () => {
 	let workers: UnstableDevWorker[];
 	let resolveReadyPromise: (value: unknown) => void;
 	const readyPromise = new Promise((resolve) => {

--- a/packages/wrangler/src/__tests__/middleware.scheduled.test.ts
+++ b/packages/wrangler/src/__tests__/middleware.scheduled.test.ts
@@ -43,10 +43,10 @@ describe("run scheduled events with middleware", () => {
 
 		it("should intercept when middleware is enabled", async () => {
 			const worker = await unstable_dev("index.js", {
-				testScheduled: true,
 				experimental: {
 					disableExperimentalWarning: true,
 					disableDevRegistry: true,
+					testScheduled: true,
 				},
 			});
 
@@ -59,10 +59,10 @@ describe("run scheduled events with middleware", () => {
 
 		it("should not trigger scheduled event on wrong route", async () => {
 			const worker = await unstable_dev("index.js", {
-				testScheduled: true,
 				experimental: {
 					disableExperimentalWarning: true,
 					disableDevRegistry: true,
+					testScheduled: true,
 				},
 			});
 
@@ -112,10 +112,10 @@ describe("run scheduled events with middleware", () => {
 
 		it("should intercept when middleware is enabled", async () => {
 			const worker = await unstable_dev("index.js", {
-				testScheduled: true,
 				experimental: {
 					disableExperimentalWarning: true,
 					disableDevRegistry: true,
+					testScheduled: true,
 				},
 			});
 
@@ -128,10 +128,10 @@ describe("run scheduled events with middleware", () => {
 
 		it("should not trigger scheduled event on wrong route", async () => {
 			const worker = await unstable_dev("index.js", {
-				testScheduled: true,
 				experimental: {
 					disableExperimentalWarning: true,
 					disableDevRegistry: true,
+					testScheduled: true,
 				},
 			});
 

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -51,13 +51,17 @@ export interface UnstableDevOptions {
 	local?: boolean;
 	accountId?: string;
 	experimental?: {
+		// Disables wrangler's warning when unstable APIs are used.
 		disableExperimentalWarning?: boolean;
+		// Disables wrangler's support multi-worker setups. May reduce flakiness when used in tests in CI.
 		disableDevRegistry?: boolean;
 		enablePagesAssetsServiceBinding?: EnablePagesAssetsServiceBindingOptions;
 		forceLocal?: boolean;
+		// Uses Miniflare 3 instead of Miniflare 2
 		experimentalLocal?: boolean;
 		experimentalLocalRemoteKv?: boolean;
 		showInteractiveDevSession?: boolean;
+		// This option shouldn't be used - We plan on removing it eventually
 		testMode?: boolean;
 		testScheduled?: boolean;
 	};
@@ -80,13 +84,15 @@ export async function unstable_dev(
 ): Promise<UnstableDevWorker> {
 	// Note that not every experimental option is passed directly through to the underlying dev API - experimental options can be used here in unstable_dev. Otherwise we could just pass experimental down to dev blindly.
 	const {
-		testMode = true,
-		disableExperimentalWarning = false,
 		disableDevRegistry = false,
-		testScheduled,
+		disableExperimentalWarning = false,
 		experimentalLocal,
 		experimentalLocalRemoteKv,
 		enablePagesAssetsServiceBinding,
+		forceLocal,
+		showInteractiveDevSession = false,
+		testMode = true,
+		testScheduled,
 	} = options?.experimental ?? {};
 	if (apiOptions) {
 		logger.error(
@@ -113,7 +119,6 @@ export async function unstable_dev(
 					script: script,
 					inspect: false,
 					logLevel: "none",
-					showInteractiveDevSession: false,
 					_: [],
 					$0: "",
 					port: options?.port ?? 0,
@@ -123,6 +128,8 @@ export async function unstable_dev(
 					experimentalLocal,
 					experimentalLocalRemoteKv,
 					enablePagesAssetsServiceBinding,
+					showInteractiveDevSession,
+					forceLocal,
 					...options,
 					onReady: (address, port) => {
 						readyPort = port;
@@ -164,10 +171,10 @@ export async function unstable_dev(
 				const devServer = startDev({
 					script: script,
 					inspect: false,
-					showInteractiveDevSession: false,
 					_: [],
 					$0: "",
 					local: true,
+					showInteractiveDevSession,
 					disableDevRegistry,
 					testScheduled,
 					experimentalLocal,

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -78,6 +78,7 @@ export async function unstable_dev(
 	options?: UnstableDevOptions,
 	apiOptions?: unknown
 ): Promise<UnstableDevWorker> {
+	// Note that not every experimental option is passed directly through to the underlying dev API - experimental options can be used here in unstable_dev. Otherwise we could just pass experimental down to dev blindly.
 	const {
 		testMode = true,
 		disableExperimentalWarning = false,
@@ -85,6 +86,7 @@ export async function unstable_dev(
 		testScheduled,
 		experimentalLocal,
 		experimentalLocalRemoteKv,
+		enablePagesAssetsServiceBinding,
 	} = options?.experimental ?? {};
 	if (apiOptions) {
 		logger.error(
@@ -120,6 +122,7 @@ export async function unstable_dev(
 					testScheduled,
 					experimentalLocal,
 					experimentalLocalRemoteKv,
+					enablePagesAssetsServiceBinding,
 					...options,
 					onReady: (address, port) => {
 						readyPort = port;
@@ -165,9 +168,11 @@ export async function unstable_dev(
 					_: [],
 					$0: "",
 					local: true,
+					disableDevRegistry,
 					testScheduled,
 					experimentalLocal,
 					experimentalLocalRemoteKv,
+					enablePagesAssetsServiceBinding,
 					...options,
 					onReady: (address, port) => {
 						readyPort = port;

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -7,22 +7,22 @@ import type { EnablePagesAssetsServiceBindingOptions } from "../miniflare-cli/ty
 import type { RequestInit, Response, RequestInfo } from "undici";
 
 export interface UnstableDevOptions {
-	config?: string;
-	env?: string;
-	ip?: string;
-	port?: number;
-	bundle?: boolean;
-	inspectorPort?: number;
-	localProtocol?: "http" | "https";
-	assets?: string;
-	site?: string;
-	siteInclude?: string[];
-	siteExclude?: string[];
-	nodeCompat?: boolean;
-	compatibilityDate?: string;
-	compatibilityFlags?: string[];
-	persist?: boolean;
-	persistTo?: string;
+	config?: string; // Path to .toml configuration file, relative to cwd
+	env?: string; // Environment to use for operations and .env files
+	ip?: string; // IP address to listen on
+	port?: number; // Port to listen on
+	bundle?: boolean; // Set to false to skip internal build steps and directly publish script
+	inspectorPort?: number; // Port for devtools to connect to
+	localProtocol?: "http" | "https"; // Protocol to listen to requests on, defaults to http.
+	assets?: string; // Static assets to be served
+	site?: string; // Root folder of static assets for Workers Sites
+	siteInclude?: string[]; // Array of .gitignore-style patterns that match file or directory names from the sites directory. Only matched items will be uploaded.
+	siteExclude?: string[]; // Array of .gitignore-style patterns that match file or directory names from the sites directory. Matched items will not be uploaded.
+	nodeCompat?: boolean; // Enable node.js compatibility
+	compatibilityDate?: string; // Date to use for compatibility checks
+	compatibilityFlags?: string[]; // Flags to use for compatibility checks
+	persist?: boolean; // Enable persistence for local mode, using default path: .wrangler/state
+	persistTo?: string; // Specify directory to use for local persistence (implies --persist)
 	vars?: {
 		[key: string]: unknown;
 	};
@@ -42,7 +42,7 @@ export interface UnstableDevOptions {
 		bucket_name: string;
 		preview_bucket_name?: string;
 	}[];
-	logLevel?: "none" | "info" | "error" | "log" | "warn" | "debug";
+	logLevel?: "none" | "info" | "error" | "log" | "warn" | "debug"; // Specify logging level  [choices: "debug", "info", "log", "warn", "error", "none"] [default: "log"]
 	logPrefix?: string;
 	inspect?: boolean;
 	local?: boolean;
@@ -55,10 +55,10 @@ export interface UnstableDevOptions {
 		experimentalLocal?: boolean; // Use Miniflare 3 instead of Miniflare 2
 		experimentalLocalRemoteKv?: boolean;
 		forceLocal?: boolean;
-		liveReload?: boolean;
+		liveReload?: boolean; // Auto reload HTML pages when change is detected in local mode
 		showInteractiveDevSession?: boolean;
 		testMode?: boolean; // This option shouldn't be used - We plan on removing it eventually
-		testScheduled?: boolean;
+		testScheduled?: boolean; // Test scheduled events by visiting /__scheduled in browser
 		watch?: boolean; // unstable_dev doesn't support watch-mode yet in testMode
 	};
 }

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -23,8 +23,6 @@ export interface UnstableDevOptions {
 	compatibilityFlags?: string[];
 	persist?: boolean;
 	persistTo?: string;
-	liveReload?: boolean;
-	watch?: boolean;
 	vars?: {
 		[key: string]: unknown;
 	};
@@ -44,26 +42,24 @@ export interface UnstableDevOptions {
 		bucket_name: string;
 		preview_bucket_name?: string;
 	}[];
-	d1Databases?: Environment["d1_databases"];
 	logLevel?: "none" | "info" | "error" | "log" | "warn" | "debug";
 	logPrefix?: string;
 	inspect?: boolean;
 	local?: boolean;
 	accountId?: string;
 	experimental?: {
-		// Disables wrangler's warning when unstable APIs are used.
-		disableExperimentalWarning?: boolean;
-		// Disables wrangler's support multi-worker setups. May reduce flakiness when used in tests in CI.
-		disableDevRegistry?: boolean;
+		d1Databases?: Environment["d1_databases"];
+		disableExperimentalWarning?: boolean; // Disables wrangler's warning when unstable APIs are used.
+		disableDevRegistry?: boolean; // Disables wrangler's support multi-worker setups. May reduce flakiness when used in tests in CI.
 		enablePagesAssetsServiceBinding?: EnablePagesAssetsServiceBindingOptions;
-		forceLocal?: boolean;
-		// Uses Miniflare 3 instead of Miniflare 2
-		experimentalLocal?: boolean;
+		experimentalLocal?: boolean; // Use Miniflare 3 instead of Miniflare 2
 		experimentalLocalRemoteKv?: boolean;
+		forceLocal?: boolean;
+		liveReload?: boolean;
 		showInteractiveDevSession?: boolean;
-		// This option shouldn't be used - We plan on removing it eventually
-		testMode?: boolean;
+		testMode?: boolean; // This option shouldn't be used - We plan on removing it eventually
 		testScheduled?: boolean;
+		watch?: boolean; // unstable_dev doesn't support watch-mode yet in testMode
 	};
 }
 
@@ -84,15 +80,18 @@ export async function unstable_dev(
 ): Promise<UnstableDevWorker> {
 	// Note that not every experimental option is passed directly through to the underlying dev API - experimental options can be used here in unstable_dev. Otherwise we could just pass experimental down to dev blindly.
 	const {
+		d1Databases,
 		disableDevRegistry = false,
 		disableExperimentalWarning = false,
 		experimentalLocal,
 		experimentalLocalRemoteKv,
 		enablePagesAssetsServiceBinding,
 		forceLocal,
+		liveReload,
 		showInteractiveDevSession = false,
 		testMode = true,
 		testScheduled,
+		watch,
 	} = options?.experimental ?? {};
 	if (apiOptions) {
 		logger.error(
@@ -123,13 +122,16 @@ export async function unstable_dev(
 					$0: "",
 					port: options?.port ?? 0,
 					local: true,
+					d1Databases,
 					disableDevRegistry,
 					testScheduled,
 					experimentalLocal,
 					experimentalLocalRemoteKv,
 					enablePagesAssetsServiceBinding,
+					liveReload,
 					showInteractiveDevSession,
 					forceLocal,
+					watch,
 					...options,
 					onReady: (address, port) => {
 						readyPort = port;
@@ -175,11 +177,14 @@ export async function unstable_dev(
 					$0: "",
 					local: true,
 					showInteractiveDevSession,
+					d1Databases,
 					disableDevRegistry,
 					testScheduled,
 					experimentalLocal,
 					experimentalLocalRemoteKv,
 					enablePagesAssetsServiceBinding,
+					liveReload,
+					watch,
 					...options,
 					onReady: (address, port) => {
 						readyPort = port;

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -45,21 +45,21 @@ export interface UnstableDevOptions {
 		preview_bucket_name?: string;
 	}[];
 	d1Databases?: Environment["d1_databases"];
-	showInteractiveDevSession?: boolean;
 	logLevel?: "none" | "info" | "error" | "log" | "warn" | "debug";
 	logPrefix?: string;
 	inspect?: boolean;
 	local?: boolean;
-	forceLocal?: boolean;
-	enablePagesAssetsServiceBinding?: EnablePagesAssetsServiceBindingOptions;
-	testScheduled?: boolean;
-	experimentalLocal?: boolean;
 	accountId?: string;
-	experimentalLocalRemoteKv?: boolean;
 	experimental?: {
-		testMode?: boolean;
 		disableExperimentalWarning?: boolean;
 		disableDevRegistry?: boolean;
+		enablePagesAssetsServiceBinding?: EnablePagesAssetsServiceBindingOptions;
+		forceLocal?: boolean;
+		experimentalLocal?: boolean;
+		experimentalLocalRemoteKv?: boolean;
+		showInteractiveDevSession?: boolean;
+		testMode?: boolean;
+		testScheduled?: boolean;
 	};
 }
 
@@ -82,6 +82,9 @@ export async function unstable_dev(
 		testMode = true,
 		disableExperimentalWarning = false,
 		disableDevRegistry = false,
+		testScheduled,
+		experimentalLocal,
+		experimentalLocalRemoteKv,
 	} = options?.experimental ?? {};
 	if (apiOptions) {
 		logger.error(
@@ -114,6 +117,9 @@ export async function unstable_dev(
 					port: options?.port ?? 0,
 					local: true,
 					disableDevRegistry,
+					testScheduled,
+					experimentalLocal,
+					experimentalLocalRemoteKv,
 					...options,
 					onReady: (address, port) => {
 						readyPort = port;
@@ -159,6 +165,9 @@ export async function unstable_dev(
 					_: [],
 					$0: "",
 					local: true,
+					testScheduled,
+					experimentalLocal,
+					experimentalLocalRemoteKv,
 					...options,
 					onReady: (address, port) => {
 						readyPort = port;

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -80,18 +80,21 @@ export async function unstable_dev(
 ): Promise<UnstableDevWorker> {
 	// Note that not every experimental option is passed directly through to the underlying dev API - experimental options can be used here in unstable_dev. Otherwise we could just pass experimental down to dev blindly.
 	const {
-		d1Databases,
+		// there are two types of "experimental" options:
+		// 1. options to unstable_dev that we're still testing or are unsure of
 		disableDevRegistry = false,
 		disableExperimentalWarning = false,
-		experimentalLocal,
-		experimentalLocalRemoteKv,
-		enablePagesAssetsServiceBinding,
 		forceLocal,
 		liveReload,
 		showInteractiveDevSession = false,
 		testMode = true,
 		testScheduled,
 		watch,
+		// 2. options for alpha/beta products/libs
+		d1Databases,
+		experimentalLocal,
+		experimentalLocalRemoteKv,
+		enablePagesAssetsServiceBinding,
 	} = options?.experimental ?? {};
 	if (apiOptions) {
 		logger.error(

--- a/packages/wrangler/src/pages/dev.tsx
+++ b/packages/wrangler/src/pages/dev.tsx
@@ -474,9 +474,7 @@ export const Handler = async ({
 		ip,
 		port,
 		inspectorPort,
-		watch: true,
 		localProtocol,
-		liveReload,
 		compatibilityDate,
 		compatibilityFlags,
 		nodeCompat,
@@ -513,26 +511,28 @@ export const Handler = async ({
 		r2: r2s.map((binding) => {
 			return { binding: binding.toString(), bucket_name: "" };
 		}),
-		d1Databases: d1s.map((binding) => ({
-			binding: binding.toString(),
-			database_id: "", // Required for types, but unused by dev
-			database_name: `local-${binding}`,
-		})),
 		persist,
 		persistTo,
 		inspect: undefined,
 		logPrefix: "pages",
 		logLevel: logLevel ?? "warn",
 		experimental: {
+			d1Databases: d1s.map((binding) => ({
+				binding: binding.toString(),
+				database_id: "", // Required for types, but unused by dev
+				database_name: `local-${binding}`,
+			})),
 			disableExperimentalWarning: true,
 			enablePagesAssetsServiceBinding: {
 				proxyPort,
 				directory,
 			},
 			experimentalLocal,
+			liveReload,
 			forceLocal: true,
 			showInteractiveDevSession: undefined,
 			testMode: false,
+			watch: true,
 		},
 	});
 	await metrics.sendMetricsEvent("run pages dev");

--- a/packages/wrangler/src/pages/dev.tsx
+++ b/packages/wrangler/src/pages/dev.tsx
@@ -480,7 +480,6 @@ export const Handler = async ({
 		compatibilityDate,
 		compatibilityFlags,
 		nodeCompat,
-		experimentalLocal,
 		vars: Object.fromEntries(
 			bindings
 				.map((binding) => binding.toString().split("="))
@@ -514,25 +513,27 @@ export const Handler = async ({
 		r2: r2s.map((binding) => {
 			return { binding: binding.toString(), bucket_name: "" };
 		}),
-
 		d1Databases: d1s.map((binding) => ({
 			binding: binding.toString(),
 			database_id: "", // Required for types, but unused by dev
 			database_name: `local-${binding}`,
 		})),
-
-		enablePagesAssetsServiceBinding: {
-			proxyPort,
-			directory,
-		},
-		forceLocal: true,
 		persist,
 		persistTo,
-		showInteractiveDevSession: undefined,
 		inspect: undefined,
 		logPrefix: "pages",
 		logLevel: logLevel ?? "warn",
-		experimental: { testMode: false, disableExperimentalWarning: true },
+		experimental: {
+			disableExperimentalWarning: true,
+			enablePagesAssetsServiceBinding: {
+				proxyPort,
+				directory,
+			},
+			experimentalLocal,
+			forceLocal: true,
+			showInteractiveDevSession: undefined,
+			testMode: false,
+		},
 	});
 	await metrics.sendMetricsEvent("run pages dev");
 


### PR DESCRIPTION
What this PR solves / how to test:
This PR closes https://github.com/cloudflare/wrangler2/issues/2344 by finalizing the options we want to support, and what we still consider experimental.

Associated docs issues/PR:

- Follow-up PR to come once 

Author has included the following, where applicable:

- [x] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [x] Checked for inclusion of relevant tests
- [x] Checked for inclusion of a relevant changeset
- [x] Checked for creation of associated docs updates
- [x] Manually pulled down the changes and spot-tested

Closes #2344
