### PR TITLE
fix: unstable_dev() experimental options incorrectly applying defaults

### DIFF
--- a/.changeset/tame-books-draw.md
+++ b/.changeset/tame-books-draw.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: unstable_dev() experimental options incorrectly applying defaults
+
+A subtle difference when removing object-spreading of experimental unstable_dev() options caused `wrangler pages dev` interactivity to stop working. This switches back to object-spreading the passed in options on top of the defaults, fixing the issue.

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -79,15 +79,26 @@ export async function unstable_dev(
 	apiOptions?: unknown
 ): Promise<UnstableDevWorker> {
 	// Note that not every experimental option is passed directly through to the underlying dev API - experimental options can be used here in unstable_dev. Otherwise we could just pass experimental down to dev blindly.
+
+	const experimentalOptions = {
+		// Defaults for "experimental" options
+		disableDevRegistry: false,
+		disableExperimentalWarning: false,
+		showInteractiveDevSession: false,
+		testMode: true,
+		// Override all options, including overwriting with "undefined"
+		...options?.experimental,
+	};
+
 	const {
 		// there are two types of "experimental" options:
 		// 1. options to unstable_dev that we're still testing or are unsure of
-		disableDevRegistry = false,
-		disableExperimentalWarning = false,
+		disableDevRegistry,
+		disableExperimentalWarning,
 		forceLocal,
 		liveReload,
-		showInteractiveDevSession = false,
-		testMode = true,
+		showInteractiveDevSession,
+		testMode,
 		testScheduled,
 		watch,
 		// 2. options for alpha/beta products/libs
@@ -95,7 +106,8 @@ export async function unstable_dev(
 		experimentalLocal,
 		experimentalLocalRemoteKv,
 		enablePagesAssetsServiceBinding,
-	} = options?.experimental ?? {};
+	} = experimentalOptions;
+
 	if (apiOptions) {
 		logger.error(
 			"unstable_dev's third argument (apiOptions) has been deprecated in favor of an `experimental` property within the second argument (options).\nPlease update your code from:\n`await unstable_dev('...', {...}, {...});`\nto:\n`await unstable_dev('...', {..., experimental: {...}});`"


### PR DESCRIPTION
A subtle difference when removing object-spreading of experimental unstable_dev() options caused `wrangler pages dev` interactivity to stop working. This switches back to object-spreading the passed in options on top of the defaults, fixing the issue.

What this PR solves / how to test:
Fixes wrangler pages dev not showing any of the keyboard shortcuts (and none of them working.)
Test with:
```shell
# Starting from root of the repo
npm run build -w wrangler

# Build dependencies
cd fixtures/pages-plugin-example
npm run build

# Test wrangler pages dev
cd ../pages-functions-app
npm run dev
```
Before: Interactive dev session did not work
After: Interactive dev session works

Associated docs issues/PR: Raised internally

Author has included the following, where applicable:

- [x] Manual test on dev machine (not sure if we can automatically test the interactive dev mode?)
- [x] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [x] Checked for inclusion of a relevant changeset
- [x] Checked for creation of associated docs updates
- [x] Manually pulled down the changes and spot-tested

Fixes # [insert issue number].
No issue that I know of, raised internally