### PR TITLE
Prioritise `workerd` condition when bundling

### DIFF
--- a/.changeset/chilly-donuts-fetch.md
+++ b/.changeset/chilly-donuts-fetch.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Prefer the `workerd` `exports` condition when bundling as per https://runtime-keys.proposal.wintercg.org/#workerd

--- a/.changeset/chilly-donuts-fetch.md
+++ b/.changeset/chilly-donuts-fetch.md
@@ -2,4 +2,9 @@
 "wrangler": minor
 ---
 
-Prefer the `workerd` `exports` condition when bundling as per https://runtime-keys.proposal.wintercg.org/#workerd
+Prefer the `workerd` `exports` condition when bundling.
+
+This can be used to build isomorphic libraries that have different implementations depending on the JavaScript runtime they're running in.
+When bundling, Wrangler will first try to load the [`workerd` key](https://runtime-keys.proposal.wintercg.org/#workerd), then `worker`, then `browser`.
+`workerd` is the [standard key](https://runtime-keys.proposal.wintercg.org/#workerd) for the Cloudflare Workers runtime.
+Learn more about the [conditional `exports` field here](https://nodejs.org/api/packages.html#conditional-exports).

--- a/.changeset/chilly-donuts-fetch.md
+++ b/.changeset/chilly-donuts-fetch.md
@@ -5,6 +5,6 @@
 Prefer the `workerd` `exports` condition when bundling.
 
 This can be used to build isomorphic libraries that have different implementations depending on the JavaScript runtime they're running in.
-When bundling, Wrangler will first try to load the [`workerd` key](https://runtime-keys.proposal.wintercg.org/#workerd), then `worker`, then `browser`.
-`workerd` is the [standard key](https://runtime-keys.proposal.wintercg.org/#workerd) for the Cloudflare Workers runtime.
+When bundling, Wrangler will try to load the [`workerd` key](https://runtime-keys.proposal.wintercg.org/#workerd).
+This is the [standard key](https://runtime-keys.proposal.wintercg.org/#workerd) for the Cloudflare Workers runtime.
 Learn more about the [conditional `exports` field here](https://nodejs.org/api/packages.html#conditional-exports).

--- a/fixtures/isomorphic-random-example/README.md
+++ b/fixtures/isomorphic-random-example/README.md
@@ -1,0 +1,7 @@
+# Isomorphic Package Example
+
+This package implements an isomorphic library that generates cryptographically-strong pseudorandom numbers.
+What this package does isn't really important here, the key part is the [`package.json`](./package.json)'s `exports` field.
+Conditional exports provide a way to load a different file depending on where the module is being imported from.
+By default, Wrangler will first try to look for a [**`workerd`** key](https://runtime-keys.proposal.wintercg.org/#workerd), then `worker`, then `browser`.
+This allows you as a library developer to implement different behaviour for different JavaScript runtimes.

--- a/fixtures/isomorphic-random-example/README.md
+++ b/fixtures/isomorphic-random-example/README.md
@@ -3,5 +3,5 @@
 This package implements an isomorphic library that generates cryptographically-strong pseudorandom numbers.
 What this package does isn't really important here, the key part is the [`package.json`](./package.json)'s `exports` field.
 Conditional exports provide a way to load a different file depending on where the module is being imported from.
-By default, Wrangler will first try to look for a [**`workerd`** key](https://runtime-keys.proposal.wintercg.org/#workerd), then `worker`, then `browser`.
+By default, Wrangler will try to look for a [**`workerd`** key](https://runtime-keys.proposal.wintercg.org/#workerd).
 This allows you as a library developer to implement different behaviour for different JavaScript runtimes.

--- a/fixtures/isomorphic-random-example/package.json
+++ b/fixtures/isomorphic-random-example/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "isomorphic-random-example",
+	"version": "0.0.1",
+	"private": true,
+	"description": "Isomorphic secure-random library, demonstrating `exports` use with Workers",
+	"exports": {
+		"node": "./src/node.js",
+		"workerd": "./src/workerd.mjs"
+	}
+}

--- a/fixtures/isomorphic-random-example/src/node.js
+++ b/fixtures/isomorphic-random-example/src/node.js
@@ -1,0 +1,5 @@
+const crypto = require("node:crypto");
+
+module.exports.randomBytes = function (length) {
+	return new Uint8Array(crypto.randomBytes(length));
+};

--- a/fixtures/isomorphic-random-example/src/workerd.mjs
+++ b/fixtures/isomorphic-random-example/src/workerd.mjs
@@ -1,0 +1,3 @@
+export function randomBytes(length) {
+	return crypto.getRandomValues(new Uint8Array(length));
+}

--- a/fixtures/worker-app/src/index.js
+++ b/fixtures/worker-app/src/index.js
@@ -1,6 +1,18 @@
 import { now } from "./dep";
+import { randomBytes } from "isomorphic-random-example";
+
+/** @param {Uint8Array} array */
+function hexEncode(array) {
+	return Array.from(array)
+		.map((x) => x.toString(16).padStart(2, "0"))
+		.join("");
+}
+
 export default {
 	async fetch(request) {
+		const { pathname } = new URL(request.url);
+		if (pathname === "/random") return new Response(hexEncode(randomBytes(8)));
+
 		console.log(
 			request.method,
 			request.url,

--- a/fixtures/worker-app/tests/index.test.ts
+++ b/fixtures/worker-app/tests/index.test.ts
@@ -20,4 +20,10 @@ describe.concurrent("'wrangler dev' correctly renders pages", () => {
 		const text = await response.text();
 		expect(text).toContain(`http://${ip}:${port}/`);
 	});
+
+	it("uses `workerd` condition when bundling", async ({ expect }) => {
+		const response = await fetch(`http://${ip}:${port}/random`);
+		const text = await response.text();
+		expect(text).toMatch(/[0-9a-f]{16}/); // 8 hex bytes
+	});
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,9 @@
 				"@cloudflare/workers-types": "^4.20221111.1"
 			}
 		},
+		"fixtures/isomorphic-random-example": {
+			"version": "0.0.1"
+		},
 		"fixtures/legacy-site-app": {
 			"version": "0.0.0",
 			"license": "ISC"
@@ -14827,6 +14830,10 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/isomorphic-random-example": {
+			"resolved": "fixtures/isomorphic-random-example",
+			"link": true
 		},
 		"node_modules/istanbul-lib-coverage": {
 			"version": "3.2.0",
@@ -39661,6 +39668,9 @@
 		},
 		"isobject": {
 			"version": "3.0.1"
+		},
+		"isomorphic-random-example": {
+			"version": "file:fixtures/isomorphic-random-example"
 		},
 		"istanbul-lib-coverage": {
 			"version": "3.2.0"

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -340,7 +340,7 @@ export async function bundleWorker(
 		sourceRoot: destination,
 		minify,
 		metafile: true,
-		conditions: ["worker", "browser"],
+		conditions: ["workerd", "worker", "browser"],
 		...(process.env.NODE_ENV && {
 			define: {
 				// use process.env["NODE_ENV" + ""] so that esbuild doesn't replace it


### PR DESCRIPTION
#### What this PR solves / how to test:

This PR adds support for the `workerd` condition when bundling Worker code. This can be used to implement isomorphic libraries that work with different JavaScript runtimes. `workerd` is the standard key for the Cloudflare Workers runtime: https://runtime-keys.proposal.wintercg.org/#workerd.

To test this PR, run `npx wrangler dev` in the `fixtures/worker-app` directory, and visit http://127.0.0.1:8787/random in your browser. Note that random data appears. We haven't enabled Node.js compatibility so we must be using the `workerd` version of the `isomorphic-random-example` package.

#### Associated docs issues/PR:

- https://github.com/cloudflare/cloudflare-docs/pull/7424

#### Author has included the following, where applicable:

- [x] Tests
- [x] Changeset

#### Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested