### PR TITLE
Only update `package-lock.json` when running changeset version script

### DIFF
--- a/.github/changeset-version.js
+++ b/.github/changeset-version.js
@@ -6,4 +6,4 @@ const { execSync } = require("node:child_process");
 // This is a workaround until this is handled automatically by `changeset version`.
 // See https://github.com/changesets/changesets/issues/421.
 execSync("npx changeset version");
-execSync("npm install");
+execSync("npm install --package-lock-only");


### PR DESCRIPTION
#### What this PR solves / how to test:

#2489 broke the `Release` CI with an error that `patch-package` couldn't be found when running `changeset-version.js`.

It looks like the `npm install` script in `changeset-version.js` is only installing production dependencies. Moving `patch-package` to `dependencies` leads to another error that `ink` cannot be found to apply the patch to. 🙃 

However, the only reason we run `npm install` here is to update `package-lock.json`, so we don't need to be running `postinstall` scripts. Therefore, this PR adds the `--package-lock-only` flag. See https://docs.npmjs.com/cli/v9/commands/npm-install.

I've tested this locally using [`act`](https://github.com/nektos/act).

#### Associated docs issues/PR:

N/A

#### Author has included the following, where applicable:

- [ ] ~~Tests~~
- [ ] ~~Changeset~~

#### Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested
