### PR TITLE
fix: send `wrangler docs d1` to the right place

### DIFF
--- a/.changeset/bright-mails-doubt.md
+++ b/.changeset/bright-mails-doubt.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: send `wrangler docs d1` to the right place

--- a/packages/wrangler/src/docs/index.ts
+++ b/packages/wrangler/src/docs/index.ts
@@ -11,6 +11,7 @@ import type {
 import type { ArgumentsCamelCase, Argv } from "yargs";
 
 const argToUrlHash = {
+	d1: "d1",
 	docs: "docs",
 	init: "init",
 	generate: "generate",
@@ -56,7 +57,7 @@ export function docsOptions(yargs: Argv<CommonYargsOptions>) {
 			"r2 object",
 			"r2 bucket",
 			// "dispatch-namespace", // TODO: Undocumented - Workers for Platforms
-			// "d1", //TODO: Undocumented
+			"d1",
 			// "pubsub", //TODO: Undocumented
 			"login",
 			"logout",


### PR DESCRIPTION
This PR is blocked until https://github.com/cloudflare/cloudflare-docs/pull/7202 gets merged.