### PR TITLE
fix wrangler publish --dry-run to not require authentication with queues

### DIFF
--- a/.changeset/serious-cats-brake.md
+++ b/.changeset/serious-cats-brake.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix `wrangler publish --dry-run` to not require authentication when using Queues

--- a/packages/wrangler/src/publish/publish.ts
+++ b/packages/wrangler/src/publish/publish.ts
@@ -609,9 +609,9 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 
 		printBindings({ ...withoutStaticAssets, vars: maskedVars });
 
-		await ensureQueuesExist(config);
-
 		if (!props.dryRun) {
+			await ensureQueuesExist(config);
+
 			// Upload the script so it has time to propagate.
 			// We can also now tell whether available_on_subdomain is set
 			try {


### PR DESCRIPTION
When wrangler configuration has queues, wrangler publish dry-run requires the user to be logged in.

This is not the expected behavior.

This originates from wrangler publish ensuring that configured queues actually exists on the user account.
This should not be a concern for dry-run. This commit fixes this.

What this PR solves / how to test:

Associated docs issues/PR:

- #2630 

Author has included the following, where applicable:

~~- [ ] Tests~~
- [x] Changeset

Reviewer has performed the following, where applicable:

~~- [ ] Checked for inclusion of relevant tests~~
- [ ] Checked for inclusion of a relevant changeset
~~- [ ] Checked for creation of associated docs updates~~
- [ ] Manually pulled down the changes and spot-tested

Fixes #2630 .
