### PR TITLE
Pipe through the DO bindings to get shimmed

### DIFF
--- a/.changeset/cuddly-spoons-search.md
+++ b/.changeset/cuddly-spoons-search.md
@@ -4,4 +4,18 @@
 
 fix: add d1 shim to durable objects
 
-This PR makes it possible to access D1 bindings from durable objects.
+This PR makes it possible to access D1 from Durable Objects.
+
+To be able to query D1 from your Durable Object, you'll need to install the latest version of wrangler, and redeploy your Worker.
+
+For a D1 binding like:
+
+```toml
+[[d1_databases]]
+binding = "DB" # i.e. available in your Worker on env.DB
+database_name = "my-database-name"
+database_id = "UUID-GOES-HERE"
+preview_database_id = "UUID-GOES-HERE"
+```
+
+You'll be able to access your D1 database via `env.DB` in your Durable Object.

--- a/.changeset/cuddly-spoons-search.md
+++ b/.changeset/cuddly-spoons-search.md
@@ -2,7 +2,7 @@
 "wrangler": patch
 ---
 
-fix: add d1 shim to durable objects
+fix: make it possible to query d1 databases from durable objects
 
 This PR makes it possible to access D1 from Durable Objects.
 

--- a/.changeset/cuddly-spoons-search.md
+++ b/.changeset/cuddly-spoons-search.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: add d1 shim to durable objects
+
+This PR makes it possible to access D1 bindings from durable objects.

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -802,9 +802,9 @@ async function applyD1BetaFacade(
 		// Reexport the DO classnames
 		.map(
 			(b) =>
-				`export const ${b.class_name} = maskDurableObjectDefinition(OTHER_EXPORTS.${b.class_name})`
+				`export const ${b.class_name} = maskDurableObjectDefinition(OTHER_EXPORTS.${b.class_name});`
 		)
-		.join(";\n");
+		.join("\n");
 
 	await esbuild.build({
 		entryPoints: [path.resolve(getBasePath(), "templates/d1-beta-facade.js")],

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -797,7 +797,7 @@ async function applyD1BetaFacade(
 	doBindings: DurableObjectBindings
 ): Promise<Entry> {
 	const targetPath = path.join(tmpDirPath, "d1-beta-facade.entry.js");
-	const doStuff = doBindings
+	const maskedDoBindings = doBindings
 		// Don't shim anything not local to this worker
 		.filter((b) => !b.script_name)
 		// Reexport the DO classnames
@@ -806,7 +806,7 @@ async function applyD1BetaFacade(
 				`export const ${b.class_name} = maskDurableObjectDefinition(OTHER_EXPORTS.${b.class_name})`
 		)
 		.join(";\n");
-	logger.log("doStuff: ", doStuff);
+
 	await esbuild.build({
 		entryPoints: [path.resolve(getBasePath(), "templates/d1-beta-facade.js")],
 		bundle: true,
@@ -820,7 +820,7 @@ async function applyD1BetaFacade(
 		define: {
 			__D1_IMPORTS__: JSON.stringify(betaD1Shims),
 			__LOCAL_MODE__: JSON.stringify(local),
-			__DO_REEXPORTS__: JSON.stringify(doStuff),
+			__DO_REEXPORTS__: JSON.stringify(maskedDoBindings),
 		},
 		outfile: targetPath,
 	});

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -6,7 +6,6 @@ import NodeGlobalsPolyfills from "@esbuild-plugins/node-globals-polyfill";
 import NodeModulesPolyfills from "@esbuild-plugins/node-modules-polyfill";
 import * as esbuild from "esbuild";
 import tmp from "tmp-promise";
-import { logger } from "./logger";
 import createModuleCollector from "./module-collection";
 import { getBasePath, toUrlPath } from "./paths";
 import type { Config } from "./config";

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -272,8 +272,6 @@ export async function bundleWorker(
 
 		Array.isArray(betaD1Shims) &&
 			betaD1Shims.length > 0 &&
-			Array.isArray(doBindings) &&
-			doBindings.length > 0 &&
 			((currentEntry: Entry) => {
 				return applyD1BetaFacade(
 					currentEntry,
@@ -800,7 +798,7 @@ async function applyD1BetaFacade(
 		getBasePath(),
 		"templates/d1-beta-facade.js"
 	);
-	if (doBindings.length > 0) {
+	if (Array.isArray(doBindings) && doBindings.length > 0) {
 		//we have DO bindings, so we need to shim them
 		const maskedDoBindings = doBindings
 			// Don't shim anything not local to this worker

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -261,6 +261,17 @@ interface EnvironmentInheritable {
 	logpush: boolean | undefined;
 }
 
+export type DurableObjectBindings = {
+	/** The name of the binding used to refer to the Durable Object */
+	name: string;
+	/** The exported class name of the Durable Object */
+	class_name: string;
+	/** The script where the Durable Object is defined (if it's external to this worker) */
+	script_name?: string;
+	/** The service environment of the script_name to bind to */
+	environment?: string;
+}[];
+
 /**
  * The `EnvironmentNonInheritable` interface declares all the configuration fields for an environment
  * that cannot be inherited from the top-level environment, and must be defined specifically.
@@ -303,16 +314,7 @@ interface EnvironmentNonInheritable {
 	 * @nonInheritable
 	 */
 	durable_objects: {
-		bindings: {
-			/** The name of the binding used to refer to the Durable Object */
-			name: string;
-			/** The exported class name of the Durable Object */
-			class_name: string;
-			/** The script where the Durable Object is defined (if it's external to this worker) */
-			script_name?: string;
-			/** The service environment of the script_name to bind to */
-			environment?: string;
-		}[];
+		bindings: DurableObjectBindings;
 	};
 
 	/**

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -27,6 +27,7 @@ import { startRemoteServer } from "./remote";
 import { validateDevProps } from "./validate-dev-props";
 
 import type { Config } from "../config";
+import type { DurableObjectBindings } from "../config/environment";
 import type { WorkerRegistry } from "../dev-registry";
 import type { Entry } from "../entry";
 import type { DevProps, DirectorySyncResult } from "./dev";
@@ -109,6 +110,7 @@ export async function startDevServer(
 			testScheduled: props.testScheduled,
 			local: props.local,
 			experimentalLocal: props.experimentalLocal,
+			doBindings: props.bindings.durable_objects?.bindings || [],
 		});
 
 		if (props.local) {
@@ -218,6 +220,7 @@ async function runEsbuild({
 	testScheduled,
 	local,
 	experimentalLocal,
+	doBindings,
 }: {
 	entry: Entry;
 	destination: string | undefined;
@@ -238,6 +241,7 @@ async function runEsbuild({
 	testScheduled?: boolean;
 	local: boolean;
 	experimentalLocal: boolean | undefined;
+	doBindings: DurableObjectBindings;
 }): Promise<EsbuildBundle | undefined> {
 	if (!destination) return;
 
@@ -279,6 +283,7 @@ async function runEsbuild({
 				testScheduled,
 				local,
 				experimentalLocal,
+				doBindings,
 		  });
 
 	return {

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -110,7 +110,7 @@ export async function startDevServer(
 			testScheduled: props.testScheduled,
 			local: props.local,
 			experimentalLocal: props.experimentalLocal,
-			doBindings: props.bindings.durable_objects?.bindings || [],
+			doBindings: props.bindings.durable_objects?.bindings ?? [],
 		});
 
 		if (props.local) {

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -123,6 +123,7 @@ export function useEsbuild({
 						minify,
 						nodeCompat,
 						betaD1Shims,
+						doBindings: durableObjects.bindings,
 						define,
 						checkFetch: true,
 						assets: assets && {

--- a/packages/wrangler/src/entry.ts
+++ b/packages/wrangler/src/entry.ts
@@ -6,6 +6,7 @@ import { execaCommand } from "execa";
 import { logger } from "./logger";
 import { getBasePath } from "./paths";
 import type { Config } from "./config";
+import type { DurableObjectBindings } from "./config/environment";
 import type { CfScriptFormat } from "./worker";
 import type { Metafile } from "esbuild";
 
@@ -235,8 +236,6 @@ export function fileExists(filePath: string): boolean {
 	}
 	return false;
 }
-
-type DurableObjectBindings = Config["durable_objects"]["bindings"];
 
 /**
  * Groups the durable object bindings into two lists:

--- a/packages/wrangler/src/pages/functions/buildPlugin.ts
+++ b/packages/wrangler/src/pages/functions/buildPlugin.ts
@@ -37,6 +37,7 @@ export function buildPlugin({
 			betaD1Shims: (betaD1Shims || []).map(
 				(binding) => `${D1_BETA_PREFIX}${binding}`
 			),
+			doBindings: [], // Pages functions don't support internal Durable Objects
 			plugins: [
 				buildNotifierPlugin(onEnd),
 				{

--- a/packages/wrangler/src/pages/functions/buildWorker.ts
+++ b/packages/wrangler/src/pages/functions/buildWorker.ts
@@ -205,6 +205,7 @@ export function buildRawWorker({
 			betaD1Shims: (betaD1Shims || []).map(
 				(binding) => `${D1_BETA_PREFIX}${binding}`
 			),
+			doBindings: [], // Pages functions don't support internal Durable Objects
 			plugins: [...plugins, buildNotifierPlugin(onEnd)],
 			isOutfile: true,
 			serveAssetsFromWorker: false,

--- a/packages/wrangler/src/pages/functions/buildWorker.ts
+++ b/packages/wrangler/src/pages/functions/buildWorker.ts
@@ -60,6 +60,7 @@ export function buildWorker({
 			betaD1Shims: (betaD1Shims || []).map(
 				(binding) => `${D1_BETA_PREFIX}${binding}`
 			),
+			doBindings: [], // Pages functions don't support internal Durable Objects
 			plugins: [
 				buildNotifierPlugin(onEnd),
 				{

--- a/packages/wrangler/src/publish/publish.ts
+++ b/packages/wrangler/src/publish/publish.ts
@@ -472,6 +472,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 						betaD1Shims: identifyD1BindingsAsBeta(config.d1_databases)?.map(
 							(db) => db.binding
 						),
+						doBindings: config.durable_objects.bindings,
 						jsxFactory,
 						jsxFragment,
 						rules: props.rules,

--- a/packages/wrangler/templates/d1-beta-facade.js
+++ b/packages/wrangler/templates/d1-beta-facade.js
@@ -1,5 +1,5 @@
 // src/shim.ts
-import worker from "__ENTRY_POINT__";
+import worker, * as OTHER_EXPORTS from "__ENTRY_POINT__";
 export * from "__ENTRY_POINT__";
 
 // src/index.ts

--- a/packages/wrangler/templates/d1-beta-facade.js
+++ b/packages/wrangler/templates/d1-beta-facade.js
@@ -245,4 +245,4 @@ var maskDurableObjectDefinition = (cls) =>
 		}
 	};
 __DO_REEXPORTS__;
-export { shim_default as default };
+export { shim_default as default, maskDurableObjectDefinition };

--- a/packages/wrangler/templates/d1-beta-facade.js
+++ b/packages/wrangler/templates/d1-beta-facade.js
@@ -238,5 +238,11 @@ var shim_default = {
 		return worker.trace(traces, getMaskedEnv(env), ctx);
 	},
 };
+var maskDurableObjectDefinition = (cls) =>
+	class extends cls {
+		constructor(state, env) {
+			super(state, getMaskedEnv(env));
+		}
+	};
 __DO_REEXPORTS__;
 export { shim_default as default };

--- a/packages/wrangler/templates/d1-beta-facade.js
+++ b/packages/wrangler/templates/d1-beta-facade.js
@@ -238,11 +238,4 @@ var shim_default = {
 		return worker.trace(traces, getMaskedEnv(env), ctx);
 	},
 };
-var maskDurableObjectDefinition = (cls) =>
-	class extends cls {
-		constructor(state, env) {
-			super(state, getMaskedEnv(env));
-		}
-	};
-__DO_REEXPORTS__;
-export { shim_default as default, maskDurableObjectDefinition };
+export { shim_default as default };

--- a/packages/wrangler/templates/d1-beta-facade.js
+++ b/packages/wrangler/templates/d1-beta-facade.js
@@ -238,4 +238,5 @@ var shim_default = {
 		return worker.trace(traces, getMaskedEnv(env), ctx);
 	},
 };
+__DO_REEXPORTS__;
 export { shim_default as default };


### PR DESCRIPTION
**What this PR solves / how to test:**
This PR makes it possible to access D1 bindings from Durable Objects.

To test, make a durable object, add D1 bindings to your project, and try query D1 from it.

**Author has included the following, where applicable:**

- [x] Changeset

**Reviewer has performed the following, where applicable:**

- [x] Checked for inclusion of a relevant changeset
- [x] Manually pulled down the changes and spot-tested

Fixes #2335 
