### PR TITLE
Allow setting build_options

### DIFF
--- a/.changeset/cold-wolves-drop.md
+++ b/.changeset/cold-wolves-drop.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Add build_options configuration to wrangler.toml

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -45,6 +45,10 @@ describe("normalizeAndValidateConfig()", () => {
 				bindings: [],
 				schema: undefined,
 			},
+			build_options: {
+				custom_pipeline: undefined,
+				stable_id: undefined,
+			},
 			send_metrics: undefined,
 			main: undefined,
 			migrations: [],

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -248,6 +248,14 @@ interface EnvironmentInheritable {
 		}[];
 	};
 
+	build_options: {
+		custom_pipeline?: {
+			mutable: boolean;
+			stages: string;
+		};
+		stable_id?: string;
+	};
+
 	/**
 	 * Send Trace Events from this worker to Workers Logpush.
 	 *

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -101,6 +101,7 @@ export function printBindings(bindings: CfWorkerInit["bindings"]) {
 		d1_databases,
 		r2_buckets,
 		logfwdr,
+		build_options,
 		services,
 		analytics_engine_datasets,
 		text_blobs,
@@ -209,6 +210,30 @@ export function printBindings(bindings: CfWorkerInit["bindings"]) {
 					value: binding.destination,
 				};
 			}),
+		});
+	}
+
+	if (
+		build_options !== undefined &&
+		build_options.custom_pipeline !== undefined &&
+		build_options.stable_id !== undefined
+	) {
+		output.push({
+			type: "build_options",
+			entries: [
+				{
+					key: "mutable",
+					value: build_options.custom_pipeline.mutable.toString(),
+				},
+				{
+					key: "stages",
+					value: build_options.custom_pipeline.stages,
+				},
+				{
+					key: "stable_id",
+					value: build_options.stable_id,
+				},
+			],
 		});
 	}
 

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -1145,6 +1145,17 @@ function normalizeAndValidateEnvironment(
 				bindings: [],
 			}
 		),
+		build_options: inheritable(
+			diagnostics,
+			topLevelEnv,
+			rawEnv,
+			"build_options",
+			isObjectWith("custom_pipeline", "stable_id"),
+			{
+				custom_pipeline: undefined,
+				stable_id: undefined,
+			}
+		),
 		unsafe: notInheritable(
 			diagnostics,
 			topLevelEnv,
@@ -1558,6 +1569,36 @@ const validateCflogfwdrBinding: ValidatorFn = (diagnostics, field, value) => {
 	return isValid;
 };
 
+const validateCfBuildOptionsBinding: ValidatorFn = (
+	diagnostics,
+	field,
+	value
+) => {
+	if (typeof value != "object" || value == null) {
+		diagnostics.errors.push(
+			`Expected "${field}" to be an object but got ${JSON.stringify(value)}`
+		);
+		return false;
+	}
+	let isValid = true;
+	if (!isRequiredProperty(value, "mutable", "boolean")) {
+		diagnostics.errors.push(`binding should have a boolean "mutable" field.`);
+		isValid = false;
+	}
+
+	if (!isRequiredProperty(value, "stages", "string")) {
+		diagnostics.errors.push(`binding should have a string "stages" field.`);
+		isValid = false;
+	}
+
+	if (!isRequiredProperty(value, "stable_id", "string")) {
+		diagnostics.errors.push(`binding should have a string "stable_id" field.`);
+		isValid = false;
+	}
+
+	return isValid;
+};
+
 /**
  * Check that the given field is a valid "unsafe" binding object.
  *
@@ -1590,6 +1631,7 @@ const validateUnsafeBinding: ValidatorFn = (diagnostics, field, value) => {
 			"r2_bucket",
 			"service",
 			"logfwdr",
+			"build_options",
 		];
 
 		if (safeBindings.includes(value.type)) {

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -883,6 +883,7 @@ function getBindings(
 		analytics_engine_datasets: configParam.analytics_engine_datasets,
 		unsafe: configParam.unsafe?.bindings,
 		logfwdr: configParam.logfwdr,
+		build_options: configParam.build_options,
 		d1_databases: identifyD1BindingsAsBeta([
 			...(configParam.d1_databases ?? []).map((d1Db) => {
 				//in local dev, bindings don't matter

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -934,6 +934,11 @@ async function getWorkerConfig(
 						};
 					}
 					break;
+				case "build_options":
+					{
+						configObj.build_options = binding;
+					}
+					break;
 				case "wasm_module":
 					{
 						configObj.wasm_modules = {

--- a/packages/wrangler/src/publish/publish.ts
+++ b/packages/wrangler/src/publish/publish.ts
@@ -552,6 +552,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			analytics_engine_datasets: config.analytics_engine_datasets,
 			dispatch_namespaces: config.dispatch_namespaces,
 			logfwdr: config.logfwdr,
+			build_options: config.build_options,
 			unsafe: config.unsafe?.bindings,
 		};
 

--- a/packages/wrangler/src/worker.ts
+++ b/packages/wrangler/src/worker.ts
@@ -159,6 +159,16 @@ interface CfLogfwdr {
 	bindings: CfLogfwdrBinding[];
 }
 
+interface CfBuildOptionsCustomPipeline {
+	mutable: boolean;
+	stages: string;
+}
+
+export interface CfBuildOptions {
+	custom_pipeline?: CfBuildOptionsCustomPipeline;
+	stable_id?: string;
+}
+
 interface CfLogfwdrBinding {
 	name: string;
 	destination: string;
@@ -215,6 +225,7 @@ export interface CfWorkerInit {
 		analytics_engine_datasets: CfAnalyticsEngineDataset[] | undefined;
 		dispatch_namespaces: CfDispatchNamespace[] | undefined;
 		logfwdr: CfLogfwdr | undefined;
+		build_options: CfBuildOptions | undefined;
 		unsafe: CfUnsafeBinding[] | undefined;
 	};
 	migrations: CfDurableObjectMigrations | undefined;


### PR DESCRIPTION
What this PR solves / how to test:

Build options are an internal Cloudflare configuration that lets you set a stable id for your worker along with custom pipeline stages.

This would be specified in your wrangler.toml like this:

[build_options]
custom_pipeline = { mutable = false, stages = "aGVsbG8gd29ybGQ="}
stable_id = "fake/stable_id"

Where stages is list of pipeline stages in capnp format, compiled, and converted to base64.

Associated docs issues/PR:

- [insert associated docs issue(s)/PR(s)]

Author has included the following, where applicable:

- [x] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes # [insert issue number].
