### PR TITLE
fix: make sure d1Databases are shimmed in _worker.js files on pages publish

### DIFF
--- a/.changeset/lovely-parents-ring.md
+++ b/.changeset/lovely-parents-ring.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Add support for D1 databases when bundling an `_worker.js` on `wrangler pages publish`

--- a/packages/wrangler/src/__tests__/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages.test.ts
@@ -1470,6 +1470,8 @@ describe("pages", () => {
 			expect(std.err).toMatchInlineSnapshot('""');
 		});
 
+		const workerHasD1Shim = (contents: string) => contents.includes("D1_ERROR");
+
 		it("should upload an Advanced Mode project", async () => {
 			// set up the directory of static files to upload.
 			mkdirSync("public");
@@ -1558,8 +1560,7 @@ describe("pages", () => {
 							                          }
 						                      `);
 
-						// Asserts that the D1 shim has been applied
-						expect(customWorkerJS).toContain("D1_ERROR");
+						expect(workerHasD1Shim(customWorkerJS as string)).toBeTruthy();
 						expect(customWorkerJS).toContain(
 							`console.log("SOMETHING FROM WITHIN THE WORKER");`
 						);

--- a/packages/wrangler/src/api/pages/publish.tsx
+++ b/packages/wrangler/src/api/pages/publish.tsx
@@ -141,6 +141,11 @@ export async function publish({
 	// Routing configuration displayed in the Functions tab of a deployment in Dash
 	let filepathRoutingConfig: string | undefined;
 
+	const d1Databases = Object.keys(
+		project.deployment_configs[isProduction ? "production" : "preview"]
+			.d1_databases ?? {}
+	);
+
 	if (!_workerJS && existsSync(functionsDirectory)) {
 		const outfile = join(tmpdir(), `./functionsWorker-${Math.random()}.js`);
 		const outputConfigPath = join(
@@ -157,10 +162,7 @@ export async function publish({
 				buildOutputDirectory: dirname(outfile),
 				routesOutputPath,
 				local: false,
-				d1Databases: Object.keys(
-					project.deployment_configs[isProduction ? "production" : "preview"]
-						.d1_databases ?? {}
-				),
+				d1Databases,
 			});
 
 			builtFunctions = readFileSync(outfile, "utf-8");
@@ -242,6 +244,7 @@ export async function publish({
 				sourcemap: true,
 				watch: false,
 				onEnd: () => {},
+				betaD1Shims: d1Databases,
 			});
 			workerFileContents = readFileSync(outfile, "utf8");
 		} else {

--- a/packages/wrangler/src/pages/types.ts
+++ b/packages/wrangler/src/pages/types.ts
@@ -10,6 +10,11 @@ export type Project = {
 	};
 	created_on: string;
 	production_branch: string;
+	deployment_configs?: {
+		production?: {
+			d1_databases?: Record<string, { id: string }>;
+		};
+	};
 };
 export type Deployment = {
 	id: string;


### PR DESCRIPTION
What this PR solves / how to test:

Associated docs issues/PR:

- [insert associated docs issue(s)/PR(s)]

Author has included the following, where applicable:

- [x] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested
