### PR TITLE
`wrangler upgrade` automated version bump

### DIFF
--- a/.changeset/spotty-poems-exist.md
+++ b/.changeset/spotty-poems-exist.md
@@ -1,0 +1,9 @@
+---
+"wrangler": minor
+---
+
+Automated Wrangler version bump:
+Added a command `upgrade` that automates the process of updating the version of Wrangler in the project's `package.json` file to the latest available version.
+Note that you will still need to run the package manager to update the `node_modules` after running this command.
+
+resolves #2071

--- a/.changeset/spotty-poems-exist.md
+++ b/.changeset/spotty-poems-exist.md
@@ -4,6 +4,5 @@
 
 Automated Wrangler version bump:
 Added a command `upgrade` that automates the process of updating the version of Wrangler in the project's `package.json` file to the latest available version.
-Note that you will still need to run the package manager to update the `node_modules` after running this command.
 
 resolves #2071

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -54,6 +54,7 @@ describe("wrangler", () => {
 			  wrangler whoami                      🕵️  Retrieve your user info and test your auth config
 			  wrangler types                       📝 Generate types from bindings & module rules in config
 			  wrangler deployments                 🚢 Displays the 10 most recent deployments for a worker
+			  wrangler upgrade                     🆕 Upgrade Wrangler installation to latest version
 
 			Flags:
 			  -c, --config   Path to .toml configuration file  [string]
@@ -102,6 +103,7 @@ describe("wrangler", () => {
 			  wrangler whoami                      🕵️  Retrieve your user info and test your auth config
 			  wrangler types                       📝 Generate types from bindings & module rules in config
 			  wrangler deployments                 🚢 Displays the 10 most recent deployments for a worker
+			  wrangler upgrade                     🆕 Upgrade Wrangler installation to latest version
 
 			Flags:
 			  -c, --config   Path to .toml configuration file  [string]

--- a/packages/wrangler/src/__tests__/upgrade.test.ts
+++ b/packages/wrangler/src/__tests__/upgrade.test.ts
@@ -28,7 +28,7 @@ describe("Upgrade", () => {
 		writeFileSync(
 			"package.json",
 			JSON.stringify({
-				dependencies: {
+				devDependencies: {
 					wrangler: "NOT-UPDATED",
 				},
 			})
@@ -55,11 +55,11 @@ describe("Upgrade", () => {
 		expect(
 			(
 				JSON.parse(readFileSync("./package.json", "utf8")) as {
-					dependencies: {
+					devDependencies: {
 						wrangler: string;
 					};
 				}
-			).dependencies.wrangler
+			).devDependencies.wrangler
 		).toBe("UPDATED-1701D");
 		expect(std.out).toMatchInlineSnapshot(`"✨ Wrangler upgrade complete! 🎉"`);
 		expect(execaSync).toHaveBeenCalledWith("pnpm", ["install"]);
@@ -102,7 +102,7 @@ describe("Upgrade", () => {
 		writeFileSync(
 			"package.json",
 			JSON.stringify({
-				dependencies: {},
+				devDependencies: {},
 			})
 		);
 		await runWrangler("upgrade");

--- a/packages/wrangler/src/__tests__/upgrade.test.ts
+++ b/packages/wrangler/src/__tests__/upgrade.test.ts
@@ -1,0 +1,73 @@
+import { readFileSync, writeFileSync } from "fs";
+import { rest } from "msw";
+import { mockConsoleMethods } from "./helpers/mock-console";
+import { useMockIsTTY } from "./helpers/mock-istty";
+import { msw } from "./helpers/msw";
+import { runInTempDir } from "./helpers/run-in-tmp";
+import { runWrangler } from "./helpers/run-wrangler";
+import writeWranglerToml from "./helpers/write-wrangler-toml";
+
+describe("Upgrade", () => {
+	runInTempDir();
+	const std = mockConsoleMethods();
+	const { setIsTTY } = useMockIsTTY();
+
+	beforeEach(() => {
+		setIsTTY(false);
+		writeFileSync(
+			"package.json",
+			JSON.stringify({
+				dependencies: {
+					wrangler: "NOT-UPDATED",
+				},
+			})
+		);
+		msw.use(
+			rest.get("https://registry.npmjs.org/wrangler", (req, res, ctx) => {
+				return res.once(
+					ctx.status(200),
+					ctx.json({
+						"dist-tags": {
+							latest: "UPDATED-1701D",
+						},
+					})
+				);
+			})
+		);
+	});
+
+	it("should change the version in package.json to the latest in npm registry", async () => {
+		writeWranglerToml();
+		await runWrangler("upgrade");
+
+		expect(
+			(
+				JSON.parse(readFileSync("./package.json", "utf8")) as {
+					dependencies: {
+						wrangler: string;
+					};
+				}
+			).dependencies.wrangler
+		).toBe("UPDATED-1701D");
+	});
+	it("should give an error message when Wrangler config can't be found", async () => {
+		await runWrangler("upgrade");
+
+		expect(std.err).toMatchInlineSnapshot(`
+		"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mFailed to find a Wrangler configuration file, unable to determine location of Worker package.json.[0m
+
+		"
+	`);
+	});
+	it("should give an error message when fetch to NPM registry fails", async () => {
+		writeWranglerToml();
+		msw.use(
+			rest.get("https://registry.npmjs.org/wrangler", (_, res) => {
+				return res.networkError("Some Network error on Fetch to NPM");
+			})
+		);
+		await expect(runWrangler("upgrade")).rejects.toMatchInlineSnapshot(
+			`[Error: Wrangler upgrade failed: FetchError: request to https://registry.npmjs.org/wrangler failed, reason: Some Network error on Fetch to NPM]`
+		);
+	});
+});

--- a/packages/wrangler/src/__tests__/upgrade.test.ts
+++ b/packages/wrangler/src/__tests__/upgrade.test.ts
@@ -2,12 +2,12 @@ import { readFileSync, writeFileSync } from "fs";
 import { execaSync } from "execa";
 import { rest } from "msw";
 import { mockConsoleMethods } from "./helpers/mock-console";
+import { mockConfirm } from "./helpers/mock-dialogs";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { msw } from "./helpers/msw";
 import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import writeWranglerToml from "./helpers/write-wrangler-toml";
-import { mockConfirm } from "./helpers/mock-dialogs";
 
 jest.mock("execa", () => {
 	return {

--- a/packages/wrangler/src/__tests__/upgrade.test.ts
+++ b/packages/wrangler/src/__tests__/upgrade.test.ts
@@ -61,7 +61,7 @@ describe("Upgrade", () => {
 				}
 			).dependencies.wrangler
 		).toBe("UPDATED-1701D");
-		expect(std.out).toMatchInlineSnapshot(`""`);
+		expect(std.out).toMatchInlineSnapshot(`"✨ Wrangler upgrade complete! 🎉"`);
 		expect(execaSync).toHaveBeenCalledWith("pnpm", ["install"]);
 	});
 
@@ -69,7 +69,7 @@ describe("Upgrade", () => {
 		await runWrangler("upgrade");
 
 		expect(std.err).toMatchInlineSnapshot(`
-		"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 Failed to find a Wrangler configuration file, unable to determine location of Worker package.json.[0m
+		"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 Wrangler failed to find a Worker project in the current directory.[0m
 
 		"
 	`);

--- a/packages/wrangler/src/api/index.ts
+++ b/packages/wrangler/src/api/index.ts
@@ -1,2 +1,4 @@
 export { unstable_dev } from "./dev";
+export { upgradeWrangler } from "./upgrade";
+
 export type { UnstableDevWorker, UnstableDevOptions } from "./dev";

--- a/packages/wrangler/src/api/upgrade.ts
+++ b/packages/wrangler/src/api/upgrade.ts
@@ -6,6 +6,7 @@ import { printWranglerBanner } from "../index";
 import { logger } from "../logger";
 import { readFileSync } from "../parse";
 import type { PackageJSON } from "../parse";
+import path from "path";
 
 export async function upgradeWrangler() {
 	await printWranglerBanner();
@@ -13,7 +14,7 @@ export async function upgradeWrangler() {
 
 	const pathToWorker = findWranglerToml();
 	if (pathToWorker) {
-		const newPath = pathToWorker.split("/").slice(0, -1).join("/");
+		const newPath = pathToWorker.split(path.sep).slice(0, -1).join(path.sep);
 		packageJsonData = JSON.parse(
 			readFileSync(`${newPath}/package.json`)
 		) as PackageJSON;

--- a/packages/wrangler/src/api/upgrade.ts
+++ b/packages/wrangler/src/api/upgrade.ts
@@ -54,6 +54,7 @@ export async function upgradeWrangler() {
 						"🚨 No lockfile found, unable to determine package manager."
 					);
 				}
+				logger.log("✨ Wrangler upgrade complete! 🎉");
 			} catch (error) {
 				throw Error(`Wrangler upgrade failed: ${error}`);
 			}
@@ -62,7 +63,7 @@ export async function upgradeWrangler() {
 		}
 	} else {
 		logger.error(
-			"🚨 Failed to find a Wrangler configuration file, unable to determine location of Worker package.json."
+			"🚨 Wrangler failed to find a Worker project in the current directory."
 		);
 	}
 }

--- a/packages/wrangler/src/api/upgrade.ts
+++ b/packages/wrangler/src/api/upgrade.ts
@@ -1,4 +1,5 @@
 import { writeFileSync, existsSync } from "fs";
+import path from "path";
 import { execaSync } from "execa";
 import { fetch } from "undici";
 import { findWranglerToml } from "../config";
@@ -6,7 +7,6 @@ import { printWranglerBanner } from "../index";
 import { logger } from "../logger";
 import { readFileSync } from "../parse";
 import type { PackageJSON } from "../parse";
-import path from "path";
 
 export async function upgradeWrangler() {
 	await printWranglerBanner();

--- a/packages/wrangler/src/api/upgrade.ts
+++ b/packages/wrangler/src/api/upgrade.ts
@@ -3,12 +3,18 @@ import path from "path";
 import { execaSync } from "execa";
 import { fetch } from "undici";
 import { findWranglerToml } from "../config";
+import { confirm } from "../dialogs";
 import { printWranglerBanner } from "../index";
 import { logger } from "../logger";
 import { readFileSync } from "../parse";
+
 import type { PackageJSON } from "../parse";
 
-export async function upgradeWrangler() {
+export async function upgradeWrangler({
+	yesFlag = false,
+}: {
+	yesFlag: boolean;
+}) {
 	await printWranglerBanner();
 	let packageJsonData: undefined | PackageJSON;
 
@@ -29,6 +35,24 @@ export async function upgradeWrangler() {
 					}
 				)["dist-tags"];
 				const latestVersion = wranglerDistTags.latest;
+
+				const currentVersion = packageJsonData.devDependencies
+					.wrangler as string;
+				logger.log(
+					`Attempting to upgrade Wrangler from ${currentVersion} to the latest version ${latestVersion}...`
+				);
+
+				if (
+					latestVersion.split(".")[0] !== currentVersion.split(".")[0] &&
+					!yesFlag
+				) {
+					const userDecision = await confirm(
+						`⚠️  A major semver change has been detected. Would you like to continue?`
+					);
+					if (userDecision === false) {
+						return;
+					}
+				}
 
 				packageJsonData.devDependencies.wrangler = latestVersion;
 				writeFileSync(

--- a/packages/wrangler/src/api/upgrade.ts
+++ b/packages/wrangler/src/api/upgrade.ts
@@ -19,7 +19,7 @@ export async function upgradeWrangler() {
 			readFileSync(`${newPath}/package.json`)
 		) as PackageJSON;
 
-		if (packageJsonData.dependencies?.wrangler) {
+		if (packageJsonData.devDependencies?.wrangler) {
 			try {
 				const wranglerDistTags = (
 					(await (
@@ -30,7 +30,7 @@ export async function upgradeWrangler() {
 				)["dist-tags"];
 				const latestVersion = wranglerDistTags.latest;
 
-				packageJsonData.dependencies.wrangler = latestVersion;
+				packageJsonData.devDependencies.wrangler = latestVersion;
 				writeFileSync(
 					`${newPath}/package.json`,
 					JSON.stringify(packageJsonData, null, 2),

--- a/packages/wrangler/src/api/upgrade.ts
+++ b/packages/wrangler/src/api/upgrade.ts
@@ -1,0 +1,68 @@
+import { writeFileSync, existsSync } from "fs";
+import { execaSync } from "execa";
+import { fetch } from "undici";
+import { findWranglerToml } from "../config";
+import { printWranglerBanner } from "../index";
+import { logger } from "../logger";
+import { readFileSync } from "../parse";
+import type { PackageJSON } from "../parse";
+
+export async function upgradeWrangler() {
+	await printWranglerBanner();
+	let packageJsonData: undefined | PackageJSON;
+
+	const pathToWorker = findWranglerToml();
+	if (pathToWorker) {
+		const newPath = pathToWorker.split("/").slice(0, -1).join("/");
+		packageJsonData = JSON.parse(
+			readFileSync(`${newPath}/package.json`)
+		) as PackageJSON;
+
+		if (packageJsonData.dependencies?.wrangler) {
+			try {
+				const wranglerDistTags = (
+					(await (
+						await fetch("https://registry.npmjs.org/wrangler")
+					).json()) as {
+						"dist-tags": { latest: string };
+					}
+				)["dist-tags"];
+				const latestVersion = wranglerDistTags.latest;
+
+				packageJsonData.dependencies.wrangler = latestVersion;
+				writeFileSync(
+					`${newPath}/package.json`,
+					JSON.stringify(packageJsonData, null, 2),
+					"utf8"
+				);
+
+				const packageLockFile = "package-lock.json";
+				const yarnLockFile = "yarn.lock";
+				const pnpmLockFile = "pnpm-lock.yaml";
+
+				if (existsSync(packageLockFile)) {
+					logger.info("🔧 Updating package-lock.json & node_modules");
+					execaSync("npm", ["install"]);
+				} else if (existsSync(yarnLockFile)) {
+					logger.info("🔧 Updating yarn.lock & node_modules");
+					execaSync("yarn", ["install"]);
+				} else if (existsSync(pnpmLockFile)) {
+					logger.info("🔧 Updating pnpm-lock.yaml & node_modules");
+					execaSync("pnpm", ["install"]);
+				} else {
+					logger.error(
+						"🚨 No lockfile found, unable to determine package manager."
+					);
+				}
+			} catch (error) {
+				throw Error(`Wrangler upgrade failed: ${error}`);
+			}
+		} else {
+			logger.error("🚨 Unable to locate Wrangler in project package.json");
+		}
+	} else {
+		logger.error(
+			"🚨 Failed to find a Wrangler configuration file, unable to determine location of Worker package.json."
+		);
+	}
+}

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -1,3 +1,4 @@
+import { readFileSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import TOML from "@iarna/toml";
 import chalk from "chalk";
@@ -50,6 +51,7 @@ import {
 import { whoami } from "./whoami";
 
 import type { Config } from "./config";
+import type { PackageJSON } from "./parse";
 import type { CommonYargsOptions } from "./yargs-types";
 import type { ArgumentsCamelCase } from "yargs";
 import type Yargs from "yargs";
@@ -606,6 +608,32 @@ export function createCLIParser(argv: string[]) {
 			} else {
 				logger.log(wranglerVersion);
 			}
+		}
+	);
+	wrangler.command(
+		"upgrade",
+		"Upgrade Wrangler installation to latest version",
+		(yargs) => {
+			yargs
+				.option("target", {
+					describe: "Specify a target version to upgrade to",
+					type: "string",
+				})
+				.epilogue(deploymentsWarning);
+		},
+		async () => {
+			await printWranglerBanner();
+
+			// Read the contents of the package.json file
+			const packageJsonData = JSON.parse(
+				readFileSync("package.json", "utf8")
+			) as PackageJSON;
+
+			// Update the version of Wrangler to the latest version
+			packageData.dependencies["wrangler"] = "latest";
+
+			// Write the updated package data back to the package.json file
+			writeFileSync("package.json", JSON.stringify(packageData, null, 2));
 		}
 	);
 

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -613,10 +613,17 @@ export function createCLIParser(argv: string[]) {
 		"upgrade",
 		"🆕 Upgrade Wrangler installation to latest version",
 		(yargs) => {
-			yargs.epilogue(deploymentsWarning);
+			yargs
+				.option("yes", {
+					describe: 'Answer "yes" to any prompts for new projects',
+					type: "boolean",
+					alias: "y",
+				})
+				.epilogue(deploymentsWarning);
 		},
-		async () => {
-			await upgradeWrangler();
+		async (upgradeArgs: ArgumentsCamelCase<{ yes: boolean }>) => {
+			const { yes: yesFlag } = upgradeArgs;
+			await upgradeWrangler({ yesFlag });
 		}
 	);
 

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -615,7 +615,7 @@ export function createCLIParser(argv: string[]) {
 		(yargs) => {
 			yargs
 				.option("yes", {
-					describe: 'Answer "yes" to any prompts for new projects',
+					describe: 'Answer "yes" to any prompts for upgrading.',
 					type: "boolean",
 					alias: "y",
 				})


### PR DESCRIPTION
Added a command `upgrade` that automates the process of updating the version of Wrangler in the project's `package.json` file to the latest available version.
~Note that you will still need to run the package manager to update the `node_modules` after running this command.~
I improved the PR and 3 major package managers are supported to automatically install for the user now.

<img width="468" alt="Screenshot 2022-12-30 at 3 24 01 PM" src="https://user-images.githubusercontent.com/27247160/210113122-17be0904-be8f-49f5-a33a-a894ad7a71c9.png">


Associated docs issues/PR:
Waiting on team input before working on docs, there could be a better approach or a way to take this further. 

Author has included the following, where applicable:

- [x] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates - https://github.com/cloudflare/cloudflare-docs/pull/7127
- [ ] Manually pulled down the changes and spot-tested

resolves #2071
