### PR TITLE
feat(api): Adds unstable_pages module to JS API

### DIFF
--- a/.changeset/green-planets-wink.md
+++ b/.changeset/green-planets-wink.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Adds unstable_pages module to JS API

--- a/package-lock.json
+++ b/package-lock.json
@@ -28242,7 +28242,7 @@
 		},
 		"packages/pages-shared": {
 			"name": "@cloudflare/pages-shared",
-			"version": "0.0.13",
+			"version": "0.0.14-prerelease-1",
 			"dependencies": {
 				"@miniflare/core": "2.11.0"
 			},
@@ -28415,6 +28415,7 @@
 			"version": "0.0.0",
 			"license": "BSD-3-Clause",
 			"devDependencies": {
+				"patch-package": "^6.5.1",
 				"wrangler": "^2.7.1"
 			}
 		},
@@ -31348,6 +31349,7 @@
 		"@cloudflare/wrangler-devtools": {
 			"version": "file:packages/wrangler-devtools",
 			"requires": {
+				"patch-package": "^6.5.1",
 				"wrangler": "^2.7.1"
 			}
 		},

--- a/packages/wrangler/src/api/index.ts
+++ b/packages/wrangler/src/api/index.ts
@@ -1,2 +1,3 @@
 export { unstable_dev } from "./dev";
 export type { UnstableDevWorker, UnstableDevOptions } from "./dev";
+export { unstable_pages } from "./pages";

--- a/packages/wrangler/src/api/pages/index.ts
+++ b/packages/wrangler/src/api/pages/index.ts
@@ -1,0 +1,5 @@
+import { publish } from "./publish";
+
+export const unstable_pages = {
+	publish,
+};

--- a/packages/wrangler/src/api/pages/publish.tsx
+++ b/packages/wrangler/src/api/pages/publish.tsx
@@ -1,0 +1,327 @@
+import { existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve as resolvePath } from "node:path";
+import { cwd } from "node:process";
+import { File, FormData } from "undici";
+import { fetchResult } from "../../cfetch";
+import { FatalError } from "../../errors";
+import { logger } from "../../logger";
+import { buildFunctions } from "../../pages/buildFunctions";
+import {
+	FunctionsNoRoutesError,
+	getFunctionsNoRoutesWarning,
+} from "../../pages/errors";
+import {
+	buildRawWorker,
+	checkRawWorker,
+} from "../../pages/functions/buildWorker";
+import { validateRoutes } from "../../pages/functions/routes-validation";
+import { upload } from "../../pages/upload";
+import type { Project, Deployment } from "@cloudflare/types";
+
+interface PagesPublishOptions {
+	/**
+	 * Path to static assets to publish to Pages
+	 */
+	directory: string;
+	/**
+	 * The Cloudflare Account ID that owns the project that's
+	 * being published
+	 */
+	accountId: string;
+	/**
+	 * The name of the project to be published
+	 */
+	projectName: string;
+	/**
+	 * Branch name to use. Defaults to production branch
+	 */
+	branch?: string;
+	/**
+	 * Whether or not to skip local file upload result caching
+	 */
+	skipCaching?: boolean;
+	/**
+	 * Commit message associated to deployment
+	 */
+	commitMessage?: string;
+	/**
+	 * Commit hash associated to deployment
+	 */
+	commitHash?: string;
+	/**
+	 * Whether or not the deployment should be considered to be
+	 * in a dirty commit state
+	 */
+	commitDirty?: boolean;
+	/**
+	 * Path to the project's functions directory. Default uses
+	 * the current working directory + /functions since this is
+	 * typically called in a CLI
+	 */
+	functionsDirectory?: string;
+
+	/**
+	 * Whether to run bundling on `_worker.js` before deploying.
+	 * Default: false
+	 */
+	bundle?: boolean;
+
+	// TODO: Allow passing in the API key and plumb it through
+	// to the API calls so that the publish function does not
+	// rely on the `CLOUDFLARE_API_KEY` environment variable
+}
+
+/**
+ * Publish a directory to an account/project.
+ * NOTE: You will need the `CLOUDFLARE_API_KEY` environment
+ * variable set
+ */
+export async function publish({
+	directory,
+	accountId,
+	projectName,
+	branch,
+	skipCaching,
+	commitMessage,
+	commitHash,
+	commitDirty,
+	functionsDirectory: customFunctionsDirectory,
+	bundle,
+}: PagesPublishOptions) {
+	let _headers: string | undefined,
+		_redirects: string | undefined,
+		_routesGenerated: string | undefined,
+		_routesCustom: string | undefined,
+		_workerJS: string | undefined;
+
+	const workerScriptPath = resolvePath(directory, "_worker.js");
+
+	try {
+		_headers = readFileSync(join(directory, "_headers"), "utf-8");
+	} catch {}
+
+	try {
+		_redirects = readFileSync(join(directory, "_redirects"), "utf-8");
+	} catch {}
+
+	try {
+		/**
+		 * Developers can specify a custom _routes.json file, for projects with Pages
+		 * Functions or projects in Advanced Mode
+		 */
+		_routesCustom = readFileSync(join(directory, "_routes.json"), "utf-8");
+	} catch {}
+
+	try {
+		_workerJS = readFileSync(workerScriptPath, "utf-8");
+	} catch {}
+
+	// Grab the bindings from the API, we need these for shims and other such hacky inserts
+	const project = await fetchResult<Project>(
+		`/accounts/${accountId}/pages/projects/${projectName}`
+	);
+	let isProduction = true;
+	if (branch) {
+		isProduction = project.production_branch === branch;
+	}
+
+	/**
+	 * Evaluate if this is an Advanced Mode or Pages Functions project. If Advanced Mode, we'll
+	 * go ahead and upload `_worker.js` as is, but if Pages Functions, we need to attempt to build
+	 * Functions first and exit if it failed
+	 */
+	let builtFunctions: string | undefined = undefined;
+	const functionsDirectory =
+		customFunctionsDirectory || join(cwd(), "functions");
+	const routesOutputPath = !existsSync(join(directory, "_routes.json"))
+		? join(tmpdir(), `_routes-${Math.random()}.json`)
+		: undefined;
+
+	// Routing configuration displayed in the Functions tab of a deployment in Dash
+	let filepathRoutingConfig: string | undefined;
+
+	if (!_workerJS && existsSync(functionsDirectory)) {
+		const outfile = join(tmpdir(), `./functionsWorker-${Math.random()}.js`);
+		const outputConfigPath = join(
+			tmpdir(),
+			`functions-filepath-routing-config-${Math.random()}.json`
+		);
+
+		try {
+			await buildFunctions({
+				outfile,
+				outputConfigPath,
+				functionsDirectory,
+				onEnd: () => {},
+				buildOutputDirectory: dirname(outfile),
+				routesOutputPath,
+				local: false,
+				d1Databases: Object.keys(
+					project.deployment_configs[isProduction ? "production" : "preview"]
+						.d1_databases ?? {}
+				),
+			});
+
+			builtFunctions = readFileSync(outfile, "utf-8");
+			filepathRoutingConfig = readFileSync(outputConfigPath, "utf-8");
+		} catch (e) {
+			if (e instanceof FunctionsNoRoutesError) {
+				logger.warn(
+					getFunctionsNoRoutesWarning(functionsDirectory, "skipping")
+				);
+			} else {
+				throw e;
+			}
+		}
+	}
+
+	const manifest = await upload({
+		directory,
+		accountId,
+		projectName,
+		skipCaching: skipCaching ?? false,
+	});
+
+	const formData = new FormData();
+
+	formData.append("manifest", JSON.stringify(manifest));
+
+	if (branch) {
+		formData.append("branch", branch);
+	}
+
+	if (commitMessage) {
+		formData.append("commit_message", commitMessage);
+	}
+
+	if (commitHash) {
+		formData.append("commit_hash", commitHash);
+	}
+
+	if (commitDirty !== undefined) {
+		formData.append("commit_dirty", commitDirty);
+	}
+
+	if (_headers) {
+		formData.append("_headers", new File([_headers], "_headers"));
+		logger.log(`✨ Uploading _headers`);
+	}
+
+	if (_redirects) {
+		formData.append("_redirects", new File([_redirects], "_redirects"));
+		logger.log(`✨ Uploading _redirects`);
+	}
+
+	if (filepathRoutingConfig) {
+		formData.append(
+			"functions-filepath-routing-config.json",
+			new File(
+				[filepathRoutingConfig],
+				"functions-filepath-routing-config.json"
+			)
+		);
+	}
+
+	/**
+	 * Advanced Mode
+	 * https://developers.cloudflare.com/pages/platform/functions/#advanced-mode
+	 *
+	 * When using a _worker.js file, the entire /functions directory is ignored
+	 * – this includes its routing and middleware characteristics.
+	 */
+	if (_workerJS) {
+		let workerFileContents = _workerJS;
+		if (bundle) {
+			const outfile = join(tmpdir(), `./bundledWorker-${Math.random()}.mjs`);
+			await buildRawWorker({
+				workerScriptPath,
+				outfile,
+				directory: directory ?? ".",
+				local: false,
+				sourcemap: true,
+				watch: false,
+				onEnd: () => {},
+			});
+			workerFileContents = readFileSync(outfile, "utf8");
+		} else {
+			await checkRawWorker(workerScriptPath, () => {});
+		}
+
+		formData.append("_worker.js", new File([workerFileContents], "_worker.js"));
+		logger.log(`✨ Uploading _worker.js`);
+
+		if (_routesCustom) {
+			// user provided a custom _routes.json file
+			try {
+				const routesCustomJSON = JSON.parse(_routesCustom);
+				validateRoutes(routesCustomJSON, join(directory, "_routes.json"));
+
+				formData.append(
+					"_routes.json",
+					new File([_routesCustom], "_routes.json")
+				);
+				logger.log(`✨ Uploading _routes.json`);
+				logger.warn(
+					`_routes.json is an experimental feature and is subject to change. Please use with care.`
+				);
+			} catch (err) {
+				if (err instanceof FatalError) {
+					throw err;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Pages Functions
+	 * https://developers.cloudflare.com/pages/platform/functions/
+	 */
+	if (builtFunctions && !_workerJS) {
+		// if Functions were build successfully, proceed to uploading the build file
+		formData.append("_worker.js", new File([builtFunctions], "_worker.js"));
+		logger.log(`✨ Uploading Functions`);
+
+		if (_routesCustom) {
+			// user provided a custom _routes.json file
+			try {
+				const routesCustomJSON = JSON.parse(_routesCustom);
+				validateRoutes(routesCustomJSON, join(directory, "_routes.json"));
+
+				formData.append(
+					"_routes.json",
+					new File([_routesCustom], "_routes.json")
+				);
+				logger.log(`✨ Uploading _routes.json`);
+				logger.warn(
+					`_routes.json is an experimental feature and is subject to change. Please use with care.`
+				);
+			} catch (err) {
+				if (err instanceof FatalError) {
+					throw err;
+				}
+			}
+		} else if (routesOutputPath) {
+			// no custom _routes.json file found, so fallback to the generated one
+			try {
+				_routesGenerated = readFileSync(routesOutputPath, "utf-8");
+
+				if (_routesGenerated) {
+					formData.append(
+						"_routes.json",
+						new File([_routesGenerated], "_routes.json")
+					);
+				}
+			} catch {}
+		}
+	}
+
+	const deploymentResponse = await fetchResult<Deployment>(
+		`/accounts/${accountId}/pages/projects/${projectName}/deployments`,
+		{
+			method: "POST",
+			body: formData,
+		}
+	);
+	return deploymentResponse;
+}

--- a/packages/wrangler/src/api/pages/publish.tsx
+++ b/packages/wrangler/src/api/pages/publish.tsx
@@ -262,9 +262,6 @@ export async function publish({
 					new File([_routesCustom], "_routes.json")
 				);
 				logger.log(`✨ Uploading _routes.json`);
-				logger.warn(
-					`_routes.json is an experimental feature and is subject to change. Please use with care.`
-				);
 			} catch (err) {
 				if (err instanceof FatalError) {
 					throw err;
@@ -293,9 +290,6 @@ export async function publish({
 					new File([_routesCustom], "_routes.json")
 				);
 				logger.log(`✨ Uploading _routes.json`);
-				logger.warn(
-					`_routes.json is an experimental feature and is subject to change. Please use with care.`
-				);
 			} catch (err) {
 				if (err instanceof FatalError) {
 					throw err;

--- a/packages/wrangler/src/cli.ts
+++ b/packages/wrangler/src/cli.ts
@@ -1,6 +1,6 @@
 import process from "process";
 import { hideBin } from "yargs/helpers";
-import { unstable_dev } from "./api";
+import { unstable_dev, unstable_pages } from "./api";
 import { FatalError } from "./errors";
 import { main } from ".";
 
@@ -24,5 +24,5 @@ if (typeof jest === "undefined" && require.main === module) {
  * It makes it possible to import wrangler from 'wrangler',
  * and call wrangler.unstable_dev().
  */
-export { unstable_dev };
+export { unstable_dev, unstable_pages };
 export type { UnstableDevWorker, UnstableDevOptions };

--- a/packages/wrangler/src/pages/build.ts
+++ b/packages/wrangler/src/pages/build.ts
@@ -1,27 +1,19 @@
-import { writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { dirname } from "node:path";
 import { FatalError } from "../errors";
 import { logger } from "../logger";
 import * as metrics from "../metrics";
-import { toUrlPath } from "../paths";
+import { buildFunctions } from "./buildFunctions";
 import { isInPagesCI } from "./constants";
 import {
 	EXIT_CODE_FUNCTIONS_NO_ROUTES_ERROR,
 	FunctionsNoRoutesError,
 	getFunctionsNoRoutesWarning,
 } from "./errors";
-import { buildPlugin } from "./functions/buildPlugin";
-import { buildWorker } from "./functions/buildWorker";
-import { generateConfigFromFileTree } from "./functions/filepath-routing";
-import { writeRoutesModule } from "./functions/routes";
-import { convertRoutesToRoutesJSONSpec } from "./functions/routes-transformation";
-import { pagesBetaWarning, RUNNING_BUILDERS } from "./utils";
+import { pagesBetaWarning } from "./utils";
 import type { YargsOptionsToInterface } from "../yargs-types";
-import type { Config } from "./functions/routes";
 import type { Argv } from "yargs";
 
-type PagesBuildArgs = YargsOptionsToInterface<typeof Options>;
+export type PagesBuildArgs = YargsOptionsToInterface<typeof Options>;
 
 export function Options(yargs: Argv) {
 	return yargs
@@ -156,115 +148,3 @@ export const Handler = async ({
 	}
 	await metrics.sendMetricsEvent("build pages functions");
 };
-
-/**
- * Builds a Functions worker based on the functions directory, with filepath and handler based routing.
- * @throws FunctionsNoRoutesError when there are no routes found in the functions directory
- */
-export async function buildFunctions({
-	outfile,
-	outputConfigPath,
-	functionsDirectory,
-	minify = false,
-	sourcemap = false,
-	fallbackService = "ASSETS",
-	watch = false,
-	onEnd,
-	plugin = false,
-	buildOutputDirectory,
-	routesOutputPath,
-	nodeCompat,
-	local,
-	d1Databases,
-}: Partial<
-	Pick<
-		PagesBuildArgs,
-		| "outputConfigPath"
-		| "minify"
-		| "sourcemap"
-		| "fallbackService"
-		| "watch"
-		| "plugin"
-		| "buildOutputDirectory"
-		| "nodeCompat"
-	>
-> & {
-	functionsDirectory: string;
-	onEnd?: () => void;
-	outfile: Required<PagesBuildArgs>["outfile"];
-	routesOutputPath?: PagesBuildArgs["outputRoutesPath"];
-	local: boolean;
-	d1Databases?: string[];
-}) {
-	RUNNING_BUILDERS.forEach(
-		(runningBuilder) => runningBuilder.stop && runningBuilder.stop()
-	);
-
-	const routesModule = join(tmpdir(), `./functionsRoutes-${Math.random()}.mjs`);
-	const baseURL = toUrlPath("/");
-
-	const config: Config = await generateConfigFromFileTree({
-		baseDir: functionsDirectory,
-		baseURL,
-	});
-
-	if (!config.routes || config.routes.length === 0) {
-		throw new FunctionsNoRoutesError(
-			`Failed to find any routes while compiling Functions in: ${functionsDirectory}`
-		);
-	}
-
-	if (routesOutputPath) {
-		const routesJSON = convertRoutesToRoutesJSONSpec(config.routes);
-		writeFileSync(routesOutputPath, JSON.stringify(routesJSON, null, 2));
-	}
-
-	if (outputConfigPath) {
-		writeFileSync(
-			outputConfigPath,
-			JSON.stringify({ ...config, baseURL }, null, 2)
-		);
-	}
-
-	await writeRoutesModule({
-		config,
-		srcDir: functionsDirectory,
-		outfile: routesModule,
-	});
-
-	const absoluteFunctionsDirectory = resolve(functionsDirectory);
-
-	if (plugin) {
-		RUNNING_BUILDERS.push(
-			await buildPlugin({
-				routesModule,
-				outfile,
-				minify,
-				sourcemap,
-				watch,
-				nodeCompat,
-				functionsDirectory: absoluteFunctionsDirectory,
-				local,
-				betaD1Shims: d1Databases,
-				onEnd,
-			})
-		);
-	} else {
-		RUNNING_BUILDERS.push(
-			await buildWorker({
-				routesModule,
-				outfile,
-				minify,
-				sourcemap,
-				fallbackService,
-				watch,
-				functionsDirectory: absoluteFunctionsDirectory,
-				local,
-				betaD1Shims: d1Databases,
-				onEnd,
-				buildOutputDirectory,
-				nodeCompat,
-			})
-		);
-	}
-}

--- a/packages/wrangler/src/pages/buildFunctions.ts
+++ b/packages/wrangler/src/pages/buildFunctions.ts
@@ -1,0 +1,126 @@
+import { writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { toUrlPath } from "../paths";
+import { FunctionsNoRoutesError } from "./errors";
+import { buildPlugin } from "./functions/buildPlugin";
+import { buildWorker } from "./functions/buildWorker";
+import { generateConfigFromFileTree } from "./functions/filepath-routing";
+import { writeRoutesModule } from "./functions/routes";
+import { convertRoutesToRoutesJSONSpec } from "./functions/routes-transformation";
+import { RUNNING_BUILDERS } from "./utils";
+import type { PagesBuildArgs } from "./build";
+import type { Config } from "./functions/routes";
+
+/**
+ * Builds a Functions worker based on the functions directory, with filepath and handler based routing.
+ * @throws FunctionsNoRoutesError when there are no routes found in the functions directory
+ */
+
+export async function buildFunctions({
+	outfile,
+	outputConfigPath,
+	functionsDirectory,
+	minify = false,
+	sourcemap = false,
+	fallbackService = "ASSETS",
+	watch = false,
+	onEnd,
+	plugin = false,
+	buildOutputDirectory,
+	routesOutputPath,
+	nodeCompat,
+	local,
+	d1Databases,
+}: Partial<
+	Pick<
+		PagesBuildArgs,
+		| "outputConfigPath"
+		| "minify"
+		| "sourcemap"
+		| "fallbackService"
+		| "watch"
+		| "plugin"
+		| "buildOutputDirectory"
+		| "nodeCompat"
+	>
+> & {
+	functionsDirectory: string;
+	onEnd?: () => void;
+	outfile: Required<PagesBuildArgs>["outfile"];
+	routesOutputPath?: PagesBuildArgs["outputRoutesPath"];
+	local: boolean;
+	d1Databases?: string[];
+}) {
+	RUNNING_BUILDERS.forEach(
+		(runningBuilder) => runningBuilder.stop && runningBuilder.stop()
+	);
+
+	const routesModule = join(tmpdir(), `./functionsRoutes-${Math.random()}.mjs`);
+	const baseURL = toUrlPath("/");
+
+	const config: Config = await generateConfigFromFileTree({
+		baseDir: functionsDirectory,
+		baseURL,
+	});
+
+	if (!config.routes || config.routes.length === 0) {
+		throw new FunctionsNoRoutesError(
+			`Failed to find any routes while compiling Functions in: ${functionsDirectory}`
+		);
+	}
+
+	if (routesOutputPath) {
+		const routesJSON = convertRoutesToRoutesJSONSpec(config.routes);
+		writeFileSync(routesOutputPath, JSON.stringify(routesJSON, null, 2));
+	}
+
+	if (outputConfigPath) {
+		writeFileSync(
+			outputConfigPath,
+			JSON.stringify({ ...config, baseURL }, null, 2)
+		);
+	}
+
+	await writeRoutesModule({
+		config,
+		srcDir: functionsDirectory,
+		outfile: routesModule,
+	});
+
+	const absoluteFunctionsDirectory = resolve(functionsDirectory);
+
+	if (plugin) {
+		RUNNING_BUILDERS.push(
+			await buildPlugin({
+				routesModule,
+				outfile,
+				minify,
+				sourcemap,
+				watch,
+				nodeCompat,
+				functionsDirectory: absoluteFunctionsDirectory,
+				local,
+				betaD1Shims: d1Databases,
+				onEnd,
+			})
+		);
+	} else {
+		RUNNING_BUILDERS.push(
+			await buildWorker({
+				routesModule,
+				outfile,
+				minify,
+				sourcemap,
+				fallbackService,
+				watch,
+				functionsDirectory: absoluteFunctionsDirectory,
+				local,
+				betaD1Shims: d1Databases,
+				onEnd,
+				buildOutputDirectory,
+				nodeCompat,
+			})
+		);
+	}
+}

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -10,7 +10,7 @@ import { FatalError } from "../errors";
 import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { getBasePath } from "../paths";
-import { buildFunctions } from "./build";
+import { buildFunctions } from "./buildFunctions";
 import { ROUTES_SPEC_VERSION, SECONDS_TO_WAIT_FOR_PROXY } from "./constants";
 import { FunctionsNoRoutesError, getFunctionsNoRoutesWarning } from "./errors";
 import { buildRawWorker, checkRawWorker } from "./functions/buildWorker";

--- a/packages/wrangler/src/pages/publish.tsx
+++ b/packages/wrangler/src/pages/publish.tsx
@@ -248,7 +248,7 @@ export const Handler = async ({
 		commitMessage,
 		commitHash,
 		commitDirty,
-		bundle,
+		bundle: bundle ?? !noBundle,
 	});
 
 	saveToConfigCache<PagesConfigCache>(PAGES_CONFIG_CACHE_FILENAME, {

--- a/packages/wrangler/src/pages/publish.tsx
+++ b/packages/wrangler/src/pages/publish.tsx
@@ -1,12 +1,8 @@
 import { execSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { dirname, join, resolve as resolvePath } from "node:path";
-import { cwd } from "node:process";
 import { render, Text } from "ink";
 import SelectInput from "ink-select-input";
 import React from "react";
-import { File, FormData } from "undici";
+import { publish } from "../api/pages/publish";
 import { fetchResult } from "../cfetch";
 import { getConfigCache, saveToConfigCache } from "../config-cache";
 import { prompt } from "../dialogs";
@@ -14,18 +10,13 @@ import { FatalError } from "../errors";
 import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { requireAuth } from "../user";
-import { buildFunctions } from "./build";
 import { PAGES_CONFIG_CACHE_FILENAME } from "./constants";
-import { FunctionsNoRoutesError, getFunctionsNoRoutesWarning } from "./errors";
-import { buildRawWorker, checkRawWorker } from "./functions/buildWorker";
-import { validateRoutes } from "./functions/routes-validation";
 import { listProjects } from "./projects";
 import { promptSelectProject } from "./prompt-select-project";
-import { upload } from "./upload";
 import { pagesBetaWarning } from "./utils";
 import type { YargsOptionsToInterface } from "../yargs-types";
 import type { PagesConfigCache } from "./types";
-import type { Project, Deployment } from "@cloudflare/types";
+import type { Project } from "@cloudflare/types";
 import type { Argv } from "yargs";
 
 type PublishArgs = YargsOptionsToInterface<typeof Options>;
@@ -248,234 +239,17 @@ export const Handler = async ({
 		}
 	}
 
-	let _headers: string | undefined,
-		_redirects: string | undefined,
-		_routesGenerated: string | undefined,
-		_routesCustom: string | undefined,
-		_workerJS: string | undefined;
-
-	const workerScriptPath = resolvePath(directory, "_worker.js");
-
-	try {
-		_headers = readFileSync(join(directory, "_headers"), "utf-8");
-	} catch {}
-
-	try {
-		_redirects = readFileSync(join(directory, "_redirects"), "utf-8");
-	} catch {}
-
-	try {
-		/**
-		 * Developers can specify a custom _routes.json file, for projects with Pages
-		 * Functions or projects in Advanced Mode
-		 */
-		_routesCustom = readFileSync(join(directory, "_routes.json"), "utf-8");
-	} catch {}
-
-	try {
-		_workerJS = readFileSync(workerScriptPath, "utf-8");
-	} catch {}
-
-	// Grab the bindings from the API, we need these for shims and other such hacky inserts
-	const project = await fetchResult<Project>(
-		`/accounts/${accountId}/pages/projects/${projectName}`
-	);
-	let isProduction = true;
-	if (branch) {
-		isProduction = project.production_branch === branch;
-	}
-
-	/**
-	 * Evaluate if this is an Advanced Mode or Pages Functions project. If Advanced Mode, we'll
-	 * go ahead and upload `_worker.js` as is, but if Pages Functions, we need to attempt to build
-	 * Functions first and exit if it failed
-	 */
-	let builtFunctions: string | undefined = undefined;
-	const functionsDirectory = join(cwd(), "functions");
-	const routesOutputPath = !existsSync(join(directory, "_routes.json"))
-		? join(tmpdir(), `_routes-${Math.random()}.json`)
-		: undefined;
-
-	// Routing configuration displayed in the Functions tab of a deployment in Dash
-	let filepathRoutingConfig: string | undefined;
-
-	if (!_workerJS && existsSync(functionsDirectory)) {
-		const outfile = join(tmpdir(), `./functionsWorker-${Math.random()}.js`);
-		const outputConfigPath = join(
-			tmpdir(),
-			`functions-filepath-routing-config-${Math.random()}.json`
-		);
-
-		try {
-			await buildFunctions({
-				outfile,
-				outputConfigPath,
-				functionsDirectory,
-				onEnd: () => {},
-				buildOutputDirectory: dirname(outfile),
-				routesOutputPath,
-				local: false,
-				d1Databases: Object.keys(
-					project.deployment_configs[isProduction ? "production" : "preview"]
-						.d1_databases ?? {}
-				),
-			});
-
-			builtFunctions = readFileSync(outfile, "utf-8");
-			filepathRoutingConfig = readFileSync(outputConfigPath, "utf-8");
-		} catch (e) {
-			if (e instanceof FunctionsNoRoutesError) {
-				logger.warn(
-					getFunctionsNoRoutesWarning(functionsDirectory, "skipping")
-				);
-			} else {
-				throw e;
-			}
-		}
-	}
-
-	const manifest = await upload({
+	const deploymentResponse = await publish({
 		directory,
 		accountId,
 		projectName,
-		skipCaching: skipCaching ?? false,
+		branch,
+		skipCaching,
+		commitMessage,
+		commitHash,
+		commitDirty,
+		bundle,
 	});
-
-	const formData = new FormData();
-
-	formData.append("manifest", JSON.stringify(manifest));
-
-	if (branch) {
-		formData.append("branch", branch);
-	}
-
-	if (commitMessage) {
-		formData.append("commit_message", commitMessage);
-	}
-
-	if (commitHash) {
-		formData.append("commit_hash", commitHash);
-	}
-
-	if (commitDirty !== undefined) {
-		formData.append("commit_dirty", commitDirty);
-	}
-
-	if (_headers) {
-		formData.append("_headers", new File([_headers], "_headers"));
-		logger.log(`✨ Uploading _headers`);
-	}
-
-	if (_redirects) {
-		formData.append("_redirects", new File([_redirects], "_redirects"));
-		logger.log(`✨ Uploading _redirects`);
-	}
-
-	if (filepathRoutingConfig) {
-		formData.append(
-			"functions-filepath-routing-config.json",
-			new File(
-				[filepathRoutingConfig],
-				"functions-filepath-routing-config.json"
-			)
-		);
-	}
-
-	/**
-	 * Advanced Mode
-	 * https://developers.cloudflare.com/pages/platform/functions/#advanced-mode
-	 *
-	 * When using a _worker.js file, the entire /functions directory is ignored
-	 * – this includes its routing and middleware characteristics.
-	 */
-	if (_workerJS) {
-		let workerFileContents = _workerJS;
-		const enableBundling = bundle || !noBundle;
-		if (enableBundling) {
-			const outfile = join(tmpdir(), `./bundledWorker-${Math.random()}.mjs`);
-			await buildRawWorker({
-				workerScriptPath,
-				outfile,
-				directory: directory ?? ".",
-				local: false,
-				sourcemap: true,
-				watch: false,
-				onEnd: () => {},
-			});
-			workerFileContents = readFileSync(outfile, "utf8");
-		} else {
-			await checkRawWorker(workerScriptPath, () => {});
-		}
-
-		formData.append("_worker.js", new File([workerFileContents], "_worker.js"));
-		logger.log(`✨ Uploading _worker.js`);
-
-		if (_routesCustom) {
-			// user provided a custom _routes.json file
-			try {
-				const routesCustomJSON = JSON.parse(_routesCustom);
-				validateRoutes(routesCustomJSON, join(directory, "_routes.json"));
-
-				formData.append(
-					"_routes.json",
-					new File([_routesCustom], "_routes.json")
-				);
-				logger.log(`✨ Uploading _routes.json`);
-			} catch (err) {
-				if (err instanceof FatalError) {
-					throw err;
-				}
-			}
-		}
-	}
-
-	/**
-	 * Pages Functions
-	 * https://developers.cloudflare.com/pages/platform/functions/
-	 */
-	if (builtFunctions && !_workerJS) {
-		// if Functions were build successfully, proceed to uploading the build file
-		formData.append("_worker.js", new File([builtFunctions], "_worker.js"));
-		logger.log(`✨ Uploading Functions`);
-
-		if (_routesCustom) {
-			// user provided a custom _routes.json file
-			try {
-				const routesCustomJSON = JSON.parse(_routesCustom);
-				validateRoutes(routesCustomJSON, join(directory, "_routes.json"));
-
-				formData.append(
-					"_routes.json",
-					new File([_routesCustom], "_routes.json")
-				);
-				logger.log(`✨ Uploading _routes.json`);
-			} catch (err) {
-				if (err instanceof FatalError) {
-					throw err;
-				}
-			}
-		} else if (routesOutputPath) {
-			// no custom _routes.json file found, so fallback to the generated one
-			try {
-				_routesGenerated = readFileSync(routesOutputPath, "utf-8");
-
-				if (_routesGenerated) {
-					formData.append(
-						"_routes.json",
-						new File([_routesGenerated], "_routes.json")
-					);
-				}
-			} catch {}
-		}
-	}
-
-	const deploymentResponse = await fetchResult<Deployment>(
-		`/accounts/${accountId}/pages/projects/${projectName}/deployments`,
-		{
-			method: "POST",
-			body: formData,
-		}
-	);
 
 	saveToConfigCache<PagesConfigCache>(PAGES_CONFIG_CACHE_FILENAME, {
 		account_id: accountId,


### PR DESCRIPTION
What this PR solves / how to test:

This PR refactors the existing Pages publish code into its own exportable function and exports it in the wrangler API under the `unstable_pages` object. This will allow folks to run the `publish` function in a scriptable JS environment and will get the entire deployment response as a variable.

Associated docs issues/PR:

- https://github.com/cloudflare/wrangler2/issues/2437

Author has included the following, where applicable:

- [ ] ~~Tests~~
- [x] Changeset

Reviewer has performed the following, where applicable:

- [x] Checked for inclusion of relevant tests
- [x] Checked for inclusion of a relevant changeset
- [x] Checked for creation of associated docs updates
- [x] Manually pulled down the changes and spot-tested
