### PR TITLE
Only check for <link> elements if response is HTML

### DIFF
--- a/.changeset/shaggy-hornets-drop.md
+++ b/.changeset/shaggy-hornets-drop.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/pages-shared": patch
+---
+
+Only check for <link> elements if response is HTML in Pages asset handler early hints code path.

--- a/.changeset/shaggy-hornets-drop.md
+++ b/.changeset/shaggy-hornets-drop.md
@@ -2,4 +2,4 @@
 "@cloudflare/pages-shared": patch
 ---
 
-Only check for <link> elements if response is HTML in Pages asset handler early hints code path.
+Only check for `<link>` elements if the asset response is HTML in Pages' Early Hints feature.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6409,12 +6409,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@types/service-worker-mock": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@types/service-worker-mock/-/service-worker-mock-2.0.1.tgz",
-			"integrity": "sha512-LqaP0QmgppRF7YEaqx4amoazHNXaX5bIFDAu62LnWIc5ku0HbgqlPKroQstAu8WsdmWIqEfI9VGlP8Skkq+m5A==",
-			"dev": true
-		},
 		"node_modules/@types/set-cookie-parser": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.2.tgz",
@@ -9847,18 +9841,6 @@
 			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz",
 			"integrity": "sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==",
 			"dev": true
-		},
-		"node_modules/dom-urls": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/dom-urls/-/dom-urls-1.1.0.tgz",
-			"integrity": "sha512-LNxCeExaNbczqMVfQUyLdd+r+smG7ixIa+doeyiJ7nTmL8aZRrJhHkEYBEYVGvYv7k2DOEBh2eKthoCmWpfICg==",
-			"dev": true,
-			"dependencies": {
-				"urijs": "^1.16.1"
-			},
-			"engines": {
-				"node": ">=0.8.0"
-			}
 		},
 		"node_modules/domain-browser": {
 			"version": "1.2.0",
@@ -19293,12 +19275,6 @@
 			"devOptional": true,
 			"license": "MIT"
 		},
-		"node_modules/lodash._basefor": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
-			"integrity": "sha512-6bc3b8grkpMgDcVJv9JYZAk/mHgcqMljzm7OsbmcE2FGUMmmLQTPHlh/dFqR8LA0GQ7z4K67JSotVKu5058v1A==",
-			"dev": true
-		},
 		"node_modules/lodash.debounce": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -19322,37 +19298,10 @@
 			"version": "3.1.0",
 			"license": "MIT"
 		},
-		"node_modules/lodash.isarray": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-			"integrity": "sha512-JwObCrNJuT0Nnbuecmqr5DgtuBppuCvGD9lxjFpAzwnVtdGoDQ1zig+5W8k5/6Gcn0gZ3936HDAlGd28i7sOGQ==",
-			"dev": true
-		},
 		"node_modules/lodash.isequal": {
 			"version": "4.5.0",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/lodash.isplainobject": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
-			"integrity": "sha512-P4wZnho5curNqeEq/x292Pb57e1v+woR7DJ84DURelKB46lby8aDEGVobSaYtzHdQBWQrJSdxcCwjlGOvvdIyg==",
-			"dev": true,
-			"dependencies": {
-				"lodash._basefor": "^3.0.0",
-				"lodash.isarguments": "^3.0.0",
-				"lodash.keysin": "^3.0.0"
-			}
-		},
-		"node_modules/lodash.keysin": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
-			"integrity": "sha512-YDB/5xkL3fBKFMDaC+cfGV00pbiJ6XoJIfRmBhv7aR6wWtbCW6IzkiWnTfkiHTF6ALD7ff83dAtB3OEaSoyQPg==",
-			"dev": true,
-			"dependencies": {
-				"lodash.isarguments": "^3.0.0",
-				"lodash.isarray": "^3.0.0"
-			}
 		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
@@ -23270,15 +23219,6 @@
 				"node": ">=8.10.0"
 			}
 		},
-		"node_modules/realistic-structured-clone": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/realistic-structured-clone/-/realistic-structured-clone-1.0.1.tgz",
-			"integrity": "sha512-UnQGgXdxTg+vwonhBz6VvfNFeqn/DUk0ntL/rSrN1mBOR261ZzLP3LQAFSBfIytyZYn4yue/64pZ7aN0x/RpiQ==",
-			"dev": true,
-			"dependencies": {
-				"lodash.isplainobject": "^3.0.2"
-			}
-		},
 		"node_modules/recast": {
 			"version": "0.21.5",
 			"resolved": "https://registry.npmjs.org/recast/-/recast-0.21.5.tgz",
@@ -24319,18 +24259,6 @@
 			"resolved": "fixtures/service-bindings-app",
 			"link": true
 		},
-		"node_modules/service-worker-mock": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/service-worker-mock/-/service-worker-mock-2.0.5.tgz",
-			"integrity": "sha512-yk6NCFnRWGfbOlP+IS4hEbJnGU8dVgtodAAKLxhkTPsOmaES44XVSWTNozK6KwI+p/0PDRrFsb2RjTMhvXiNkA==",
-			"dev": true,
-			"dependencies": {
-				"dom-urls": "^1.1.0",
-				"shelving-mock-indexeddb": "^1.1.0",
-				"url-search-params": "^0.10.0",
-				"w3c-hr-time": "^1.0.1"
-			}
-		},
 		"node_modules/set-blocking": {
 			"version": "2.0.0",
 			"license": "ISC"
@@ -24424,28 +24352,6 @@
 		"node_modules/shell-quote": {
 			"version": "1.7.3",
 			"license": "MIT"
-		},
-		"node_modules/shelving-mock-event": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/shelving-mock-event/-/shelving-mock-event-1.0.12.tgz",
-			"integrity": "sha512-2F+IZ010rwV3sA/Kd2hnC1vGNycsxeBJmjkXR8+4IOlv5e+Wvj+xH+A8Cv8/Z0lUyCut/HcxSpeDccYTVtnuaQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/shelving-mock-indexeddb": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/shelving-mock-indexeddb/-/shelving-mock-indexeddb-1.1.0.tgz",
-			"integrity": "sha512-akHJAmGL/dplJ4FZNxPxVbOxMw8Ey6wAnB9+3+GCUNqPUcJaskS55GijxZtarTfAYB4XQyu+FLtjcq2Oa3e2Lg==",
-			"dev": true,
-			"dependencies": {
-				"realistic-structured-clone": "^1.0.1",
-				"shelving-mock-event": "^1.0.12"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
 		},
 		"node_modules/side-channel": {
 			"version": "1.0.4",
@@ -26693,12 +26599,6 @@
 				"punycode": "^2.1.0"
 			}
 		},
-		"node_modules/urijs": {
-			"version": "1.19.11",
-			"resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
-			"integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
-			"dev": true
-		},
 		"node_modules/urix": {
 			"version": "0.1.0",
 			"license": "MIT"
@@ -26722,13 +26622,6 @@
 				"querystringify": "^2.1.1",
 				"requires-port": "^1.0.0"
 			}
-		},
-		"node_modules/url-search-params": {
-			"version": "0.10.2",
-			"resolved": "https://registry.npmjs.org/url-search-params/-/url-search-params-0.10.2.tgz",
-			"integrity": "sha512-d6GYsr992Bo9rzTZFc9BUw3UFAAg3prE9JGVBgW2TLTbI3rSvg4VDa0BFXHMzKkWbAuhrmaFWpucpRJl+3W7Jg==",
-			"deprecated": "now available as @ungap/url-search-params",
-			"dev": true
 		},
 		"node_modules/url/node_modules/punycode": {
 			"version": "1.3.2",
@@ -28249,10 +28142,8 @@
 			"devDependencies": {
 				"@miniflare/cache": "2.11.0",
 				"@miniflare/html-rewriter": "2.11.0",
-				"@types/service-worker-mock": "^2.0.1",
 				"concurrently": "^7.3.0",
-				"glob": "^8.0.3",
-				"service-worker-mock": "^2.0.5"
+				"glob": "^8.0.3"
 			}
 		},
 		"packages/pages-shared/node_modules/brace-expansion": {
@@ -28415,6 +28306,7 @@
 			"version": "0.0.0",
 			"license": "BSD-3-Clause",
 			"devDependencies": {
+				"patch-package": "^6.5.1",
 				"wrangler": "^2.7.1"
 			}
 		},
@@ -31244,10 +31136,8 @@
 				"@miniflare/cache": "2.11.0",
 				"@miniflare/core": "2.11.0",
 				"@miniflare/html-rewriter": "2.11.0",
-				"@types/service-worker-mock": "^2.0.1",
 				"concurrently": "^7.3.0",
-				"glob": "^8.0.3",
-				"service-worker-mock": "^2.0.5"
+				"glob": "^8.0.3"
 			},
 			"dependencies": {
 				"brace-expansion": {
@@ -31348,6 +31238,7 @@
 		"@cloudflare/wrangler-devtools": {
 			"version": "file:packages/wrangler-devtools",
 			"requires": {
+				"patch-package": "^6.5.1",
 				"wrangler": "^2.7.1"
 			}
 		},
@@ -34001,12 +33892,6 @@
 				}
 			}
 		},
-		"@types/service-worker-mock": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@types/service-worker-mock/-/service-worker-mock-2.0.1.tgz",
-			"integrity": "sha512-LqaP0QmgppRF7YEaqx4amoazHNXaX5bIFDAu62LnWIc5ku0HbgqlPKroQstAu8WsdmWIqEfI9VGlP8Skkq+m5A==",
-			"dev": true
-		},
 		"@types/set-cookie-parser": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.2.tgz",
@@ -36446,15 +36331,6 @@
 			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz",
 			"integrity": "sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==",
 			"dev": true
-		},
-		"dom-urls": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/dom-urls/-/dom-urls-1.1.0.tgz",
-			"integrity": "sha512-LNxCeExaNbczqMVfQUyLdd+r+smG7ixIa+doeyiJ7nTmL8aZRrJhHkEYBEYVGvYv7k2DOEBh2eKthoCmWpfICg==",
-			"dev": true,
-			"requires": {
-				"urijs": "^1.16.1"
-			}
 		},
 		"domain-browser": {
 			"version": "1.2.0",
@@ -42724,12 +42600,6 @@
 			"version": "4.17.21",
 			"devOptional": true
 		},
-		"lodash._basefor": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
-			"integrity": "sha512-6bc3b8grkpMgDcVJv9JYZAk/mHgcqMljzm7OsbmcE2FGUMmmLQTPHlh/dFqR8LA0GQ7z4K67JSotVKu5058v1A==",
-			"dev": true
-		},
 		"lodash.debounce": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -42749,36 +42619,9 @@
 		"lodash.isarguments": {
 			"version": "3.1.0"
 		},
-		"lodash.isarray": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-			"integrity": "sha512-JwObCrNJuT0Nnbuecmqr5DgtuBppuCvGD9lxjFpAzwnVtdGoDQ1zig+5W8k5/6Gcn0gZ3936HDAlGd28i7sOGQ==",
-			"dev": true
-		},
 		"lodash.isequal": {
 			"version": "4.5.0",
 			"dev": true
-		},
-		"lodash.isplainobject": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
-			"integrity": "sha512-P4wZnho5curNqeEq/x292Pb57e1v+woR7DJ84DURelKB46lby8aDEGVobSaYtzHdQBWQrJSdxcCwjlGOvvdIyg==",
-			"dev": true,
-			"requires": {
-				"lodash._basefor": "^3.0.0",
-				"lodash.isarguments": "^3.0.0",
-				"lodash.keysin": "^3.0.0"
-			}
-		},
-		"lodash.keysin": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
-			"integrity": "sha512-YDB/5xkL3fBKFMDaC+cfGV00pbiJ6XoJIfRmBhv7aR6wWtbCW6IzkiWnTfkiHTF6ALD7ff83dAtB3OEaSoyQPg==",
-			"dev": true,
-			"requires": {
-				"lodash.isarguments": "^3.0.0",
-				"lodash.isarray": "^3.0.0"
-			}
 		},
 		"lodash.merge": {
 			"version": "4.6.2"
@@ -45507,15 +45350,6 @@
 				"picomatch": "^2.2.1"
 			}
 		},
-		"realistic-structured-clone": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/realistic-structured-clone/-/realistic-structured-clone-1.0.1.tgz",
-			"integrity": "sha512-UnQGgXdxTg+vwonhBz6VvfNFeqn/DUk0ntL/rSrN1mBOR261ZzLP3LQAFSBfIytyZYn4yue/64pZ7aN0x/RpiQ==",
-			"dev": true,
-			"requires": {
-				"lodash.isplainobject": "^3.0.2"
-			}
-		},
 		"recast": {
 			"version": "0.21.5",
 			"resolved": "https://registry.npmjs.org/recast/-/recast-0.21.5.tgz",
@@ -46316,18 +46150,6 @@
 		"service-bindings-app": {
 			"version": "file:fixtures/service-bindings-app"
 		},
-		"service-worker-mock": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/service-worker-mock/-/service-worker-mock-2.0.5.tgz",
-			"integrity": "sha512-yk6NCFnRWGfbOlP+IS4hEbJnGU8dVgtodAAKLxhkTPsOmaES44XVSWTNozK6KwI+p/0PDRrFsb2RjTMhvXiNkA==",
-			"dev": true,
-			"requires": {
-				"dom-urls": "^1.1.0",
-				"shelving-mock-indexeddb": "^1.1.0",
-				"url-search-params": "^0.10.0",
-				"w3c-hr-time": "^1.0.1"
-			}
-		},
 		"set-blocking": {
 			"version": "2.0.0"
 		},
@@ -46393,22 +46215,6 @@
 		},
 		"shell-quote": {
 			"version": "1.7.3"
-		},
-		"shelving-mock-event": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/shelving-mock-event/-/shelving-mock-event-1.0.12.tgz",
-			"integrity": "sha512-2F+IZ010rwV3sA/Kd2hnC1vGNycsxeBJmjkXR8+4IOlv5e+Wvj+xH+A8Cv8/Z0lUyCut/HcxSpeDccYTVtnuaQ==",
-			"dev": true
-		},
-		"shelving-mock-indexeddb": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/shelving-mock-indexeddb/-/shelving-mock-indexeddb-1.1.0.tgz",
-			"integrity": "sha512-akHJAmGL/dplJ4FZNxPxVbOxMw8Ey6wAnB9+3+GCUNqPUcJaskS55GijxZtarTfAYB4XQyu+FLtjcq2Oa3e2Lg==",
-			"dev": true,
-			"requires": {
-				"realistic-structured-clone": "^1.0.1",
-				"shelving-mock-event": "^1.0.12"
-			}
 		},
 		"side-channel": {
 			"version": "1.0.4",
@@ -48017,12 +47823,6 @@
 				"punycode": "^2.1.0"
 			}
 		},
-		"urijs": {
-			"version": "1.19.11",
-			"resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
-			"integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
-			"dev": true
-		},
 		"urix": {
 			"version": "0.1.0"
 		},
@@ -48053,12 +47853,6 @@
 				"querystringify": "^2.1.1",
 				"requires-port": "^1.0.0"
 			}
-		},
-		"url-search-params": {
-			"version": "0.10.2",
-			"resolved": "https://registry.npmjs.org/url-search-params/-/url-search-params-0.10.2.tgz",
-			"integrity": "sha512-d6GYsr992Bo9rzTZFc9BUw3UFAAg3prE9JGVBgW2TLTbI3rSvg4VDa0BFXHMzKkWbAuhrmaFWpucpRJl+3W7Jg==",
-			"dev": true
 		},
 		"urlpattern-polyfill": {
 			"version": "4.0.3"

--- a/packages/pages-shared/__tests__/asset-server/handler.test.ts
+++ b/packages/pages-shared/__tests__/asset-server/handler.test.ts
@@ -500,10 +500,9 @@ async function getTestResponse({
 				}
 			);
 		},
-		waitUntil: (async (promise: Promise<unknown>) => {
+		waitUntil: async (promise: Promise<unknown>) => {
 			spies.waitUntil.push(promise);
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		}) as any,
+		},
 		caches: {
 			...spies.caches,
 			open(cacheName) {

--- a/packages/pages-shared/__tests__/jest.setup.ts
+++ b/packages/pages-shared/__tests__/jest.setup.ts
@@ -1,3 +1,10 @@
-import makeServiceWorkerEnv from "service-worker-mock";
+import { fetch, Headers, Request, Response } from "@miniflare/core";
+import { HTMLRewriter } from "@miniflare/html-rewriter";
 
-Object.assign(globalThis, makeServiceWorkerEnv());
+Object.assign(globalThis, {
+	fetch,
+	Headers,
+	Request,
+	Response,
+	HTMLRewriter,
+});

--- a/packages/pages-shared/__tests__/jest.setup.ts
+++ b/packages/pages-shared/__tests__/jest.setup.ts
@@ -1,7 +1,8 @@
 import { fetch, Headers, Request, Response } from "@miniflare/core";
 import { HTMLRewriter } from "@miniflare/html-rewriter";
+import { polyfill } from "../environment-polyfills";
 
-Object.assign(globalThis, {
+polyfill({
 	fetch,
 	Headers,
 	Request,

--- a/packages/pages-shared/asset-server/handler.ts
+++ b/packages/pages-shared/asset-server/handler.ts
@@ -279,11 +279,10 @@ export async function generateHandler<
 		const extraHeaders = new Headers({
 			"access-control-allow-origin": "*",
 			"referrer-policy": "strict-origin-when-cross-origin",
+			...(existingHeaders.has("content-type")
+				? { "x-content-type-options": "nosniff" }
+				: {}),
 		});
-
-		if (existingHeaders.has("content-type")) {
-			extraHeaders.append("x-content-type-options", "nosniff");
-		}
 
 		const headers = new Headers({
 			// But we intentionally override existing headers

--- a/packages/pages-shared/asset-server/handler.ts
+++ b/packages/pages-shared/asset-server/handler.ts
@@ -311,7 +311,7 @@ export async function generateHandler<
 
 			if (
 				waitUntil &&
-				response.headers.get("Content-Type")?.includes("text/html")
+				isHTMLContentType(response.headers.get("Content-Type"))
 			) {
 				waitUntil(
 					(async () => {
@@ -512,7 +512,7 @@ export async function generateHandler<
 			}
 
 			if (
-				asset.contentType.startsWith("text/html") &&
+				isHTMLContentType(asset.contentType) &&
 				metadata.analytics?.version === ANALYTICS_VERSION
 			) {
 				return new HTMLRewriter()
@@ -653,4 +653,12 @@ function isPreview(url: URL): boolean {
 		return url.hostname.split(".").length > 3 ? true : false;
 	}
 	return false;
+}
+
+/**
+ * Whether or not the passed in string looks like an HTML
+ * Content-Type header
+ */
+function isHTMLContentType(contentType?: string | null) {
+	return contentType?.startsWith("text/html") || false;
 }

--- a/packages/pages-shared/environment-polyfills/miniflare-tre.ts
+++ b/packages/pages-shared/environment-polyfills/miniflare-tre.ts
@@ -2,11 +2,13 @@ import { polyfill } from ".";
 
 export default async () => {
 	const mf = await import("@miniflare/tre");
+	const { HTMLRewriter } = await import("@miniflare/html-rewriter");
 
 	polyfill({
 		fetch: mf.fetch,
 		Headers: mf.Headers,
 		Request: mf.Request,
 		Response: mf.Response,
+		HTMLRewriter,
 	});
 };

--- a/packages/pages-shared/environment-polyfills/miniflare.ts
+++ b/packages/pages-shared/environment-polyfills/miniflare.ts
@@ -2,11 +2,13 @@ import { polyfill } from ".";
 
 export default async () => {
 	const mf = await import("@miniflare/core");
+	const { HTMLRewriter } = await import("@miniflare/html-rewriter");
 
 	polyfill({
 		fetch: mf.fetch,
 		Headers: mf.Headers,
 		Request: mf.Request,
 		Response: mf.Response,
+		HTMLRewriter,
 	});
 };

--- a/packages/pages-shared/environment-polyfills/types.ts
+++ b/packages/pages-shared/environment-polyfills/types.ts
@@ -37,6 +37,7 @@ export type PolyfilledRuntimeEnvironment = {
 	Headers: typeof Headers;
 	Request: typeof Request;
 	Response: typeof Response;
+	HTMLRewriter: typeof HTMLRewriter;
 };
 
 export { fetch, Headers, Request, Response };

--- a/packages/pages-shared/package.json
+++ b/packages/pages-shared/package.json
@@ -14,7 +14,7 @@
 	],
 	"scripts": {
 		"check:type": "tsc",
-		"test": "jest"
+		"test": "jest --silent=false"
 	},
 	"jest": {
 		"coverageReporters": [
@@ -47,9 +47,7 @@
 	"devDependencies": {
 		"@miniflare/cache": "2.11.0",
 		"@miniflare/html-rewriter": "2.11.0",
-		"@types/service-worker-mock": "^2.0.1",
 		"concurrently": "^7.3.0",
-		"glob": "^8.0.3",
-		"service-worker-mock": "^2.0.5"
+		"glob": "^8.0.3"
 	}
 }


### PR DESCRIPTION
What this PR solves / how to test:

This prevents the Pages Asset Server from performing unnecessary checks for preload/preconnect links. I've reproduced the unintended behavior and wrote an internal integration test to ensure that this change solves the problem.

Associated docs issues/PR:

- N/A

Author has included the following, where applicable:

- [ ] Tests
- [ ] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [x] Manually pulled down the changes and spot-tested
