### PR TITLE
fix(d1): ensure that migrations support compound statements

### DIFF
--- a/.changeset/silent-ads-pay.md
+++ b/.changeset/silent-ads-pay.md
@@ -1,0 +1,12 @@
+---
+"wrangler": patch
+---
+
+fix(d1): ensure that migrations support compound statements
+
+This fix updates the SQL statement splitting so that it does not split in the middle of compound statements.
+Previously we were using a third party splitting library, but this needed fixing and was actually unnecessary for our purposes.
+So a new splitter has been implemented and the library dependency removed.
+Also the error handling in `d1 migrations apply` has been improved to handle a wider range of error types.
+
+Fixes #2463

--- a/package-lock.json
+++ b/package-lock.json
@@ -2630,21 +2630,6 @@
 				"node": ">=0.1.90"
 			}
 		},
-		"node_modules/@databases/split-sql-query": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@databases/split-sql-query/-/split-sql-query-1.0.3.tgz",
-			"integrity": "sha512-Q3UYX85e34yE9KXa095AJtJhBQ0NpLfC0kS9ydFKuNB25cto4YddY52RuXN81m2t0pS1Atg31ylNpKfNCnUPdA==",
-			"dev": true,
-			"peerDependencies": {
-				"@databases/sql": "*"
-			}
-		},
-		"node_modules/@databases/sql": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@databases/sql/-/sql-3.2.0.tgz",
-			"integrity": "sha512-xQZzKIa0lvcdo0MYxnyFMVS1TRla9lpDSCYkobJl19vQEOJ9TqE4o8QBGRJNUfhSkbQIWyvMeBl3KBBbqyUVQQ==",
-			"dev": true
-		},
 		"node_modules/@esbuild-plugins/node-globals-polyfill": {
 			"version": "0.1.1",
 			"license": "ISC",
@@ -28348,8 +28333,6 @@
 			"devDependencies": {
 				"@cloudflare/types": "^6.18.4",
 				"@cloudflare/workers-types": "^4.20221111.1",
-				"@databases/split-sql-query": "^1.0.3",
-				"@databases/sql": "^3.2.0",
 				"@iarna/toml": "^3.0.0",
 				"@microsoft/api-extractor": "^7.28.3",
 				"@miniflare/tre": "^3.0.0-next.8",
@@ -31375,19 +31358,6 @@
 			"integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
 			"dev": true,
 			"optional": true
-		},
-		"@databases/split-sql-query": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@databases/split-sql-query/-/split-sql-query-1.0.3.tgz",
-			"integrity": "sha512-Q3UYX85e34yE9KXa095AJtJhBQ0NpLfC0kS9ydFKuNB25cto4YddY52RuXN81m2t0pS1Atg31ylNpKfNCnUPdA==",
-			"dev": true,
-			"requires": {}
-		},
-		"@databases/sql": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@databases/sql/-/sql-3.2.0.tgz",
-			"integrity": "sha512-xQZzKIa0lvcdo0MYxnyFMVS1TRla9lpDSCYkobJl19vQEOJ9TqE4o8QBGRJNUfhSkbQIWyvMeBl3KBBbqyUVQQ==",
-			"dev": true
 		},
 		"@esbuild-plugins/node-globals-polyfill": {
 			"version": "0.1.1",
@@ -48969,8 +48939,6 @@
 				"@cloudflare/kv-asset-handler": "^0.2.0",
 				"@cloudflare/types": "^6.18.4",
 				"@cloudflare/workers-types": "^4.20221111.1",
-				"@databases/split-sql-query": "^1.0.3",
-				"@databases/sql": "^3.2.0",
 				"@esbuild-plugins/node-globals-polyfill": "^0.1.1",
 				"@esbuild-plugins/node-modules-polyfill": "^0.1.4",
 				"@iarna/toml": "^3.0.0",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -116,8 +116,6 @@
 	"devDependencies": {
 		"@cloudflare/types": "^6.18.4",
 		"@cloudflare/workers-types": "^4.20221111.1",
-		"@databases/split-sql-query": "^1.0.3",
-		"@databases/sql": "^3.2.0",
 		"@iarna/toml": "^3.0.0",
 		"@microsoft/api-extractor": "^7.28.3",
 		"@miniflare/tre": "^3.0.0-next.8",

--- a/packages/wrangler/src/__tests__/d1/d1.test.ts
+++ b/packages/wrangler/src/__tests__/d1/d1.test.ts
@@ -1,9 +1,9 @@
 import { cwd } from "process";
-import { mockConsoleMethods } from "./helpers/mock-console";
-import { useMockIsTTY } from "./helpers/mock-istty";
-import { runInTempDir } from "./helpers/run-in-tmp";
-import { runWrangler } from "./helpers/run-wrangler";
-import writeWranglerToml from "./helpers/write-wrangler-toml";
+import { mockConsoleMethods } from "../helpers/mock-console";
+import { useMockIsTTY } from "../helpers/mock-istty";
+import { runInTempDir } from "../helpers/run-in-tmp";
+import { runWrangler } from "../helpers/run-wrangler";
+import writeWranglerToml from "../helpers/write-wrangler-toml";
 
 function endEventLoop() {
 	return new Promise((resolve) => setImmediate(resolve));

--- a/packages/wrangler/src/__tests__/d1/splitter.test.ts
+++ b/packages/wrangler/src/__tests__/d1/splitter.test.ts
@@ -1,0 +1,255 @@
+import splitSqlQuery, { mayContainMultipleStatements } from "../../d1/splitter";
+
+describe("mayContainMultipleStatements()", () => {
+	it("should return false if there is only a semi-colon at the end", () => {
+		expect(mayContainMultipleStatements(`SELECT * FROM my_table`)).toBe(false);
+		expect(
+			mayContainMultipleStatements(`SELECT * FROM my_table WHERE id = 42;`)
+		).toBe(false);
+		expect(
+			mayContainMultipleStatements(`SELECT * FROM my_table WHERE id = 42;   `)
+		).toBe(false);
+	});
+
+	it("should return true if there is a semi-colon before the end of the string", () => {
+		expect(
+			mayContainMultipleStatements(
+				`SELECT * FROM my_table WHERE val = "foo;bar";`
+			)
+		).toBe(true);
+	});
+
+	it("should return true if there is more than one statement", () => {
+		expect(
+			mayContainMultipleStatements(
+				`
+      INSERT INTO my_table (id, value) VALUES (42, 'foo');
+      SELECT * FROM my_table WHERE id = 42;
+    `
+			)
+		).toBe(true);
+	});
+});
+
+describe("splitSqlQuery()", () => {
+	it("should return original SQL if there are no real statements", () => {
+		expect(splitSqlQuery(`;;;`)).toMatchInlineSnapshot(`
+		Array [
+		  ";;;",
+		]
+	`);
+	});
+
+	it("should not split single statements", () => {
+		expect(splitSqlQuery(`SELECT * FROM my_table`)).toMatchInlineSnapshot(`
+		Array [
+		  "SELECT * FROM my_table",
+		]
+	`);
+		expect(splitSqlQuery(`SELECT * FROM my_table WHERE id = 42;`))
+			.toMatchInlineSnapshot(`
+		Array [
+		  "SELECT * FROM my_table WHERE id = 42;",
+		]
+	`);
+		expect(
+			splitSqlQuery(
+				`
+      SELECT * FROM my_table WHERE id = 42;
+    `
+			)
+		).toMatchInlineSnapshot(`
+		Array [
+		  "
+		      SELECT * FROM my_table WHERE id = 42;
+		    ",
+		]
+	`);
+	});
+
+	it("should handle strings", () => {
+		expect(
+			splitSqlQuery(
+				`
+      SELECT * FROM my_table WHERE val = "foo;bar";
+    `
+			)
+		).toMatchInlineSnapshot(`
+		Array [
+		  "SELECT * FROM my_table WHERE val = \\"foo;bar\\"",
+		]
+	`);
+	});
+
+	it("should handle inline comments", () => {
+		expect(
+			splitSqlQuery(
+				`SELECT * FROM my_table -- semicolons; in; comments; don't count;
+        WHERE val = 'foo;bar'
+        AND "col;name" = \`other;col\`; -- or identifiers (Postgres or MySQL style)`
+			)
+		).toMatchInlineSnapshot(`
+		Array [
+		  "SELECT * FROM my_table -- semicolons; in; comments; don't count;
+		        WHERE val = 'foo;bar'
+		        AND \\"col;name\\" = \`other;col\`",
+		  "-- or identifiers (Postgres or MySQL style)",
+		]
+	`);
+	});
+
+	it("should handle block comments", () => {
+		expect(
+			splitSqlQuery(
+				`/****
+        * Block comments are ignored;
+        ****/
+			SELECT * FROM my_table /* semicolons; in; comments; don't count; */
+        WHERE val = 'foo;bar' AND count / 2 > 0`
+			)
+		).toMatchInlineSnapshot(`
+		Array [
+		  "/****
+		        * Block comments are ignored;
+		        ****/
+					SELECT * FROM my_table /* semicolons; in; comments; don't count; */
+		        WHERE val = 'foo;bar' AND count / 2 > 0",
+		]
+	`);
+	});
+
+	it("should split multiple statements", () => {
+		expect(
+			splitSqlQuery(
+				`
+        INSERT INTO my_table (id, value) VALUES (42, 'foo');
+        SELECT * FROM my_table WHERE id = 42 - 10;
+      `
+			)
+		).toMatchInlineSnapshot(`
+		Array [
+		  "INSERT INTO my_table (id, value) VALUES (42, 'foo')",
+		  "SELECT * FROM my_table WHERE id = 42 - 10",
+		]
+	`);
+	});
+
+	it("should handle whitespace between statements", () => {
+		expect(
+			splitSqlQuery(`
+        CREATE DOMAIN custom_types.email AS TEXT CHECK (VALUE ~ '^.+@.+$');
+        CREATE TYPE custom_types.currency AS ENUM('USD', 'GBP');
+
+        CREATE TYPE custom_types.money_with_currency AS (
+          value NUMERIC(1000, 2),
+          currency custom_types.currency,
+          description TEXT
+        );
+        CREATE TYPE custom_types.balance_pair AS (
+          income custom_types.money_with_currency,
+          expenditure custom_types.money_with_currency
+        );
+
+        CREATE TABLE custom_types.accounts (
+          email custom_types.email NOT NULL PRIMARY KEY,
+          balance custom_types.money_with_currency
+        );
+        CREATE TABLE custom_types.balance_pairs (
+          balance custom_types.balance_pair
+        );
+      `)
+		).toMatchInlineSnapshot(`
+		Array [
+		  "CREATE DOMAIN custom_types.email AS TEXT CHECK (VALUE ~ '^.+@.+$')",
+		  "CREATE TYPE custom_types.currency AS ENUM('USD', 'GBP')",
+		  "CREATE TYPE custom_types.money_with_currency AS (
+		          value NUMERIC(1000, 2),
+		          currency custom_types.currency,
+		          description TEXT
+		        )",
+		  "CREATE TYPE custom_types.balance_pair AS (
+		          income custom_types.money_with_currency,
+		          expenditure custom_types.money_with_currency
+		        )",
+		  "CREATE TABLE custom_types.accounts (
+		          email custom_types.email NOT NULL PRIMARY KEY,
+		          balance custom_types.money_with_currency
+		        )",
+		  "CREATE TABLE custom_types.balance_pairs (
+		          balance custom_types.balance_pair
+		        )",
+		]
+	`);
+	});
+
+	it("should handle $...$ style string markers", () => {
+		expect(
+			splitSqlQuery(`
+          CREATE OR REPLACE FUNCTION update_updated_at_column()
+          RETURNS TRIGGER AS $$
+          BEGIN
+              NEW.updated_at = now();
+              RETURN NEW;
+          END;
+          $$ language 'plpgsql';
+          CREATE TRIGGER <trigger_name> BEFORE UPDATE ON <table_name> FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column();
+        `)
+		).toMatchInlineSnapshot(`
+		    Array [
+		      "CREATE OR REPLACE FUNCTION update_updated_at_column()
+		              RETURNS TRIGGER AS $$
+		              BEGIN
+		                  NEW.updated_at = now();
+		                  RETURN NEW;
+		              END;
+		              $$ language 'plpgsql'",
+		      "CREATE TRIGGER <trigger_name> BEFORE UPDATE ON <table_name> FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column()",
+		    ]
+	  `);
+		expect(
+			splitSqlQuery(
+				`$SomeTag$Dianne's$WrongTag$;$some non tag an$identifier;; horse$SomeTag$;$SomeTag$Dianne's horse$SomeTag$`
+			)
+		).toMatchInlineSnapshot(`
+		Array [
+		  "$SomeTag$Dianne's$WrongTag$;$some non tag an$identifier;; horse$SomeTag$",
+		  "$SomeTag$Dianne's horse$SomeTag$",
+		]
+	`);
+	});
+
+	it("should handle compound statements", () => {
+		expect(
+			splitSqlQuery(`
+    CREATE TRIGGER IF NOT EXISTS update_trigger AFTER UPDATE ON items
+    BEGIN
+        DELETE FROM updates WHERE item_id=old.id;
+    END;
+    CREATE TRIGGER IF NOT EXISTS actors_search_fts_update AFTER UPDATE ON actors
+    BEGIN
+        DELETE FROM search_fts WHERE rowid=old.rowid;
+        INSERT INTO search_fts (rowid, type, name, preferredUsername)
+        VALUES (new.rowid,
+                new.type,
+                json_extract(new.properties, '$.name'),
+                json_extract(new.properties, '$.preferredUsername'));
+    END;`)
+		).toMatchInlineSnapshot(`
+		Array [
+		  "CREATE TRIGGER IF NOT EXISTS update_trigger AFTER UPDATE ON items
+		    BEGIN
+		        DELETE FROM updates WHERE item_id=old.id;
+		    END",
+		  "CREATE TRIGGER IF NOT EXISTS actors_search_fts_update AFTER UPDATE ON actors
+		    BEGIN
+		        DELETE FROM search_fts WHERE rowid=old.rowid;
+		        INSERT INTO search_fts (rowid, type, name, preferredUsername)
+		        VALUES (new.rowid,
+		                new.type,
+		                json_extract(new.properties, '$.name'),
+		                json_extract(new.properties, '$.preferredUsername'));
+		    END",
+		]
+	`);
+	});
+});

--- a/packages/wrangler/src/d1/execute.tsx
+++ b/packages/wrangler/src/d1/execute.tsx
@@ -11,9 +11,11 @@ import { withConfig } from "../config";
 import { getLocalPersistencePath } from "../dev/get-local-persistence-path";
 import { confirm } from "../dialogs";
 import { logger } from "../logger";
+import { readFileSync } from "../parse";
 import { readableRelative } from "../paths";
 import { requireAuth } from "../user";
 import * as options from "./options";
+import splitSqlQuery from "./splitter";
 import {
 	d1BetaWarning,
 	getDatabaseByNameOrBinding,
@@ -21,8 +23,6 @@ import {
 } from "./utils";
 import type { Config, ConfigFields, DevConfig, Environment } from "../config";
 import type { Database } from "./types";
-import type splitSqlQuery from "@databases/split-sql-query";
-import type { SQL, SQLQuery } from "@databases/sql";
 import type { Statement as StatementType } from "@miniflare/d1";
 import type { createSQLiteDB as createSQLiteDBType } from "@miniflare/shared";
 import type { Argv } from "yargs";
@@ -103,19 +103,15 @@ export async function executeSql(
 	file?: string,
 	command?: string
 ) {
-	const { parser, splitter } = await loadSqlUtils();
-
-	const sql = file
-		? parser.file(file)
-		: command
-		? parser.__dangerous__rawValue(command)
-		: null;
+	const sql = file ? readFileSync(file) : command;
 
 	if (!sql) throw new Error(`Error: must provide --command or --file.`);
 	if (persistTo && !local)
 		throw new Error(`Error: can't use --persist-to without --local`);
 
-	const queries = splitSql(splitter, sql);
+	logger.log(`🌀 Mapping SQL input into an array of statements`);
+	const queries = splitSqlQuery(sql);
+
 	if (file && sql) {
 		if (queries[0].startsWith("SQLite format 3")) {
 			//TODO: update this error to recommend using `wrangler d1 restore` when it exists
@@ -309,18 +305,6 @@ function logResult(r: QueryResult | QueryResult[]) {
 	);
 }
 
-function splitSql(splitter: (query: SQLQuery) => SQLQuery[], sql: SQLQuery) {
-	// We have no interpolations, so convert everything to text
-	logger.log(`🌀 Mapping SQL input into an array of statements`);
-	return splitter(sql).map(
-		(q) =>
-			q.format({
-				escapeIdentifier: (_) => "",
-				formatValue: (_, __) => ({ placeholder: "", value: "" }),
-			}).text
-	);
-}
-
 function batchSplit(queries: string[]) {
 	logger.log(`🌀 Parsing ${queries.length} statements`);
 	const num_batches = Math.ceil(queries.length / QUERY_LIMIT);
@@ -336,17 +320,4 @@ function batchSplit(queries: string[]) {
 		);
 	}
 	return batches;
-}
-
-async function loadSqlUtils() {
-	const [
-		{ default: parser },
-		{
-			// No idea why this is doubly-nested, see https://github.com/ForbesLindesay/atdatabases/issues/255
-			default: { default: splitter },
-		},
-	] = await npxImport<
-		[{ default: SQL }, { default: { default: typeof splitSqlQuery } }]
-	>(["@databases/sql@3.2.0", "@databases/split-sql-query@1.0.3"], logger.log);
-	return { parser, splitter };
 }

--- a/packages/wrangler/src/d1/migrations/apply.tsx
+++ b/packages/wrangler/src/d1/migrations/apply.tsx
@@ -162,7 +162,9 @@ Your database may not be available to serve requests during the migration, conti
 				const err = e as ParseError;
 
 				success = false;
-				errorNotes = err.notes.map((msg) => msg.text);
+				errorNotes = err.notes?.map((msg) => msg.text) ?? [
+					err.message ?? err.toString(),
+				];
 			}
 
 			migration.Status = success ? "✅" : "❌";

--- a/packages/wrangler/src/d1/splitter.ts
+++ b/packages/wrangler/src/d1/splitter.ts
@@ -1,0 +1,161 @@
+/**
+ * @module
+ * This code is inspired by that of https://www.atdatabases.org/docs/split-sql-query, which is published under MIT license,
+ * and is Copyright (c) 2019 Forbes Lindesay.
+ *
+ * See https://github.com/ForbesLindesay/atdatabases/blob/103c1e7/packages/split-sql-query/src/index.ts
+ * for the original code.
+ */
+
+/**
+ * Is the given `sql` string likely to contain multiple statements.
+ *
+ * If `mayContainMultipleStatements()` returns `false` you can be confident that the sql
+ * does not contain multiple statements. Otherwise you have to check further.
+ */
+export function mayContainMultipleStatements(sql: string): boolean {
+	const trimmed = sql.trimEnd();
+	const semiColonIndex = trimmed.indexOf(";");
+	return semiColonIndex !== -1 && semiColonIndex !== trimmed.length - 1;
+}
+
+/**
+ * Split an SQLQuery into an array of statements
+ */
+export default function splitSqlQuery(sql: string): string[] {
+	if (!mayContainMultipleStatements(sql)) return [sql];
+	const split = splitSqlIntoStatements(sql);
+	if (split.length === 0) {
+		return [sql];
+	} else {
+		return split;
+	}
+}
+
+function splitSqlIntoStatements(sql: string): string[] {
+	const statements: string[] = [];
+	let str = "";
+	const compoundStatementStack: ((s: string) => boolean)[] = [];
+
+	const iterator = sql[Symbol.iterator]();
+	let next = iterator.next();
+	while (!next.done) {
+		const char = next.value;
+
+		if (compoundStatementStack[0]?.(str + char)) {
+			compoundStatementStack.shift();
+		}
+
+		switch (char) {
+			case `'`:
+			case `"`:
+			case "`":
+				str += char + consumeUntilMarker(iterator, char);
+				break;
+			case `$`: {
+				const dollarQuote =
+					"$" + consumeWhile(iterator, isDollarQuoteIdentifier);
+				str += dollarQuote;
+				if (dollarQuote.endsWith("$")) {
+					str += consumeUntilMarker(iterator, dollarQuote);
+				}
+				break;
+			}
+			case `-`:
+				str += char;
+				next = iterator.next();
+				if (!next.done && next.value === "-") {
+					str += next.value + consumeUntilMarker(iterator, "\n");
+					break;
+				} else {
+					continue;
+				}
+			case `/`:
+				str += char;
+				next = iterator.next();
+				if (!next.done && next.value === "*") {
+					str += next.value + consumeUntilMarker(iterator, "*/");
+					break;
+				} else {
+					continue;
+				}
+			case `;`:
+				if (compoundStatementStack.length === 0) {
+					statements.push(str);
+					str = "";
+				} else {
+					str += char;
+				}
+				break;
+			default:
+				str += char;
+				break;
+		}
+
+		if (isCompoundStatementStart(str)) {
+			compoundStatementStack.unshift(isCompoundStatementEnd);
+		}
+
+		next = iterator.next();
+	}
+	statements.push(str);
+
+	return statements
+		.map((statement) => statement.trim())
+		.filter((statement) => statement.length > 0);
+}
+
+/**
+ * Pulls characters from the string iterator while the predicate remains true.
+ */
+function consumeWhile(
+	iterator: Iterator<string>,
+	predicate: (str: string) => boolean
+) {
+	let next = iterator.next();
+	let str = "";
+	while (!next.done) {
+		str += next.value;
+		if (!predicate(str)) {
+			break;
+		}
+		next = iterator.next();
+	}
+	return str;
+}
+
+/**
+ * Pulls characters from the string iterator until the `endMarker` is found.
+ */
+function consumeUntilMarker(iterator: Iterator<string>, endMarker: string) {
+	return consumeWhile(iterator, (str) => !str.endsWith(endMarker));
+}
+
+/**
+ * Returns true if the `str` ends with a dollar-quoted string marker.
+ * See https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-DOLLAR-QUOTING.
+ */
+function isDollarQuoteIdentifier(str: string) {
+	const lastChar = str.slice(-1);
+	return (
+		// The $ marks the end of the identifier
+		lastChar !== "$" &&
+		// we allow numbers, underscore and letters with diacritical marks
+		(/[0-9_]/i.test(lastChar) ||
+			lastChar.toLowerCase() !== lastChar.toUpperCase())
+	);
+}
+
+/**
+ * Returns true if the `str` ends with a compound statement `BEGIN` marker.
+ */
+function isCompoundStatementStart(str: string) {
+	return /\sBEGIN\s$/.test(str);
+}
+
+/**
+ * Returns true if the `str` ends with a compound statement `END` marker.
+ */
+function isCompoundStatementEnd(str: string) {
+	return /\sEND[;\s]$/.test(str);
+}


### PR DESCRIPTION
What this PR solves / how to test:

This fix updates the SQL statement splitting so that it does not split in the middle of compound statements.
Previously we were using a third party splitting library, but this needed fixing and was actually unnecessary for our purposes.
So a new splitter has been implemented and the library dependency removed.
Also the error handling in `d1 migrations apply` has been improved to handle a wider range of error types.

Fixes #2463

To test manually, create a simple migration script `migrations/0000_initial.sql` that contains a compound statement:

```
CREATE TABLE IF NOT EXISTS actors (
  id TEXT PRIMARY KEY,
  type TEXT NOT NULL,
  properties TEXT NOT NULL DEFAULT (json_object())
);

CREATE VIRTUAL TABLE IF NOT EXISTS search_fts USING fts5 (
    type,
    name,
);

CREATE TRIGGER IF NOT EXISTS actors_search_fts_update AFTER UPDATE ON actors
BEGIN
    DELETE FROM search_fts WHERE rowid=old.rowid;
    INSERT INTO search_fts (rowid, type, name, preferredUsername)
    VALUES (new.rowid,
            new.type,
            json_extract(new.properties, '$.name'),
            json_extract(new.properties, '$.preferredUsername'));
END;
```

Then update the wrangler to have a pseudo D1 binding:

```
[[d1_databases]]
binding = "DATABASE"
database_name = "database"
database_id = "xxxx-xxxx-xxxx-xxxx"
```

Finally try to apply the migrations locally:

```
npx wrangler d1 migrations apply --local database
```


Associated docs issues/PR:

- N/A

Author has included the following, where applicable:

- [x] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes # [insert issue number].
