### PR TITLE
fix: bump d1js

### DIFF
--- a/.changeset/real-actors-laugh.md
+++ b/.changeset/real-actors-laugh.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+---
+
+fix: bump d1js
+
+This PR bumps d1js, adding the following functionality to the d1 alpha shim:
+
+- validates supported types
+- converts ArrayBuffer to array
+- converts typedArray to array


### PR DESCRIPTION
This PR bumps d1js, adding the following functionality to the d1 alpha shim:

- validates supported types
- converts ArrayBuffer to array
- converts typedArray to array
