### PR TITLE
fix: Remove "experimental _routes.json" warnings

### DIFF
--- a/.changeset/forty-beds-sort.md
+++ b/.changeset/forty-beds-sort.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+---
+
+Remove "experimental \_routes.json" warnings
+
+`_routes.json` is no longer considered an experimental feature, so let's
+remove all warnings we have in place for that.

--- a/packages/wrangler/src/__tests__/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages.test.ts
@@ -1823,12 +1823,7 @@ describe("pages", () => {
 			✨ Deployment complete! Take a peek over at https://abcxyz.foo.pages.dev/"
 			`);
 
-			expect(std.warn).toMatchInlineSnapshot(`
-			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m_routes.json is an experimental feature and is subject to change. Please use with care.[0m
-
-			"
-			`);
-
+			expect(std.warn).toMatchInlineSnapshot(`""`);
 			expect(std.err).toMatchInlineSnapshot('""');
 		});
 
@@ -2125,11 +2120,7 @@ and that at least one include rule is provided.
 			✨ Deployment complete! Take a peek over at https://abcxyz.foo.pages.dev/"
 			`);
 
-			expect(std.warn).toMatchInlineSnapshot(`
-			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m_routes.json is an experimental feature and is subject to change. Please use with care.[0m
-
-			"
-		`);
+			expect(std.warn).toMatchInlineSnapshot(`""`);
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 

--- a/packages/wrangler/src/pages/publish.tsx
+++ b/packages/wrangler/src/pages/publish.tsx
@@ -388,9 +388,6 @@ export const Handler = async ({
 					new File([_routesCustom], "_routes.json")
 				);
 				logger.log(`✨ Uploading _routes.json`);
-				logger.warn(
-					`_routes.json is an experimental feature and is subject to change. Please use with care.`
-				);
 			} catch (err) {
 				if (err instanceof FatalError) {
 					throw err;
@@ -419,9 +416,6 @@ export const Handler = async ({
 					new File([_routesCustom], "_routes.json")
 				);
 				logger.log(`✨ Uploading _routes.json`);
-				logger.warn(
-					`_routes.json is an experimental feature and is subject to change. Please use with care.`
-				);
 			} catch (err) {
 				if (err instanceof FatalError) {
 					throw err;


### PR DESCRIPTION
`_routes.json` is no longer considered an experimental feature, so let's remove all warnings we have in place for that.

What this PR solves / how to test:

Associated docs issues/PR:

- [insert associated docs issue(s)/PR(s)]

Author has included the following, where applicable:

- [x] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes # [insert issue number].
