### PR TITLE
fix: create d1 dir on wrangler d1 execute command with --yes/-y option

### DIFF
--- a/.changeset/khaki-suns-boil.md
+++ b/.changeset/khaki-suns-boil.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix d1 directory not being created when running the `wrangler d1 execute` command with the `--yes`/`-y` flag

--- a/packages/wrangler/src/d1/execute.tsx
+++ b/packages/wrangler/src/d1/execute.tsx
@@ -200,10 +200,10 @@ async function executeLocally(
 			logger.log
 		);
 
-	if (!existsSync(dbDir) && shouldPrompt) {
-		const ok = await confirm(
-			`About to create ${readableRelative(dbPath)}, ok?`
-		);
+	if (!existsSync(dbDir)) {
+		const ok =
+			!shouldPrompt ||
+			(await confirm(`About to create ${readableRelative(dbPath)}, ok?`));
 		if (!ok) return null;
 		await mkdir(dbDir, { recursive: true });
 	}


### PR DESCRIPTION
What this PR solves / how to test:

Associated docs issues/PR:

- [insert associated docs issue(s)/PR(s)]

Author has included the following, where applicable:

- [ ] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [x] Checked for inclusion of relevant tests
- [x] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes # [insert issue number].
