### PR TITLE
Deployment Details

### DIFF
--- a/.changeset/brown-wasps-fail.md
+++ b/.changeset/brown-wasps-fail.md
@@ -28,5 +28,5 @@ Added a positional in the 'Deployments' command <deployment-id>.
     async fetch(request) {
       return new Response('Hello World from Deployment 1701-E');
     },
-  };"
+  };
 ```

--- a/.changeset/brown-wasps-fail.md
+++ b/.changeset/brown-wasps-fail.md
@@ -1,0 +1,32 @@
+---
+"wrangler": minor
+---
+
+Added a positional in the 'Deployments' command <deployment-id>.
+<deployment-id> will get the details of the deployment, including versioned script, bindings, and usage model information.
+
+```ts
+	{
+    Tag: '',
+    Number: 0,
+    'Metadata.author_id': 'Picard-Gamma-6-0-7-3',
+    'Metadata.author_email': 'picard@vinyard.com',
+    'Metadata.source': 'wrangler',
+    'Metadata.created_on': '2021-01-01T00:00:00.000000Z',
+    'Metadata.modified_on': '2021-01-01T00:00:00.000000Z',
+    'resources.script': {
+      etag: 'mock-e-tag',
+      handlers: [ 'fetch' ],
+      last_deployed_from: 'wrangler'
+    },
+    'resources.bindings': []
+  }
+
+
+
+  export default {
+    async fetch(request) {
+      return new Response('Hello World from Deployment 1701-E');
+    },
+  };"
+```

--- a/packages/wrangler/src/__tests__/deployments.test.ts
+++ b/packages/wrangler/src/__tests__/deployments.test.ts
@@ -1,18 +1,18 @@
-// import * as fs from "fs";
-// import * as TOML from "@iarna/toml";
 import * as fs from "node:fs";
 import * as TOML from "@iarna/toml";
-import { rest } from "msw";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import {
 	msw,
 	mswSuccessOauthHandlers,
 	mswSuccessUserHandlers,
+	mswSuccessDeploymentDetails,
+	mswSuccessDeploymentScriptMetadata,
 } from "./helpers/msw";
 import { mswSuccessDeployments } from "./helpers/msw";
 import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
+import writeWranglerToml from "./helpers/write-wrangler-toml";
 
 describe("deployments", () => {
 	const std = mockConsoleMethods();
@@ -26,27 +26,32 @@ describe("deployments", () => {
 			...mswSuccessDeployments,
 			...mswSuccessOauthHandlers,
 			...mswSuccessUserHandlers,
-			rest.get(
-				"*/accounts/:accountId/workers/services/:scriptName",
-				(_, response, context) => {
-					return response.once(
-						context.status(200),
-						context.json({
-							success: true,
-							errors: [],
-							messages: [],
-							result: {
-								default_environment: {
-									script: {
-										tag: "MOCK-TAG",
-									},
-								},
-							},
-						})
-					);
-				}
-			)
+			...mswSuccessDeploymentScriptMetadata,
+			...mswSuccessDeploymentDetails
 		);
+	});
+
+	it("should log helper message for deployments command", async () => {
+		await runWrangler("deployments --help");
+		expect(std.out).toMatchInlineSnapshot(`
+		"wrangler deployments [deployment-id]
+
+		🚢 Displays the 10 most recent deployments for a worker
+
+		Positionals:
+		  deployment-id  The ID of the deployment you want to inspect  [string]
+
+		Flags:
+		  -c, --config   Path to .toml configuration file  [string]
+		  -e, --env      Environment to use for operations and .env files  [string]
+		  -h, --help     Show help  [boolean]
+		  -v, --version  Show version number  [boolean]
+
+		Options:
+		      --name  The name of your worker  [string]
+
+		🚧\`wrangler deployments\` is a beta command. Please report any issues to https://github.com/cloudflare/wrangler2/issues/new/choose"
+	`);
 	});
 
 	it("should log deployments", async () => {
@@ -55,7 +60,6 @@ describe("deployments", () => {
 			TOML.stringify({
 				compatibility_date: "2022-01-12",
 				name: "test-script-name",
-				first_party_worker: true,
 			}),
 			"utf-8"
 		);
@@ -101,5 +105,43 @@ describe("deployments", () => {
 		await expect(runWrangler("deployments")).rejects.toMatchInlineSnapshot(
 			`[Error: Required Worker name missing. Please specify the Worker name in wrangler.toml, or pass it as an argument with \`--name\`]`
 		);
+	});
+
+	describe("deployment details", () => {
+		it("should log deployment details", async () => {
+			writeWranglerToml();
+			fs.writeFileSync(
+				"./wrangler.toml",
+				TOML.stringify({
+					compatibility_date: "2022-01-12",
+					name: "test-script-name",
+				}),
+				"utf-8"
+			);
+
+			await runWrangler("deployments 1701-E");
+
+			expect(std.out).toMatchInlineSnapshot(`
+			"🚧\`wrangler deployments\` is a beta command. Please report any issues to https://github.com/cloudflare/wrangler2/issues/new/choose
+
+			{
+			  Tag: '',
+			  Number: 0,
+			  'Metadata.author_id': 'Picard-Gamma-6-0-7-3',
+			  'Metadata.author_email': 'Jean-Luc-Picard@federation.org',
+			  'Metadata.source': 'wrangler',
+			  'Metadata.created_on': '2021-01-01T00:00:00.000000Z',
+			  'Metadata.modified_on': '2021-01-01T00:00:00.000000Z',
+			  'resources.script': 'MOCK-TAG',
+			  'resources.bindings': []
+			}
+
+						export default {
+							async fetch(request) {
+								return new Response('Hello World from Deployment 1701-E');
+							},
+						};"
+		`);
+		});
 	});
 });

--- a/packages/wrangler/src/__tests__/deployments.test.ts
+++ b/packages/wrangler/src/__tests__/deployments.test.ts
@@ -132,7 +132,11 @@ describe("deployments", () => {
 			  'Metadata.source': 'wrangler',
 			  'Metadata.created_on': '2021-01-01T00:00:00.000000Z',
 			  'Metadata.modified_on': '2021-01-01T00:00:00.000000Z',
-			  'resources.script': 'MOCK-TAG',
+			  'resources.script': {
+			    etag: 'mock-e-tag',
+			    handlers: [ 'fetch' ],
+			    last_deployed_from: 'wrangler'
+			  },
 			  'resources.bindings': []
 			}
 

--- a/packages/wrangler/src/__tests__/deployments.test.ts
+++ b/packages/wrangler/src/__tests__/deployments.test.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import * as TOML from "@iarna/toml";
+import { rest } from "msw";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import {
@@ -8,6 +9,7 @@ import {
 	mswSuccessUserHandlers,
 	mswSuccessDeploymentDetails,
 	mswSuccessDeploymentScriptMetadata,
+	createFetchResult,
 } from "./helpers/msw";
 import { mswSuccessDeployments } from "./helpers/msw";
 import { runInTempDir } from "./helpers/run-in-tmp";
@@ -37,6 +39,9 @@ describe("deployments", () => {
 		"wrangler deployments [deployment-id]
 
 		🚢 Displays the 10 most recent deployments for a worker
+
+		Commands:
+		  wrangler deployments rollback [deployment-id]  🔙 Rollback a deployment
 
 		Positionals:
 		  deployment-id  The ID of the deployment you want to inspect  [string]
@@ -145,6 +150,54 @@ describe("deployments", () => {
 								return new Response('Hello World from Deployment 1701-E');
 							},
 						};"
+		`);
+		});
+	});
+	describe("rollback subcommand", () => {
+		it("should successfully rollback and output a message", async () => {
+			msw.use(
+				// query param ?rollback_to=<deployment-id>
+				rest.put(
+					"*/account/:accountID/workers/scripts/:scriptName",
+					(req, res, ctx) => {
+						return res.once(
+							ctx.json(
+								createFetchResult(
+									req.url.searchParams.get("rollback_to") === "Intrepid-Class"
+										? {
+												created_on: "2222-11-18T16:40:48.50545Z",
+												modified_on: "2222-01-20T18:08:47.464024Z",
+												id: "space_craft_1",
+												tag: "alien_tech_001",
+												tags: ["hyperdrive", "laser_cannons", "shields"],
+												deployment_id: "galactic_mission_alpha",
+												logpush: true,
+												etag: "13a3240e8fb414561b0366813b0b8f42b3e6cfa0d9e70e99835dae83d0d8a794",
+												handlers: [
+													"interstellar_communication",
+													"hyperspace_navigation",
+												],
+												last_deployed_from: "spaceport_alpha",
+												usage_model: "intergalactic",
+												script: `addEventListener('interstellar_communication', event =\u003e
+							{ event.respondWith(transmit(event.request)) }
+							)`,
+												size: "1 light-year",
+										  }
+										: {}
+								)
+							)
+						);
+					}
+				)
+			);
+
+			await runWrangler("deployments rollback Intrepid-Class");
+			expect(std.out).toMatchInlineSnapshot(`
+			"🚧\`wrangler deployments\` is a beta command. Please report any issues to https://github.com/cloudflare/wrangler2/issues/new/choose
+
+			Successfully rolled back to deployment ID: Intrepid-Class
+			Rollbacks metadata: undefined"
 		`);
 		});
 	});

--- a/packages/wrangler/src/__tests__/helpers/msw/handlers/deployments.ts
+++ b/packages/wrangler/src/__tests__/helpers/msw/handlers/deployments.ts
@@ -53,17 +53,68 @@ export const mswSuccessDeployments = [
 	),
 ];
 
-export const mswSuccessLastDeployment = [
+export const mswSuccessDeploymentScriptMetadata = [
 	rest.get(
 		"*/accounts/:accountId/workers/services/:scriptName",
 		(_, res, ctx) => {
 			return res.once(
 				ctx.json(
 					createFetchResult({
-						default_environment: { script: { last_deployed_from: "wrangler" } },
+						default_environment: {
+							script: { last_deployed_from: "wrangler", tag: "MOCK-TAG" },
+						},
 					})
 				)
 			);
+		}
+	),
+];
+
+export const mswSuccessDeploymentDetails = [
+	rest.get(
+		"*/accounts/:accountId/workers/deployments/by-script/:scriptTag/detail/:deploymentId",
+		(_, res, ctx) => {
+			return res.once(
+				ctx.json(
+					createFetchResult({
+						Tag: "",
+						Number: 0,
+						Metadata: {
+							author_id: "Picard-Gamma-6-0-7-3",
+							author_email: "Jean-Luc-Picard@federation.org",
+							source: "wrangler",
+							created_on: "2021-01-01T00:00:00.000000Z",
+							modified_on: "2021-01-01T00:00:00.000000Z",
+						},
+						resources: {
+							script: {
+								etag: "mock-e-tag",
+								handlers: ["fetch"],
+								last_deployed_from: "wrangler",
+							},
+							bindings: [],
+						},
+					})
+				)
+			);
+		}
+	),
+	// ?deployment=<deploymentid> param used to get deployment <script content> as text
+	rest.get(
+		"*/accounts/:accountId/workers/scripts/:scriptName",
+		(req, res, ctx) => {
+			let scriptContent = "";
+			if (req.url.searchParams.get("deployment") === "1701-E") {
+				scriptContent = `
+			export default {
+				async fetch(request) {
+					return new Response('Hello World from Deployment 1701-E');
+				},
+			};`;
+			} else {
+				scriptContent = "DIDN'T GET SCRIPT CONTENT";
+			}
+			return res.once(ctx.text(scriptContent));
 		}
 	),
 ];

--- a/packages/wrangler/src/__tests__/helpers/msw/index.ts
+++ b/packages/wrangler/src/__tests__/helpers/msw/index.ts
@@ -2,7 +2,8 @@ import { setupServer } from "msw/node";
 import { default as mswAccessHandlers } from "./handlers/access";
 import {
 	mswSuccessDeployments,
-	mswSuccessLastDeployment,
+	mswSuccessDeploymentScriptMetadata,
+	mswSuccessDeploymentDetails,
 } from "./handlers/deployments";
 import { mswSuccessNamespacesHandlers } from "./handlers/namespaces";
 import { mswSuccessOauthHandlers } from "./handlers/oauth";
@@ -45,6 +46,7 @@ export {
 	mswSucessScriptHandlers,
 	mswZoneHandlers,
 	mswSuccessDeployments,
+	mswSuccessDeploymentDetails,
 	mswAccessHandlers,
-	mswSuccessLastDeployment,
+	mswSuccessDeploymentScriptMetadata,
 };

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -31,29 +31,29 @@ describe("wrangler", () => {
 			"wrangler
 
 			Commands:
-			  wrangler docs [command]              📚 Open wrangler's docs in your browser
-			  wrangler init [name]                 📥 Initialize a basic Worker project, including a wrangler.toml file
-			  wrangler generate [name] [template]  ✨ Generate a new Worker project from an existing Worker template. See https://github.com/cloudflare/templates
-			  wrangler dev [script]                👂 Start a local server for developing your worker
-			  wrangler publish [script]            🆙 Publish your Worker to Cloudflare.
-			  wrangler delete [script]             🗑  Delete your Worker from Cloudflare.
-			  wrangler tail [worker]               🦚 Starts a log tailing session for a published Worker.
-			  wrangler secret                      🤫 Generate a secret that can be referenced in a Worker
-			  wrangler secret:bulk <json>          🗄️  Bulk upload secrets for a Worker
-			  wrangler kv:namespace                🗂️  Interact with your Workers KV Namespaces
-			  wrangler kv:key                      🔑 Individually manage Workers KV key-value pairs
-			  wrangler kv:bulk                     💪 Interact with multiple Workers KV key-value pairs at once
-			  wrangler pages                       ⚡️ Configure Cloudflare Pages
-			  wrangler queues                      🇶 Configure Workers Queues
-			  wrangler r2                          📦 Interact with an R2 store
-			  wrangler dispatch-namespace          📦 Interact with a dispatch namespace
-			  wrangler d1                          🗄  Interact with a D1 database
-			  wrangler pubsub                      📮 Interact and manage Pub/Sub Brokers
-			  wrangler login                       🔓 Login to Cloudflare
-			  wrangler logout                      🚪 Logout from Cloudflare
-			  wrangler whoami                      🕵️  Retrieve your user info and test your auth config
-			  wrangler types                       📝 Generate types from bindings & module rules in config
-			  wrangler deployments                 🚢 Displays the 10 most recent deployments for a worker
+			  wrangler docs [command]               📚 Open wrangler's docs in your browser
+			  wrangler init [name]                  📥 Initialize a basic Worker project, including a wrangler.toml file
+			  wrangler generate [name] [template]   ✨ Generate a new Worker project from an existing Worker template. See https://github.com/cloudflare/templates
+			  wrangler dev [script]                 👂 Start a local server for developing your worker
+			  wrangler publish [script]             🆙 Publish your Worker to Cloudflare.
+			  wrangler delete [script]              🗑  Delete your Worker from Cloudflare.
+			  wrangler tail [worker]                🦚 Starts a log tailing session for a published Worker.
+			  wrangler secret                       🤫 Generate a secret that can be referenced in a Worker
+			  wrangler secret:bulk <json>           🗄️  Bulk upload secrets for a Worker
+			  wrangler kv:namespace                 🗂️  Interact with your Workers KV Namespaces
+			  wrangler kv:key                       🔑 Individually manage Workers KV key-value pairs
+			  wrangler kv:bulk                      💪 Interact with multiple Workers KV key-value pairs at once
+			  wrangler pages                        ⚡️ Configure Cloudflare Pages
+			  wrangler queues                       🇶 Configure Workers Queues
+			  wrangler r2                           📦 Interact with an R2 store
+			  wrangler dispatch-namespace           📦 Interact with a dispatch namespace
+			  wrangler d1                           🗄  Interact with a D1 database
+			  wrangler pubsub                       📮 Interact and manage Pub/Sub Brokers
+			  wrangler login                        🔓 Login to Cloudflare
+			  wrangler logout                       🚪 Logout from Cloudflare
+			  wrangler whoami                       🕵️  Retrieve your user info and test your auth config
+			  wrangler types                        📝 Generate types from bindings & module rules in config
+			  wrangler deployments [deployment-id]  🚢 Displays the 10 most recent deployments for a worker
 
 			Flags:
 			  -c, --config   Path to .toml configuration file  [string]
@@ -79,29 +79,29 @@ describe("wrangler", () => {
 			wrangler
 
 			Commands:
-			  wrangler docs [command]              📚 Open wrangler's docs in your browser
-			  wrangler init [name]                 📥 Initialize a basic Worker project, including a wrangler.toml file
-			  wrangler generate [name] [template]  ✨ Generate a new Worker project from an existing Worker template. See https://github.com/cloudflare/templates
-			  wrangler dev [script]                👂 Start a local server for developing your worker
-			  wrangler publish [script]            🆙 Publish your Worker to Cloudflare.
-			  wrangler delete [script]             🗑  Delete your Worker from Cloudflare.
-			  wrangler tail [worker]               🦚 Starts a log tailing session for a published Worker.
-			  wrangler secret                      🤫 Generate a secret that can be referenced in a Worker
-			  wrangler secret:bulk <json>          🗄️  Bulk upload secrets for a Worker
-			  wrangler kv:namespace                🗂️  Interact with your Workers KV Namespaces
-			  wrangler kv:key                      🔑 Individually manage Workers KV key-value pairs
-			  wrangler kv:bulk                     💪 Interact with multiple Workers KV key-value pairs at once
-			  wrangler pages                       ⚡️ Configure Cloudflare Pages
-			  wrangler queues                      🇶 Configure Workers Queues
-			  wrangler r2                          📦 Interact with an R2 store
-			  wrangler dispatch-namespace          📦 Interact with a dispatch namespace
-			  wrangler d1                          🗄  Interact with a D1 database
-			  wrangler pubsub                      📮 Interact and manage Pub/Sub Brokers
-			  wrangler login                       🔓 Login to Cloudflare
-			  wrangler logout                      🚪 Logout from Cloudflare
-			  wrangler whoami                      🕵️  Retrieve your user info and test your auth config
-			  wrangler types                       📝 Generate types from bindings & module rules in config
-			  wrangler deployments                 🚢 Displays the 10 most recent deployments for a worker
+			  wrangler docs [command]               📚 Open wrangler's docs in your browser
+			  wrangler init [name]                  📥 Initialize a basic Worker project, including a wrangler.toml file
+			  wrangler generate [name] [template]   ✨ Generate a new Worker project from an existing Worker template. See https://github.com/cloudflare/templates
+			  wrangler dev [script]                 👂 Start a local server for developing your worker
+			  wrangler publish [script]             🆙 Publish your Worker to Cloudflare.
+			  wrangler delete [script]              🗑  Delete your Worker from Cloudflare.
+			  wrangler tail [worker]                🦚 Starts a log tailing session for a published Worker.
+			  wrangler secret                       🤫 Generate a secret that can be referenced in a Worker
+			  wrangler secret:bulk <json>           🗄️  Bulk upload secrets for a Worker
+			  wrangler kv:namespace                 🗂️  Interact with your Workers KV Namespaces
+			  wrangler kv:key                       🔑 Individually manage Workers KV key-value pairs
+			  wrangler kv:bulk                      💪 Interact with multiple Workers KV key-value pairs at once
+			  wrangler pages                        ⚡️ Configure Cloudflare Pages
+			  wrangler queues                       🇶 Configure Workers Queues
+			  wrangler r2                           📦 Interact with an R2 store
+			  wrangler dispatch-namespace           📦 Interact with a dispatch namespace
+			  wrangler d1                           🗄  Interact with a D1 database
+			  wrangler pubsub                       📮 Interact and manage Pub/Sub Brokers
+			  wrangler login                        🔓 Login to Cloudflare
+			  wrangler logout                       🚪 Logout from Cloudflare
+			  wrangler whoami                       🕵️  Retrieve your user info and test your auth config
+			  wrangler types                        📝 Generate types from bindings & module rules in config
+			  wrangler deployments [deployment-id]  🚢 Displays the 10 most recent deployments for a worker
 
 			Flags:
 			  -c, --config   Path to .toml configuration file  [string]

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -32,7 +32,7 @@ import {
 	createFetchResult,
 	msw,
 	mswSuccessDeployments,
-	mswSuccessLastDeployment,
+	mswSuccessDeploymentScriptMetadata,
 } from "./helpers/msw";
 import { FileReaderSync } from "./helpers/msw/read-file-sync";
 import { runInTempDir } from "./helpers/run-in-tmp";
@@ -7284,7 +7284,7 @@ function mockDeploymentsListRequest() {
 }
 
 function mockLastDeploymentRequest() {
-	msw.use(...mswSuccessLastDeployment);
+	msw.use(...mswSuccessDeploymentScriptMetadata);
 }
 
 /** Create a mock handler for the request to upload a worker script. */

--- a/packages/wrangler/src/deployments.ts
+++ b/packages/wrangler/src/deployments.ts
@@ -1,9 +1,15 @@
 import { URLSearchParams } from "url";
 import { fetchResult, fetchScriptContent } from "./cfetch";
+import { readConfig } from "./config";
 import { logger } from "./logger";
 import * as metrics from "./metrics";
+import { requireAuth } from "./user";
+import { getScriptName, printWranglerBanner } from ".";
+
 import type { Config } from "./config";
+import type { ConfigPath } from "./index";
 import type { ServiceMetadataRes } from "./init";
+import type { ArgumentsCamelCase } from "yargs";
 
 export type DeploymentListRes = {
 	latest: {
@@ -129,4 +135,47 @@ function sourceStr(source: string): string {
 		default:
 			return "Other";
 	}
+}
+
+export async function rollbackDeployment(
+	accountId: string,
+	scriptName: string | undefined,
+	{ send_metrics: sendMetrics }: { send_metrics?: Config["send_metrics"] } = {},
+	deploymentId: string
+) {
+	await metrics.sendMetricsEvent(
+		"rollback deployments",
+		{ view: scriptName ? "single" : "all" },
+		{
+			sendMetrics,
+		}
+	);
+	try {
+		const rollbackResponse = await fetchResult<DeploymentListRes["latest"]>(
+			`/account/${accountId}/workers/scripts/${scriptName}?rollback_to=${deploymentId}`,
+			{ method: "PUT" }
+		);
+
+		logger.log(`Successfully rolled back to deployment ID: ${deploymentId}`);
+		logger.log("Rollbacks metadata:", rollbackResponse.metadata);
+	} catch (e) {
+		console.log(e);
+	}
+}
+
+export async function initializeDeployments(
+	yargs: ArgumentsCamelCase,
+	deploymentsWarning: string
+) {
+	await printWranglerBanner();
+	const config = readConfig(yargs.config as ConfigPath, yargs);
+	const accountId = await requireAuth(config);
+	const scriptName = getScriptName(
+		{ name: yargs.name as string, env: undefined },
+		config
+	);
+
+	logger.log(`${deploymentsWarning}\n`);
+
+	return { accountId, scriptName, config };
 }

--- a/packages/wrangler/src/deployments.ts
+++ b/packages/wrangler/src/deployments.ts
@@ -1,5 +1,5 @@
 import { URLSearchParams } from "url";
-import { fetchResult } from "./cfetch";
+import { fetchResult, fetchScriptContent } from "./cfetch";
 import { logger } from "./logger";
 import * as metrics from "./metrics";
 import type { Config } from "./config";
@@ -37,7 +37,8 @@ export type DeploymentListRes = {
 export async function deployments(
 	accountId: string,
 	scriptName: string | undefined,
-	{ send_metrics: sendMetrics }: { send_metrics?: Config["send_metrics"] } = {}
+	{ send_metrics: sendMetrics }: { send_metrics?: Config["send_metrics"] } = {},
+	deploymentId: string
 ) {
 	if (!scriptName) {
 		throw new Error(
@@ -53,11 +54,49 @@ export async function deployments(
 		}
 	);
 
-	const scriptMetadata = await fetchResult<ServiceMetadataRes>(
-		`/accounts/${accountId}/workers/services/${scriptName}`
-	);
+	const scriptTag = (
+		await fetchResult<ServiceMetadataRes>(
+			`/accounts/${accountId}/workers/services/${scriptName}`
+		)
+	).default_environment.script.tag;
 
-	const scriptTag = scriptMetadata.default_environment.script.tag;
+	if (deploymentId) {
+		const scriptContent = await fetchScriptContent(
+			`/accounts/${accountId}/workers/scripts/${scriptName}?deployment=${deploymentId}`
+		);
+		const deploymentDetails = await fetchResult<DeploymentListRes["latest"]>(
+			`/accounts/${accountId}/workers/deployments/by-script/${scriptTag}/detail/${deploymentId}`
+		);
+
+		const flatObj: Record<string, unknown> = {};
+		for (const deployDetailsKey in deploymentDetails) {
+			if (
+				Object.prototype.hasOwnProperty.call(
+					deploymentDetails,
+					deployDetailsKey
+				)
+			) {
+				//@ts-expect-error flattening objects causes the index signature to error
+				const value = deploymentDetails[deployDetailsKey];
+				if (typeof value === "object" && value !== null) {
+					for (const subKey in value) {
+						if (Object.prototype.hasOwnProperty.call(value, subKey)) {
+							flatObj[`${deployDetailsKey}.${subKey}`] = value[subKey];
+						}
+					}
+				} else {
+					flatObj[deployDetailsKey] = value;
+				}
+			}
+		}
+
+		logger.log(flatObj);
+		logger.log(scriptContent);
+
+		// early return to skip the deployments listings
+		return;
+	}
+
 	const params = new URLSearchParams({ order: "asc" });
 	const { items: deploys } = await fetchResult<DeploymentListRes>(
 		`/accounts/${accountId}/workers/deployments/by-script/${scriptTag}`,

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -565,17 +565,26 @@ export function createCLIParser(argv: string[]) {
 	const deploymentsWarning =
 		"🚧`wrangler deployments` is a beta command. Please report any issues to https://github.com/cloudflare/wrangler2/issues/new/choose";
 	wrangler.command(
-		"deployments",
+		"deployments [deployment-id]",
 		"🚢 Displays the 10 most recent deployments for a worker",
-		(yargs) => {
+		(yargs) =>
 			yargs
+				.positional("deployment-id", {
+					describe: "The ID of the deployment you want to inspect",
+					type: "string",
+					demandOption: false,
+				})
 				.option("name", {
 					describe: "The name of your worker",
 					type: "string",
 				})
-				.epilogue(deploymentsWarning);
-		},
-		async (deploymentsYargs: ArgumentsCamelCase<{ name: string }>) => {
+				.epilogue(deploymentsWarning),
+		async (
+			deploymentsYargs: ArgumentsCamelCase<{
+				name: string;
+				deploymentId: string;
+			}>
+		) => {
 			await printWranglerBanner();
 			const config = readConfig(
 				deploymentsYargs.config as ConfigPath,
@@ -588,7 +597,12 @@ export function createCLIParser(argv: string[]) {
 			);
 
 			logger.log(`${deploymentsWarning}\n`);
-			await deployments(accountId, scriptName, config);
+			await deployments(
+				accountId,
+				scriptName,
+				config,
+				deploymentsYargs.deploymentId
+			);
 		}
 	);
 

--- a/packages/wrangler/src/metrics/send-event.ts
+++ b/packages/wrangler/src/metrics/send-event.ts
@@ -57,7 +57,8 @@ export type EventNames =
 	| "run dev (api)"
 	| "run pages dev"
 	| "view docs"
-	| "view deployments";
+	| "view deployments"
+	| "rollback deployments";
 
 /**
  * Send a metrics event, with no extra properties, to Cloudflare, if usage tracking is enabled.


### PR DESCRIPTION
Added a positional in the 'Deployments' command `<deployment-id>`.
`<deployment-id>` will get the details of the deployment, including versioned script, bindings, and usage model information.

What this PR solves / how to test:
1. Pull down PR
2. Run `wrangler deployments <insert-deployment-id> 
3. output should look something like this:

```ts
{
    Tag: '',
    Number: 0,
    'Metadata.author_id': 'Picard-Gamma-6-0-7-3',
    'Metadata.author_email': 'picard@vinyard.com',
    'Metadata.source': 'wrangler',
    'Metadata.created_on': '2021-01-01T00:00:00.000000Z',
    'Metadata.modified_on': '2021-01-01T00:00:00.000000Z',
    'resources.script': {
      etag: 'mock-e-tag',
      handlers: [ 'fetch' ],
      last_deployed_from: 'wrangler'
    },
    'resources.bindings': []
}

export default {
  async fetch(request) {
     return new Response('Hello World from Deployment 1701-E');
    },
};
```

Associated docs issues/PR:

- [ ] TODO: [insert associated docs issue(s)/PR(s)]
- [x] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Internal Ticket.
