### PR TITLE
fix: path should be optional for `wrangler d1 backup download`

### DIFF
--- a/.changeset/grumpy-pants-relax.md
+++ b/.changeset/grumpy-pants-relax.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: path should be optional for wrangler d1 backup download
+
+This PR fixes a bug that forces folks to provide a `--output` flag to `wrangler d1 backup download`.

--- a/packages/wrangler/src/d1/backups.tsx
+++ b/packages/wrangler/src/d1/backups.tsx
@@ -1,5 +1,4 @@
 import fs from "node:fs/promises";
-import process from "node:process";
 import * as path from "path";
 import { render } from "ink";
 import Table from "ink-table";
@@ -192,8 +191,7 @@ export const DownloadHandler = withConfig<BackupDownloadArgs>(
 			name
 		);
 		const filename =
-			output ||
-			path.join(process.cwd(), `${name}.${backupId.slice(0, 8)}.sqlite3`);
+			output || path.resolve(`${name}.${backupId.slice(0, 8)}.sqlite3`);
 
 		logger.log(`🌀 Downloading backup ${backupId} from '${name}'`);
 		const response = await getBackupResponse(accountId, db.uuid, backupId);

--- a/packages/wrangler/src/d1/backups.tsx
+++ b/packages/wrangler/src/d1/backups.tsx
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import process from "node:process";
 import * as path from "path";
 import { render } from "ink";
 import Table from "ink-table";
@@ -192,10 +193,7 @@ export const DownloadHandler = withConfig<BackupDownloadArgs>(
 		);
 		const filename =
 			output ||
-			path.join(
-				process.env.INIT_CWD as string,
-				`${name}.${backupId.slice(0, 8)}.sqlite3`
-			);
+			path.join(process.cwd(), `${name}.${backupId.slice(0, 8)}.sqlite3`);
 
 		logger.log(`🌀 Downloading backup ${backupId} from '${name}'`);
 		const response = await getBackupResponse(accountId, db.uuid, backupId);


### PR DESCRIPTION
What this PR solves / how to test:

Running `wrangler d1 backup download <NAME> <ID>` fails with the following output:

```
rozenmd@QRVX0PWXHR d1-local-migrate % wrangler d1 backup download test3 asdf
▲ [WARNING] Processing wrangler.toml configuration:

    - D1 Bindings are currently in alpha to allow the API to evolve before general availability.
      Please report any issues to https://github.com/cloudflare/wrangler2/issues/new/choose
      Note: Run this command with the environment variable NO_D1_WARNING=true to hide this message

      For example: `export NO_D1_WARNING=true && wrangler <YOUR COMMAND HERE>`


🚧 D1 is currently in open alpha and is not recommended for production data and traffic.
Please report any bugs to https://github.com/cloudflare/wrangler2/issues/new/choose.
To request features, visit https://community.cloudflare.com/c/developers/d1.
To give feedback, visit https://discord.gg/cloudflaredev

✘ [ERROR] The "path" argument must be of type string. Received undefined


If you think this is a bug then please create an issue at https://github.com/cloudflare/wrangler2/issues/new/choose
```

This is because `process.env.INIT_CWD` can be undefined, and we assumed it can't be.

Associated docs issues/PR:

- N/A

Author has included the following, where applicable:

- [x] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [x] Checked for inclusion of a relevant changeset
- [x] Checked for creation of associated docs updates
- [x] Manually pulled down the changes and spot-tested

Fixes #2292
