### PR TITLE
fix: do not crash in wrangler dev when passing a request object to fetch

### DIFF
--- a/.changeset/perfect-grapes-fold.md
+++ b/.changeset/perfect-grapes-fold.md
@@ -1,0 +1,10 @@
+---
+"wrangler": patch
+---
+
+fix: do not crash in wrangler dev when passing a request object to fetch
+
+This reverts and fixes the changes in https://github.com/cloudflare/wrangler2/pull/1769
+which does not support creating requests from requests whose bodies have already been consumed.
+
+Fixes #2562

--- a/fixtures/worker-app/src/index.js
+++ b/fixtures/worker-app/src/index.js
@@ -1,11 +1,16 @@
 import { now } from "./dep";
 export default {
-	fetch(request) {
+	async fetch(request) {
 		console.log(
 			request.method,
 			request.url,
 			new Map([...request.headers]),
 			request.cf
+		);
+
+		await fetch(new URL("https://example.com"));
+		await fetch(
+			new Request("https://example.com", { method: "POST", body: "foo" })
 		);
 
 		return new Response(`${request.url} ${now()}`);

--- a/packages/wrangler/templates/checked-fetch.js
+++ b/packages/wrangler/templates/checked-fetch.js
@@ -1,7 +1,15 @@
 const urls = new Set();
 
 export function checkedFetch(request, init) {
-	const url = new URL(new Request(request, init).url);
+	const url =
+		request instanceof URL
+			? request
+			: new URL(
+					(typeof request === "string"
+						? new Request(request, init)
+						: request
+					).url
+			  );
 	if (url.port && url.port !== "443" && url.protocol === "https:") {
 		if (!urls.has(url.toString())) {
 			urls.add(url.toString());


### PR DESCRIPTION

What this PR solves / how to test:

This reverts and fixes the changes in https://github.com/cloudflare/wrangler2/pull/1769 which does not support creating requests from requests whose bodies have already been consumed.

Fixes #2562

---

To test you can simply run the `fixtures/worker-app` project:

```
npm run build
cd fixtures/worker-app
npx wrangler dev
```

Without the fix, one or both of the new lines in that fixture (added by this PR) will cause an error.

Associated docs issues/PR:

- N/A

Author has included the following, where applicable:

- [x] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes # [insert issue number].
