### PR TITLE
Add package lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,10 @@
 				"node": ">=16.13"
 			}
 		},
+		"fixtures/d1-worker-app": {
+			"version": "1.0.0",
+			"license": "ISC"
+		},
 		"fixtures/external-durable-objects-app": {
 			"devDependencies": {
 				"@cloudflare/workers-types": "^4.20221111.1"
@@ -9432,6 +9436,10 @@
 			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
 			"integrity": "sha512-NJGVKPS81XejHcLhaLJS7plab0fK3slPh11mESeeDq2W4ZI5kUKK/LRRdVDvjJseojbPB7ZwjnyOybg3Igea/A==",
 			"dev": true
+		},
+		"node_modules/d1-worker-app": {
+			"resolved": "fixtures/d1-worker-app",
+			"link": true
 		},
 		"node_modules/damerau-levenshtein": {
 			"version": "1.0.8",
@@ -36185,6 +36193,9 @@
 			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
 			"integrity": "sha512-NJGVKPS81XejHcLhaLJS7plab0fK3slPh11mESeeDq2W4ZI5kUKK/LRRdVDvjJseojbPB7ZwjnyOybg3Igea/A==",
 			"dev": true
+		},
+		"d1-worker-app": {
+			"version": "file:fixtures/d1-worker-app"
 		},
 		"damerau-levenshtein": {
 			"version": "1.0.8",


### PR DESCRIPTION
What this PR solves / how to test:
`d1-worker-app` wasn't in the `package-lock.json` file, and so `npm ci` will fail

Associated docs issues/PR:

- [insert associated docs issue(s)/PR(s)]

Author has included the following, where applicable:

- [ ] Tests
- [ ] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes # [insert issue number].
