### PR TITLE
fix: Copy module imports related files to outdir

### DIFF
--- a/.changeset/tiny-swans-kick.md
+++ b/.changeset/tiny-swans-kick.md
@@ -1,0 +1,20 @@
+---
+"wrangler": patch
+---
+
+fix: Copy module imports related files to outdir
+
+When we bundle a Worker `esbuild` takes care of writing the
+results to the output directory. However, if the Worker contains
+any `external` imports, such as text/wasm/binary module imports,
+that cannot be inlined into the same bundle file, `bundleWorker`
+will not copy these files to the output directory. This doesn't
+affect `wrangler publish` per se, because of how the Worker
+upload FormData is created. It does however create some
+inconsistencies when running `wrangler publish --outdir` or
+`wrangler publish --outdir --dry-run`, in that, `outdir` will
+not contain those external import files.
+
+This commit addresses this issue by making sure the aforementioned
+files do get copied over to `outdir` together with `esbuild`'s
+resulting bundle files.

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -395,13 +395,23 @@ export async function bundleWorker(
 		_path.includes(".map")
 	)[0];
 
+	const resolvedEntryPointPath = path.resolve(
+		entry.directory,
+		entryPointOutputs[0][0]
+	);
+
+	// copy all referenced modules into the output bundle directory
+	for (const module of moduleCollector.modules) {
+		fs.writeFileSync(
+			path.join(path.dirname(resolvedEntryPointPath), module.name),
+			module.content
+		);
+	}
+
 	return {
 		modules: moduleCollector.modules,
 		dependencies,
-		resolvedEntryPointPath: path.resolve(
-			entry.directory,
-			entryPointOutputs[0][0]
-		),
+		resolvedEntryPointPath,
 		bundleType,
 		stop: result.stop,
 		sourceMapPath,

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -1,7 +1,7 @@
 import assert from "node:assert";
 import { fork } from "node:child_process";
 import { realpathSync } from "node:fs";
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import chalk from "chalk";
 import getPort from "get-port";
@@ -164,15 +164,6 @@ function useLocalWorker({
 		const abortController = new AbortController();
 		async function startLocalWorker() {
 			if (!bundle || !format) return;
-
-			// In local mode, we want to copy all referenced modules into
-			// the output bundle directory before starting up
-			for (const module of bundle.modules) {
-				await writeFile(
-					path.join(path.dirname(bundle.path), module.name),
-					module.content
-				);
-			}
 
 			const scriptPath = realpathSync(bundle.path);
 

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -1,6 +1,5 @@
 import { fork } from "node:child_process";
 import { realpathSync } from "node:fs";
-import { writeFile } from "node:fs/promises";
 import * as path from "node:path";
 import * as util from "node:util";
 import onExit from "signal-exit";
@@ -342,15 +341,6 @@ export async function startLocalServer({
 		if (bindings.services && bindings.services.length > 0) {
 			logger.warn(
 				"⎔ Support for service bindings in local mode is experimental and may change."
-			);
-		}
-
-		// In local mode, we want to copy all referenced modules into
-		// the output bundle directory before starting up
-		for (const module of bundle.modules) {
-			await writeFile(
-				path.join(path.dirname(bundle.path), module.name),
-				module.content
 			);
 		}
 


### PR DESCRIPTION
**What this PR solves / how to test:**

When we bundle a Worker, `esbuild` takes care of writing the results to the output directory. However, if the Worker contains any `external` imports, such as text/wasm/binary module imports, that cannot be inlined into the same bundle file, `bundleWorker` will not copy these files to the output directory. This doesn't affect `wrangler publish` per se, because of how the Worker upload FormData is created. It does however create some inconsistencies when running `wrangler publish --outdir` or `wrangler publish --outdir --dry-run`, in that, `outdir` will not contain those external import files.

This commit addresses this issue by making sure the aforementioned files do get copied over to `outdir` together with `esbuild`'s resulting bundle files.

Also.... Pages could really use this for our upcoming wasm support work ^.^

**Associated docs issues/PR:**
not relevant

**Author has included the following, where applicable:**

- [x] Tests
- [x] Changeset

**Reviewer has performed the following, where applicable:**

- [x] Checked for inclusion of relevant tests
- [x] Checked for inclusion of a relevant changeset
- [x] Checked for creation of associated docs updates
- [x] Manually pulled down the changes and spot-tested

Fixes # [insert issue number].
