### PR TITLE
fix: cleans up `d1 list` output for json

### DIFF
--- a/.changeset/rare-laws-sing.md
+++ b/.changeset/rare-laws-sing.md
@@ -2,7 +2,7 @@
 "wrangler": patch
 ---
 
-fix: cleans up `d1 list` output for json
+fix: implement `d1 list --json` with clean output for piping into other commands
 
 Before:
 

--- a/.changeset/rare-laws-sing.md
+++ b/.changeset/rare-laws-sing.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: cleans up `d1 list` output for json

--- a/.changeset/rare-laws-sing.md
+++ b/.changeset/rare-laws-sing.md
@@ -3,3 +3,45 @@
 ---
 
 fix: cleans up `d1 list` output for json
+
+Before:
+
+```bash
+rozenmd@cflaptop test % npx wrangler d1 list
+--------------------
+🚧 D1 is currently in open alpha and is not recommended for production data and traffic
+🚧 Please report any bugs to https://github.com/cloudflare/wrangler2/issues/new/choose
+🚧 To request features, visit https://community.cloudflare.com/c/developers/d1
+🚧 To give feedback, visit https://discord.gg/cloudflaredev
+--------------------
+
+┌──────────────────────────────┬─────────────────┐
+│ uuid                         │ name            │
+├──────────────────────────────┼─────────────────┤
+│ xxxxxx-xxxx-xxxx-xxxx-xxxxxx │ test            │
+├──────────────────────────────┼─────────────────┤
+│ xxxxxx-xxxx-xxxx-xxxx-xxxxxx │ test2           │
+├──────────────────────────────┼─────────────────┤
+│ xxxxxx-xxxx-xxxx-xxxx-xxxxxx │ test3           │
+└──────────────────────────────┴─────────────────┘
+```
+
+After:
+
+```bash
+rozenmd@cflaptop test % npx wrangler d1 list --json
+[
+  {
+    "uuid": "xxxxxx-xxxx-xxxx-xxxx-xxxxxx",
+    "name": "test"
+  },
+  {
+    "uuid": "xxxxxx-xxxx-xxxx-xxxx-xxxxxx",
+    "name": "test2"
+  },
+  {
+    "uuid": "xxxxxx-xxxx-xxxx-xxxx-xxxxxx",
+    "name": "test3"
+  },
+]
+```

--- a/packages/wrangler/src/__tests__/d1/d1.test.ts
+++ b/packages/wrangler/src/__tests__/d1/d1.test.ts
@@ -1,9 +1,6 @@
-import { cwd } from "process";
 import { mockConsoleMethods } from "../helpers/mock-console";
-import { useMockIsTTY } from "../helpers/mock-istty";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
-import writeWranglerToml from "../helpers/write-wrangler-toml";
 
 function endEventLoop() {
 	return new Promise((resolve) => setImmediate(resolve));
@@ -12,7 +9,6 @@ function endEventLoop() {
 describe("d1", () => {
 	const std = mockConsoleMethods();
 	runInTempDir();
-	const { setIsTTY } = useMockIsTTY();
 
 	it("should show help when no argument is passed", async () => {
 		await runWrangler("d1");
@@ -85,45 +81,5 @@ describe("d1", () => {
 		🚧 To give feedback, visit https://discord.gg/cloudflaredev
 		--------------------"
 	`);
-	});
-
-	describe("migrate", () => {
-		describe("apply", () => {
-			it("should not attempt to login in local mode", async () => {
-				setIsTTY(false);
-				writeWranglerToml({
-					d1_databases: [
-						{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
-					],
-				});
-				// If we get to the point where we are checking for migrations then we have not been asked to log in.
-				await expect(
-					runWrangler("d1 migrations apply --local DATABASE")
-				).rejects.toThrowError(
-					`No migrations present at ${cwd().replaceAll("\\", "/")}/migrations.`
-				);
-			});
-
-			it("should try to read D1 config from wrangler.toml", async () => {
-				setIsTTY(false);
-				writeWranglerToml();
-				await expect(
-					runWrangler("d1 migrations apply DATABASE")
-				).rejects.toThrowError(
-					"Can't find a DB with name/binding 'DATABASE' in local config. Check info in wrangler.toml..."
-				);
-			});
-
-			it("should not try to read wrangler.toml in local mode", async () => {
-				setIsTTY(false);
-				writeWranglerToml();
-				// If we get to the point where we are checking for migrations then we have not checked wrangler.toml.
-				await expect(
-					runWrangler("d1 migrations apply --local DATABASE")
-				).rejects.toThrowError(
-					`No migrations present at ${cwd().replaceAll("\\", "/")}/migrations.`
-				);
-			});
-		});
 	});
 });

--- a/packages/wrangler/src/__tests__/d1/migrate.test.ts
+++ b/packages/wrangler/src/__tests__/d1/migrate.test.ts
@@ -1,0 +1,48 @@
+import { cwd } from "process";
+import { useMockIsTTY } from "../helpers/mock-istty";
+import { runInTempDir } from "../helpers/run-in-tmp";
+import { runWrangler } from "../helpers/run-wrangler";
+import writeWranglerToml from "../helpers/write-wrangler-toml";
+
+describe("migrate", () => {
+	runInTempDir();
+	const { setIsTTY } = useMockIsTTY();
+
+	describe("apply", () => {
+		it("should not attempt to login in local mode", async () => {
+			setIsTTY(false);
+			writeWranglerToml({
+				d1_databases: [
+					{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
+				],
+			});
+			// If we get to the point where we are checking for migrations then we have not been asked to log in.
+			await expect(
+				runWrangler("d1 migrations apply --local DATABASE")
+			).rejects.toThrowError(
+				`No migrations present at ${cwd().replaceAll("\\", "/")}/migrations.`
+			);
+		});
+
+		it("should try to read D1 config from wrangler.toml", async () => {
+			setIsTTY(false);
+			writeWranglerToml();
+			await expect(
+				runWrangler("d1 migrations apply DATABASE")
+			).rejects.toThrowError(
+				"Can't find a DB with name/binding 'DATABASE' in local config. Check info in wrangler.toml..."
+			);
+		});
+
+		it("should not try to read wrangler.toml in local mode", async () => {
+			setIsTTY(false);
+			writeWranglerToml();
+			// If we get to the point where we are checking for migrations then we have not checked wrangler.toml.
+			await expect(
+				runWrangler("d1 migrations apply --local DATABASE")
+			).rejects.toThrowError(
+				`No migrations present at ${cwd().replaceAll("\\", "/")}/migrations.`
+			);
+		});
+	});
+});

--- a/packages/wrangler/src/d1/list.tsx
+++ b/packages/wrangler/src/d1/list.tsx
@@ -12,18 +12,26 @@ import type {
 import type { Database } from "./types";
 
 export function Options(d1ListYargs: CommonYargsArgv) {
-	return d1ListYargs.epilogue(d1BetaWarning);
+	return d1ListYargs
+		.option("json", {
+			describe: "return output as clean JSON",
+			type: "boolean",
+		})
+		.epilogue(d1BetaWarning);
 }
 
-export async function Handler(
-	_: StrictYargsOptionsToInterface<typeof Options>
-): Promise<void> {
+export async function Handler({
+	json,
+}: StrictYargsOptionsToInterface<typeof Options>): Promise<void> {
 	const accountId = await requireAuth({});
-	logger.log(d1BetaWarning);
-
 	const dbs: Array<Database> = await listDatabases(accountId);
 
-	render(<Table data={dbs}></Table>);
+	if (json) {
+		logger.log(JSON.stringify(dbs, null, 2));
+	} else {
+		logger.log(d1BetaWarning);
+		render(<Table data={dbs}></Table>);
+	}
 }
 
 export const listDatabases = async (

--- a/packages/wrangler/src/d1/list.tsx
+++ b/packages/wrangler/src/d1/list.tsx
@@ -16,6 +16,7 @@ export function Options(d1ListYargs: CommonYargsArgv) {
 		.option("json", {
 			describe: "return output as clean JSON",
 			type: "boolean",
+			default: false,
 		})
 		.epilogue(d1BetaWarning);
 }


### PR DESCRIPTION
This PR hides the warning messages, and just returns clean json when running `wrangler d1 list --json`

Before:
```bash
rozenmd@cflaptop test % npx wrangler d1 list
--------------------
🚧 D1 is currently in open alpha and is not recommended for production data and traffic
🚧 Please report any bugs to https://github.com/cloudflare/wrangler2/issues/new/choose
🚧 To request features, visit https://community.cloudflare.com/c/developers/d1
🚧 To give feedback, visit https://discord.gg/cloudflaredev
--------------------

┌──────────────────────────────┬─────────────────┐
│ uuid                         │ name            │
├──────────────────────────────┼─────────────────┤
│ xxxxxx-xxxx-xxxx-xxxx-xxxxxx │ test            │
├──────────────────────────────┼─────────────────┤
│ xxxxxx-xxxx-xxxx-xxxx-xxxxxx │ test2           │
├──────────────────────────────┼─────────────────┤
│ xxxxxx-xxxx-xxxx-xxxx-xxxxxx │ test3           │
└──────────────────────────────┴─────────────────┘
```


After:
```bash
rozenmd@cflaptop test % npx wrangler d1 list --json
[
  {
    "uuid": "xxxxxx-xxxx-xxxx-xxxx-xxxxxx",
    "name": "test"
  },
  {
    "uuid": "xxxxxx-xxxx-xxxx-xxxx-xxxxxx",
    "name": "test2"
  },
  {
    "uuid": "xxxxxx-xxxx-xxxx-xxxx-xxxxxx",
    "name": "test3"
  },
]
```

Closes https://github.com/cloudflare/wrangler2/issues/2323