### PR TITLE
fix: wrangler init --from-dash incorrectly expects index.ts while writing index.js

### DIFF
--- a/.changeset/fair-peas-bow.md
+++ b/.changeset/fair-peas-bow.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: wrangler init --from-dash incorrectly expects index.ts while writing index.js
+
+This PR fixes a bug where Wrangler would write a `wrangler.toml` expecting an index.ts file, while writing an index.js file.

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -599,7 +599,7 @@ export async function initHandler(args: InitArgs) {
 					isWritingScripts: shouldWritePackageJsonScripts,
 					isCreatingWranglerToml: justCreatedWranglerToml,
 					packagePath: pathToPackageJson,
-					scriptPath: "src/index.ts",
+					scriptPath: "src/index.js",
 					//? Should we have Environment argument for `wrangler init --from-dash` - Jacob
 					extraToml: (await getWorkerConfig(accountId, fromDashScriptName, {
 						defaultEnvironment,


### PR DESCRIPTION
@JacobMGEvans can you confirm that `wrangler init --from-dash` should be writing an index.js?

Fixes https://github.com/cloudflare/wrangler2/issues/2549