### PR TITLE
Move `<ChooseAccount>` to `remote.tsx`

### DIFF
--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -1,5 +1,7 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import { Text } from "ink";
+import SelectInput from "ink-select-input";
 import React, { useState, useEffect, useRef } from "react";
 import { useErrorHandler } from "react-error-boundary";
 import { printBundleSize } from "../bundle-reporter";
@@ -12,7 +14,6 @@ import { logger } from "../logger";
 import { startPreviewServer, usePreviewServer } from "../proxy";
 import { syncAssets } from "../sites";
 import {
-	ChooseAccount,
 	getAccountChoices,
 	requireApiToken,
 	saveAccountToCache,
@@ -600,4 +601,30 @@ function getWorkerAccountAndContext(props: {
 	};
 
 	return { workerAccount, workerContext };
+}
+
+/**
+ * A component that allows the user to select from a list of available accounts.
+ */
+function ChooseAccount(props: {
+	accounts: ChooseAccountItem[];
+	onSelect: (account: { name: string; id: string }) => void;
+	onError: (error: Error) => void;
+}) {
+	return (
+		<>
+			<Text bold>Select an account from below:</Text>
+			<SelectInput
+				items={props.accounts.map((item) => ({
+					key: item.id,
+					label: item.name,
+					value: item,
+				}))}
+				onSelect={(item) => {
+					logger.log(`Using account: "${item.value.name} - ${item.value.id}"`);
+					props.onSelect({ id: item.value.id, name: item.value.name });
+				}}
+			/>
+		</>
+	);
 }

--- a/packages/wrangler/src/user/choose-account.tsx
+++ b/packages/wrangler/src/user/choose-account.tsx
@@ -1,40 +1,10 @@
-import { Text } from "ink";
-import SelectInput from "ink-select-input";
-import React from "react";
 import { fetchListResult } from "../cfetch";
-import { logger } from "../logger";
 import { getCloudflareAccountIdFromEnv } from "./auth-variables";
 
 export type ChooseAccountItem = {
 	id: string;
 	name: string;
 };
-
-/**
- * A component that allows the user to select from a list of available accounts.
- */
-export function ChooseAccount(props: {
-	accounts: ChooseAccountItem[];
-	onSelect: (account: { name: string; id: string }) => void;
-	onError: (error: Error) => void;
-}) {
-	return (
-		<>
-			<Text bold>Select an account from below:</Text>
-			<SelectInput
-				items={props.accounts.map((item) => ({
-					key: item.id,
-					label: item.name,
-					value: item,
-				}))}
-				onSelect={(item) => {
-					logger.log(`Using account: "${item.value.name} - ${item.value.id}"`);
-					props.onSelect({ id: item.value.id, name: item.value.name });
-				}}
-			/>
-		</>
-	);
-}
 
 /**
  * Infer a list of available accounts for the current user.


### PR DESCRIPTION
#### What this PR solves / how to test:

`<ChooseAccount>` was only being used by `remote.tsx`, but it was included in `choose-account.tsx`, meaning `ink` needed to be imported here. Unfortunately, `choose-account.tsx` is a transitive dependency of `cfetch`, meaning any file that made Cloudflare API calls ended up importing `ink`. `ink` has a transitive dependency on `yoga-layout` which allocates WebAssembly memory on import. This change moves `<ChooseAccount>` to `remote.tsx`, a file which already uses `ink`, to help alleviate out-of-memory issues.

#### Associated docs issues/PR:

N/A

#### Author has included the following, where applicable:

- [ ] ~~Tests~~
- [ ] ~~Changeset~~

#### Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested
