### PR TITLE
chore: bump esbuild to 0.16.3

### DIFF
--- a/.changeset/silver-peas-push.md
+++ b/.changeset/silver-peas-push.md
@@ -3,4 +3,4 @@
 "wranglerjs-compat-webpack-plugin": patch
 ---
 
-fix: bump esbuild to 0.15.0
+fix: bump esbuild to 0.15.18

--- a/.changeset/silver-peas-push.md
+++ b/.changeset/silver-peas-push.md
@@ -3,4 +3,4 @@
 "wranglerjs-compat-webpack-plugin": patch
 ---
 
-fix: bump esbuild to 0.16.17 (fixes a bug in esbuild's 0.15.13 release that would cause it to hang, is the latest release before a major breaking change that requires us to refactor)
+fix: bump esbuild to 0.16.3 (fixes a bug in esbuild's 0.15.13 release that would cause it to hang, is the latest release before a major breaking change that requires us to refactor)

--- a/.changeset/silver-peas-push.md
+++ b/.changeset/silver-peas-push.md
@@ -3,4 +3,4 @@
 "wranglerjs-compat-webpack-plugin": patch
 ---
 
-fix: bump esbuild to 0.15.18
+fix: bump esbuild to 0.16.13 (fixes a bug in one of the 0.15.x releases)

--- a/.changeset/silver-peas-push.md
+++ b/.changeset/silver-peas-push.md
@@ -3,4 +3,4 @@
 "wranglerjs-compat-webpack-plugin": patch
 ---
 
-fix: bump esbuild to 0.16.13 (fixes a bug in one of the 0.15.x releases)
+fix: bump esbuild to 0.16.17 (fixes a bug in esbuild's 0.15.13 release that would cause it to hang, is the latest release before a major breaking change that requires us to refactor)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10152,9 +10152,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.0.tgz",
-			"integrity": "sha512-UUDSelGc/EOhzn0zpkdhLA3iB+jq2OS5gnMUMz/BqAKBIsWR2fTHqrddNPt2PNj3OUchqcMcTHSUBr+VpYpcsQ==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.18.tgz",
+			"integrity": "sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==",
 			"hasInstallScript": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
@@ -10163,27 +10163,28 @@
 				"node": ">=12"
 			},
 			"optionalDependencies": {
-				"@esbuild/linux-loong64": "0.15.0",
-				"esbuild-android-64": "0.15.0",
-				"esbuild-android-arm64": "0.15.0",
-				"esbuild-darwin-64": "0.15.0",
-				"esbuild-darwin-arm64": "0.15.0",
-				"esbuild-freebsd-64": "0.15.0",
-				"esbuild-freebsd-arm64": "0.15.0",
-				"esbuild-linux-32": "0.15.0",
-				"esbuild-linux-64": "0.15.0",
-				"esbuild-linux-arm": "0.15.0",
-				"esbuild-linux-arm64": "0.15.0",
-				"esbuild-linux-mips64le": "0.15.0",
-				"esbuild-linux-ppc64le": "0.15.0",
-				"esbuild-linux-riscv64": "0.15.0",
-				"esbuild-linux-s390x": "0.15.0",
-				"esbuild-netbsd-64": "0.15.0",
-				"esbuild-openbsd-64": "0.15.0",
-				"esbuild-sunos-64": "0.15.0",
-				"esbuild-windows-32": "0.15.0",
-				"esbuild-windows-64": "0.15.0",
-				"esbuild-windows-arm64": "0.15.0"
+				"@esbuild/android-arm": "0.15.18",
+				"@esbuild/linux-loong64": "0.15.18",
+				"esbuild-android-64": "0.15.18",
+				"esbuild-android-arm64": "0.15.18",
+				"esbuild-darwin-64": "0.15.18",
+				"esbuild-darwin-arm64": "0.15.18",
+				"esbuild-freebsd-64": "0.15.18",
+				"esbuild-freebsd-arm64": "0.15.18",
+				"esbuild-linux-32": "0.15.18",
+				"esbuild-linux-64": "0.15.18",
+				"esbuild-linux-arm": "0.15.18",
+				"esbuild-linux-arm64": "0.15.18",
+				"esbuild-linux-mips64le": "0.15.18",
+				"esbuild-linux-ppc64le": "0.15.18",
+				"esbuild-linux-riscv64": "0.15.18",
+				"esbuild-linux-s390x": "0.15.18",
+				"esbuild-netbsd-64": "0.15.18",
+				"esbuild-openbsd-64": "0.15.18",
+				"esbuild-sunos-64": "0.15.18",
+				"esbuild-windows-32": "0.15.18",
+				"esbuild-windows-64": "0.15.18",
+				"esbuild-windows-arm64": "0.15.18"
 			}
 		},
 		"node_modules/esbuild-android-64": {
@@ -10525,10 +10526,25 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/esbuild/node_modules/@esbuild/android-arm": {
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.18.tgz",
+			"integrity": "sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==",
+			"cpu": [
+				"arm"
+			],
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.0.tgz",
-			"integrity": "sha512-7ChD3qsxRPIPp9bfjspZiM/x8B1UZL7IKwp0YdnC1kKsDCB5Q8/TexedeeEbkI9inlunu8Lll2lP2wnkiXTCLA==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.18.tgz",
+			"integrity": "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==",
 			"cpu": [
 				"loong64"
 			],
@@ -10541,9 +10557,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-android-64": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.0.tgz",
-			"integrity": "sha512-A9wa6quw4nYIhCDH6rudxSTOAIfSOYU3eME8ZkfP21P+WTxz0pFORFDuBjVAcLhkora3bDc23C8UeloKiiQPOg==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.18.tgz",
+			"integrity": "sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==",
 			"cpu": [
 				"x64"
 			],
@@ -10556,9 +10572,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-android-arm64": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.0.tgz",
-			"integrity": "sha512-ujdverhuFUfW99HdF+L9n1wzG950lVL1AJVc1SEbJRaQC22tVq9xXNXkLLq7v4hSZWrdz/MT3hwhnQF0KTMxNg==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.18.tgz",
+			"integrity": "sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -10571,9 +10587,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-darwin-64": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.0.tgz",
-			"integrity": "sha512-aA5SVtXCetQ9ChREG8xDdzv43XGbdz+u4AxQgQZrRu0gXD3yJfawfZgquaej3CxVAlrOgBPbu5z+tA5SVhXAxQ==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.18.tgz",
+			"integrity": "sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==",
 			"cpu": [
 				"x64"
 			],
@@ -10586,9 +10602,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-darwin-arm64": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.0.tgz",
-			"integrity": "sha512-CaxPS5JUQpldeIMVqw0K+vlGfyMphvtIWugPMyXPGTDmUAcWXSha1QRgJ5Fxa9d/cC4DKeC8L8/q7ClzinXxfA==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.18.tgz",
+			"integrity": "sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==",
 			"cpu": [
 				"arm64"
 			],
@@ -10601,9 +10617,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-freebsd-64": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.0.tgz",
-			"integrity": "sha512-O9yvjry2bmX8sxx42JfwW6g/usZ0e3ndfb3+bquu20qkuEfDodqHNzotOjaKSREvxpw+Ub1zNtXvA/FFekSaOA==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.18.tgz",
+			"integrity": "sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==",
 			"cpu": [
 				"x64"
 			],
@@ -10616,9 +10632,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-freebsd-arm64": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.0.tgz",
-			"integrity": "sha512-Zv8bNAG1lYyCtWi+PVndgys6KRBe5hQgD81tK3zdZ6XEitpCPwF8QShYbV8RacG1YBD7aHKSoWKGkT9+5bMGhw==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.18.tgz",
+			"integrity": "sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==",
 			"cpu": [
 				"arm64"
 			],
@@ -10631,9 +10647,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-linux-32": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.0.tgz",
-			"integrity": "sha512-QZqCG55D5Wof1WmBJMuihNroLM9S2oDXGkqB0ZHMA67CQw+3cAwWxOKW36n6VFaKiE4MhvUuW7jI+lr2D7nXQQ==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.18.tgz",
+			"integrity": "sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==",
 			"cpu": [
 				"ia32"
 			],
@@ -10646,9 +10662,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-linux-64": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.0.tgz",
-			"integrity": "sha512-cmB2vAUWf9W8768H0DuOi6VUrQPCinx/oYhRbuR1TZj873vg1GTqc55LAh1cYCC0xEMd9MjO4YfI43OX4ewI1w==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.18.tgz",
+			"integrity": "sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==",
 			"cpu": [
 				"x64"
 			],
@@ -10661,9 +10677,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-linux-arm": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.0.tgz",
-			"integrity": "sha512-UyY0Vqd9ngfeWBeJrrqHiXf4ozqXxzNT8ebdNt1ay5hfu/uXes3eVkt1YHP2dcxG/APPE4XDxvKlx0SoSwHP6Q==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.18.tgz",
+			"integrity": "sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==",
 			"cpu": [
 				"arm"
 			],
@@ -10676,9 +10692,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-linux-arm64": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.0.tgz",
-			"integrity": "sha512-bJc8k64Lss+2V8yx9kh4Q48SYPR/k0kxyep2pmvzaGm+AreeMnXI0J33zF4tU/OW9r3pwa74F3/MxF6x275Yhg==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.18.tgz",
+			"integrity": "sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==",
 			"cpu": [
 				"arm64"
 			],
@@ -10691,9 +10707,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-linux-mips64le": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.0.tgz",
-			"integrity": "sha512-NoOxC4a1XfM4/zGBIujIuxhPVWvS6UgqE/ksyjZ6qgHQD9lWVjcEv3iPEKKIuHXPE1s+YHvJrdXVup96aVvflQ==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.18.tgz",
+			"integrity": "sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==",
 			"cpu": [
 				"mips64el"
 			],
@@ -10706,9 +10722,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-linux-ppc64le": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.0.tgz",
-			"integrity": "sha512-OUkEhJAYPaYPvHZxjgnJhWB0qD8q8l1q8CnGLngmPAxb9WZrFwPYmykWBTSqGXeG08stScpkIQXy4HTSF8rH+w==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.18.tgz",
+			"integrity": "sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==",
 			"cpu": [
 				"ppc64"
 			],
@@ -10721,9 +10737,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-linux-riscv64": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.0.tgz",
-			"integrity": "sha512-DuSujKNrdCN+kvA0+BBS/ULaINuOeI0iU9XzhIRtTCR5cFJWd6aQTHluKEc3C/a/ib2KTVNjM21cUHi4Tj0NZA==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.18.tgz",
+			"integrity": "sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==",
 			"cpu": [
 				"riscv64"
 			],
@@ -10736,9 +10752,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-linux-s390x": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.0.tgz",
-			"integrity": "sha512-ttGGhgXRpJbsD+XXS2NIBThuEh8EvAJEnVQ9vzXviniPuvpuwKLFNBRPqtX3gE5o2bUQnh5ZugmDVuD9GW2ROg==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.18.tgz",
+			"integrity": "sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==",
 			"cpu": [
 				"s390x"
 			],
@@ -10751,9 +10767,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-netbsd-64": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.0.tgz",
-			"integrity": "sha512-rb6sIQ/gZeQNrgplSLJ0zLirLwr3vQCzbL1jb0Ypay83Uup2s+OEI+Vw+oJ2SomrhVyOPwk/R4AY713bJKdLsQ==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.18.tgz",
+			"integrity": "sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==",
 			"cpu": [
 				"x64"
 			],
@@ -10766,9 +10782,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-openbsd-64": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.0.tgz",
-			"integrity": "sha512-CeU7hw291UJQpNg/oJLefmM9Rdeddo2ya9Vw9hdDrUyZAAZckqVRLDh9t4OdqJuXFdlo6BM2qhZCcY22O7wfGg==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.18.tgz",
+			"integrity": "sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==",
 			"cpu": [
 				"x64"
 			],
@@ -10781,9 +10797,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-sunos-64": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.0.tgz",
-			"integrity": "sha512-nE7EcgDw9RT4fR+GJZ5a0spPb2HKT77viCjrGl6GSeb/n3RhxGgVGwPQDI/KRwyVeQMqEOTtHQMNPwNr9TKDDQ==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.18.tgz",
+			"integrity": "sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==",
 			"cpu": [
 				"x64"
 			],
@@ -10796,9 +10812,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-windows-32": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.0.tgz",
-			"integrity": "sha512-FUPwJmPwBoqe8ShhOMfHtSElh1Nyc3s+Kru3m7lDJCjNr3ctx9YJKuzRsz4UXow6Wo79LMQGNyjysQ7UuKgvHQ==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.18.tgz",
+			"integrity": "sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -10811,9 +10827,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-windows-64": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.0.tgz",
-			"integrity": "sha512-zNM5bSVOY0SzMFB6k3ZdMwg4JmLVLpEmgVd2fU2STDmEOXdY1APAFPVWkbWMtLF/nfLfaJLfps7+IIJgGyQbGA==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.18.tgz",
+			"integrity": "sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==",
 			"cpu": [
 				"x64"
 			],
@@ -10826,9 +10842,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/esbuild-windows-arm64": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.0.tgz",
-			"integrity": "sha512-sqhmDwUhUULUnViLD7jAqo4FaOhLN/FMW+dFVSvxSTA9pZSr2w6efky91vTWOcTUmspvYyHyOrJmtktp1ffIaw==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.18.tgz",
+			"integrity": "sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -28378,7 +28394,7 @@
 				"@miniflare/durable-objects": "2.11.0",
 				"blake3-wasm": "^2.1.5",
 				"chokidar": "^3.5.3",
-				"esbuild": "0.15.0",
+				"esbuild": "0.15.18",
 				"miniflare": "2.11.0",
 				"nanoid": "^3.3.3",
 				"path-to-regexp": "^6.2.0",
@@ -28645,7 +28661,7 @@
 				"@types/rimraf": "^3.0.2",
 				"@types/tar": "^6.1.1",
 				"@types/webpack": "^4.41.32",
-				"esbuild": "0.15.0",
+				"esbuild": "0.15.18",
 				"execa": "^6.1.0",
 				"jest": "^27.5.1",
 				"jest-fetch-mock": "^3.0.3",
@@ -36724,157 +36740,164 @@
 			}
 		},
 		"esbuild": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.0.tgz",
-			"integrity": "sha512-UUDSelGc/EOhzn0zpkdhLA3iB+jq2OS5gnMUMz/BqAKBIsWR2fTHqrddNPt2PNj3OUchqcMcTHSUBr+VpYpcsQ==",
+			"version": "0.15.18",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.18.tgz",
+			"integrity": "sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==",
 			"requires": {
-				"@esbuild/linux-loong64": "0.15.0",
-				"esbuild-android-64": "0.15.0",
-				"esbuild-android-arm64": "0.15.0",
-				"esbuild-darwin-64": "0.15.0",
-				"esbuild-darwin-arm64": "0.15.0",
-				"esbuild-freebsd-64": "0.15.0",
-				"esbuild-freebsd-arm64": "0.15.0",
-				"esbuild-linux-32": "0.15.0",
-				"esbuild-linux-64": "0.15.0",
-				"esbuild-linux-arm": "0.15.0",
-				"esbuild-linux-arm64": "0.15.0",
-				"esbuild-linux-mips64le": "0.15.0",
-				"esbuild-linux-ppc64le": "0.15.0",
-				"esbuild-linux-riscv64": "0.15.0",
-				"esbuild-linux-s390x": "0.15.0",
-				"esbuild-netbsd-64": "0.15.0",
-				"esbuild-openbsd-64": "0.15.0",
-				"esbuild-sunos-64": "0.15.0",
-				"esbuild-windows-32": "0.15.0",
-				"esbuild-windows-64": "0.15.0",
-				"esbuild-windows-arm64": "0.15.0"
+				"@esbuild/android-arm": "0.15.18",
+				"@esbuild/linux-loong64": "0.15.18",
+				"esbuild-android-64": "0.15.18",
+				"esbuild-android-arm64": "0.15.18",
+				"esbuild-darwin-64": "0.15.18",
+				"esbuild-darwin-arm64": "0.15.18",
+				"esbuild-freebsd-64": "0.15.18",
+				"esbuild-freebsd-arm64": "0.15.18",
+				"esbuild-linux-32": "0.15.18",
+				"esbuild-linux-64": "0.15.18",
+				"esbuild-linux-arm": "0.15.18",
+				"esbuild-linux-arm64": "0.15.18",
+				"esbuild-linux-mips64le": "0.15.18",
+				"esbuild-linux-ppc64le": "0.15.18",
+				"esbuild-linux-riscv64": "0.15.18",
+				"esbuild-linux-s390x": "0.15.18",
+				"esbuild-netbsd-64": "0.15.18",
+				"esbuild-openbsd-64": "0.15.18",
+				"esbuild-sunos-64": "0.15.18",
+				"esbuild-windows-32": "0.15.18",
+				"esbuild-windows-64": "0.15.18",
+				"esbuild-windows-arm64": "0.15.18"
 			},
 			"dependencies": {
+				"@esbuild/android-arm": {
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.18.tgz",
+					"integrity": "sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==",
+					"optional": true
+				},
 				"@esbuild/linux-loong64": {
-					"version": "0.15.0",
-					"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.0.tgz",
-					"integrity": "sha512-7ChD3qsxRPIPp9bfjspZiM/x8B1UZL7IKwp0YdnC1kKsDCB5Q8/TexedeeEbkI9inlunu8Lll2lP2wnkiXTCLA==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.18.tgz",
+					"integrity": "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==",
 					"optional": true
 				},
 				"esbuild-android-64": {
-					"version": "0.15.0",
-					"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.0.tgz",
-					"integrity": "sha512-A9wa6quw4nYIhCDH6rudxSTOAIfSOYU3eME8ZkfP21P+WTxz0pFORFDuBjVAcLhkora3bDc23C8UeloKiiQPOg==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.18.tgz",
+					"integrity": "sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==",
 					"optional": true
 				},
 				"esbuild-android-arm64": {
-					"version": "0.15.0",
-					"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.0.tgz",
-					"integrity": "sha512-ujdverhuFUfW99HdF+L9n1wzG950lVL1AJVc1SEbJRaQC22tVq9xXNXkLLq7v4hSZWrdz/MT3hwhnQF0KTMxNg==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.18.tgz",
+					"integrity": "sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==",
 					"optional": true
 				},
 				"esbuild-darwin-64": {
-					"version": "0.15.0",
-					"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.0.tgz",
-					"integrity": "sha512-aA5SVtXCetQ9ChREG8xDdzv43XGbdz+u4AxQgQZrRu0gXD3yJfawfZgquaej3CxVAlrOgBPbu5z+tA5SVhXAxQ==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.18.tgz",
+					"integrity": "sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==",
 					"optional": true
 				},
 				"esbuild-darwin-arm64": {
-					"version": "0.15.0",
-					"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.0.tgz",
-					"integrity": "sha512-CaxPS5JUQpldeIMVqw0K+vlGfyMphvtIWugPMyXPGTDmUAcWXSha1QRgJ5Fxa9d/cC4DKeC8L8/q7ClzinXxfA==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.18.tgz",
+					"integrity": "sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==",
 					"optional": true
 				},
 				"esbuild-freebsd-64": {
-					"version": "0.15.0",
-					"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.0.tgz",
-					"integrity": "sha512-O9yvjry2bmX8sxx42JfwW6g/usZ0e3ndfb3+bquu20qkuEfDodqHNzotOjaKSREvxpw+Ub1zNtXvA/FFekSaOA==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.18.tgz",
+					"integrity": "sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==",
 					"optional": true
 				},
 				"esbuild-freebsd-arm64": {
-					"version": "0.15.0",
-					"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.0.tgz",
-					"integrity": "sha512-Zv8bNAG1lYyCtWi+PVndgys6KRBe5hQgD81tK3zdZ6XEitpCPwF8QShYbV8RacG1YBD7aHKSoWKGkT9+5bMGhw==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.18.tgz",
+					"integrity": "sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==",
 					"optional": true
 				},
 				"esbuild-linux-32": {
-					"version": "0.15.0",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.0.tgz",
-					"integrity": "sha512-QZqCG55D5Wof1WmBJMuihNroLM9S2oDXGkqB0ZHMA67CQw+3cAwWxOKW36n6VFaKiE4MhvUuW7jI+lr2D7nXQQ==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.18.tgz",
+					"integrity": "sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==",
 					"optional": true
 				},
 				"esbuild-linux-64": {
-					"version": "0.15.0",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.0.tgz",
-					"integrity": "sha512-cmB2vAUWf9W8768H0DuOi6VUrQPCinx/oYhRbuR1TZj873vg1GTqc55LAh1cYCC0xEMd9MjO4YfI43OX4ewI1w==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.18.tgz",
+					"integrity": "sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==",
 					"optional": true
 				},
 				"esbuild-linux-arm": {
-					"version": "0.15.0",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.0.tgz",
-					"integrity": "sha512-UyY0Vqd9ngfeWBeJrrqHiXf4ozqXxzNT8ebdNt1ay5hfu/uXes3eVkt1YHP2dcxG/APPE4XDxvKlx0SoSwHP6Q==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.18.tgz",
+					"integrity": "sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==",
 					"optional": true
 				},
 				"esbuild-linux-arm64": {
-					"version": "0.15.0",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.0.tgz",
-					"integrity": "sha512-bJc8k64Lss+2V8yx9kh4Q48SYPR/k0kxyep2pmvzaGm+AreeMnXI0J33zF4tU/OW9r3pwa74F3/MxF6x275Yhg==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.18.tgz",
+					"integrity": "sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==",
 					"optional": true
 				},
 				"esbuild-linux-mips64le": {
-					"version": "0.15.0",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.0.tgz",
-					"integrity": "sha512-NoOxC4a1XfM4/zGBIujIuxhPVWvS6UgqE/ksyjZ6qgHQD9lWVjcEv3iPEKKIuHXPE1s+YHvJrdXVup96aVvflQ==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.18.tgz",
+					"integrity": "sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==",
 					"optional": true
 				},
 				"esbuild-linux-ppc64le": {
-					"version": "0.15.0",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.0.tgz",
-					"integrity": "sha512-OUkEhJAYPaYPvHZxjgnJhWB0qD8q8l1q8CnGLngmPAxb9WZrFwPYmykWBTSqGXeG08stScpkIQXy4HTSF8rH+w==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.18.tgz",
+					"integrity": "sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==",
 					"optional": true
 				},
 				"esbuild-linux-riscv64": {
-					"version": "0.15.0",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.0.tgz",
-					"integrity": "sha512-DuSujKNrdCN+kvA0+BBS/ULaINuOeI0iU9XzhIRtTCR5cFJWd6aQTHluKEc3C/a/ib2KTVNjM21cUHi4Tj0NZA==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.18.tgz",
+					"integrity": "sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==",
 					"optional": true
 				},
 				"esbuild-linux-s390x": {
-					"version": "0.15.0",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.0.tgz",
-					"integrity": "sha512-ttGGhgXRpJbsD+XXS2NIBThuEh8EvAJEnVQ9vzXviniPuvpuwKLFNBRPqtX3gE5o2bUQnh5ZugmDVuD9GW2ROg==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.18.tgz",
+					"integrity": "sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==",
 					"optional": true
 				},
 				"esbuild-netbsd-64": {
-					"version": "0.15.0",
-					"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.0.tgz",
-					"integrity": "sha512-rb6sIQ/gZeQNrgplSLJ0zLirLwr3vQCzbL1jb0Ypay83Uup2s+OEI+Vw+oJ2SomrhVyOPwk/R4AY713bJKdLsQ==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.18.tgz",
+					"integrity": "sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==",
 					"optional": true
 				},
 				"esbuild-openbsd-64": {
-					"version": "0.15.0",
-					"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.0.tgz",
-					"integrity": "sha512-CeU7hw291UJQpNg/oJLefmM9Rdeddo2ya9Vw9hdDrUyZAAZckqVRLDh9t4OdqJuXFdlo6BM2qhZCcY22O7wfGg==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.18.tgz",
+					"integrity": "sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==",
 					"optional": true
 				},
 				"esbuild-sunos-64": {
-					"version": "0.15.0",
-					"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.0.tgz",
-					"integrity": "sha512-nE7EcgDw9RT4fR+GJZ5a0spPb2HKT77viCjrGl6GSeb/n3RhxGgVGwPQDI/KRwyVeQMqEOTtHQMNPwNr9TKDDQ==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.18.tgz",
+					"integrity": "sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==",
 					"optional": true
 				},
 				"esbuild-windows-32": {
-					"version": "0.15.0",
-					"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.0.tgz",
-					"integrity": "sha512-FUPwJmPwBoqe8ShhOMfHtSElh1Nyc3s+Kru3m7lDJCjNr3ctx9YJKuzRsz4UXow6Wo79LMQGNyjysQ7UuKgvHQ==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.18.tgz",
+					"integrity": "sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==",
 					"optional": true
 				},
 				"esbuild-windows-64": {
-					"version": "0.15.0",
-					"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.0.tgz",
-					"integrity": "sha512-zNM5bSVOY0SzMFB6k3ZdMwg4JmLVLpEmgVd2fU2STDmEOXdY1APAFPVWkbWMtLF/nfLfaJLfps7+IIJgGyQbGA==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.18.tgz",
+					"integrity": "sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==",
 					"optional": true
 				},
 				"esbuild-windows-arm64": {
-					"version": "0.15.0",
-					"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.0.tgz",
-					"integrity": "sha512-sqhmDwUhUULUnViLD7jAqo4FaOhLN/FMW+dFVSvxSTA9pZSr2w6efky91vTWOcTUmspvYyHyOrJmtktp1ffIaw==",
+					"version": "0.15.18",
+					"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.18.tgz",
+					"integrity": "sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==",
 					"optional": true
 				}
 			}
@@ -49064,7 +49087,7 @@
 				"concurrently": "^7.2.2",
 				"devtools-protocol": "^0.0.955664",
 				"dotenv": "^16.0.0",
-				"esbuild": "0.15.0",
+				"esbuild": "0.15.18",
 				"execa": "^6.1.0",
 				"express": "^4.18.1",
 				"finalhandler": "^1.2.0",
@@ -49211,7 +49234,7 @@
 				"@types/rimraf": "^3.0.2",
 				"@types/tar": "^6.1.1",
 				"@types/webpack": "^4.41.32",
-				"esbuild": "0.15.0",
+				"esbuild": "0.15.18",
 				"execa": "^6.1.0",
 				"jest": "^27.5.1",
 				"jest-fetch-mock": "^3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10152,9 +10152,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.18.tgz",
-			"integrity": "sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==",
+			"version": "0.16.3",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.3.tgz",
+			"integrity": "sha512-71f7EjPWTiSguen8X/kxEpkAS7BFHwtQKisCDDV3Y4GLGWBaoSCyD5uXkaUew6JDzA9FEN1W23mdnSwW9kqCeg==",
 			"hasInstallScript": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
@@ -10163,28 +10163,28 @@
 				"node": ">=12"
 			},
 			"optionalDependencies": {
-				"@esbuild/android-arm": "0.15.18",
-				"@esbuild/linux-loong64": "0.15.18",
-				"esbuild-android-64": "0.15.18",
-				"esbuild-android-arm64": "0.15.18",
-				"esbuild-darwin-64": "0.15.18",
-				"esbuild-darwin-arm64": "0.15.18",
-				"esbuild-freebsd-64": "0.15.18",
-				"esbuild-freebsd-arm64": "0.15.18",
-				"esbuild-linux-32": "0.15.18",
-				"esbuild-linux-64": "0.15.18",
-				"esbuild-linux-arm": "0.15.18",
-				"esbuild-linux-arm64": "0.15.18",
-				"esbuild-linux-mips64le": "0.15.18",
-				"esbuild-linux-ppc64le": "0.15.18",
-				"esbuild-linux-riscv64": "0.15.18",
-				"esbuild-linux-s390x": "0.15.18",
-				"esbuild-netbsd-64": "0.15.18",
-				"esbuild-openbsd-64": "0.15.18",
-				"esbuild-sunos-64": "0.15.18",
-				"esbuild-windows-32": "0.15.18",
-				"esbuild-windows-64": "0.15.18",
-				"esbuild-windows-arm64": "0.15.18"
+				"@esbuild/android-arm": "0.16.3",
+				"@esbuild/android-arm64": "0.16.3",
+				"@esbuild/android-x64": "0.16.3",
+				"@esbuild/darwin-arm64": "0.16.3",
+				"@esbuild/darwin-x64": "0.16.3",
+				"@esbuild/freebsd-arm64": "0.16.3",
+				"@esbuild/freebsd-x64": "0.16.3",
+				"@esbuild/linux-arm": "0.16.3",
+				"@esbuild/linux-arm64": "0.16.3",
+				"@esbuild/linux-ia32": "0.16.3",
+				"@esbuild/linux-loong64": "0.16.3",
+				"@esbuild/linux-mips64el": "0.16.3",
+				"@esbuild/linux-ppc64": "0.16.3",
+				"@esbuild/linux-riscv64": "0.16.3",
+				"@esbuild/linux-s390x": "0.16.3",
+				"@esbuild/linux-x64": "0.16.3",
+				"@esbuild/netbsd-x64": "0.16.3",
+				"@esbuild/openbsd-x64": "0.16.3",
+				"@esbuild/sunos-x64": "0.16.3",
+				"@esbuild/win32-arm64": "0.16.3",
+				"@esbuild/win32-ia32": "0.16.3",
+				"@esbuild/win32-x64": "0.16.3"
 			}
 		},
 		"node_modules/esbuild-android-64": {
@@ -10527,9 +10527,9 @@
 			}
 		},
 		"node_modules/esbuild/node_modules/@esbuild/android-arm": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.18.tgz",
-			"integrity": "sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==",
+			"version": "0.16.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.3.tgz",
+			"integrity": "sha512-mueuEoh+s1eRbSJqq9KNBQwI4QhQV6sRXIfTyLXSHGMpyew61rOK4qY21uKbXl1iBoMb0AdL1deWFCQVlN2qHA==",
 			"cpu": [
 				"arm"
 			],
@@ -10541,10 +10541,145 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/esbuild/node_modules/@esbuild/android-arm64": {
+			"version": "0.16.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.3.tgz",
+			"integrity": "sha512-RolFVeinkeraDvN/OoRf1F/lP0KUfGNb5jxy/vkIMeRRChkrX/HTYN6TYZosRJs3a1+8wqpxAo5PI5hFmxyPRg==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/android-x64": {
+			"version": "0.16.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.3.tgz",
+			"integrity": "sha512-SFpTUcIT1bIJuCCBMCQWq1bL2gPTjWoLZdjmIhjdcQHaUfV41OQfho6Ici5uvvkMmZRXIUGpM3GxysP/EU7ifQ==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/darwin-arm64": {
+			"version": "0.16.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.3.tgz",
+			"integrity": "sha512-DO8WykMyB+N9mIDfI/Hug70Dk1KipavlGAecxS3jDUwAbTpDXj0Lcwzw9svkhxfpCagDmpaTMgxWK8/C/XcXvw==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/darwin-x64": {
+			"version": "0.16.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.3.tgz",
+			"integrity": "sha512-uEqZQ2omc6BvWqdCiyZ5+XmxuHEi1SPzpVxXCSSV2+Sh7sbXbpeNhHIeFrIpRjAs0lI1FmA1iIOxFozKBhKgRQ==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.16.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.3.tgz",
+			"integrity": "sha512-nJansp3sSXakNkOD5i5mIz2Is/HjzIhFs49b1tjrPrpCmwgBmH9SSzhC/Z1UqlkivqMYkhfPwMw1dGFUuwmXhw==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/freebsd-x64": {
+			"version": "0.16.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.3.tgz",
+			"integrity": "sha512-TfoDzLw+QHfc4a8aKtGSQ96Wa+6eimljjkq9HKR0rHlU83vw8aldMOUSJTUDxbcUdcgnJzPaX8/vGWm7vyV7ug==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/linux-arm": {
+			"version": "0.16.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.3.tgz",
+			"integrity": "sha512-VwswmSYwVAAq6LysV59Fyqk3UIjbhuc6wb3vEcJ7HEJUtFuLK9uXWuFoH1lulEbE4+5GjtHi3MHX+w1gNHdOWQ==",
+			"cpu": [
+				"arm"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/linux-arm64": {
+			"version": "0.16.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.3.tgz",
+			"integrity": "sha512-7I3RlsnxEFCHVZNBLb2w7unamgZ5sVwO0/ikE2GaYvYuUQs9Qte/w7TqWcXHtCwxvZx/2+F97ndiUQAWs47ZfQ==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/linux-ia32": {
+			"version": "0.16.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.3.tgz",
+			"integrity": "sha512-X8FDDxM9cqda2rJE+iblQhIMYY49LfvW4kaEjoFbTTQ4Go8G96Smj2w3BRTwA8IHGoi9dPOPGAX63dhuv19UqA==",
+			"cpu": [
+				"ia32"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.18.tgz",
-			"integrity": "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==",
+			"version": "0.16.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.3.tgz",
+			"integrity": "sha512-hIbeejCOyO0X9ujfIIOKjBjNAs9XD/YdJ9JXAy1lHA+8UXuOqbFe4ErMCqMr8dhlMGBuvcQYGF7+kO7waj2KHw==",
 			"cpu": [
 				"loong64"
 			],
@@ -10556,160 +10691,10 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/esbuild/node_modules/esbuild-android-64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.18.tgz",
-			"integrity": "sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-android-arm64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.18.tgz",
-			"integrity": "sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-darwin-64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.18.tgz",
-			"integrity": "sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-darwin-arm64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.18.tgz",
-			"integrity": "sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-freebsd-64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.18.tgz",
-			"integrity": "sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-freebsd-arm64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.18.tgz",
-			"integrity": "sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-linux-32": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.18.tgz",
-			"integrity": "sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==",
-			"cpu": [
-				"ia32"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-linux-64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.18.tgz",
-			"integrity": "sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-linux-arm": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.18.tgz",
-			"integrity": "sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==",
-			"cpu": [
-				"arm"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-linux-arm64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.18.tgz",
-			"integrity": "sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-linux-mips64le": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.18.tgz",
-			"integrity": "sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==",
+		"node_modules/esbuild/node_modules/@esbuild/linux-mips64el": {
+			"version": "0.16.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.3.tgz",
+			"integrity": "sha512-znFRzICT/V8VZQMt6rjb21MtAVJv/3dmKRMlohlShrbVXdBuOdDrGb+C2cZGQAR8RFyRe7HS6klmHq103WpmVw==",
 			"cpu": [
 				"mips64el"
 			],
@@ -10721,10 +10706,10 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/esbuild/node_modules/esbuild-linux-ppc64le": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.18.tgz",
-			"integrity": "sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==",
+		"node_modules/esbuild/node_modules/@esbuild/linux-ppc64": {
+			"version": "0.16.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.3.tgz",
+			"integrity": "sha512-EV7LuEybxhXrVTDpbqWF2yehYRNz5e5p+u3oQUS2+ZFpknyi1NXxr8URk4ykR8Efm7iu04//4sBg249yNOwy5Q==",
 			"cpu": [
 				"ppc64"
 			],
@@ -10736,10 +10721,10 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/esbuild/node_modules/esbuild-linux-riscv64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.18.tgz",
-			"integrity": "sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==",
+		"node_modules/esbuild/node_modules/@esbuild/linux-riscv64": {
+			"version": "0.16.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.3.tgz",
+			"integrity": "sha512-uDxqFOcLzFIJ+r/pkTTSE9lsCEaV/Y6rMlQjUI9BkzASEChYL/aSQjZjchtEmdnVxDKETnUAmsaZ4pqK1eE5BQ==",
 			"cpu": [
 				"riscv64"
 			],
@@ -10751,10 +10736,10 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/esbuild/node_modules/esbuild-linux-s390x": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.18.tgz",
-			"integrity": "sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==",
+		"node_modules/esbuild/node_modules/@esbuild/linux-s390x": {
+			"version": "0.16.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.3.tgz",
+			"integrity": "sha512-NbeREhzSxYwFhnCAQOQZmajsPYtX71Ufej3IQ8W2Gxskfz9DK58ENEju4SbpIj48VenktRASC52N5Fhyf/aliQ==",
 			"cpu": [
 				"s390x"
 			],
@@ -10766,10 +10751,25 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/esbuild/node_modules/esbuild-netbsd-64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.18.tgz",
-			"integrity": "sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==",
+		"node_modules/esbuild/node_modules/@esbuild/linux-x64": {
+			"version": "0.16.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.3.tgz",
+			"integrity": "sha512-SDiG0nCixYO9JgpehoKgScwic7vXXndfasjnD5DLbp1xltANzqZ425l7LSdHynt19UWOcDjG9wJJzSElsPvk0w==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/netbsd-x64": {
+			"version": "0.16.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.3.tgz",
+			"integrity": "sha512-AzbsJqiHEq1I/tUvOfAzCY15h4/7Ivp3ff/o1GpP16n48JMNAtbW0qui2WCgoIZArEHD0SUQ95gvR0oSO7ZbdA==",
 			"cpu": [
 				"x64"
 			],
@@ -10781,10 +10781,10 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/esbuild/node_modules/esbuild-openbsd-64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.18.tgz",
-			"integrity": "sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==",
+		"node_modules/esbuild/node_modules/@esbuild/openbsd-x64": {
+			"version": "0.16.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.3.tgz",
+			"integrity": "sha512-gSABi8qHl8k3Cbi/4toAzHiykuBuWLZs43JomTcXkjMZVkp0gj3gg9mO+9HJW/8GB5H89RX/V0QP4JGL7YEEVg==",
 			"cpu": [
 				"x64"
 			],
@@ -10796,10 +10796,10 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/esbuild/node_modules/esbuild-sunos-64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.18.tgz",
-			"integrity": "sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==",
+		"node_modules/esbuild/node_modules/@esbuild/sunos-x64": {
+			"version": "0.16.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.3.tgz",
+			"integrity": "sha512-SF9Kch5Ete4reovvRO6yNjMxrvlfT0F0Flm+NPoUw5Z4Q3r1d23LFTgaLwm3Cp0iGbrU/MoUI+ZqwCv5XJijCw==",
 			"cpu": [
 				"x64"
 			],
@@ -10811,10 +10811,25 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/esbuild/node_modules/esbuild-windows-32": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.18.tgz",
-			"integrity": "sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==",
+		"node_modules/esbuild/node_modules/@esbuild/win32-arm64": {
+			"version": "0.16.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.3.tgz",
+			"integrity": "sha512-u5aBonZIyGopAZyOnoPAA6fGsDeHByZ9CnEzyML9NqntK6D/xl5jteZUKm/p6nD09+v3pTM6TuUIqSPcChk5gg==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/win32-ia32": {
+			"version": "0.16.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.3.tgz",
+			"integrity": "sha512-GlgVq1WpvOEhNioh74TKelwla9KDuAaLZrdxuuUgsP2vayxeLgVc+rbpIv0IYF4+tlIzq2vRhofV+KGLD+37EQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -10826,27 +10841,12 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/esbuild/node_modules/esbuild-windows-64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.18.tgz",
-			"integrity": "sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==",
+		"node_modules/esbuild/node_modules/@esbuild/win32-x64": {
+			"version": "0.16.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.3.tgz",
+			"integrity": "sha512-5/JuTd8OWW8UzEtyf19fbrtMJENza+C9JoPIkvItgTBQ1FO2ZLvjbPO6Xs54vk0s5JB5QsfieUEshRQfu7ZHow==",
 			"cpu": [
 				"x64"
-			],
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild/node_modules/esbuild-windows-arm64": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.18.tgz",
-			"integrity": "sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==",
-			"cpu": [
-				"arm64"
 			],
 			"optional": true,
 			"os": [
@@ -28394,7 +28394,7 @@
 				"@miniflare/durable-objects": "2.11.0",
 				"blake3-wasm": "^2.1.5",
 				"chokidar": "^3.5.3",
-				"esbuild": "0.15.18",
+				"esbuild": "0.16.3",
 				"miniflare": "2.11.0",
 				"nanoid": "^3.3.3",
 				"path-to-regexp": "^6.2.0",
@@ -28661,7 +28661,7 @@
 				"@types/rimraf": "^3.0.2",
 				"@types/tar": "^6.1.1",
 				"@types/webpack": "^4.41.32",
-				"esbuild": "0.15.18",
+				"esbuild": "0.16.3",
 				"execa": "^6.1.0",
 				"jest": "^27.5.1",
 				"jest-fetch-mock": "^3.0.3",
@@ -36740,164 +36740,164 @@
 			}
 		},
 		"esbuild": {
-			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.18.tgz",
-			"integrity": "sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==",
+			"version": "0.16.3",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.3.tgz",
+			"integrity": "sha512-71f7EjPWTiSguen8X/kxEpkAS7BFHwtQKisCDDV3Y4GLGWBaoSCyD5uXkaUew6JDzA9FEN1W23mdnSwW9kqCeg==",
 			"requires": {
-				"@esbuild/android-arm": "0.15.18",
-				"@esbuild/linux-loong64": "0.15.18",
-				"esbuild-android-64": "0.15.18",
-				"esbuild-android-arm64": "0.15.18",
-				"esbuild-darwin-64": "0.15.18",
-				"esbuild-darwin-arm64": "0.15.18",
-				"esbuild-freebsd-64": "0.15.18",
-				"esbuild-freebsd-arm64": "0.15.18",
-				"esbuild-linux-32": "0.15.18",
-				"esbuild-linux-64": "0.15.18",
-				"esbuild-linux-arm": "0.15.18",
-				"esbuild-linux-arm64": "0.15.18",
-				"esbuild-linux-mips64le": "0.15.18",
-				"esbuild-linux-ppc64le": "0.15.18",
-				"esbuild-linux-riscv64": "0.15.18",
-				"esbuild-linux-s390x": "0.15.18",
-				"esbuild-netbsd-64": "0.15.18",
-				"esbuild-openbsd-64": "0.15.18",
-				"esbuild-sunos-64": "0.15.18",
-				"esbuild-windows-32": "0.15.18",
-				"esbuild-windows-64": "0.15.18",
-				"esbuild-windows-arm64": "0.15.18"
+				"@esbuild/android-arm": "0.16.3",
+				"@esbuild/android-arm64": "0.16.3",
+				"@esbuild/android-x64": "0.16.3",
+				"@esbuild/darwin-arm64": "0.16.3",
+				"@esbuild/darwin-x64": "0.16.3",
+				"@esbuild/freebsd-arm64": "0.16.3",
+				"@esbuild/freebsd-x64": "0.16.3",
+				"@esbuild/linux-arm": "0.16.3",
+				"@esbuild/linux-arm64": "0.16.3",
+				"@esbuild/linux-ia32": "0.16.3",
+				"@esbuild/linux-loong64": "0.16.3",
+				"@esbuild/linux-mips64el": "0.16.3",
+				"@esbuild/linux-ppc64": "0.16.3",
+				"@esbuild/linux-riscv64": "0.16.3",
+				"@esbuild/linux-s390x": "0.16.3",
+				"@esbuild/linux-x64": "0.16.3",
+				"@esbuild/netbsd-x64": "0.16.3",
+				"@esbuild/openbsd-x64": "0.16.3",
+				"@esbuild/sunos-x64": "0.16.3",
+				"@esbuild/win32-arm64": "0.16.3",
+				"@esbuild/win32-ia32": "0.16.3",
+				"@esbuild/win32-x64": "0.16.3"
 			},
 			"dependencies": {
 				"@esbuild/android-arm": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.18.tgz",
-					"integrity": "sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==",
+					"version": "0.16.3",
+					"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.3.tgz",
+					"integrity": "sha512-mueuEoh+s1eRbSJqq9KNBQwI4QhQV6sRXIfTyLXSHGMpyew61rOK4qY21uKbXl1iBoMb0AdL1deWFCQVlN2qHA==",
+					"optional": true
+				},
+				"@esbuild/android-arm64": {
+					"version": "0.16.3",
+					"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.3.tgz",
+					"integrity": "sha512-RolFVeinkeraDvN/OoRf1F/lP0KUfGNb5jxy/vkIMeRRChkrX/HTYN6TYZosRJs3a1+8wqpxAo5PI5hFmxyPRg==",
+					"optional": true
+				},
+				"@esbuild/android-x64": {
+					"version": "0.16.3",
+					"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.3.tgz",
+					"integrity": "sha512-SFpTUcIT1bIJuCCBMCQWq1bL2gPTjWoLZdjmIhjdcQHaUfV41OQfho6Ici5uvvkMmZRXIUGpM3GxysP/EU7ifQ==",
+					"optional": true
+				},
+				"@esbuild/darwin-arm64": {
+					"version": "0.16.3",
+					"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.3.tgz",
+					"integrity": "sha512-DO8WykMyB+N9mIDfI/Hug70Dk1KipavlGAecxS3jDUwAbTpDXj0Lcwzw9svkhxfpCagDmpaTMgxWK8/C/XcXvw==",
+					"optional": true
+				},
+				"@esbuild/darwin-x64": {
+					"version": "0.16.3",
+					"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.3.tgz",
+					"integrity": "sha512-uEqZQ2omc6BvWqdCiyZ5+XmxuHEi1SPzpVxXCSSV2+Sh7sbXbpeNhHIeFrIpRjAs0lI1FmA1iIOxFozKBhKgRQ==",
+					"optional": true
+				},
+				"@esbuild/freebsd-arm64": {
+					"version": "0.16.3",
+					"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.3.tgz",
+					"integrity": "sha512-nJansp3sSXakNkOD5i5mIz2Is/HjzIhFs49b1tjrPrpCmwgBmH9SSzhC/Z1UqlkivqMYkhfPwMw1dGFUuwmXhw==",
+					"optional": true
+				},
+				"@esbuild/freebsd-x64": {
+					"version": "0.16.3",
+					"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.3.tgz",
+					"integrity": "sha512-TfoDzLw+QHfc4a8aKtGSQ96Wa+6eimljjkq9HKR0rHlU83vw8aldMOUSJTUDxbcUdcgnJzPaX8/vGWm7vyV7ug==",
+					"optional": true
+				},
+				"@esbuild/linux-arm": {
+					"version": "0.16.3",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.3.tgz",
+					"integrity": "sha512-VwswmSYwVAAq6LysV59Fyqk3UIjbhuc6wb3vEcJ7HEJUtFuLK9uXWuFoH1lulEbE4+5GjtHi3MHX+w1gNHdOWQ==",
+					"optional": true
+				},
+				"@esbuild/linux-arm64": {
+					"version": "0.16.3",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.3.tgz",
+					"integrity": "sha512-7I3RlsnxEFCHVZNBLb2w7unamgZ5sVwO0/ikE2GaYvYuUQs9Qte/w7TqWcXHtCwxvZx/2+F97ndiUQAWs47ZfQ==",
+					"optional": true
+				},
+				"@esbuild/linux-ia32": {
+					"version": "0.16.3",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.3.tgz",
+					"integrity": "sha512-X8FDDxM9cqda2rJE+iblQhIMYY49LfvW4kaEjoFbTTQ4Go8G96Smj2w3BRTwA8IHGoi9dPOPGAX63dhuv19UqA==",
 					"optional": true
 				},
 				"@esbuild/linux-loong64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.18.tgz",
-					"integrity": "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==",
+					"version": "0.16.3",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.3.tgz",
+					"integrity": "sha512-hIbeejCOyO0X9ujfIIOKjBjNAs9XD/YdJ9JXAy1lHA+8UXuOqbFe4ErMCqMr8dhlMGBuvcQYGF7+kO7waj2KHw==",
 					"optional": true
 				},
-				"esbuild-android-64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.18.tgz",
-					"integrity": "sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==",
+				"@esbuild/linux-mips64el": {
+					"version": "0.16.3",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.3.tgz",
+					"integrity": "sha512-znFRzICT/V8VZQMt6rjb21MtAVJv/3dmKRMlohlShrbVXdBuOdDrGb+C2cZGQAR8RFyRe7HS6klmHq103WpmVw==",
 					"optional": true
 				},
-				"esbuild-android-arm64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.18.tgz",
-					"integrity": "sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==",
+				"@esbuild/linux-ppc64": {
+					"version": "0.16.3",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.3.tgz",
+					"integrity": "sha512-EV7LuEybxhXrVTDpbqWF2yehYRNz5e5p+u3oQUS2+ZFpknyi1NXxr8URk4ykR8Efm7iu04//4sBg249yNOwy5Q==",
 					"optional": true
 				},
-				"esbuild-darwin-64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.18.tgz",
-					"integrity": "sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==",
+				"@esbuild/linux-riscv64": {
+					"version": "0.16.3",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.3.tgz",
+					"integrity": "sha512-uDxqFOcLzFIJ+r/pkTTSE9lsCEaV/Y6rMlQjUI9BkzASEChYL/aSQjZjchtEmdnVxDKETnUAmsaZ4pqK1eE5BQ==",
 					"optional": true
 				},
-				"esbuild-darwin-arm64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.18.tgz",
-					"integrity": "sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==",
+				"@esbuild/linux-s390x": {
+					"version": "0.16.3",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.3.tgz",
+					"integrity": "sha512-NbeREhzSxYwFhnCAQOQZmajsPYtX71Ufej3IQ8W2Gxskfz9DK58ENEju4SbpIj48VenktRASC52N5Fhyf/aliQ==",
 					"optional": true
 				},
-				"esbuild-freebsd-64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.18.tgz",
-					"integrity": "sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==",
+				"@esbuild/linux-x64": {
+					"version": "0.16.3",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.3.tgz",
+					"integrity": "sha512-SDiG0nCixYO9JgpehoKgScwic7vXXndfasjnD5DLbp1xltANzqZ425l7LSdHynt19UWOcDjG9wJJzSElsPvk0w==",
 					"optional": true
 				},
-				"esbuild-freebsd-arm64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.18.tgz",
-					"integrity": "sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==",
+				"@esbuild/netbsd-x64": {
+					"version": "0.16.3",
+					"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.3.tgz",
+					"integrity": "sha512-AzbsJqiHEq1I/tUvOfAzCY15h4/7Ivp3ff/o1GpP16n48JMNAtbW0qui2WCgoIZArEHD0SUQ95gvR0oSO7ZbdA==",
 					"optional": true
 				},
-				"esbuild-linux-32": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.18.tgz",
-					"integrity": "sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==",
+				"@esbuild/openbsd-x64": {
+					"version": "0.16.3",
+					"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.3.tgz",
+					"integrity": "sha512-gSABi8qHl8k3Cbi/4toAzHiykuBuWLZs43JomTcXkjMZVkp0gj3gg9mO+9HJW/8GB5H89RX/V0QP4JGL7YEEVg==",
 					"optional": true
 				},
-				"esbuild-linux-64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.18.tgz",
-					"integrity": "sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==",
+				"@esbuild/sunos-x64": {
+					"version": "0.16.3",
+					"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.3.tgz",
+					"integrity": "sha512-SF9Kch5Ete4reovvRO6yNjMxrvlfT0F0Flm+NPoUw5Z4Q3r1d23LFTgaLwm3Cp0iGbrU/MoUI+ZqwCv5XJijCw==",
 					"optional": true
 				},
-				"esbuild-linux-arm": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.18.tgz",
-					"integrity": "sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==",
+				"@esbuild/win32-arm64": {
+					"version": "0.16.3",
+					"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.3.tgz",
+					"integrity": "sha512-u5aBonZIyGopAZyOnoPAA6fGsDeHByZ9CnEzyML9NqntK6D/xl5jteZUKm/p6nD09+v3pTM6TuUIqSPcChk5gg==",
 					"optional": true
 				},
-				"esbuild-linux-arm64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.18.tgz",
-					"integrity": "sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==",
+				"@esbuild/win32-ia32": {
+					"version": "0.16.3",
+					"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.3.tgz",
+					"integrity": "sha512-GlgVq1WpvOEhNioh74TKelwla9KDuAaLZrdxuuUgsP2vayxeLgVc+rbpIv0IYF4+tlIzq2vRhofV+KGLD+37EQ==",
 					"optional": true
 				},
-				"esbuild-linux-mips64le": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.18.tgz",
-					"integrity": "sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==",
-					"optional": true
-				},
-				"esbuild-linux-ppc64le": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.18.tgz",
-					"integrity": "sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==",
-					"optional": true
-				},
-				"esbuild-linux-riscv64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.18.tgz",
-					"integrity": "sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==",
-					"optional": true
-				},
-				"esbuild-linux-s390x": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.18.tgz",
-					"integrity": "sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==",
-					"optional": true
-				},
-				"esbuild-netbsd-64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.18.tgz",
-					"integrity": "sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==",
-					"optional": true
-				},
-				"esbuild-openbsd-64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.18.tgz",
-					"integrity": "sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==",
-					"optional": true
-				},
-				"esbuild-sunos-64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.18.tgz",
-					"integrity": "sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==",
-					"optional": true
-				},
-				"esbuild-windows-32": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.18.tgz",
-					"integrity": "sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==",
-					"optional": true
-				},
-				"esbuild-windows-64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.18.tgz",
-					"integrity": "sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==",
-					"optional": true
-				},
-				"esbuild-windows-arm64": {
-					"version": "0.15.18",
-					"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.18.tgz",
-					"integrity": "sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==",
+				"@esbuild/win32-x64": {
+					"version": "0.16.3",
+					"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.3.tgz",
+					"integrity": "sha512-5/JuTd8OWW8UzEtyf19fbrtMJENza+C9JoPIkvItgTBQ1FO2ZLvjbPO6Xs54vk0s5JB5QsfieUEshRQfu7ZHow==",
 					"optional": true
 				}
 			}
@@ -49087,7 +49087,7 @@
 				"concurrently": "^7.2.2",
 				"devtools-protocol": "^0.0.955664",
 				"dotenv": "^16.0.0",
-				"esbuild": "0.15.18",
+				"esbuild": "0.16.3",
 				"execa": "^6.1.0",
 				"express": "^4.18.1",
 				"finalhandler": "^1.2.0",
@@ -49234,7 +49234,7 @@
 				"@types/rimraf": "^3.0.2",
 				"@types/tar": "^6.1.1",
 				"@types/webpack": "^4.41.32",
-				"esbuild": "0.15.18",
+				"esbuild": "0.16.3",
 				"execa": "^6.1.0",
 				"jest": "^27.5.1",
 				"jest-fetch-mock": "^3.0.3",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -105,7 +105,7 @@
 		"@miniflare/durable-objects": "2.11.0",
 		"blake3-wasm": "^2.1.5",
 		"chokidar": "^3.5.3",
-		"esbuild": "0.16.3",
+		"esbuild": "0.16.17",
 		"miniflare": "2.11.0",
 		"nanoid": "^3.3.3",
 		"path-to-regexp": "^6.2.0",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -105,7 +105,7 @@
 		"@miniflare/durable-objects": "2.11.0",
 		"blake3-wasm": "^2.1.5",
 		"chokidar": "^3.5.3",
-		"esbuild": "0.15.0",
+		"esbuild": "0.15.18",
 		"miniflare": "2.11.0",
 		"nanoid": "^3.3.3",
 		"path-to-regexp": "^6.2.0",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -105,7 +105,7 @@
 		"@miniflare/durable-objects": "2.11.0",
 		"blake3-wasm": "^2.1.5",
 		"chokidar": "^3.5.3",
-		"esbuild": "0.15.18",
+		"esbuild": "0.16.3",
 		"miniflare": "2.11.0",
 		"nanoid": "^3.3.3",
 		"path-to-regexp": "^6.2.0",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -105,7 +105,7 @@
 		"@miniflare/durable-objects": "2.11.0",
 		"blake3-wasm": "^2.1.5",
 		"chokidar": "^3.5.3",
-		"esbuild": "0.16.17",
+		"esbuild": "0.16.3",
 		"miniflare": "2.11.0",
 		"nanoid": "^3.3.3",
 		"path-to-regexp": "^6.2.0",

--- a/packages/wranglerjs-compat-webpack-plugin/package.json
+++ b/packages/wranglerjs-compat-webpack-plugin/package.json
@@ -55,7 +55,7 @@
 		"@types/rimraf": "^3.0.2",
 		"@types/tar": "^6.1.1",
 		"@types/webpack": "^4.41.32",
-		"esbuild": "0.16.17",
+		"esbuild": "0.16.3",
 		"execa": "^6.1.0",
 		"jest": "^27.5.1",
 		"jest-fetch-mock": "^3.0.3",

--- a/packages/wranglerjs-compat-webpack-plugin/package.json
+++ b/packages/wranglerjs-compat-webpack-plugin/package.json
@@ -55,7 +55,7 @@
 		"@types/rimraf": "^3.0.2",
 		"@types/tar": "^6.1.1",
 		"@types/webpack": "^4.41.32",
-		"esbuild": "0.15.0",
+		"esbuild": "0.15.18",
 		"execa": "^6.1.0",
 		"jest": "^27.5.1",
 		"jest-fetch-mock": "^3.0.3",

--- a/packages/wranglerjs-compat-webpack-plugin/package.json
+++ b/packages/wranglerjs-compat-webpack-plugin/package.json
@@ -55,7 +55,7 @@
 		"@types/rimraf": "^3.0.2",
 		"@types/tar": "^6.1.1",
 		"@types/webpack": "^4.41.32",
-		"esbuild": "0.15.18",
+		"esbuild": "0.16.3",
 		"execa": "^6.1.0",
 		"jest": "^27.5.1",
 		"jest-fetch-mock": "^3.0.3",

--- a/packages/wranglerjs-compat-webpack-plugin/package.json
+++ b/packages/wranglerjs-compat-webpack-plugin/package.json
@@ -55,7 +55,7 @@
 		"@types/rimraf": "^3.0.2",
 		"@types/tar": "^6.1.1",
 		"@types/webpack": "^4.41.32",
-		"esbuild": "0.16.3",
+		"esbuild": "0.16.17",
 		"execa": "^6.1.0",
 		"jest": "^27.5.1",
 		"jest-fetch-mock": "^3.0.3",


### PR DESCRIPTION
bump esbuild to 0.16.3 (fixes a bug in esbuild's 0.15.13 release that would cause it to hang)

closes https://github.com/cloudflare/wrangler2/issues/1732