### PR TITLE
[D1] Don't require login when running `wrangler d1 migrations list`

### DIFF
--- a/.changeset/quiet-cups-listen.md
+++ b/.changeset/quiet-cups-listen.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: remove the need to login when running `d1 migrations list --local`

--- a/packages/wrangler/src/__tests__/d1/migrate.test.ts
+++ b/packages/wrangler/src/__tests__/d1/migrate.test.ts
@@ -10,6 +10,21 @@ describe("migrate", () => {
 	runInTempDir();
 	const { setIsTTY } = useMockIsTTY();
 
+	describe("create", () => {
+		it("should reject the --local flag for create", async () => {
+			setIsTTY(false);
+			writeWranglerToml({
+				d1_databases: [
+					{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
+				],
+			});
+
+			await expect(
+				runWrangler("d1 migrations create test some-message --local DATABASE")
+			).rejects.toThrowError(`Unknown argument: local`);
+		});
+	});
+
 	describe("apply", () => {
 		it("should not attempt to login in local mode", async () => {
 			setIsTTY(false);

--- a/packages/wrangler/src/d1/migrations/apply.tsx
+++ b/packages/wrangler/src/d1/migrations/apply.tsx
@@ -29,12 +29,14 @@ import type {
 export function ApplyOptions(yargs: CommonYargsArgv) {
 	return DatabaseWithLocal(yargs);
 }
+
 type ApplyHandlerOptions = StrictYargsOptionsToInterface<typeof ApplyOptions>;
+
 export const ApplyHandler = withConfig<ApplyHandlerOptions>(
 	async ({ config, database, local, persistTo }): Promise<void> => {
 		logger.log(d1BetaWarning);
 
-		const databaseInfo = await getDatabaseInfoFromConfig(config, database);
+		const databaseInfo = getDatabaseInfoFromConfig(config, database);
 		if (!databaseInfo && !local) {
 			throw new Error(
 				`Can't find a DB with name/binding '${database}' in local config. Check info in wrangler.toml...`

--- a/packages/wrangler/src/d1/migrations/apply.tsx
+++ b/packages/wrangler/src/d1/migrations/apply.tsx
@@ -51,10 +51,10 @@ export const ApplyHandler = withConfig<ApplyHandlerOptions>(
 			false
 		);
 
-		const migrationTableName =
+		const migrationsTableName =
 			databaseInfo?.migrationsTableName ?? DEFAULT_MIGRATION_TABLE;
 		await initMigrationsTable(
-			migrationTableName,
+			migrationsTableName,
 			local,
 			config,
 			database,
@@ -63,7 +63,7 @@ export const ApplyHandler = withConfig<ApplyHandlerOptions>(
 
 		const unappliedMigrations = (
 			await getUnappliedMigrations(
-				migrationTableName,
+				migrationsTableName,
 				migrationsPath,
 				local,
 				config,
@@ -124,7 +124,7 @@ Your database may not be available to serve requests during the migration, conti
 				"utf8"
 			);
 			query += `
-								INSERT INTO ${migrationTableName} (name)
+								INSERT INTO ${migrationsTableName} (name)
 								values ('${migration.Name}');
 						`;
 

--- a/packages/wrangler/src/d1/migrations/create.tsx
+++ b/packages/wrangler/src/d1/migrations/create.tsx
@@ -20,13 +20,15 @@ export function CreateOptions(yargs: CommonYargsArgv) {
 		demandOption: true,
 	});
 }
+
 type CreateHandlerOptions = StrictYargsOptionsToInterface<typeof CreateOptions>;
+
 export const CreateHandler = withConfig<CreateHandlerOptions>(
 	async ({ config, database, message }): Promise<void> => {
 		await requireAuth({});
 		logger.log(d1BetaWarning);
 
-		const databaseInfo = await getDatabaseInfoFromConfig(config, database);
+		const databaseInfo = getDatabaseInfoFromConfig(config, database);
 		if (!databaseInfo) {
 			throw new Error(
 				`Can't find a DB with name/binding '${database}' in local config. Check info in wrangler.toml...`

--- a/packages/wrangler/src/d1/migrations/list.tsx
+++ b/packages/wrangler/src/d1/migrations/list.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import { withConfig } from "../../config";
 import { logger } from "../../logger";
 import { requireAuth } from "../../user";
+import { DEFAULT_MIGRATION_PATH, DEFAULT_MIGRATION_TABLE } from "../constants";
 import { d1BetaWarning, getDatabaseInfoFromConfig } from "../utils";
 import {
 	getMigrationsPath,
@@ -30,7 +31,7 @@ export const ListHandler = withConfig<ListHandlerOptions>(
 		logger.log(d1BetaWarning);
 
 		const databaseInfo = await getDatabaseInfoFromConfig(config, database);
-		if (!databaseInfo) {
+		if (!databaseInfo && !local) {
 			throw new Error(
 				`Can't find a DB with name/binding '${database}' in local config. Check info in wrangler.toml...`
 			);
@@ -39,13 +40,16 @@ export const ListHandler = withConfig<ListHandlerOptions>(
 		if (!config.configPath) {
 			return;
 		}
-		const { migrationsTableName, migrationsFolderPath } = databaseInfo;
 
 		const migrationsPath = await getMigrationsPath(
 			path.dirname(config.configPath),
-			migrationsFolderPath,
+			databaseInfo?.migrationsFolderPath ?? DEFAULT_MIGRATION_PATH,
 			false
 		);
+
+		const migrationsTableName =
+			databaseInfo?.migrationsTableName ?? DEFAULT_MIGRATION_TABLE;
+
 		await initMigrationsTable(
 			migrationsTableName,
 			local,

--- a/packages/wrangler/src/d1/migrations/list.tsx
+++ b/packages/wrangler/src/d1/migrations/list.tsx
@@ -23,6 +23,7 @@ export function ListOptions(yargs: CommonYargsArgv) {
 }
 
 type ListHandlerOptions = StrictYargsOptionsToInterface<typeof ListOptions>;
+
 export const ListHandler = withConfig<ListHandlerOptions>(
 	async ({ config, database, local, persistTo }): Promise<void> => {
 		if (!local) {
@@ -30,7 +31,7 @@ export const ListHandler = withConfig<ListHandlerOptions>(
 		}
 		logger.log(d1BetaWarning);
 
-		const databaseInfo = await getDatabaseInfoFromConfig(config, database);
+		const databaseInfo = getDatabaseInfoFromConfig(config, database);
 		if (!databaseInfo && !local) {
 			throw new Error(
 				`Can't find a DB with name/binding '${database}' in local config. Check info in wrangler.toml...`

--- a/packages/wrangler/src/d1/migrations/list.tsx
+++ b/packages/wrangler/src/d1/migrations/list.tsx
@@ -20,10 +20,13 @@ import type {
 export function ListOptions(yargs: CommonYargsArgv) {
 	return DatabaseWithLocal(yargs);
 }
+
 type ListHandlerOptions = StrictYargsOptionsToInterface<typeof ListOptions>;
 export const ListHandler = withConfig<ListHandlerOptions>(
 	async ({ config, database, local, persistTo }): Promise<void> => {
-		await requireAuth({});
+		if (!local) {
+			await requireAuth({});
+		}
 		logger.log(d1BetaWarning);
 
 		const databaseInfo = await getDatabaseInfoFromConfig(config, database);


### PR DESCRIPTION
What this PR solves / how to test:

A patch was applied to `wrangler d1 migrations apply` back in December to not require login - this PR adds a similar patch to `wrangler d1 migrations list`

Author has included the following, where applicable:

- [x] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Closes https://github.com/cloudflare/wrangler2/issues/2515
